### PR TITLE
Add BATS linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,3 +23,17 @@ jobs:
     - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       env:
         GOOS: ${{ matrix.os }}
+  bats:
+    name: Lint BATS
+    runs-on: ubuntu-latest
+    if: ${{!(github.event_name == 'push' && github.repository_owner == 'rancher-sandbox' && github.ref_type == 'branch' && !github.ref_protected)}}
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      with:
+        go-version-file: go.mod
+    - name: Install shfmt
+      run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
+    - run: make -C bats lint

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ run:
 .PHONY: run
 
 lint:
+	$(MAKE) -C bats lint
 	golangci-lint run
 .PHONY: lint
 

--- a/Makefile
+++ b/Makefile
@@ -99,74 +99,10 @@ ltag:
 	go tool ltag -v -t .ltag -path . --excludes=lib
 .PHONY: ltag
 
-# BATS integration testing targets
-BATS_CORE := ./bats/lib/bats-core/bin/bats
-
-# Check if BATS core exists
-check-bats:
-	@if [ ! -f "$(BATS_CORE)" ]; then \
-		echo "BATS core not found. Please run 'git submodule update --init --recursive' to initialize BATS submodules."; \
-		exit 1; \
-	fi
-.PHONY: check-bats
-
-# Run BATS tests for BATS helpers
-bats-helpers: check-bats
-	$(BATS_CORE) bats/helpers/
-.PHONY: bats-helpers
-
-# Run CLI tests
-bats-cli: check-bats build-rdd
-	PATH="$(PWD)/bin:$$PATH" RDD_INSTANCE=bats-cli $(BATS_CORE) bats/tests/10-cli/
-.PHONY: bats-cli
-
-# Run service tests
-bats-service: check-bats build-rdd
-	PATH="$(PWD)/bin:$$PATH" RDD_INSTANCE=bats-service $(BATS_CORE) bats/tests/20-service/
-.PHONY: bats-service
-
-# Run RDD API group controller tests
-bats-rdd: check-bats build-rdd build-rdd-controller
-	PATH="$(PWD)/bin:$$PATH" RDD_INSTANCE=bats-rdd-controller $(BATS_CORE) bats/tests/31-rdd-controllers/
-.PHONY: bats-rdd
-
-# Run app API group controller tests
-bats-app: check-bats build-rdd
-	PATH="$(PWD)/bin:$$PATH" RDD_INSTANCE=bats-app-controller $(BATS_CORE) bats/tests/32-app-controllers/
-.PHONY: bats-app
-
-# Run all controller tests
-bats-controllers: bats-rdd bats-app
-.PHONY: bats-controllers
-
-# Run all BATS tests
-bats-all: bats-helpers bats-cli bats-service bats-controllers
-.PHONY: bats-all
-
-# Run BATS tests with timeout to prevent hanging
-bats-timeout: check-bats build-rdd
-	PATH="$(PWD)/bin:$$PATH" timeout 600 $(BATS_CORE) bats/tests/
-.PHONY: bats-timeout
-
-# Run specific BATS test file
-# Usage: make bats-file FILE=bats/tests/31-rdd-controllers/configmapreplicaset.bats
-bats-file: check-bats build-rdd build-all-controllers
-	@if [ -z "$(FILE)" ]; then \
-		echo "Usage: make bats-file FILE=path/to/test.bats"; \
-		exit 1; \
-	fi
-	PATH="$(PWD)/bin:$$PATH" $(BATS_CORE) "$(FILE)"
-.PHONY: bats-file
-
-# Run BATS tests with trace output for debugging
-# Usage: make bats-trace FILE=bats/tests/31-rdd-controllers/configmapreplicaset.bats
-bats-trace: check-bats build-rdd build-all-controllers
-	@if [ -z "$(FILE)" ]; then \
-		echo "Usage: make bats-trace FILE=path/to/test.bats"; \
-		exit 1; \
-	fi
-	PATH="$(PWD)/bin:$$PATH" RDD_TRACE=true $(BATS_CORE) "$(FILE)"
-.PHONY: bats-trace
+BATS_TARGETS := $(shell $(MAKE) -C bats --print-data-base --question --no-builtin-variables | awk -F: '$$1 ~ /^bats-/ { print $$1 }')
+$(BATS_TARGETS):
+	@$(MAKE) -C bats $@
+.PHONY: $(BATS_TARGETS)
 
 clean:
 	-rm -r bin

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -78,3 +78,13 @@ bats-trace: check-bats build-rdd build-all-controllers
 	fi
 	PATH="$(PWD)/../bin:$$PATH" RDD_TRACE=true $(BATS_CORE) "$(FILE)"
 .PHONY: bats-trace
