### PR TITLE
CI: Add spelling

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,0 +1,6 @@
+routable #https://en.wiktionary.org/wiki/routable#English
+standalone #https://en.wiktionary.org/wiki/standalone#English
+startable #https://en.wiktionary.org/wiki/startable
+unmarshal #https://en.wiktionary.org/wiki/unmarshal#English
+versioned #https://en.wiktionary.org/wiki/versioned#English
+whitespaces #https://en.wiktionary.org/wiki/whitespaces#English

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -1,0 +1,6 @@
+# Perl regular expressions for paths that are to be ignored.
+(?:^|/)\.gitmodules$
+(?:^|/)go\.mod$
+(?:^|/)go\.sum$
+# configuration for check-spelling itself
+^\.github/actions/spelling/

--- a/.github/actions/spelling/expect/golang.txt
+++ b/.github/actions/spelling/expect/golang.txt
@@ -1,0 +1,30 @@
+# Generic golang
+deepcopy
+
+# Generic Kubernetes
+apigroup
+configmap
+crd
+gcflags
+GOGC
+GOTRACEBACK
+groupversion
+healthz
+KCP
+kerrors
+omitzero
+protobuf
+readyz
+replicaset
+serviceaccount
+
+# Library functions
+Eventf
+Infof
+RLock
+RUnlock
+Warningf
+
+# kubebuilder
+kubebuilder
+XValidation

--- a/.github/actions/spelling/expect/rd.txt
+++ b/.github/actions/spelling/expect/rd.txt
@@ -1,0 +1,13 @@
+# Terms specific to Rancher Desktop
+ctl
+ctrctl
+devmode
+# limit ranger is currently commented out as an import
+limitranger
+nerdctl
+nochange
+rancherdesktop
+rdctl
+rdd
+# shared controller manager
+scm

--- a/.github/actions/spelling/expect/tech.txt
+++ b/.github/actions/spelling/expect/tech.txt
@@ -1,0 +1,35 @@
+# Generic technical terms
+backgrounding
+backquotes
+crt
+FQDNs
+gui
+hyperlinks
+lte
+OIDC
+remoting
+vms
+
+# Architectures
+aarch
+
+# Linux
+distros
+opensuse
+pids
+tarball
+veth
+zst
+zypper
+
+# Windows
+APPDATA
+cygwin
+LOCALAPPDATA
+msys
+PROGRAMFILES
+netsh
+SYSTEMROOT
+winver
+WSL
+wslpath

--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -1,0 +1,68 @@
+# Words from tools.
+buildvcs
+cpanm
+cpanminus
+limactl
+limavm
+ltag
+mindepth
+maxdepth
+moby
+netcat
+
+# golangci-lint & its linter / formatter names
+golangci
+bodyclose
+copyloopvar
+depguard
+dupword
+errcheck
+errorlint
+forbidigo
+gci
+gocritic
+godot
+gofmt
+gofumpt
+govet
+ineffassign
+intrange
+nakedret
+noctx
+perfsprint
+usetesting
+
+# golangci-lint options
+localmodule
+nolint
+nolintlint
+gotest
+unlabel
+errorf
+strconcat
+mgechev
+
+# awk
+RLENGTH
+RSTART
+
+# bash
+neq
+
+# C & compilers
+ALLOCA
+ldflags
+sprintf
+
+# make
+addprefix
+addsuffix
+DBSTAT
+DSQLITE
+endef
+notdir
+VTAB
+
+# check-spelling
+hunspell
+dic

--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -49,6 +49,9 @@ RSTART
 # bash
 neq
 
+# bats
+batslib
+
 # C & compilers
 ALLOCA
 ldflags

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -1,0 +1,16 @@
+# Acceptable patterns to exclude.
+
+# SHA1 hashes, for e.g. git commits.
+\b[0-9a-fA-F]{40}\b
+
+# Rancher Desktop domain
+\brancherdesktop\.io\b
+
+# URLs
+\bhttps?://[\S]+
+
+# Directives to skip the current full line
+^.*spellchecker:ignore.*$
+
+# K3s Versions; but it must include the "k" to prevent silly typos.
+[^[:alnum:]][Kk]3s[Vv]ersions?\b

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,5 +35,5 @@ jobs:
       with:
         go-version-file: go.mod
     - name: Install shfmt
-      run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
+      run: go install mvdan.cc/sh/v3/cmd/shfmt@latest # spellchecker:ignore
     - run: make -C bats lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,10 +6,33 @@ permissions:
   contents: read
 
 jobs:
+  get-pr-number:
+    name: Lookup Pull Request
+    outputs:
+      number: ${{ steps.lookup.outputs.number }}
+    runs-on: ubuntu-latest
+    steps:
+    - id: lookup
+      if: >-
+        github.event_name == 'push' &&
+        github.repository_owner == 'rancher-sandbox' &&
+        github.ref_type == 'branch' &&
+        !github.ref_protected
+      shell: bash
+      run: >-
+        printf "number=%s\n" >>"$GITHUB_OUTPUT"
+        $(gh pr list
+        --repo ${{ github.repository }}
+        --search ${{ github.sha }}
+        --json number
+        --jq '.[0].number')
+      env:
+        GH_TOKEN: ${{ github.token }}
   golangci-lint:
     name: golangci-lint
+    needs: get-pr-number
     runs-on: ubuntu-latest
-    if: ${{!(github.event_name == 'push' && github.repository_owner == 'rancher-sandbox' && github.ref_type == 'branch' && !github.ref_protected)}}
+    if: ${{ ! needs.get-pr-number.outputs.number }}
     strategy:
       matrix:
         os: [darwin, linux, windows]
@@ -25,8 +48,9 @@ jobs:
         GOOS: ${{ matrix.os }}
   bats:
     name: Lint BATS
+    needs: get-pr-number
     runs-on: ubuntu-latest
-    if: ${{!(github.event_name == 'push' && github.repository_owner == 'rancher-sandbox' && github.ref_type == 'branch' && !github.ref_protected)}}
+    if: ${{ ! needs.get-pr-number.outputs.number }}
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
@@ -37,3 +61,18 @@ jobs:
     - name: Install shfmt
       run: go install mvdan.cc/sh/v3/cmd/shfmt@latest # spellchecker:ignore
     - run: make -C bats lint
