### PR TITLE
Refactor the notary-events BATS tests

### DIFF
--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -42,6 +42,7 @@ source "$PATH_BATS_HELPERS/os.bash"
 source "$PATH_BATS_HELPERS/utils.bash"
 source "$PATH_BATS_HELPERS/controller.bash"
 source "$PATH_BATS_HELPERS/instance.bash"
+source "$PATH_BATS_HELPERS/numeric.bash"
 
 # defaults.bash uses is_windows() from os.bash and
 # validate_enum() and is_true() from utils.bash.

--- a/bats/helpers/numeric.bash
+++ b/bats/helpers/numeric.bash
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# assert_output_ge - Assert that the integer value of $output is greater than or equal to expected
+assert_output_ge() {
+  local -i expected=$1
+  local -i actual
+
+  if [[ $output =~ ^-?[0-9]+$ ]]; then
+    actual="$output"
+  else
+    batslib_print_kv_single_or_multi 8 \
+      'expected' ">= $expected" \
+      'actual'   "$output (not a valid integer)" \
+    | batslib_decorate 'output does not contain a valid integer' \
+    | fail
+    return $?
+  fi
+
+  if (( actual < expected )); then
+    batslib_print_kv_single_or_multi 8 \
+      'expected' ">= $expected" \
+      'actual'   "$actual" \
+    | batslib_decorate 'output is less than expected minimum' \
+    | fail
+  fi
+}
+
+# assert_output_lt - Assert that the integer value of $output is less than expected
+assert_output_lt() {
+  local -i expected=$1
+  local -i actual
+
+  if [[ $output =~ ^-?[0-9]+$ ]]; then
+    actual="$output"
+  else
+    batslib_print_kv_single_or_multi 8 \
+      'expected' "< $expected" \
+      'actual'   "$output (not a valid integer)" \
+    | batslib_decorate 'output does not contain a valid integer' \
+    | fail
+    return $?
+  fi
+
+  if (( actual >= expected )); then
+    batslib_print_kv_single_or_multi 8 \
+      'expected' "< $expected" \
+      'actual'   "$actual" \
+    | batslib_decorate 'output is not less than expected maximum' \
+    | fail
+  fi
+}

--- a/bats/helpers/numeric.bats
+++ b/bats/helpers/numeric.bats
@@ -1,0 +1,42 @@
+# bats file_tags=opensuse
+
+load '../helpers/load'
+
+local_setup() {
+    output=1
+}
+
+@test '1 >= 0' {
+    assert_output_ge 0
+}
+
+@test '1 >= 1' {
+    assert_output_ge 1
+}
+
+@test '1 not >= 2' {
+    run assert_output_ge 2
+    assert_failure
+}
+
+@test 'zero not >= 2' {
+    output="zero"
+    run assert_output_ge 2
+    assert_failure
+}
+
+@test '1 < 2' {
+    assert_output_lt 2
+}
+
+@test '1 not < 1' {
+    run assert_output_lt 1
+    assert_failure
+}
+
+@test 'zero not < 1' {
+    output="zero"
+    run assert_output_lt 1
+    assert_failure
+}
+

--- a/bats/tests/31-rdd-controllers/notary-events.bats
+++ b/bats/tests/31-rdd-controllers/notary-events.bats
@@ -61,43 +61,36 @@ wait_for_events() {
     try --max 10 --delay 1 -- assert_events_exist "${resource_name}" "${reason}"
 }
 
