### PR TITLE
CI: Add golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [darwin, linux, windows]
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      with:
+        go-version-file: go.mod
+    - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+      env:
+        GOOS: ${{ matrix.os }}


### PR DESCRIPTION
This adds golangci-lint to a GitHub action.

- We run it for darwin, linux, and windows, but do so using `GOOS` because Linux runners are faster.
- I elected to go for the action instead of running `make lint` for caching &etc.; however, `make lint` should be kept working (and ideally run as a pre-commit hook on developer machines).
- This should be tested after #8 merges; hence draft for now.