+  spelling:
+    name: Check Spelling
+    needs: get-pr-number
+    runs-on: ubuntu-latest
+    if: ${{ ! needs.get-pr-number.outputs.number }}
+    steps:
+    - run: sudo apt install cpanminus
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+        submodules: recursive
+    - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      with:
+        go-version-file: go.mod
+    - run: make spelling

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bin/*
+/.github/actions/spelling/expect/golang-generated.txt
+/bin/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = bats/lib/bats-support
 	url = https://github.com/rancher-sandbox/bats-support.git
 	branch = master
+[submodule "tools/check-spelling"]
+	path = .github/actions/spelling/check-spelling
+	url = https://github.com/check-spelling/check-spelling.git

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,7 +117,6 @@ linters:
       checks:
       - all
       - -QF*
-      - -SA3000  # false positive for Go 1.15+. See https://github.com/golang/go/issues/34129
       - -ST1000
       - -ST1001  # duplicates revive.dot-imports
       - -ST1022
@@ -128,18 +127,6 @@ linters:
     - common-false-positives
     - legacy
     - std-error-handling
-    rules:
-    # Allow using Uid, Gid in pkg/osutil.
-    - path: pkg/osutil/
-      text: '(?i)(uid)|(gid)'
-    # Disable some linters for test files.
-    - linters:
-      - godot
-      path: _test\.go
-    # Disable perfsprint for fmt.Sprint until https://github.com/catenacyber/perfsprint/issues/39 gets fixed.
-    - linters:
-      - perfsprint
-      text: fmt.Sprint.* can be replaced with faster
 issues:
   # Maximum issues count per one linter.
   max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,13 @@ ldflags:
 build: build-rdd build-all-controllers
 .PHONY: build
 
-build-rdd:
+GOLANG_SOURCES := $(shell find . -name '*.go') go.mod go.sum
+
+bin/rdd$(EXE): $(GOLANG_SOURCES)
 	CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" \
-	CGO_ENABLED=1 go build -tags="$(TAGS)" -buildvcs=false -gcflags="all=${GCFLAGS}" -ldflags="$(LDFLAGS)" -o bin/rdd ./cmd/rdd
-	ls -lh ./bin/rdd
+	CGO_ENABLED=1 go build -tags="$(TAGS)" -buildvcs=false -gcflags="all=${GCFLAGS}" -ldflags="$(LDFLAGS)" -o $@ ./cmd/rdd
+	ls -lh $@
+build-rdd: bin/rdd$(EXE)
 .PHONY: build-rdd
 
 # API Group Controller management - Auto-discovery of API groups
@@ -55,17 +58,18 @@ API_GROUPS := $(notdir $(shell find pkg/controllers -type d -mindepth 1 -maxdept
 
 # Generate build targets for API group controllers
 define API_GROUP_CONTROLLER_TARGETS
-build-$(1)-controller:
-	CGO_ENABLED=0 go build -tags="$(TAGS)" -buildvcs=false -gcflags="all=$${GCFLAGS}" -ldflags="$(LDFLAGS)" -o bin/$(1)-controller ./cmd/$(1)-controller
-	ls -lh ./bin/$(1)-controller
+bin/$(1)-controller$$(EXE): $$(GOLANG_SOURCES)
+	CGO_ENABLED=0 go build -tags="$(TAGS)" -buildvcs=false -gcflags="all=$${GCFLAGS}" -ldflags="$(LDFLAGS)" -o $$@ ./cmd/$(1)-controller
+	ls -lh $$@
+build-$(1)-controller: bin/$(1)-controller$(EXE)
 .PHONY: build-$(1)-controller
 
 test-$(1)-controllers:
 	go test -v ./pkg/controllers/$(1)/...
 .PHONY: test-$(1)-controllers
 
-run-$(1)-controller:
-	./bin/$(1)-controller
+run-$(1)-controller: bin/$(1)-controller$(EXE)
+	$<
 .PHONY: run-$(1)-controller
 endef
 
@@ -82,8 +86,8 @@ test-all-controllers: $(addprefix test-,$(addsuffix -controllers,$(API_GROUPS)))
 run-all-controllers: $(addprefix run-,$(addsuffix -controller,$(API_GROUPS)))
 .PHONY: run-all-controllers
 
-run:
-	./bin/rdd start
+run: bin/rdd$(EXE)
+	$< start
 .PHONY: run
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 # SPDX-FileCopyrightText: The Rancher Desktop Authors
 # SPDX-FileCopyrightText: The KCP Authors
 
-KUBE_VERSION := $(shell go list -m -f '{{.Version}}' 'k8s.io/kubernetes')
+EXE := $(if $(shell sh -c 'command -v winver.exe'),.exe,)
+KUBE_VERSION := $(shell go$(EXE) list -m -f '{{.Version}}' 'k8s.io/kubernetes')
 KUBE_MAJOR_VERSION := $(shell echo $(KUBE_VERSION) | sed 's/v\([0-9]*\).*/\1/')
 KUBE_MINOR_VERSION := $(shell echo $(KUBE_VERSION) | sed "s/v[0-9]*\.\([0-9]*\).*/\1/")
 GIT_COMMIT := $(shell git rev-parse --short HEAD || echo 'local')
@@ -98,6 +99,12 @@ lint:
 format:
 	golangci-lint fmt
 .PHONY: format
+
+.github/actions/spelling/expect/golang-generated.txt: scripts/spell-check-generate-golang-expect.go $(GOLANG_SOURCES)
+	go$(EXE) run $<
+spelling: scripts/check-spelling.sh .github/actions/spelling/expect/golang-generated.txt
+	$<
+.PHONY: spelling
 
 ltag:
 	# exclude bats/lib, but --excludes only takes a dir name, not a path name

--- a/bats/helpers/utils.bats
+++ b/bats/helpers/utils.bats
@@ -515,7 +515,7 @@ get_json_test_data() {
     trace "output=$output"
     trace "stderr=${stderr:-}"
     assert_success
-    assert_output $'foo\nbaz'
+    assert_output foo$'\n'baz
     output=$stderr assert_output bar
 }
 
