### PR TITLE
CI: Skip on unprotected upstream branches

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,6 +9,7 @@ jobs:
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
+    if: ${{!(github.event_name == 'push' && github.repository_owner == 'rancher-sandbox' && github.ref_type == 'branch' && !github.ref_protected)}}
     strategy:
       matrix:
         os: [darwin, linux, windows]


### PR DESCRIPTION
This disables the CI run on push to upstream repository branch that is _not_ protected, i.e. topic branches that are upstream.  This is meant to prevent running duplicate checks (because these branches are expected to be made into pull requests instead).