+
+# https://www.shellcheck.net/wiki/SC1091 -- Not following: xxx was not specified as input (see shellcheck -x)
+# https://www.shellcheck.net/wiki/SC2034 -- xxx appears unused. Verify use (or export if used externally)
+# https://www.shellcheck.net/wiki/SC2154 -- xxx is referenced but not assigned
+TEST_FILES := $(shell find helpers tests -name '*.bash' -o -name '*.bats')
+SC_EXCLUDES ?= SC1091,SC2034,SC2154
+lint: $(TEST_FILES)
+	shellcheck --shell=bats --exclude=$(SC_EXCLUDES) $(TEST_FILES)
+	shfmt --language-dialect=bats --indent=4 --diff $(TEST_FILES)
+.PHONY: lint

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# BATS integration testing targets
+BATS_CORE := ./lib/bats-core/bin/bats
+
+default: bats-all
+
+# Check if BATS core exists
+check-bats:
+	@if [ ! -f "$(BATS_CORE)" ]; then \
+		echo "BATS core not found. Please run 'git submodule update --init --recursive' to initialize BATS submodules." >&2; \
+		exit 1; \
+	fi
+.PHONY: check-bats
+
+# Targets for the top level
+TOPLEVEL_TARGETS := build-rdd build-rdd-controller build-all-controllers
+$(TOPLEVEL_TARGETS):
+	@$(MAKE) -C .. $@
+.PHONY: $(TOPLEVEL_TARGETS)
+
+# Run BATS tests for BATS helpers
+bats-helpers: check-bats
+	$(BATS_CORE) helpers/
+.PHONY: bats-helpers
+
+# Run CLI tests
+bats-cli: check-bats build-rdd
+	PATH="$(PWD)/../bin:$$PATH" RDD_INSTANCE=bats-cli $(BATS_CORE) tests/10-cli/
+.PHONY: bats-cli
+
+# Run service tests
+bats-service: check-bats build-rdd
+	PATH="$(PWD)/../bin:$$PATH" RDD_INSTANCE=bats-service $(BATS_CORE) tests/20-service/
+.PHONY: bats-service
+
+# Run RDD API group controller tests
+bats-rdd: check-bats build-rdd build-rdd-controller
+	PATH="$(PWD)/../bin:$$PATH" RDD_INSTANCE=bats-rdd-controller $(BATS_CORE) tests/31-rdd-controllers/
+.PHONY: bats-rdd
+
+# Run app API group controller tests
+bats-app: check-bats build-rdd
+	PATH="$(PWD)/../bin:$$PATH" RDD_INSTANCE=bats-app-controller $(BATS_CORE) tests/32-app-controllers/
+.PHONY: bats-app
+
+# Run all controller tests
+bats-controllers: bats-rdd bats-app
+.PHONY: bats-controllers
+
+# Run all BATS tests
+bats-all: bats-helpers bats-cli bats-service bats-controllers
+.PHONY: bats-all
+
+# Run BATS tests with timeout to prevent hanging
+bats-timeout: check-bats build-rdd
+	PATH="$(PWD)/../bin:$$PATH" timeout 600 $(BATS_CORE) tests/
+.PHONY: bats-timeout
+
+# Run specific BATS test file
+# Usage: make bats-file FILE=bats/tests/31-rdd-controllers/configmapreplicaset.bats
+bats-file: check-bats build-rdd build-all-controllers
+	@if [ -z "$(FILE)" ]; then \
+		echo "Usage: make bats-file FILE=path/to/test.bats"; \
+		exit 1; \
+	fi
+	PATH="$(PWD)/../bin:$$PATH" $(BATS_CORE) "$(FILE)"
+.PHONY: bats-file
+
+# Run BATS tests with trace output for debugging
+# Usage: make bats-trace FILE=bats/tests/31-rdd-controllers/configmapreplicaset.bats
+bats-trace: check-bats build-rdd build-all-controllers
+	@if [ -z "$(FILE)" ]; then \
+		echo "Usage: make bats-trace FILE=path/to/test.bats"; \
+		exit 1; \
+	fi
+	PATH="$(PWD)/../bin:$$PATH" RDD_TRACE=true $(BATS_CORE) "$(FILE)"
+.PHONY: bats-trace

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -87,4 +87,7 @@ SC_EXCLUDES ?= SC1091,SC2034,SC2154
 lint: $(TEST_FILES)
 	shellcheck --shell=bats --exclude=$(SC_EXCLUDES) $(TEST_FILES)
 	shfmt --language-dialect=bats --indent=4 --diff $(TEST_FILES)
-.PHONY: lint
+lint-fix: $(TEST_FILES)
+	shellcheck --shell=bats --exclude=$(SC_EXCLUDES) $(TEST_FILES)
+	shfmt --language-dialect=bats --indent=4 --write $(TEST_FILES)
+.PHONY: lint lint-fix

