### PR TITLE
CI: Add dependabot

### DIFF
--- a/.github/actions/get-token/action.yaml
+++ b/.github/actions/get-token/action.yaml
@@ -1,0 +1,40 @@
+name: Get Token
+description: >-
+  This action attempts to get a token with the requested permissions; if this is
+  not running from the upstream repository, it attempts to get the token from a
+  secret.  Otherwise, it uses the vault actions.
+  This requires permissions set described in
+  https://github.com/rancher-eio/read-vault-secrets
+inputs:
+  token-secret:
+    description: Secret to fall back to
+    required: false
+outputs:
+  token:
+    description: The GitHub token retrieved
+    value: ${{ github.repository_owner == 'rancher-sandbox' && steps.gen-token.outputs.token || steps.get-secret.outputs.token }}
+runs:
+  using: composite
+  steps:
+  - id: vault
+    name: Read vault secrets
+    if: github.repository_owner == 'rancher-sandbox'
+    uses: rancher-eio/read-vault-secrets@main
+    with:
+      secrets: |
+        secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+        secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
+  - id: gen-token
+    name: Generate token
+    if: github.repository_owner == 'rancher-sandbox'
+    uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
+    with:
+      app-id: ${{ env.APP_ID }}
+      private-key: ${{ env.PRIVATE_KEY }}
+  - id: get-secret
+    name: Fetch secret.
+    if: github.repository_owner != 'rancher-sandbox'
+    run: echo "token=$SECRET" >> "$GITHUB_OUTPUT"
+    shell: bash
+    env:
+      SECRET: ${{ inputs.token-secret }}

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,3 +1,4 @@
+cooldown #https://en.wiktionary.org/wiki/cooldown#English
 routable #https://en.wiktionary.org/wiki/routable#English
 standalone #https://en.wiktionary.org/wiki/standalone#English
 startable #https://en.wiktionary.org/wiki/startable

--- a/.github/actions/spelling/expect/golang.txt
+++ b/.github/actions/spelling/expect/golang.txt
@@ -1,5 +1,6 @@
 # Generic golang
 deepcopy
+gomod
 
 # Generic Kubernetes
 apigroup

--- a/.github/actions/spelling/expect/rd.txt
+++ b/.github/actions/spelling/expect/rd.txt
@@ -2,6 +2,7 @@
 ctl
 ctrctl
 devmode