-assert_events_after_timestamp() {
-    local resource_name=$1
-    local after_timestamp=$2
-    local reason=$3
-
-    run -0 rdd ctl get events  --field-selector involvedObject.name="${resource_name}" -o json
-    run -0 jq ".items | map(select(.reason == \"$reason\" and .lastTimestamp > \"$after_timestamp\")) | length" <<<"$output"
-    refute_output 0
-}
-
-count_events_with_reason() {
-    local resource_name=$1
-    local reason=$2
-
-    run rdd ctl get events  --field-selector involvedObject.name="${resource_name}" -o json
-    if [ "$status" -ne 0 ]; then
-        echo "0"
-        return
-    fi
-
-    jq ".items | map(select(.reason == \"$reason\")) | length" <<<"$output"
-}
-
 get_events_after_timestamp() {
     local resource_name=$1
-    local after_timestamp=$2
+    local timestamp=$2
     local reason=$3
-
-    try --max 10 --delay 1 -- assert_events_after_timestamp "${resource_name}" "${after_timestamp}" "${reason}"
 
     run rdd ctl get events --field-selector involvedObject.name="${resource_name}" -o json
     if [ "$status" -ne 0 ]; then
-        echo ""
-        return 1
+        echo "[]"
+        return 0
     fi
 
-    jq -r ".items | map(select(.lastTimestamp > \"$after_timestamp\" and .reason == \"$reason\"))" <<<"$output"
+    jq -r ".items | map(select(.lastTimestamp > \"$timestamp\" and .reason == \"$reason\"))" <<<"$output"
+}
+
+assert_events_after_timestamp() {
+    local resource_name=$1
+    local timestamp=$2
+    local reason=$3
+
+    run -0 get_events_after_timestamp "$resource_name" "$timestamp" "$reason"
+    run -0 jq 'length' <<<"$output"
+    refute_output 0
+}
+
+wait_for_events_after_timestamp() {
+    local resource_name=$1
+    local timestamp=$2
+    local reason=$3
+
+    try --max 10 --delay 1 -- assert_events_after_timestamp "${resource_name}" "${timestamp}" "${reason}"
 }
 
 get_latest_event_timestamp() {
@@ -128,13 +121,15 @@ get_latest_event_timestamp() {
 
     # Get the timestamp of the most recent event before update
     run -0 get_latest_event_timestamp "events"
-    local timestamp=$output
+    timestamp=$output
 
     # Update with a different value
     update_notary_value "events" "new-event-value"
 
     # Wait for status update and new events
     wait_for_notary_status "events" "new-event-value"
+    wait_for_events_after_timestamp "events" "$timestamp" "SpecUpdate"
+    wait_for_events_after_timestamp "events" "$timestamp" "ValueRecorded"
 
     # Verify we have new SpecUpdate and ValueRecorded events containing the new value
     run -0 get_events_after_timestamp "events" "$timestamp" "SpecUpdate"
@@ -143,88 +138,44 @@ get_latest_event_timestamp() {
     assert_output --partial "new-event-value"
 }
 
-@test 'verify event generation when value unchanged' {
-    create_notary "nochange" "unchanged-value" "nochange-history"
-
-    # Wait for initial ConfigMap creation and events
-    wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "nochange" 1
-    wait_for_events "nochange" "SpecUpdate"
-    wait_for_events "nochange" "ValueRecorded"
-
-    # Get the timestamp of the most recent event before update
-    run -0 get_latest_event_timestamp "nochange"
-    local timestamp=$output
-
-    # First change to a different value to ensure we have a different state
-    update_notary_value "nochange" "different-value"
-    wait_for_notary_status "nochange" "different-value"
-
-    # Now change back to the original value to test the "same value" scenario
-    update_notary_value "nochange" "unchanged-value"
-    wait_for_notary_status "nochange" "unchanged-value"
-
-    # Check events - should have SpecUpdate and ValueRecorded events showing the changes
-    run -0 rdd ctl get events --field-selector involvedObject.name=nochange
-    assert_output --partial "SpecUpdate"
-    assert_output --partial "unchanged-value"
-    assert_output --partial "ValueRecorded"
-}
-
-@test 'test event deduplication behavior' {
-    create_notary "dedup" "dedup-value" "dedup-history"
+@test 'test no-change events with annotation updates' {
+    create_notary "dedup" "constant-value" "dedup-history"
 
     # Wait for initial ConfigMap creation and events
     wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "dedup" 1
     wait_for_events "dedup" "SpecUpdate"
     wait_for_events "dedup" "ValueRecorded"
 
-    # Make multiple distinct changes to test event generation and deduplication
-    update_notary_value "dedup" "value-1"
-    wait_for_notary_status "dedup" "value-1"
+    # Get the timestamp before triggering multiple identical reconciles
+    run -0 get_latest_event_timestamp "dedup"
+    timestamp=$output
 
-    update_notary_value "dedup" "value-2"
-    wait_for_notary_status "dedup" "value-2"
+    # Trigger multiple reconciles with identical spec.value by changing annotations
+    # Each will generate identical SpecUpdate and NoChange events that Kubernetes should deduplicate
+    run -0 rdd ctl annotate notary dedup test-annotation-1=value1
+    run -0 rdd ctl annotate notary dedup test-annotation-2=value2
+    run -0 rdd ctl annotate notary dedup test-annotation-3=value3
+    run -0 rdd ctl annotate notary dedup test-annotation-4=value4
 
-    update_notary_value "dedup" "value-3"
-    wait_for_notary_status "dedup" "value-3"
+    # Wait for events to be processed
+    wait_for_events "dedup" "SpecUpdate"
+    wait_for_events "dedup" "NoChange"
 
-    # Get all events for this resource
-    run -0 rdd ctl get events --field-selector involvedObject.name=dedup -o wide
-
-    # Count how many SpecUpdate and ValueRecorded events we have
-    # Kubernetes should deduplicate similar events automatically
-    local spec_update_count=$(count_events_with_reason "dedup" "SpecUpdate")
-    local value_recorded_count=$(count_events_with_reason "dedup" "ValueRecorded")
-
-    # We should have multiple events but they may be deduplicated by Kubernetes
-    [ "$spec_update_count" -ge 1 ]
-    [ "$value_recorded_count" -ge 1 ]
-
-    # Verify we have events for multiple values
-    assert_output --partial "value-1"
-    assert_output --partial "value-2"
-    assert_output --partial "value-3"
-}
-
-@test 'test no-change events with annotation updates' {
-    create_notary "anno" "constant-value" "anno-history"
-
-    # Wait for initial ConfigMap creation and events
-    wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "anno" 1
-    wait_for_events "anno" "SpecUpdate"
-    wait_for_events "anno" "ValueRecorded"
-
-    # Get the timestamp of the most recent event before annotation update
-    run -0 get_latest_event_timestamp "anno"
-    local timestamp=$output
-
-    # Update an annotation to force a reconcile without changing the value
-    run -0 rdd ctl annotate notary anno test-annotation=test-value
-
-    # Should have both SpecUpdate and NoChange events
-    run -0 get_events_after_timestamp "anno" "$timestamp" "SpecUpdate"
+    # Count events after the timestamp - should be deduplicated by Kubernetes
+    # It is not clear if Kubernetes will always catch all duplicates, but it should get at least 1
+    run -0 get_events_after_timestamp "dedup" "$timestamp" "SpecUpdate"
     assert_output --partial "constant-value"
 
-    run -0 get_events_after_timestamp "anno" "$timestamp" "NoChange"
+    run -0 jq 'length' <<<"$output"
+    assert_output_lt 4
+
+    run -0 get_events_after_timestamp "dedup" "$timestamp" "NoChange"
     assert_output --partial "value unchanged"
+
+    run -0 jq 'length' <<<"$output"
+    assert_output_lt 4
+
+    run -0 get_events_after_timestamp "dedup" "$timestamp" "ValueRecorded"
+    run -0 jq 'length' <<<"$output"
+    assert_output 0
 }

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -30,9 +30,8 @@ assert_process_exited() {
 
 @test "external controller starts and registers" {
     # Start external rdd-controller binary in background
-    # Store PID to verify it auto-exits later
     ./bin/rdd-controller &
-    # Store PID for later tests to verify auto-cleanup
+    # Store PID to verify it auto-exits later
     echo "$!" > "${BATS_FILE_TMPDIR}/controller_pid"
 
     # Wait for external controller to register in discovery system
@@ -122,7 +121,6 @@ EOF
 
 @test "external controller auto-exits when control plane stops" {
     # Get the stored PID from the controller start test
-    local controller_pid
     controller_pid=$(cat "${BATS_FILE_TMPDIR}/controller_pid")
 
     # Verify the external controller process is currently running


### PR DESCRIPTION
This is based on a older refactoring that got lost in the rebase shuffle.

The previous events tests are not actually testing the right things, as you can't test that no events are generated by setting the value repeatedly. The calls get eliminated by the apiserver before they even reach the admission controller. The way to test this is by making some other change to the resource, like adding a label or annotation. Those can then generate duplicate events, that in turn can be deduplicated by Kubernetes again.

But if we never produce duplicate events, then we cannot prove that they would be de-duplicated.