--- a/bats/README.md
+++ b/bats/README.md
@@ -1,0 +1,10 @@
+# bats
+
+This directory contains [BATS] tests for Rancher Desktop Daemon.
+
+[BATS]: https://bats-core.readthedocs.io/
+
+## Execution environment
+
+Commands are executed with the working directory set to the directory containing
+this file, i.e. `.../bats/`.

--- a/bats/helpers/instance.bash
+++ b/bats/helpers/instance.bash
@@ -1,13 +1,13 @@
 # Calculate the RDD_INSTANCE index for the current RDD_INSTANCE
 # This mirrors the Index() function in pkg/RDD_INSTANCE/RDD_INSTANCE.go
 get_instance_index() {
-    if [[ $RDD_INSTANCE =~ ^[0-9]+$ ]] && (( RDD_INSTANCE > 0 )) && (( RDD_INSTANCE < 100 )); then
-         echo "$RDD_INSTANCE"
-         return
+    if [[ $RDD_INSTANCE =~ ^[0-9]+$ ]] && ((RDD_INSTANCE > 0)) && ((RDD_INSTANCE < 100)); then
+        echo "$RDD_INSTANCE"
+        return
     fi
 
     local i sum
-    for ((i=0, sum=0; i<${#RDD_INSTANCE}; i++)); do
+    for ((i = 0, sum = 0; i < ${#RDD_INSTANCE}; i++)); do
         sum=$((sum + $(printf "%d" "'${RDD_INSTANCE:$i:1}")))
     done
     echo $((100 + (sum % 100)))

--- a/bats/helpers/instance.bats
+++ b/bats/helpers/instance.bats
@@ -13,10 +13,10 @@ load 'load'
 
 @test 'get_instance_index calculates correct checksum for string instances' {
     RDD_INSTANCE=bats run get_instance_index
-    assert_output "126"  # 100 + (98+97+116+115) % 100 = 100 + 26 = 126
+    assert_output "126" # 100 + (98+97+116+115) % 100 = 100 + 26 = 126
 
-    RDD_INSTANCE=test run get_instance_index
-    assert_output "148"  # 100 + (116+101+115+116) % 100 = 100 + 48 = 148
+    RDD_INSTANCE="test" run get_instance_index
+    assert_output "148" # 100 + (116+101+115+116) % 100 = 100 + 48 = 148
 }
 
 @test 'get_instance_index handles edge cases' {
@@ -31,11 +31,11 @@ load 'load'
 
 @test 'get_expected_port calculates correct ports' {
     RDD_INSTANCE=bats run get_expected_port 6443
-    assert_output "6569"  # 6443 + 126 = 6569
+    assert_output "6569" # 6443 + 126 = 6569
 
     RDD_INSTANCE=5 run get_expected_port 6443
-    assert_output "6448"  # 6443 + 5 = 6448
+    assert_output "6448" # 6443 + 5 = 6448
 
     RDD_INSTANCE=5 run get_expected_port 8080
-    assert_output "8085"  # 8080 + 5 = 8085
+    assert_output "8085" # 8080 + 5 = 8085
 }

--- a/bats/helpers/numeric.bash
+++ b/bats/helpers/numeric.bash
@@ -2,50 +2,50 @@
 
 # assert_output_ge - Assert that the integer value of $output is greater than or equal to expected
 assert_output_ge() {
-  local -i expected=$1
-  local -i actual
+    local -i expected=$1
+    local -i actual
 
-  if [[ $output =~ ^-?[0-9]+$ ]]; then
-    actual="$output"
-  else
-    batslib_print_kv_single_or_multi 8 \
-      'expected' ">= $expected" \
-      'actual'   "$output (not a valid integer)" \
-    | batslib_decorate 'output does not contain a valid integer' \
-    | fail
-    return $?
-  fi
+    if [[ $output =~ ^-?[0-9]+$ ]]; then
+        actual="$output"
+    else
+        batslib_print_kv_single_or_multi 8 \
+            'expected' ">= $expected" \
+            'actual' "$output (not a valid integer)" |
+            batslib_decorate 'output does not contain a valid integer' |
+            fail
+        return $?
+    fi
 
-  if (( actual < expected )); then
-    batslib_print_kv_single_or_multi 8 \
-      'expected' ">= $expected" \
-      'actual'   "$actual" \
-    | batslib_decorate 'output is less than expected minimum' \
-    | fail
-  fi
+    if ((actual < expected)); then
+        batslib_print_kv_single_or_multi 8 \
+            'expected' ">= $expected" \
+            'actual' "$actual" |
+            batslib_decorate 'output is less than expected minimum' |
+            fail
+    fi
 }
 
 # assert_output_lt - Assert that the integer value of $output is less than expected
 assert_output_lt() {
-  local -i expected=$1
-  local -i actual
+    local -i expected=$1
+    local -i actual
 
-  if [[ $output =~ ^-?[0-9]+$ ]]; then
-    actual="$output"
-  else
-    batslib_print_kv_single_or_multi 8 \
-      'expected' "< $expected" \
-      'actual'   "$output (not a valid integer)" \
-    | batslib_decorate 'output does not contain a valid integer' \
-    | fail
-    return $?
-  fi
+    if [[ $output =~ ^-?[0-9]+$ ]]; then
+        actual="$output"
+    else
+        batslib_print_kv_single_or_multi 8 \
+            'expected' "< $expected" \
+            'actual' "$output (not a valid integer)" |
+            batslib_decorate 'output does not contain a valid integer' |
+            fail
+        return $?
+    fi
 
-  if (( actual >= expected )); then
-    batslib_print_kv_single_or_multi 8 \
-      'expected' "< $expected" \
-      'actual'   "$actual" \
-    | batslib_decorate 'output is not less than expected maximum' \
-    | fail
-  fi
+    if ((actual >= expected)); then
+        batslib_print_kv_single_or_multi 8 \
+            'expected' "< $expected" \
+            'actual' "$actual" |
+            batslib_decorate 'output is not less than expected maximum' |
+            fail
+    fi
 }

--- a/bats/helpers/numeric.bats
+++ b/bats/helpers/numeric.bats
@@ -39,4 +39,3 @@ local_setup() {
     run assert_output_lt 1
     assert_failure
 }
-

--- a/bats/tests/10-cli/1-version.bats
+++ b/bats/tests/10-cli/1-version.bats
@@ -38,7 +38,7 @@ assert_version() {
 @test 'rdd --version and rdd version produce same output' {
     run -0 rdd --version
     local version_flag_output="$output"
-    
+
     run -0 rdd version
     assert_output "$version_flag_output"
 }

--- a/bats/tests/10-cli/3-devmode.bats
+++ b/bats/tests/10-cli/3-devmode.bats
@@ -25,4 +25,3 @@ local_setup_file() {
     run -0 env RDD_DEVELOPER_MODE=true /tmp/rdd svc status
     assert_line --partial "developer mode"
 }
-

--- a/bats/tests/20-service/5-port-fallback.bats
+++ b/bats/tests/20-service/5-port-fallback.bats
@@ -1,3 +1,6 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031 # Modifications to NETCAT_PIDS are not lost.
+
 load '../../helpers/load'
 
 # Port fallback testing to ensure RDD can run when ports are busy
@@ -12,6 +15,7 @@ local_teardown() {
 # Extract port from kubeconfig server URL
 get_kubeconfig_port() {
     run -0 rdd ctl config view --output='jsonpath={.clusters[0].cluster.server}'
+    # shellcheck disable=SC2001 # shell replace doesn't do captures.
     sed 's/.*127\.0\.0\.1:\([0-9]*\).*/\1/' <<<"$output"
 }
 
@@ -46,7 +50,7 @@ is_port_available() {
 
     rdd svc start
 
-   # Verify kubeconfig uses the expected port
+    # Verify kubeconfig uses the expected port
     run -0 get_kubeconfig_port
     assert_output "$expected_port"
 

--- a/bats/tests/31-rdd-controllers/configmapreplicaset.bats
+++ b/bats/tests/31-rdd-controllers/configmapreplicaset.bats
@@ -69,18 +69,18 @@ wait_for_configmaps() {
     # Check first ConfigMap contains original data plus index
     run -0 rdd ctl get configmap basic-0 -o json
     local basic0_json="$output"
-    
+
     run -0 jq -r '.data | keys[]' <<<"$basic0_json"
     assert_line "config.yaml"
     assert_line "app.properties"
     assert_line "index"
-    
+
     run -0 jq -r '.data."config.yaml"' <<<"$basic0_json"
     assert_output --partial "test-app"
-    
+
     run -0 jq -r '.data."app.properties"' <<<"$basic0_json"
     assert_output --partial "server.port=8080"
-    
+
     run -0 rdd ctl get configmap basic-0 -o jsonpath='{.data.index}'
     assert_output "0"
 
@@ -92,18 +92,18 @@ wait_for_configmaps() {
 @test 'verify ConfigMap owner references are set' {
     run -0 rdd ctl get configmap basic-0 -o json
     local configmap_json="$output"
-    
+
     # Verify owner reference exists and has correct kind
     run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"$configmap_json"
     assert_output "ConfigMapReplicaSet"
-    
+
     run -0 jq -r '.metadata.ownerReferences[0].name' <<<"$configmap_json"
     assert_output "basic"
 
     # Verify the controller reference is set for garbage collection
     run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"$configmap_json"
     assert_output "true"
-    
+
     run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion' <<<"$configmap_json"
     assert_output "true"
 }
@@ -112,10 +112,10 @@ wait_for_configmaps() {
     # Extract and validate complete owner reference structure
     run -0 rdd ctl get cmrs basic -o json
     local parent_json="$output"
-    
+
     run -0 jq -r '.metadata.uid' <<<"$parent_json"
     local parent_uid=$output
-    
+
     run -0 jq -r '.apiVersion' <<<"$parent_json"
     local parent_apiversion=$output
 
@@ -200,62 +200,62 @@ wait_for_configmaps() {
     # Verify old ConfigMaps (0,1) still have original data
     run -0 rdd ctl get configmap basic-0 -o json
     local basic0_json="$output"
-    
+
     run -0 jq -r '.data."config.yaml"' <<<"$basic0_json"
     assert_output --partial "test-app"
     refute_output --partial "updated: true"
     refute_output --partial "version: 2.0.0"
-    
+
     run -0 jq -r '.data."app.properties"' <<<"$basic0_json"
     assert_output --partial "server.port=8080"
-    
+
     run -0 jq -r '.data.index' <<<"$basic0_json"
     assert_output "0"
-    
+
     run -0 jq -r '.data | has("new-file.txt")' <<<"$basic0_json"
     assert_output "false"
 
     run -0 rdd ctl get configmap basic-1 -o json
     local basic1_json="$output"
-    
+
     run -0 jq -r '.data."config.yaml"' <<<"$basic1_json"
     assert_output --partial "test-app"
     refute_output --partial "updated: true"
     refute_output --partial "version: 2.0.0"
-    
+
     run -0 jq -r '.data."app.properties"' <<<"$basic1_json"
     assert_output --partial "server.port=8080"
-    
+
     run -0 jq -r '.data.index' <<<"$basic1_json"
     assert_output "1"
-    
+
     run -0 jq -r '.data | has("new-file.txt")' <<<"$basic1_json"
     assert_output "false"
 
     # Verify new ConfigMaps (2,3) have updated data
     run -0 rdd ctl get configmap basic-2 -o json
     local basic2_json="$output"
-    
+
     run -0 jq -r '.data."config.yaml"' <<<"$basic2_json"
     assert_output --partial "updated: true"
     assert_output --partial "version: 2.0.0"
-    
+
     run -0 jq -r '.data."new-file.txt"' <<<"$basic2_json"
     assert_output "This is a new file"
-    
+
     run -0 jq -r '.data.index' <<<"$basic2_json"
     assert_output "2"
 
     run -0 rdd ctl get configmap basic-3 -o json
     local basic3_json="$output"
-    
+
     run -0 jq -r '.data."config.yaml"' <<<"$basic3_json"
     assert_output --partial "updated: true"
     assert_output --partial "version: 2.0.0"
-    
+
     run -0 jq -r '.data."new-file.txt"' <<<"$basic3_json"
     assert_output "This is a new file"
-    
+
     run -0 jq -r '.data.index' <<<"$basic3_json"
     assert_output "3"
 }

--- a/bats/tests/31-rdd-controllers/notary-admission.bats
+++ b/bats/tests/31-rdd-controllers/notary-admission.bats
@@ -48,7 +48,7 @@ local_setup_file() {
 }
 
 @test "invalid resource is rejected" {
-    cat > "${BATS_TMPDIR}/invalid-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/invalid-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -66,7 +66,7 @@ EOF
 
 @test "case-insensitive validation works" {
     # Test "Invalid" (capital I)
-    cat > "${BATS_TMPDIR}/invalid-case1.yaml" << EOF
+    cat >"${BATS_TMPDIR}/invalid-case1.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -83,7 +83,7 @@ EOF
 
 @test "edge case values are handled correctly" {
     # Test value that contains "invalid" but doesn't start with it
-    cat > "${BATS_TMPDIR}/contains-invalid.yaml" << EOF
+    cat >"${BATS_TMPDIR}/contains-invalid.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -97,7 +97,7 @@ EOF
     assert_output --partial "test-contains-invalid created"
 
     # Test empty value
-    cat > "${BATS_TMPDIR}/empty-value.yaml" << EOF
+    cat >"${BATS_TMPDIR}/empty-value.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -113,7 +113,7 @@ EOF
 
 @test "warnings are shown for long values" {
     # Create a resource with a value longer than 24 characters
-    cat > "${BATS_TMPDIR}/long-value-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/long-value-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -131,7 +131,7 @@ EOF
 
 @test "no warnings for short values" {
     # Create a resource with a value shorter than 24 characters
-    cat > "${BATS_TMPDIR}/short-value-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/short-value-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -149,7 +149,7 @@ EOF
 
 @test "dry-run=client validation works" {
     # Create a valid notary resource for dry-run testing
-    cat > "${BATS_TMPDIR}/dry-run-client-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/dry-run-client-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -169,7 +169,7 @@ EOF
 
 @test "dry-run=server validation works" {
     # Create a valid notary resource for dry-run testing
-    cat > "${BATS_TMPDIR}/dry-run-server-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/dry-run-server-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -190,7 +190,7 @@ EOF
 
 @test "dry-run=server rejects invalid values" {
     # Create an invalid notary resource for dry-run testing
-    cat > "${BATS_TMPDIR}/dry-run-server-invalid.yaml" << EOF
+    cat >"${BATS_TMPDIR}/dry-run-server-invalid.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -211,7 +211,7 @@ EOF
 
 @test "dry-run=server shows warnings for long values" {
     # Create a resource with a long value for dry-run testing
-    cat > "${BATS_TMPDIR}/dry-run-server-long.yaml" << EOF
+    cat >"${BATS_TMPDIR}/dry-run-server-long.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -232,7 +232,7 @@ EOF
 }
 
 @test "dry-run=client update validation works" {
-    cat > "${BATS_TMPDIR}/original-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/original-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -249,7 +249,7 @@ EOF
     run -0 rdd ctl get notary test-dry-run-update-client -o jsonpath='{.spec.value}'
     assert_output "original-value"
 
-    cat > "${BATS_TMPDIR}/updated-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/updated-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -269,7 +269,7 @@ EOF
 }
 
 @test "dry-run=server update validation works" {
-    cat > "${BATS_TMPDIR}/original-notary-server.yaml" << EOF
+    cat >"${BATS_TMPDIR}/original-notary-server.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -285,7 +285,7 @@ EOF
     run -0 rdd ctl get notary test-dry-run-update-server -o jsonpath='{.spec.value}'
     assert_output "original-server-value"
 
-    cat > "${BATS_TMPDIR}/updated-notary-server.yaml" << EOF
+    cat >"${BATS_TMPDIR}/updated-notary-server.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -306,7 +306,7 @@ EOF
 
 @test "dry-run=server update rejects invalid values" {
     # First create an actual resource with valid value
-    cat > "${BATS_TMPDIR}/valid-original.yaml" << EOF
+    cat >"${BATS_TMPDIR}/valid-original.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -323,7 +323,7 @@ EOF
     run -0 rdd ctl get notary test-dry-run-update-invalid -o jsonpath='{.spec.value}'
     assert_output "valid-original-value"
 
-    cat > "${BATS_TMPDIR}/invalid-update.yaml" << EOF
+    cat >"${BATS_TMPDIR}/invalid-update.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -345,7 +345,7 @@ EOF
 
 @test "dry-run=server update shows warnings for long values" {
     # First create an actual resource with short value
-    cat > "${BATS_TMPDIR}/short-original.yaml" << EOF
+    cat >"${BATS_TMPDIR}/short-original.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -361,7 +361,7 @@ EOF
     run -0 rdd ctl get notary test-dry-run-update-warn -o jsonpath='{.spec.value}'
     assert_output "short-value"
 
-    cat > "${BATS_TMPDIR}/long-update.yaml" << EOF
+    cat >"${BATS_TMPDIR}/long-update.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:

--- a/bats/tests/31-rdd-controllers/notary-events.bats
+++ b/bats/tests/31-rdd-controllers/notary-events.bats
@@ -96,7 +96,7 @@ wait_for_events_after_timestamp() {
 get_latest_event_timestamp() {
     local resource_name=$1
 
-    run rdd ctl get events  --field-selector involvedObject.name="${resource_name}" -o json
+    run rdd ctl get events --field-selector involvedObject.name="${resource_name}" -o json
     if [ "$status" -ne 0 ]; then
         echo ""
         return 1

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -30,7 +30,7 @@ assert_process_exited() {
 
 @test "external controller starts and registers" {
     # Start external rdd-controller binary in background
-    ./bin/rdd-controller &
+    ../bin/rdd-controller &
     # Store PID to verify it auto-exits later
     echo "$!" > "${BATS_FILE_TMPDIR}/controller_pid"
 

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -32,7 +32,7 @@ assert_process_exited() {
     # Start external rdd-controller binary in background
     ../bin/rdd-controller &
     # Store PID to verify it auto-exits later
-    echo "$!" > "${BATS_FILE_TMPDIR}/controller_pid"
+    echo "$!" >"${BATS_FILE_TMPDIR}/controller_pid"
 
     # Wait for external controller to register in discovery system
     try --max 20 --delay 1 -- rdd ctl get configmap rdd-controller-manager -n rdd-system
@@ -49,19 +49,19 @@ assert_process_exited() {
     # Verify webhook configuration structure
     run -0 rdd ctl get validatingwebhookconfiguration notary-validator -o jsonpath='{.webhooks[0].name}'
     assert_output "notary.rdd.rancherdesktop.io"
-    
+
     run -0 rdd ctl get validatingwebhookconfiguration notary-validator -o json
     run -0 jq -r '.webhooks[0].clientConfig.url' <<<"$output"
     assert_output --partial "https://127.0.0.1:"
     assert_output --partial "/validate-rdd-rancherdesktop-io-v1alpha1-notary"
-    
+
     run -0 rdd ctl get validatingwebhookconfiguration notary-validator -o jsonpath='{.webhooks[0].failurePolicy}'
     assert_output "Fail"
 }
 
 @test "webhook rejects invalid resources" {
     # Test that validation works via webhook (external mode)
-    cat > "${BATS_TMPDIR}/external-invalid-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/external-invalid-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -81,7 +81,7 @@ EOF
 
 @test "webhook accepts valid resources" {
     # Test that valid resources work via webhook
-    cat > "${BATS_TMPDIR}/external-valid-notary.yaml" << EOF
+    cat >"${BATS_TMPDIR}/external-valid-notary.yaml" <<EOF
 apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
@@ -107,14 +107,14 @@ EOF
     run -0 rdd ctl get configmap test-config -o json
     run -0 jq -r '.data.change_000' <<<"$output"
     assert_output --partial "value=valid-external-test"
-    
+
     run -0 rdd ctl get configmap test-config -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}'
     assert_output "notary-controller"
 
     # Verify notary status is updated
     run -0 rdd ctl get notary test-external-valid -o jsonpath='{.status.lastRecordedValue}'
     assert_output "valid-external-test"
-    
+
     run -0 rdd ctl get notary test-external-valid -o jsonpath='{.status.configMapStatus}'
     assert_output "Updated"
 }

--- a/bats/tests/31-rdd-controllers/notary.bats
+++ b/bats/tests/31-rdd-controllers/notary.bats
@@ -60,13 +60,13 @@ wait_for_notary_status() {
 @test 'verify ConfigMap has correct name and content' {
     run -0 rdd ctl get configmap "basic-history" -o json
     local json="$output"
-    
+
     run -0 jq -r '.data.change_000' <<<"$json"
     assert_output --partial "value=initial-value"
-    
+
     run -0 jq -r '.data.latest_change' <<<"$json"
     assert_output --partial "value=initial-value"
-    
+
     run -0 jq -r '.data.change_count' <<<"$json"
     assert_output 0
 }
@@ -78,20 +78,20 @@ wait_for_notary_status() {
     # Check labels
     run -0 jq -r '.metadata.labels."app.kubernetes.io/managed-by"' <<<"$json"
     assert_output "notary-controller"
-    
+
     run -0 jq -r '.metadata.labels."app.kubernetes.io/instance"' <<<"$json"
     assert_output "basic"
 
     # Check owner references
     run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"$json"
     assert_output "Notary"
-    
+
     run -0 jq -r '.metadata.ownerReferences[0].name' <<<"$json"
     assert_output "basic"
-    
+
     run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"$json"
     assert_output "true"
-    
+
     run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion' <<<"$json"
     assert_output "true"
 }
@@ -99,16 +99,16 @@ wait_for_notary_status() {
 @test 'verify Notary status is updated' {
     run -0 rdd ctl get notary basic -o json
     local json="$output"
-    
+
     run -0 jq -r 'has("status")' <<<"$json"
     assert_output "true"
-    
+
     run -0 jq -r '.status.lastRecordedValue' <<<"$json"
     assert_output "initial-value"
-    
+
     run -0 jq -r '.status.configMapStatus' <<<"$json"
     assert_output "Updated"
-    
+
     run -0 jq -r '.status.changeCount' <<<"$json"
     assert_output 1
 }
@@ -124,16 +124,16 @@ wait_for_notary_status() {
 @test 'verify ConfigMap records the change' {
     run -0 rdd ctl get configmap "basic-history" -o json
     local json="$output"
-    
+
     run -0 jq -r '.data.change_000' <<<"$json"
     assert_output --partial "value=initial-value"
 
     run -0 jq -r '.data.change_001' <<<"$json"
     assert_output --partial "value=updated-value"
-    
+
     run -0 jq -r '.data.latest_change' <<<"$json"
     assert_output --partial "value=updated-value"
-    
+
     run -0 jq -r '.data.change_count' <<<"$json"
     assert_output 1
 }
@@ -141,13 +141,13 @@ wait_for_notary_status() {
 @test 'verify Notary status shows updated change count' {
     run -0 rdd ctl get notary basic -o json
     local json="$output"
-    
+
     run -0 jq -r '.status.lastRecordedValue' <<<"$json"
     assert_output "updated-value"
-    
+
     run -0 jq -r '.status.configMapStatus' <<<"$json"
     assert_output "Updated"
-    
+
     run -0 jq -r '.status.changeCount' <<<"$json"
     assert_output 2
 }
@@ -167,20 +167,20 @@ wait_for_notary_status() {
     # Verify all changes are recorded
     run -0 jq -r '.data.change_000' <<<"$json"
     assert_output --partial "value=initial-value"
-    
+
     run -0 jq -r '.data.change_001' <<<"$json"
     assert_output --partial "value=updated-value"
-    
+
     run -0 jq -r '.data.change_002' <<<"$json"
     assert_output --partial "value=third-value"
-    
+
     run -0 jq -r '.data.change_003' <<<"$json"
     assert_output --partial "value=fourth-value"
 
     # Verify latest change and count
     run -0 jq -r '.data.latest_change' <<<"$json"
     assert_output --partial "value=fourth-value"
-    
+
     run -0 jq -r '.data.change_count' <<<"$json"
     assert_output 3
 }

--- a/bats/tests/32-app-controllers/demo.bats
+++ b/bats/tests/32-app-controllers/demo.bats
@@ -88,16 +88,16 @@ local_setup_file() {
     # Processing condition might be True briefly or False if already completed
     # So just verify we have the Ready condition and some processing has occurred
     run -0 get_demo_status "processedCount"
-    [ "$output" -ge 0 ]  # Should have some status
+    [ "$output" -ge 0 ] # Should have some status
 }
 
 @test 'verify initial Demo status' {
     run -0 rdd ctl get demo demo -o json
     local demo_json="$output"
-    
+
     run -0 jq -r 'has("status")' <<<"$demo_json"
     assert_output "true"
-    
+
     run -0 jq -r '.status | has("processedCount")' <<<"$demo_json"
     assert_output "true"
 
@@ -132,7 +132,7 @@ local_setup_file() {
 @test 'verify Demo status after completion' {
     run -0 rdd ctl get demo demo -o json
     local demo_json="$output"
-    
+
     # Should have processed all 3 messages
     run -0 jq -r '.status.processedCount' <<<"$demo_json"
     assert_output "3"
@@ -232,10 +232,10 @@ EOF
     # Verify final state
     run -0 rdd ctl get demo demo -o json
     local demo_json="$output"
-    
+
     run -0 jq -r '.status.processedCount' <<<"$demo_json"
     assert_output "15"
-    
+
     run -0 jq -r '.spec.message' <<<"$demo_json"
     assert_output "Updated message"
 }
@@ -266,10 +266,10 @@ EOF
     # Verify it works
     run -0 rdd ctl get demo demo -o json
     local demo_json="$output"
-    
+
     run -0 jq -r '.status.processedCount' <<<"$demo_json"
     assert_output "2"
-    
+
     run -0 jq -r '.spec.message' <<<"$demo_json"
     assert_output "Recreation test"
 }
@@ -295,26 +295,26 @@ EOF
     # Check comprehensive status
     run -0 rdd ctl get demo demo -o json
     local demo_json="$output"
-    
+
     run -0 jq -r 'has("status")' <<<"$demo_json"
     assert_output "true"
-    
+
     run -0 jq -r '.status.processedCount' <<<"$demo_json"
     assert_output "2"
-    
+
     run -0 jq -r '.status | has("lastProcessed")' <<<"$demo_json"
     assert_output "true"
-    
+
     run -0 jq -r '.status | has("conditions")' <<<"$demo_json"
     assert_output "true"
 
     # Extract condition statuses using jq
     run -0 jq -r '.status.conditions[] | select(.type == "Ready") | .status' <<<"$demo_json"
     local ready_status="$output"
-    
+
     run -0 jq -r '.status.conditions[] | select(.type == "Processing") | .status' <<<"$demo_json"
     local processing_status="$output"
-    
+
     run -0 jq -r '.status.conditions[] | select(.type == "Completed") | .status' <<<"$demo_json"
     local completed_status="$output"
 


### PR DESCRIPTION
Fixes #17

This moves the BATS-related make targets to the `BATS` directory, so that the top level makefile is easier to parse.  All the targets can still be run at the top level (it just runs `make -C`).

For the fixes commit, `git show --ignore-space-at-eol` is recommended.