+eio
 # limit ranger is currently commented out as an import
 limitranger
 nerdctl

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7
+- package-ecosystem: gomod # spellchecker:ignore
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7
+  ignore:
+  - { dependency-name: k8s.io/api } # spellchecker:ignore
+  - { dependency-name: k8s.io/apiextensions-apiserver } # spellchecker:ignore
+  - { dependency-name: k8s.io/apimachinery } # spellchecker:ignore
+  - { dependency-name: k8s.io/apiserver } # spellchecker:ignore
+  - { dependency-name: k8s.io/cli-runtime } # spellchecker:ignore
+  - { dependency-name: k8s.io/client-go } # spellchecker:ignore
+  - { dependency-name: k8s.io/cloud-provider } # spellchecker:ignore
+  - { dependency-name: k8s.io/cluster-bootstrap } # spellchecker:ignore
+  - { dependency-name: k8s.io/code-generator } # spellchecker:ignore
+  - { dependency-name: k8s.io/component-base } # spellchecker:ignore
+  - { dependency-name: k8s.io/component-helpers } # spellchecker:ignore
+  - { dependency-name: k8s.io/controller-manager } # spellchecker:ignore
+  - { dependency-name: k8s.io/cri-api } # spellchecker:ignore
+  - { dependency-name: k8s.io/cri-client } # spellchecker:ignore
+  - { dependency-name: k8s.io/csi-translation-lib } # spellchecker:ignore
+  - { dependency-name: k8s.io/dynamic-resource-allocation } # spellchecker:ignore
+  - { dependency-name: k8s.io/endpointslice } # spellchecker:ignore
+  - { dependency-name: k8s.io/externaljwt } # spellchecker:ignore
+  - { dependency-name: k8s.io/kms } # spellchecker:ignore
+  - { dependency-name: k8s.io/kube-aggregator } # spellchecker:ignore
+  - { dependency-name: k8s.io/kube-controller-manager } # spellchecker:ignore
+  - { dependency-name: k8s.io/kube-proxy } # spellchecker:ignore
+  - { dependency-name: k8s.io/kube-scheduler } # spellchecker:ignore
+  - { dependency-name: k8s.io/kubectl } # spellchecker:ignore
+  - { dependency-name: k8s.io/kubelet } # spellchecker:ignore
+  - { dependency-name: k8s.io/metrics } # spellchecker:ignore
+  - { dependency-name: k8s.io/mount-utils } # spellchecker:ignore
+  - { dependency-name: k8s.io/pod-security-admission } # spellchecker:ignore
+  - { dependency-name: k8s.io/sample-apiserver } # spellchecker:ignore
+  - { dependency-name: k8s.io/sample-cli-plugin } # spellchecker:ignore
+  - { dependency-name: k8s.io/sample-controller } # spellchecker:ignore
+  groups:
+    golang-x:
+      patterns: [ golang.org/x/* ]

--- a/.github/workflows/go-mod-k8s-sync.yaml
+++ b/.github/workflows/go-mod-k8s-sync.yaml
@@ -1,0 +1,99 @@
+name: Sync go.mod Kubernetes modules
+on:
+  pull_request_target:
+    types: [ opened, reopened, synchronize ]
+    paths:
+    - 'go.mod'
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+jobs:
+  update-go-mod:
+    # We only run this for pull requests from the same repository.  This is
+    # important for security reasons, as we use pull_request_target.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      changed: ${{ steps.changed.outputs.changed }}
+      go-mod: ${{ steps.changed.outputs.go-mod }}
+      go-sum: ${{ steps.changed.outputs.go-sum }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+        ref: ${{ github.head_ref }}
+    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      with:
+        go-version-file: go.mod
+    - run: go run scripts/go-module-k8s-bump/main.go
+    - run: go mod tidy
+    - name: Check for changes
+      id: changed
+      run: |
+        if [ -n "$(git status --porcelain -- go.mod)" ]; then
+          {
+            echo changed=true
+            echo 'go-mod<<@@EOF@@'
+            cat go.mod
+            echo '@@EOF@@'
+            echo 'go-sum<<@@EOF@@'
+            cat go.sum
+            echo '@@EOF@@'
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo '```diff'
+            git diff go.mod
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo changed= >> "$GITHUB_OUTPUT"
+          echo "### No changes to go.mod required" >> "$GITHUB_STEP_SUMMARY"
+        fi
+  commit-changes:
+    needs: update-go-mod
+    if: needs.update-go-mod.outputs.changed
+    permissions:
+      contents: read
+      id-token: write # Required for ./.github/actions/get-token
+    runs-on: ubuntu-latest
+    steps:
+    # Check out the base ref first to make sure get-token is ours.
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        ref: ${{ github.base_ref }}
+    - id: get-token
+      uses: ./.github/actions/get-token
+      with:
+        token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: true
+        ref: ${{ github.head_ref }}
+        token: ${{ steps.get-token.outputs.token }}
+    - run: cat <<<$GO_MOD >go.mod
+      env:
+        GO_MOD: ${{ needs.update-go-mod.outputs.go-mod }}
+    - run: cat <<<$GO_SUM >go.sum
+      env:
+        GO_SUM: ${{ needs.update-go-mod.outputs.go-sum }}
+    - name: Commit changes
+      run: >-
+        git
+        -c user.name="$GIT_AUTHOR_NAME"
+        -c user.email="$GIT_AUTHOR_EMAIL"
+        commit
+        --message='Update Kubernetes go modules'
+        --signoff
+        --
+        go.mod go.sum
+      env:
+        GIT_AUTHOR_NAME: Rancher Desktop Dependency Manager
+        GIT_AUTHOR_EMAIL: donotuse@rancherdesktop.io # spellchecker:ignore
+    - name: Push changes
+      run: |
+        git show
+        git push origin ${{ github.head_ref }}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
 	go.etcd.io/etcd/api/v3 v3.6.4
+	golang.org/x/mod v0.27.0
 	golang.org/x/sys v0.35.0
 	k8s.io/api v0.34.0
 	k8s.io/apiextensions-apiserver v0.34.0
@@ -159,7 +160,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
-	golang.org/x/mod v0.27.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect

--- a/scripts/go-module-k8s-bump/main.go
+++ b/scripts/go-module-k8s-bump/main.go
@@ -6,6 +6,8 @@
 // Kubernetes components match.
 //
 // This must be run with internet access, and may modify `go.mod` and `go.sum`.
+//
+// See `.github/workflows/go-mod-k8s-sync.yaml` for where this is run on CI.
 package main
 
 import (
@@ -20,11 +22,15 @@ import (
 
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+
+	"sigs.k8s.io/yaml"
 )
 
 const (
 	// The name of the main Kubernetes package.
 	anchorPackage = "k8s.io/kubernetes"
+	// Path to dependabot configuration.
+	dependabotConfigPath = ".github/dependabot.yml"
 )
 
 // Run the command, setting up stdout/stderr.
@@ -133,7 +139,58 @@ func updateGoMod(ctx context.Context) error {
 		return err
 	}
 
+	if err := checkDependabotConfig(targetModules); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// Check the dependabot configuration to make sure it is ignoring all of the
+// Kubernetes modules correctly; print out a list of missing modules and return
+// an error if any are missing.  We do not modify the file in-place because
+// doing so would end up dropping any comments in the file.
+func checkDependabotConfig(modules map[string]bool) error {
+	buf, err := os.ReadFile(dependabotConfigPath)
+	if err != nil {
+		return fmt.Errorf("error reading dependabot configuration: %w", err)
+	}
+	var config struct {
+		Updates []struct {
+			PackageEcosystem string `json:"package-ecosystem"`
+			Ignore           []struct {
+				DependencyName string `json:"dependency-name"`
+			}
+		}
+	}
+	if err := yaml.Unmarshal(buf, &config); err != nil {
+		return fmt.Errorf("failed to unmarshal dependabot configuration: %w", err)
+	}
+	for _, updates := range config.Updates {
+		if updates.PackageEcosystem != "gomod" {
+			continue
+		}
+		found := make(map[string]bool)
+		for _, dependency := range updates.Ignore {
+			found[dependency.DependencyName] = true
+		}
+		var missing []string
+		for module := range modules {
+			if _, ok := found[module]; !ok {
+				missing = append(missing, module)
+			}
+		}
+		if len(missing) == 0 {
+			return nil
+		}
+		slices.Sort(missing)
+		fmt.Fprintf(os.Stderr, "Dependabot configuration is missing ignore packages:\n")
+		for _, module := range missing {
+			fmt.Fprintf(os.Stderr, "  - { dependency-name: %s } # spellchecker:%s\n", module, "ignore")
+		}
+		return errors.New("dependabot configuration is not ignoring Kubernetes packages")
+	}
+	return errors.New("failed to find dependabot golang configuration")
 }
 
 func main() {

--- a/scripts/go-module-k8s-bump/main.go
+++ b/scripts/go-module-k8s-bump/main.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+// Command go-module-k8s-bump is used to bump Kubernetes versions in the
+// top-level `go.mod` because we require `replace` directives to make various
+// Kubernetes components match.
+//
+// This must be run with internet access, and may modify `go.mod` and `go.sum`.
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
+)
+
+const (
+	// The name of the main Kubernetes package.
+	anchorPackage = "k8s.io/kubernetes"
+)
+
+// Run the command, setting up stdout/stderr.
+func runCommand(ctx context.Context, capture bool, name string, args ...string) (string, error) {
+	var buf bytes.Buffer
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stderr = os.Stderr
+	if capture {
+		cmd.Stdout = &buf
+	} else {
+		cmd.Stdout = os.Stderr
+	}
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// Download the k8s.io/kubernetes package, and determine which packages are found
+// in its staging/ directory.
+func findModules(ctx context.Context, mod module.Version) (map[string]bool, error) {
+	// The canonical list of packages is found in the Kubernetes source tree,
+	// under `staging/src/...`; however, there is no good way to find that.  We
+	// make do by checking the `go.mod` of the main `k8s.io/kubernetes` package.
+	// To do so, though, we need to `go get` the specific version first.
+	// Note that `go get` does _not_ end up with the `staging/src/...` files.
+	_, err := runCommand(ctx, false, "go", "get", mod.String())
+	if err != nil {
+		return nil, err
+	}
+	modFilePath, err := runCommand(ctx, true, "go", "list", "-m", "-f", "{{.GoMod}}", mod.Path)
+	if err != nil {
+		return nil, err
+	}
+	modFilePath = strings.TrimSpace(modFilePath)
+	if modFilePath == "" {
+		return nil, errors.New("failed to find Kubernetes go.mod")
+	}
+	data, err := os.ReadFile(modFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Kubernetes go.mod: %w", err)
+	}
+	// `modfile.ParseLax` ignores `replace` directives, so we need to use `Parse`.
+	file, err := modfile.Parse(modFilePath, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Kubernetes go.mod: %w", err)
+	}
+
+	results := make(map[string]bool)
+	for _, replace := range file.Replace {
+		if strings.HasPrefix(replace.Old.Path, "k8s.io/") {
+			results[replace.Old.Path] = true
+		}
+	}
+	return results, nil
+}
+
+// Update the go.mod file in the working directory such that all k8s.io modules
+// use the same version as the anchor module (using v0 instead of v1).
+func updateGoMod(ctx context.Context) error {
+	data, err := os.ReadFile("go.mod")
+	if err != nil {
+		return err
+	}
+	file, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return err
+	}
+
+	i := slices.IndexFunc(file.Require, func(r *modfile.Require) bool {
+		return r.Mod.Path == anchorPackage
+	})
+	if i < 0 {
+		return fmt.Errorf("failed to find module %s in go.mod", anchorPackage)
+	}
+	anchorRequire := file.Require[i]
+	targetVersion := strings.Replace(anchorRequire.Mod.Version, "v1.", "v0.", 1)
+	targetModules, err := findModules(ctx, anchorRequire.Mod)
+	if err != nil {
+		return fmt.Errorf("failed to find Kubernetes sub-packages: %w", err)
+	}
+
+	// Just always add everything; we run `go mod tidy` after, and that will
+	// remove things we added that are not necessary.
+	for pkg := range targetModules {
+		if err := file.AddRequire(pkg, targetVersion); err != nil {
+			return fmt.Errorf("error updating require %s: %w", pkg, err)
+		}
+		if err := file.AddReplace(pkg, "", pkg, targetVersion); err != nil {
+			return fmt.Errorf("error updating replace: %s => %s: %w", pkg, pkg, err)
+		}
+	}
+
+	file.Cleanup()
+
+	result, err := file.Format()
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile("go.mod", result, 0o644); err != nil {
+		return err
+	}
+
+	if _, err := runCommand(ctx, false, "go", "mod", "tidy"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := updateGoMod(context.Background()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
The Kubernetes modules are kind of weird due to how they manage `/staging` (see info [here](https://github.com/kubernetes/kubernetes/blob/c0b9ab3351622bec1d921690cbe9e2f4e86cddcd/staging/README.md)), so there's something extra to do it separately and then make fix-up commits like we did with the Rancher Desktop dependabot action.

The script can be tested locally with `go run scripts/go-module-k8s-bump/main.go` (try modifying `go.mod` to use `k8s.io/kubernetes v1.34.1` before running it, for example; no need to use `go get` or anything like that).

We may need to ask for EIO help to set up vault secrets; we may need to confirm that after the first run fails.