### PR TITLE
Implement unified logging system with global --log-level flag

### DIFF
--- a/bats/tests/10-cli/4-log-level.bats
+++ b/bats/tests/10-cli/4-log-level.bats
@@ -1,0 +1,90 @@
+load '../../helpers/load'
+
+assert_klog_level() {
+    local level=$1
+    run -0 jq --compact-output . "$PATH_APP_HOME/args.json"
+    assert_line --partial "\"-v\",\"$level\""
+}
+
+# Test log level validation
+@test 'invalid log level shows error' {
+    run -1 rdd --log-level=invalid svc delete
+    assert_output --partial 'not a valid logrus Level: \"invalid\"'
+}
+
+@test 'valid log levels work: error' {
+    # `rdd svc delete` will always succeed and only emits "info" level messages.
+    run -0 rdd --log-level=error svc delete
+    refute_output
+}
+
+@test 'valid log levels work: warn' {
+    run -0 rdd --log-level=warn svc delete
+    refute_output
+}
+
+@test 'valid log levels work: warning' {
+    run -0 rdd --log-level warning svc delete
+    refute_output
+}
+
+@test 'valid log levels work: info' {
+    run -0 rdd --log-level=info svc delete
+    assert_line --partial "control plane does not exist"
+}
+
+@test 'valid log levels work: debug' {
+    run -0 rdd --log-level=debug svc delete
+    assert_line --partial "control plane does not exist"
+}
+
+@test 'valid log levels work: trace' {
+    run -0 rdd --log-level=trace svc delete
+    assert_line --partial "control plane does not exist"
+}
+
+# Test log level persistence in service configuration
+@test 'debug log level creates service with -v 1' {
+    rdd svc delete
+    run -0 rdd --log-level=debug svc create --controllers=""
+    assert_klog_level 1
+}
+
+@test 'trace log level creates service with -v 2' {
+    rdd svc delete
+    run -0 rdd --log-level=trace svc create --controllers=""
+    assert_klog_level 2
+}
+
+@test 'error log level creates service with -v 0' {
+    run -0 rdd svc delete
+    run -0 rdd --log-level=error svc create --controllers=""
+    assert_klog_level 0
+}
+
+# Test default log levels based on developer mode
+@test 'default log level in developer mode creates -v 1' {
+    run -0 rdd svc delete
+    # Developer mode should default to debug level
+    run -0 env RDD_DEVELOPER_MODE=1 rdd svc create --controllers=""
+    assert_klog_level 1
+}
+
+@test 'default log level in non-developer mode creates -v 0' {
+    run -0 rdd svc delete
+    # Non-developer mode should default to warning level
+    run -0 env RDD_DEVELOPER_MODE=0 rdd svc create --controllers=""
+    assert_klog_level 0
+}
+
+# Test start command override behavior
+@test 'start command can override log level for session' {
+    run -0 rdd svc delete
+    # Create with error level
+    run -0 rdd --log-level=error svc create --controllers=""
+    assert_klog_level 0
+
+    # Start with trace level override (this doesn't change persistent args)
+    run -0 rdd --log-level=trace svc start
+    assert_klog_level 0
+}

--- a/cmd/rdd/main.go
+++ b/cmd/rdd/main.go
@@ -66,6 +66,28 @@ func parseInstanceFlag() {
 	}
 }
 
+// setLogLevel sets the log level from command flags.
+func setLogLevel(cmd *cobra.Command, _ []string) error {
+	logLevel, err := cmd.Root().Flags().GetString("log-level")
+	if err != nil {
+		return err
+	}
+	if logLevel == "" {
+		// Default log level: warn for regular mode, debug for developer mode
+		if developer.Mode() {
+			logLevel = "debug"
+		} else {
+			logLevel = "warn"
+		}
+	}
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(level)
+	return nil
+}
+
 func newVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
@@ -86,12 +108,22 @@ func main() {
 		Long: help.Doc(`
 			RDD manages the Rancher Desktop 2 background services.
 		`),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		PersistentPreRunE: setLogLevel,
 	}
 
 	// Add version flag with verflag-compatible behavior
 	version.AddVersionFlag(cmd.Flags())
+
+	// Add global log-level flag
+	var levels []string
+	for _, level := range logrus.AllLevels {
+		if level != logrus.PanicLevel {
+			levels = append(levels, level.String())
+		}
+	}
+	cmd.PersistentFlags().String("log-level", "", "Log level: "+strings.Join(levels, ", "))
 
 	ctlCmd := newCtlCommand()
 	ctlCmd.Hidden = !developer.Mode()

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -16,6 +16,18 @@ import (
 	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
 )
 
+// logrusLevelToKlog converts current logrus level to klog level.
+func logrusLevelToKlog() string {
+	switch logrus.GetLevel() {
+	case logrus.DebugLevel:
+		return "1"
+	case logrus.TraceLevel:
+		return "2"
+	default:
+		return "0"
+	}
+}
+
 func newServiceCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:           "service",
@@ -101,6 +113,7 @@ func serviceCreateAction(cmd *cobra.Command, args []string) error {
 		}
 		args = append(args, "--secure-port", strconv.Itoa(securePort))
 	}
+	args = append(args, "-v", logrusLevelToKlog())
 
 	if err := service.Create(cmd.Context(), args); err != nil {
 		return err
@@ -153,6 +166,7 @@ func serviceStartAction(cmd *cobra.Command, args []string) error {
 			}
 			serveArgs = append(serveArgs, "--secure-port", strconv.Itoa(securePort))
 		}
+		serveArgs = append(serveArgs, "-v", logrusLevelToKlog())
 		serveArgs = append(serveArgs, args...)
 
 		if err := service.Start(cmd.Context(), serveArgs); err != nil {
@@ -224,6 +238,7 @@ func newServiceStatusCommand() *cobra.Command {
 		Use:  "status",
 		Long: "Show control plane status",
 		RunE: func(*cobra.Command, []string) error {
+			logrus.SetLevel(logrus.InfoLevel)
 			logrus.Infof("%q control plane has been created: %v", instance.Name(), service.Exists())
 			logrus.Infof("%q control plane has been started: %v", instance.Name(), service.Running())
 			logrus.Infof("%q control plane PID is: %v", instance.Name(), service.PID())

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
-	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	// Justify blank import.
 	_ "k8s.io/component-base/metrics/prometheus/workqueue"
@@ -570,7 +569,7 @@ func NewServeCommand() *cobra.Command {
 	var namedFlagSets cliflag.NamedFlagSets
 	s.AddFlags(&namedFlagSets)
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
-	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), command.Name(), logs.SkipLoggingConfigurationFlags())
+	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), command.Name())
 
 	fs := command.Flags()
 	for _, f := range namedFlagSets.FlagSets {


### PR DESCRIPTION
Eliminates need to run `rdd svc serve` manually with logging options; user doesn't need to know about klog settings.