@@ -678,7 +678,7 @@ get_json_test_data() {
 
 @test 'load_var mix of existing and non-existing variables' {
     DOES_NOT_EXIST=false
-    # Can't use `run` because variable would be sourced in a subshell
+    # Can't use `run` because variable would be loaded in a subshell
     load_var FOO DOES_NOT_EXIST BAR || DOES_NOT_EXIST=true
     [[ $DOES_NOT_EXIST == true ]]
     # shellcheck disable=SC2031

--- a/bats/tests/20-service/4-start-parameters.bats
+++ b/bats/tests/20-service/4-start-parameters.bats
@@ -3,28 +3,28 @@ load '../../helpers/load'
 # Controller testing using CRD presence validation
 
 assert_rdd_controllers() {
-    run -0 rdd ctl get crd notaries.rdd.rancherdesktop.io
+    run -0 rdd ctl get CustomResourceDefinition notaries.rdd.rancherdesktop.io
     assert_output --partial "notaries.rdd.rancherdesktop.io"
 
-    run -0 rdd ctl get crd configmapreplicasets.rdd.rancherdesktop.io
+    run -0 rdd ctl get CustomResourceDefinition configmapreplicasets.rdd.rancherdesktop.io
     assert_output --partial "configmapreplicasets.rdd.rancherdesktop.io"
 }
 
 assert_app_controllers() {
-    run -0 rdd ctl get crd demos.app.rancherdesktop.io
+    run -0 rdd ctl get CustomResourceDefinition demos.app.rancherdesktop.io
     assert_output --partial "demos.app.rancherdesktop.io"
 }
 
 refute_rdd_controllers() {
-    run -1 rdd ctl get crd notaries.rdd.rancherdesktop.io
+    run -1 rdd ctl get CustomResourceDefinition notaries.rdd.rancherdesktop.io
     assert_output --partial "NotFound"
 
-    run -1 rdd ctl get crd configmapreplicasets.rdd.rancherdesktop.io
+    run -1 rdd ctl get CustomResourceDefinition configmapreplicasets.rdd.rancherdesktop.io
     assert_output --partial "NotFound"
 }
 
 refute_app_controllers() {
-    run -1 rdd ctl get crd demos.app.rancherdesktop.io
+    run -1 rdd ctl get CustomResourceDefinition demos.app.rancherdesktop.io
     assert_output --partial "NotFound"
 }
 

--- a/bats/tests/31-rdd-controllers/configmap-replicaset.bats
+++ b/bats/tests/31-rdd-controllers/configmap-replicaset.bats
@@ -36,7 +36,7 @@ EOF
 
 delete_configmapreplicaset() {
     local name=$1
-    delete_resource "cmrs" "${name}"
+    delete_resource "ConfigMapReplicaSet" "${name}"
 }
 
 wait_for_configmaps() {
@@ -50,7 +50,7 @@ wait_for_configmaps() {
 }
 
 @test 'verify ConfigMapReplicaSet is created in Kubernetes' {
-    try --max 5 --delay 3 -- rdd ctl get cmrs basic
+    try --max 5 --delay 3 -- rdd ctl get ConfigMapReplicaSet basic
 }
 
 @test 'wait for controller to create 3 ConfigMaps' {
@@ -110,14 +110,14 @@ wait_for_configmaps() {
 
 @test 'debug owner references before deletion' {
     # Extract and validate complete owner reference structure
-    run -0 rdd ctl get cmrs basic -o json
+    run -0 rdd ctl get ConfigMapReplicaSet basic -o json
     local parent_json="$output"
 
     run -0 jq -r '.metadata.uid' <<<"$parent_json"
     local parent_uid=$output
 
     run -0 jq -r '.apiVersion' <<<"$parent_json"
-    local parent_apiversion=$output
+    local parent_api_version=$output
 
     # Verify owner reference structure
     run -0 rdd ctl get configmap basic-0 -o json
@@ -131,17 +131,17 @@ wait_for_configmaps() {
     run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion // false' <<<"$configmap"
     local ref_block_deletion=$output
     run -0 jq -r '.metadata.ownerReferences[0].apiVersion // empty' <<<"$configmap"
-    local ref_apiversion=$output
+    local ref_api_version=$output
 
     # Validate all fields are correct
     [ "$ref_uid" = "$parent_uid" ]
     [ "$ref_controller" = "true" ]
     [ "$ref_block_deletion" = "true" ]
-    [ "$ref_apiversion" = "$parent_apiversion" ]
+    [ "$ref_api_version" = "$parent_api_version" ]
 }
 
 @test 'scale ConfigMapReplicaSet up to 5 replicas' {
-    rdd ctl patch cmrs basic --type='merge' -p='{"spec":{"replicas":5}}'
+    rdd ctl patch ConfigMapReplicaSet basic --type='merge' -p='{"spec":{"replicas":5}}'
 }
 
 @test 'wait for scaling up to complete (5 ConfigMaps)' {
@@ -166,7 +166,7 @@ wait_for_configmaps() {
 }
 
 @test 'scale ConfigMapReplicaSet down to 2 replicas' {
-    rdd ctl patch cmrs basic --type='merge' -p='{"spec":{"replicas":2}}'
+    rdd ctl patch ConfigMapReplicaSet basic --type='merge' -p='{"spec":{"replicas":2}}'
 }
 
 @test 'wait for scaling down to complete (2 ConfigMaps)' {
@@ -189,10 +189,10 @@ wait_for_configmaps() {
 
 @test 'update ConfigMapReplicaSet data' {
     # Update the ConfigMapReplicaSet data
-    rdd ctl patch cmrs basic --type='merge' -p='{"spec":{"data":{"config.yaml":"updated: true\nversion: 2.0.0\n","new-file.txt":"This is a new file"}}}'
+    rdd ctl patch ConfigMapReplicaSet basic --type='merge' -p='{"spec":{"data":{"config.yaml":"updated: true\n''version: 2.0.0\n","new-file.txt":"This is a new file"}}}'
 
     # Increase replica count from 2 to 4 to create new replicas with updated data
-    rdd ctl patch cmrs basic --type='merge' -p='{"spec":{"replicas":4}}'
+    rdd ctl patch ConfigMapReplicaSet basic --type='merge' -p='{"spec":{"replicas":4}}'
 
     # Wait for new ConfigMaps to be created
     wait_for_configmaps "basic" 4
@@ -267,7 +267,7 @@ wait_for_configmaps() {
     refute_output
 
     # Check parent resource finalizers (should have cleanup finalizer)
-    run -0 rdd ctl get cmrs basic -o jsonpath='{.metadata.finalizers}'
+    run -0 rdd ctl get ConfigMapReplicaSet basic -o jsonpath='{.metadata.finalizers}'
     assert_output --partial "rdd.rancherdesktop.io/configmapreplicaset-cleanup"
 }
 
@@ -278,7 +278,7 @@ wait_for_configmaps() {
 @test 'verify parent resource deletion triggers finalizer cleanup' {
     # Parent should be deleted by the finalizer after ConfigMaps are cleaned up
     # The finalizer should handle cleanup automatically
-    run -1 rdd ctl get cmrs basic
+    run -1 rdd ctl get ConfigMapReplicaSet basic
 }
 
 @test 'wait for ConfigMaps to be cleaned up by finalizer' {
@@ -290,7 +290,7 @@ wait_for_configmaps() {
 }
 
 @test 'verify zero replicas ConfigMapReplicaSet is created' {
-    try --max 12 --delay 5 -- rdd ctl get cmrs zero
+    try --max 12 --delay 5 -- rdd ctl get ConfigMapReplicaSet zero
 }
 
 @test 'verify no ConfigMaps are created for zero replicas' {
@@ -330,7 +330,7 @@ wait_for_configmaps() {
     wait_for_configmaps "status" 3
 
     # Check the status of the ConfigMapReplicaSet
-    run -0 rdd ctl get cmrs status -o json
+    run -0 rdd ctl get ConfigMapReplicaSet status -o json
     run -0 jq -r 'has("status")' <<<"$output"
     assert_output "true"
 }

--- a/bats/tests/31-rdd-controllers/notary-admission.bats
+++ b/bats/tests/31-rdd-controllers/notary-admission.bats
@@ -10,21 +10,21 @@ local_setup_file() {
 
 @test "webhook configuration is created" {
     # Wait for the webhook configuration to be created
-    try --max 20 --delay 3 -- rdd ctl get validatingwebhookconfiguration notary-validator
+    try --max 20 --delay 3 -- rdd ctl get ValidatingWebHookConfiguration notary-validator
 
     # Check that the webhook configuration exists
-    run -0 rdd ctl get validatingwebhookconfiguration notary-validator
+    run -0 rdd ctl get ValidatingWebHookConfiguration notary-validator
     assert_output --partial "notary-validator"
 }
 
 @test "webhook URL is properly configured" {
-    run -0 rdd ctl get validatingwebhookconfiguration notary-validator -o jsonpath='{.webhooks[0].clientConfig.url}'
+    run -0 rdd ctl get ValidatingWebHookConfiguration notary-validator -o jsonpath='{.webhooks[0].clientConfig.url}'
     assert_output --partial "https://127.0.0.1:"
     assert_output --partial "/validate-rdd-rancherdesktop-io-v1alpha1-notary"
 }
 
 @test "webhook configuration has correct structure" {
-    run -0 rdd ctl get validatingwebhookconfiguration notary-validator -o jsonpath='{.webhooks[0]}'
+    run -0 rdd ctl get ValidatingWebHookConfiguration notary-validator -o jsonpath='{.webhooks[0]}'
     local json=$output
 
     run -0 jq -r '.failurePolicy' <<<"$output"

--- a/bats/tests/31-rdd-controllers/notary-events.bats
+++ b/bats/tests/31-rdd-controllers/notary-events.bats
@@ -139,43 +139,43 @@ get_latest_event_timestamp() {
 }
 
 @test 'test no-change events with annotation updates' {
-    create_notary "dedup" "constant-value" "dedup-history"
+    create_notary "dupe" "constant-value" "dupe-history"
 
     # Wait for initial ConfigMap creation and events
-    wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "dedup" 1
-    wait_for_events "dedup" "SpecUpdate"
-    wait_for_events "dedup" "ValueRecorded"
+    wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "dupe" 1
+    wait_for_events "dupe" "SpecUpdate"
+    wait_for_events "dupe" "ValueRecorded"
 
     # Get the timestamp before triggering multiple identical reconciles
-    run -0 get_latest_event_timestamp "dedup"
+    run -0 get_latest_event_timestamp "dupe"
     timestamp=$output
 
     # Trigger multiple reconciles with identical spec.value by changing annotations
     # Each will generate identical SpecUpdate and NoChange events that Kubernetes should deduplicate
-    run -0 rdd ctl annotate notary dedup test-annotation-1=value1
-    run -0 rdd ctl annotate notary dedup test-annotation-2=value2
-    run -0 rdd ctl annotate notary dedup test-annotation-3=value3
-    run -0 rdd ctl annotate notary dedup test-annotation-4=value4
+    run -0 rdd ctl annotate notary dupe test-annotation-1=value1
+    run -0 rdd ctl annotate notary dupe test-annotation-2=value2
+    run -0 rdd ctl annotate notary dupe test-annotation-3=value3
+    run -0 rdd ctl annotate notary dupe test-annotation-4=value4
 
     # Wait for events to be processed
-    wait_for_events "dedup" "SpecUpdate"
-    wait_for_events "dedup" "NoChange"
+    wait_for_events "dupe" "SpecUpdate"
+    wait_for_events "dupe" "NoChange"
 
     # Count events after the timestamp - should be deduplicated by Kubernetes
     # It is not clear if Kubernetes will always catch all duplicates, but it should get at least 1
-    run -0 get_events_after_timestamp "dedup" "$timestamp" "SpecUpdate"
+    run -0 get_events_after_timestamp "dupe" "$timestamp" "SpecUpdate"
     assert_output --partial "constant-value"
 
     run -0 jq 'length' <<<"$output"
     assert_output_lt 4
 
-    run -0 get_events_after_timestamp "dedup" "$timestamp" "NoChange"
+    run -0 get_events_after_timestamp "dupe" "$timestamp" "NoChange"
     assert_output --partial "value unchanged"
 
     run -0 jq 'length' <<<"$output"
     assert_output_lt 4
 
-    run -0 get_events_after_timestamp "dedup" "$timestamp" "ValueRecorded"
+    run -0 get_events_after_timestamp "dupe" "$timestamp" "ValueRecorded"
     run -0 jq 'length' <<<"$output"
     assert_output 0
 }

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -44,18 +44,18 @@ assert_process_exited() {
 
 @test "webhook configuration is created" {
     # Wait for webhook configuration to be created by external controller
-    try --max 20 --delay 1 -- rdd ctl get validatingwebhookconfiguration notary-validator
+    try --max 20 --delay 1 -- rdd ctl get ValidatingWebhookConfiguration notary-validator
 
     # Verify webhook configuration structure
-    run -0 rdd ctl get validatingwebhookconfiguration notary-validator -o jsonpath='{.webhooks[0].name}'
+    run -0 rdd ctl get ValidatingWebhookConfiguration notary-validator -o jsonpath='{.webhooks[0].name}'
     assert_output "notary.rdd.rancherdesktop.io"
 
-    run -0 rdd ctl get validatingwebhookconfiguration notary-validator -o json
+    run -0 rdd ctl get ValidatingWebhookConfiguration notary-validator -o json
     run -0 jq -r '.webhooks[0].clientConfig.url' <<<"$output"
     assert_output --partial "https://127.0.0.1:"
     assert_output --partial "/validate-rdd-rancherdesktop-io-v1alpha1-notary"
 
-    run -0 rdd ctl get validatingwebhookconfiguration notary-validator -o jsonpath='{.webhooks[0].failurePolicy}'
+    run -0 rdd ctl get ValidatingWebhookConfiguration notary-validator -o jsonpath='{.webhooks[0].failurePolicy}'
     assert_output "Fail"
 }
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -14,9 +14,9 @@ The control plane has both a [service directory](cmd_service.md#service-director
 
 [^lima]: RDD will set `LIMA_HOME` to `~/.rd2/lima` instead of `$APPDATA/rancher-desktop-2/lima` because of socket name length constraints.
 
-It is currently not a goal to support RDD running as a system service; it is always tied to a user session[^wsl2]. Design decisions should still attempt to not make that harder, in case this ever becomes a goal.
+It is currently not a goal to support RDD running as a system service; it is always tied to a user session[^WSL2]. Design decisions should still attempt to not make that harder, in case this ever becomes a goal.
 
-[^wsl2]: On Windows WSL2 also depends on the user being logged in. It would require a Hyper-V Lima driver before it could run as a system service.
+[^WSL2]: On Windows WSL2 also depends on the user being logged in. It would require a Hyper-V Lima driver before it could run as a system service.
 
 ### Side-by-Side Operation
 
@@ -30,7 +30,7 @@ Supporting multiple RDD instances in parallel allows developers to run BATS inte
 
 It also makes it possible to compare 2 different configurations running concurrently without having to switch back and forth using snapshots. This makes it easy to test a new release without affecting the current "production" version.
 
-This is controlled by the `RDD_INSTANCE` environment variable (defaults to `2`) or the global `--instance` flag. With `RDD_INSTANCE=bats` or `rdd --instance=bats` the service directory becomes `$APPDATA/rancher-desktop-bats` and the path directory becomes `~/.rdbats`.
+This is controlled by the `RDD_INSTANCE` environment variable (defaults to `2`) or the global `--instance` flag. With `RDD_INSTANCE=bats` or `rdd --instance=bats` the service directory becomes `$APPDATA/rancher-desktop-bats` and the path directory becomes `~/.rdbats`. <!-- spellchecker:ignore -->
 
 Similarly the docker and kube contexts (normally `rancher-desktop-2`) become `rancher-desktop-bats`.
 
@@ -56,7 +56,7 @@ RDD includes controllers for multiple API groups. Each group can be separately v
 Provides basic infrastructure services. Examples include:
 
 * [resource APIs](api_resource.md) for downloading, caching and locating files
-* [url monitoring APIs](api_urlmon.md) periodically check for new versions
+* [url monitoring APIs](api_url_monitor.md) periodically check for new versions
 * [diagnostics APIs](api_diagnostic.md) can raise warnings and errors from any component
 * [service lifecycle](api_service.md) explains how the control plane start up and shuts down
 * [snapshot APIs](api_snapshot.md) can save and restore all or part of the state of the RDD service

--- a/docs/design/api_resource.md
+++ b/docs/design/api_resource.md
@@ -46,7 +46,7 @@ spec:
   readonly: true
 status:
   progress: "Downloading xxx 28%"
-  localPath: "/Users/xxx/Libary/Caches/..."
+  localPath: "/Users/xxx/Library/Caches/..."
 ```
 
 To avoid additional local copies the `Checkout` object may suggest a destination for the checkout.

--- a/docs/design/api_url_monitor.md
+++ b/docs/design/api_url_monitor.md
@@ -1,6 +1,6 @@
 # URL Monitor API
 
-The `urlmonitor` API periodically downloads a URL, records when the content has last changed, and caches the content.
+The `URLMonitor` API periodically downloads a URL, records when the content has last changed, and caches the content.
 
 It will be used to watch the `k3s-version.json` file and the upgrade responder information.
 

--- a/docs/design/gui.md
+++ b/docs/design/gui.md
@@ -2,9 +2,9 @@
 
 ## Startup sequence
 
-The GUI will only run an external process once to get the kube config for the rdd control plane[^rdx].
+The GUI will only run an external process once to get the kube config for the rdd control plane[^RDX].
 
-[^rdx]: The only exception is running external processes for RDX extensions.
+[^RDX]: The only exception is running external processes for RDX extensions.
 
 1.  Run `rdd service config`.
     This will create the rdd instance (with default settings) if it doesn't exist yet.

--- a/docs/design/package.md
+++ b/docs/design/package.md
@@ -24,7 +24,7 @@ Snapshots come in different variants: VM snapshots, namespace snapshots, and RDD
 
 All of them can be store in an RDD package. One package may include multiple snapshots.
 
-### Airgap installation bundles
+### Airgap installation bundles <!-- spellchecker:ignore -->
 
 It is possible to bundle all
 

--- a/docs/design/style-guide.md
+++ b/docs/design/style-guide.md
@@ -11,7 +11,7 @@ Always use default RDD instance: "The `~/.rd2/bin` directory". **Not** "The `~/.
 ## Terminology
 
 * "API groups" are \`rdd.rancherdesktop.io\`. Always lowercase, fully qualified, and using backquotes, not rdd, \`rdd\` or \`RDD.rancherdesktop.io\`.
-* "Object types" are \`App\`, or \`LimaVM\`. They are mixed case and always using backquots, not App, \`app\` or \`limavm\`.
+* "Object types" are \`App\`, or \`LimaVM\`. They are mixed case and always using backquotes, not App, \`app\` or \`limavm\`.
 * Use "control plane" (or "RDD") and not "daemon".
 
 ### Instances

--- a/pkg/controllers/app/demo/crd.yaml
+++ b/pkg/controllers/app/demo/crd.yaml
@@ -55,7 +55,21 @@ spec:
               conditions:
                 description: Conditions represent the latest available observations of the demo's current state
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}"
+                  description: |
+                    Condition contains details for one aspect of the current state of this API Resource.
+                    ---
+                    This struct is intended for direct use as an array at the field path .status.conditions.  For example,
+
+                      type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
+                          // +patchMergeKey=type
+                          // +patchStrategy=merge
+                          // +listType=map
+                          // +listMapKey=type
+                          Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+                          // other fields
+                      }
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -100,7 +114,7 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         ---
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        useful (see .node.status.conditions), the ability to resolve conflicts is important.
                         The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$

--- a/pkg/controllers/rdd/configmapreplicaset/crd.yaml
+++ b/pkg/controllers/rdd/configmapreplicaset/crd.yaml
@@ -10,7 +10,7 @@ spec:
     plural: configmapreplicasets
     singular: configmapreplicaset
     shortNames:
-    - cmrs
+    - cmrs # spellchecker:ignore
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/pkg/controllers/rdd/notary/validation_test.go
+++ b/pkg/controllers/rdd/notary/validation_test.go
@@ -100,7 +100,7 @@ func TestValidateNotary(t *testing.T) {
 			name: "exactly 24 characters - no warning",
 			notary: &v1alpha1.Notary{
 				Spec: v1alpha1.NotarySpec{
-					Value: "exactly24characterslong", // exactly 24 chars
+					Value: "exactly24characters-long", // exactly 24 chars
 				},
 			},
 			expectError:    false,
@@ -110,7 +110,7 @@ func TestValidateNotary(t *testing.T) {
 			name: "25 characters - should warn",
 			notary: &v1alpha1.Notary{
 				Spec: v1alpha1.NotarySpec{
-					Value: "exactly25characterslong!!", // exactly 25 chars
+					Value: "exactly25characters-long!", // exactly 25 chars
 				},
 			},
 			expectError:     false,

--- a/pkg/service/cmd/help.go
+++ b/pkg/service/cmd/help.go
@@ -22,27 +22,27 @@ const (
 
 // setPartialUsageAndHelpFunc set both usage and help function.
 // Print the flag sets we need instead of all of them.
-func setPartialUsageAndHelpFunc(cmd *cobra.Command, fss cliflag.NamedFlagSets, cols int, flags []string) {
+func setPartialUsageAndHelpFunc(cmd *cobra.Command, named cliflag.NamedFlagSets, cols int, flags []string) {
 	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
 		fmt.Fprintf(cmd.OutOrStderr(), usageFmt, cmd.UseLine())
-		printMostImportantFlags(cmd.OutOrStderr(), fss, cols, flags)
+		printMostImportantFlags(cmd.OutOrStderr(), named, cols, flags)
 		fmt.Fprintf(cmd.OutOrStderr(), "\nUse \"%s\" for a list of all flags available.\n", cmd.CommandPath())
 		return nil
 	})
 	cmd.SetHelpFunc(func(cmd *cobra.Command, _ []string) {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
-		printMostImportantFlags(cmd.OutOrStdout(), fss, cols, flags)
+		printMostImportantFlags(cmd.OutOrStdout(), named, cols, flags)
 		fmt.Fprintf(cmd.OutOrStderr(), "\nUse \"%s options\" for a list of all flags available.\n", cmd.CommandPath())
 	})
 }
 
-func printMostImportantFlags(w io.Writer, fss cliflag.NamedFlagSets, cols int, visibleFlags []string) {
+func printMostImportantFlags(w io.Writer, named cliflag.NamedFlagSets, cols int, visibleFlags []string) {
 	visibleFlagsSet := sets.New[string](visibleFlags...)
 	filteredFFS := cliflag.NamedFlagSets{}
 	filteredFS := filteredFFS.FlagSet("Most important")
 
-	for _, name := range fss.Order {
-		fs := fss.FlagSets[name]
+	for _, name := range named.Order {
+		fs := named.FlagSets[name]
 		if !fs.HasFlags() {
 			continue
 		}

--- a/pkg/service/cmd/options/options.go
+++ b/pkg/service/cmd/options/options.go
@@ -109,14 +109,14 @@ func NewOptions(rootDir string) *Options {
 }
 
 // AddFlags adds flags for a specific APIServer to the specified FlagSet.
-func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
-	o.ControlPlane.AddFlags(fss)
+func (o *Options) AddFlags(flags *cliflag.NamedFlagSets) {
+	o.ControlPlane.AddFlags(flags)
 
-	etcdServers := fss.FlagSet("etcd").Lookup("etcd-servers")
+	etcdServers := flags.FlagSet("etcd").Lookup("etcd-servers")
 	etcdServers.Usage += " By default an embedded etcd server is started."
 
-	o.AdminAuthentication.AddFlags(fss.FlagSet("RDD Standalone Authentication"))
-	o.Controllers.AddFlags(fss.FlagSet("Options"))
+	o.AdminAuthentication.AddFlags(flags.FlagSet("RDD Standalone Authentication"))
+	o.Controllers.AddFlags(flags.FlagSet("Options"))
 }
 
 // Complete fills in any fields not set that are required to have valid data.

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -743,7 +743,7 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 	return nil
 }
 
-// createServerChain creates the apiservers connected via delegation.
+// createServerChain creates the apiserver instances connected via delegation.
 func createServerChain(config options.CompletedConfig) (*aggregatorapiserver.APIAggregator, error) {
 	// 1. Basic not found handler
 	notFoundHandler := notfoundhandler.New(config.ControlPlane.Generic.Serializer, genericapifilters.NoMuxAndDiscoveryIncompleteKey)

--- a/pkg/service/readiness/ready.go
+++ b/pkg/service/readiness/ready.go
@@ -448,9 +448,10 @@ func unreadyComponentsFromError(err error) sets.Set[string] {
 	unreadyComponents := sets.New[string]()
 	for _, line := range strings.Split(innerErr, `\n`) {
 		if name := strings.TrimPrefix(strings.TrimSuffix(line, ` failed: reason withheld`), `[-]`); name != line {
-			// NB: sometimes the error we get is truncated (server-side?) to something like: `\n[-]poststar") has prevented the request from succeeding`
-			// In those cases, the `name` here is also truncated, but nothing we can do about that. For that reason, the list of components returned is
-			// not durable and should not be parsed.
+			// NB: sometimes the error we get is truncated (server-side?) to something like:
+			// `\n[-]poststar") has prevented the request from succeeding` # spellchecker:ignore
+			// In those cases, the `name` here is also truncated, but nothing we can do about that.
+			// For that reason, the list of components returned is not durable and should not be parsed.
 			unreadyComponents.Insert(name)
 		}
 	}

--- a/scripts/check-spelling.sh
+++ b/scripts/check-spelling.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# This script runs check-spelling on the parent repository.
+
+set -o errexit -o nounset
+
+check_prerequisites() {
+    case $(uname -s) in # BSD uname doesn't support long option `--kernel-name`
+        Darwin) check_prerequisites_darwin;;
+        Linux) check_prerequisites_linux;;
+        CYGWIN*|MINGW*|MSYS*) check_prerequisites_windows;;
+        *) printf "Prerequisites not checked on %s\n" "$(uname -s)" >&2 ;;
+    esac
+}
+
+check_prerequisites_darwin() {
+    if command -v cpanm &>/dev/null; then
+        return
+    fi
+    echo "Please install cpanminus first:" >&2
+    if command -v brew &>/dev/null; then
+        echo "brew install cpanminus" >&2
+    fi
+    exit 1
+}
+
+check_prerequisites_linux() {
+    if ! command -v cpanm &>/dev/null; then
+        echo "Please install cpanminus first:" >&2
+        if command -v zypper &>/dev/null; then
+            echo "zypper install perl-App-cpanminus perl-HTTP-Date perl-URI perl-YAML-PP" >&2
+        elif command -v apt &>/dev/null; then
+            echo "apt install cpanminus" >&2
+        fi
+        exit 1
+    fi
+}
+
+check_prerequisites_windows() {
+    # cygwin, mingw, msys (WSL2 uses the Linux path).
+    echo "Skipping spell checking, Windows is not supported; please use WSL instead."
+    exit
+}
+
+find_script() {
+    local script
+    script=$(dirname "${BASH_SOURCE[0]}")/../.github/actions/spelling/check-spelling/unknown-words.sh
+
+    if [[ ! -x "$script" ]]; then
+        printf "Failed to find check-spelling script %s - please run \`git submodule update --init\`\n" "$script" >&2
+        exit 1
+    fi
+
+    echo "$script"
+}
+
+check_prerequisites
+script=$(find_script)
+warnings=(
+    bad-regex
+    binary-file
+    deprecated-feature
+    large-file
+    limited-references
+    no-newline-at-eof
+    noisy-file
+    non-alpha-in-dictionary
+    token-is-substring
+    unexpected-line-ending
+    whitespace-in-dictionary
+    minified-file
+    unsupported-configuration
+    no-files-to-check
+)
+
+INPUTS=$(yq --output-format=json <<EOF
+    suppress_push_for_open_pull_request: 1
+    checkout: true
+    check_file_names: 1
+    post_comment: 0
+    use_magic_file: 1
+    report-timing: 1
+    warnings: $(IFS=,; echo "${warnings[*]}")
+    use_sarif: ${CI:-0}
+    extra_dictionary_limit: 20
+    extra_dictionaries:
+        cspell:en_CA/src/hunspell-en_CA-large/en_CA-large.dic
+        cspell:software-terms/dict/softwareTerms.txt
+        cspell:aws/aws.txt
+        cspell:cpp/src/stdlib-cmath.txt
+        cspell:css/dict/css.txt
+        cspell:docker/src/docker-words.txt
+        cspell:filetypes/filetypes.txt
+        cspell:fullstack/dict/fullstack.txt
+        cspell:golang/dict/go.txt
+        cspell:html/dict/html.txt
+        cspell:k8s/dict/k8s.txt
+        cspell:node/dict/node.txt
+        cspell:npm/dict/npm.txt
+        cspell:shell/dict/shell-all-words.txt
+        cspell:typescript/dict/typescript.txt
+EOF
+)
+
+export INPUTS
+
+if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    # check-spelling falls over without this set; it writes to this file.
+    export GITHUB_STEP_SUMMARY=/dev/null
+fi
+
+exec "$script"

--- a/scripts/spell-check-generate-golang-expect.go
+++ b/scripts/spell-check-generate-golang-expect.go
@@ -1,0 +1,235 @@
+// Command generate-golang-expect generates spelling exclusions.
+// This should be run at the top level.
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"maps"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+)
+
+const (
+	expectFile = ".github/actions/spelling/expect/golang-generated.txt"
+)
+
+type checker struct {
+	// Words that will go in the "expect" list
+	expect map[string]bool
+	// Words that end with an "s" but are singular
+	singular map[string]bool
+}
+
+// Process one golang source file, updating `c.expect` with new words found via
+// the imports in the given file.  This is a `fs.WalkDirFunc`.
+// Currently this only supports the `import ()` form (i.e. multi-line import
+// declaration).
+func (c *checker) checkFile(path string, d fs.DirEntry, err error) error {
+	if err != nil {
+		return err
+	}
+	if d.Type() != 0 {
+		return nil
+	}
+	if !strings.HasSuffix(d.Name(), ".go") {
+		return nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", path, err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	matcher := regexp.MustCompile(`^\s*(?:import\s+)?(?:(\S+)\s+)?"([^"]+)"$`)
+	inImport := false // Set to true when we're in the import section.
+	for scanner.Scan() {
+		if !inImport {
+			inImport = strings.HasPrefix(scanner.Text(), "import ")
+		}
+		if !inImport {
+			continue
+		}
+		if strings.HasPrefix(scanner.Text(), ")") {
+			break // End of imports
+		}
+		matches := matcher.FindStringSubmatch(scanner.Text())
+		if matches == nil {
+			continue
+		}
+		// Split the import path by dots, slashes, and other non-alpha-numeric
+		// separators.
+		words := strings.FieldsFunc(strings.ToLower(matches[2]), func(r rune) bool {
+			return !unicode.In(r, unicode.N, unicode.L)
+		})
+		// wordMap is the set of words in this import; this is used to check if
+		// the explicit package name is valid.
+		wordMap := make(map[string]bool)
+		for _, word := range words {
+			wordMap[word] = true
+			wordParts := strings.FieldsFunc(word, unicode.IsNumber)
+			if len(wordParts) > 1 {
+				// This word contains numbers; register each part separately, as
+				// check-spelling splits on numbers.
+				for _, part := range wordParts {
+					c.expect[part] = true
+				}
+			} else if _, ok := c.singular[word]; !ok && len(word) > 3 && strings.HasSuffix(word, "s") {
+				// This is (probably) a plural word; add it as well as the singular form to the known list.
+				// But only add the plural to the known-words list (because it's actually in use).
+				wordMap[word[:len(word)-1]] = true
+				c.expect[word] = true
+			} else {
+				// This is a normal word, possibly starting or ending with digits; add it.
+				c.expect[wordParts[0]] = true
+			}
+		}
+		// Sometimes the explicit package name has abbreviations; this is set of
+		// them so that we can match them up.  The key is a set of space-separated
+		// strings; we add the value if all of the words in the key are found.
+		extraMappings := map[string]string{
+			"apiserver":              "genericapi", // spellchecker:ignore
+			"authentication":         "authenticator",
+			"controller":             "ctrl",
+			"certificate":            "cert",
+			"kubernetes":             "kube",
+			"rancher desktop daemon": "rdd",
+		}
+	extraMappingsLoop:
+		for k, v := range extraMappings {
+			for word := range strings.FieldsSeq(k) {
+				if _, ok := wordMap[word]; !ok {
+					continue extraMappingsLoop
+				}
+			}
+			wordMap[v] = true
+		}
+
+		// For checking the package name, use the set of words.
+		words = slices.Collect(maps.Keys(wordMap))
+		// Sort word by longest to shortest
+		slices.SortFunc(words, func(a, b string) int {
+			return len(b) - len(a)
+		})
+		packageName := matches[1]
+		if len(packageName) < 2 {
+			continue // No explicit package name, or imported for side effects
+		}
+		for packageName != "" {
+			found := false
+			for _, word := range words {
+				if strings.HasPrefix(packageName, word) {
+					packageName = packageName[len(word):]
+					found = true
+					break
+				}
+			}
+			if !found {
+				break
+			}
+		}
+		if packageName == "" {
+			// check-spelling ignores digits too; do that here.
+			for word := range strings.FieldsFuncSeq(matches[1], unicode.IsNumber) {
+				c.expect[word] = true
+			}
+		} else {
+			log.Printf("alias %q not found in %v\n", matches[1], words)
+		}
+	}
+
+	return nil
+}
+
+// Generate a set of words in the system dictionary, if available.  This is used
+// to avoid unnecessarily adding entries to the list.
+func (c *checker) getWords() (map[string]bool, error) {
+	f, err := os.Open("/usr/share/dict/words")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	words := make(map[string]bool)
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanWords)
+	for scanner.Scan() {
+		words[scanner.Text()] = true
+	}
+	// Also add every single-letter words, since those get ignored anyway.
+	for c := 'a'; c <= 'z'; c++ {
+		words[string(c)] = true
+	}
+	return words, nil
+}
+
+// Run the spell checker word list generator.
+func (c *checker) run() error {
+	dictionaryWords, err := c.getWords()
+	if err != nil {
+		return err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to find working directory: %w", err)
+	}
+	if err := fs.WalkDir(os.DirFS(cwd), ".", c.checkFile); err != nil {
+		return err
+	}
+	f, err := os.Create(expectFile)
+	if err != nil {
+		return err
+	}
+	// Walk the words (sorted in ASCII order), and emit words to the word list.
+	for _, word := range slices.Sorted(maps.Keys(c.expect)) {
+		if _, ok := dictionaryWords[word]; ok {
+			continue // Skip known dictionary words.
+		}
+		if _, ok := c.singular[word]; !ok && strings.HasSuffix(word, "s") {
+			singular := word[:len(word)-1]
+			if _, ok := dictionaryWords[singular]; ok {
+				// If the singular form exists in the dictionary, skip the plural form.
+				continue
+			}
+			if _, ok := c.expect[singular]; ok {
+				// The singular form exists in a word we found.
+				continue
+			}
+		}
+		if _, err := f.WriteString(word + "\n"); err != nil {
+			// Something went wrong writing the word list; remove it.
+			_ = f.Close()
+			_ = os.Remove(expectFile)
+			return err
+		}
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(expectFile)
+		return err
+	}
+	return nil
+}
+
+func main() {
+	c := checker{
+		expect: make(map[string]bool),
+		singular: map[string]bool{
+			"kubernetes": true,
+			"logrus":     true,
+			"prometheus": true,
+			"readiness":  true,
+		},
+	}
+	if err := c.run(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This adds a `make spelling` target that runs the same `check-spelling` script that Rancher Desktop 1.x uses.

Note that it doesn't really understand golang imports (where it's typical to mush a bunch of words together as the import name), so there's some code to auto-generate a word list based on that.  That's messier than I'd like, but that would remain until we find a spell checker that has more language-specific support.

I added the `en-CA` dictionary to work around an issue with the spell checker on macOS, where it would randomly ignore some files (‽) and therefore decide that the word _tarball_ is unused, and then flag _tarballs_ (plural) as an unknown word.  I realize that dictionary _probably_ doesn't contain the relevant word, but it jiggles the complex system enough to shut it up.