### PR TITLE
Add lima create/start/stop/delete subcommands

### DIFF
--- a/bats/tests/33-lima-controllers/lima-cli.bats
+++ b/bats/tests/33-lima-controllers/lima-cli.bats
@@ -1,0 +1,58 @@
+load '../../helpers/load'
+
+# LimaVM CLI tests - tests the rdd lima subcommand for managing LimaVM resources.
+
+local_setup_file() {
+    setup_rdd_control_plane "lima"
+    rdd ctl create namespace "lima-test-ns"
+}
+
+assert_running() {
+    local state=$1
+    run -0 rdd ctl get limavm test-vm -n lima-test-ns -o jsonpath='{.spec.running}'
+    assert_output "$state"
+}
+
+@test "lima create/start/stop/delete basic workflow" {
+    # Create VM
+    run -0 rdd limavm create test-vm -n lima-test-ns
+    assert_output --partial 'created'
+    assert_running "false"
+
+    # Start the VM (cross-namespace lookup: no -n flag needed)
+    run -0 rdd limavm start test-vm
+    assert_output --partial 'started'
+    assert_running "true"
+
+    # Stop the VM
+    run -0 rdd limavm stop test-vm
+    assert_output --partial 'stopped'
+    assert_running "false"
+
+    # Delete the VM
+    run -0 rdd limavm delete test-vm
+    assert_output --partial 'deleted'
+    run -1 rdd ctl get limavm test-vm -n lima-test-ns
+    assert_output --partial "not found"
+}
+
+@test "lima commands fail gracefully when VM does not exist" {
+    run -1 rdd limavm start nonexistent
+    assert_output --partial 'not found in any namespace'
+
+    run -1 rdd limavm stop nonexistent
+    assert_output --partial 'not found in any namespace'
+
+    run -1 rdd limavm delete nonexistent
+    assert_output --partial 'not found in any namespace'
+}
+
+@test "lima help text is displayed" {
+    # lima is an alias of the limavm command
+    run -0 rdd lima --help
+    assert_output --partial "LimaVM virtual machines"
+    assert_output --partial "Create a new LimaVM"
+    assert_output --partial "Start a LimaVM"
+    assert_output --partial "Stop a LimaVM"
+    assert_output --partial "Delete a LimaVM"
+}

--- a/bats/tests/33-lima-controllers/limavm-admission.bats
+++ b/bats/tests/33-lima-controllers/limavm-admission.bats
@@ -11,47 +11,9 @@ local_setup_file() {
     rdd ctl create namespace "test-ns3"
 }
 
-# create_limavm_yaml <name> <namespace> [labels]
-# Example: create_limavm_yaml "my-vm" "test-ns1" "updated=true"
-create_limavm_yaml() {
-    local name=$1
-    local namespace=$2
-    local labels=${3:-}
-
-    cat <<EOF
-apiVersion: lima.rancherdesktop.io/v1alpha1
-kind: LimaVM
-metadata:
-  name: ${name}
-  namespace: ${namespace}
-EOF
-
-    if [[ -n ${labels} ]]; then
-        cat <<EOF
-  labels:
-    ${labels}
-EOF
-    fi
-
-    cat <<EOF
-spec: {}
-EOF
-}
-
-# Usage: apply_limavm <name> <namespace> [labels]
-# Example: apply_limavm "my-vm" "test-ns1" "updated=true" "--dry-run=server"
-apply_limavm() {
-    local name=$1
-    local namespace=$2
-    local labels=${3:-}
-
-    run -0 create_limavm_yaml "${name}" "${namespace}" "${labels}"
-    rdd ctl apply -f - <<<"$output"
-}
-
 @test "webhook configuration has correct structure" {
     # Wait for the webhook configuration to be created
-    try --max 20 --delay 3 -- rdd ctl get ValidatingWebHookConfiguration limavm-validator
+    try --max 20 --delay 3 -- rdd ctl get ValidatingWebHookConfiguration "limavm-validator"
 
     run -0 rdd ctl get ValidatingWebHookConfiguration limavm-validator -o jsonpath='{.webhooks[0]}'
     local json=$output
@@ -59,7 +21,7 @@ apply_limavm() {
     run -0 jq_raw '.failurePolicy' "$json"
     assert_output "Fail"
 
-    run -0 jq_raw ".name" "$json"
+    run -0 jq_raw '.name' "$json"
     assert_output "limavm.lima.rancherdesktop.io"
 
     run -0 jq_raw '.rules[0].apiGroups[0]' "$json"
@@ -77,9 +39,8 @@ apply_limavm() {
 }
 
 @test "create LimaVM in first namespace succeeds" {
-    # Create first LimaVM in test-ns1
-    run -0 apply_limavm "my-vm" "test-ns1"
-    assert_output --partial "my-vm created"
+    run -0 rdd lima create "my-vm" -n "test-ns1"
+    assert_output --partial "created"
 
     # Verify the LimaVM was created
     run -0 rdd ctl get limavm "my-vm" -n "test-ns1" -o name
@@ -88,67 +49,62 @@ apply_limavm() {
 
 @test "duplicate LimaVM name in different namespace is rejected" {
     # Try to create LimaVM with same name in test-ns2
-    run -1 apply_limavm "my-vm" "test-ns2"
-    assert_output --partial "Forbidden"
-    assert_output --partial 'LimaVM name "my-vm" is already used in namespace "test-ns1"'
-    assert_output --partial "LimaVM names must be unique across all namespaces"
+    run -1 rdd lima create "my-vm" -n "test-ns2"
+    assert_output --partial "denied the request"
+    assert_output --partial "already used"
+    assert_output --partial "unique across all namespaces"
 
     # Verify the LimaVM was NOT created in test-ns2
-    run -1 rdd ctl get limavm my-vm -n test-ns2
+    run -1 rdd ctl get limavm "my-vm" -n "test-ns2"
     assert_output --partial "not found"
 }
 
-@test "duplicate LimaVM name in same namespace is updating the existing instance" {
-    # Update the existing LimaVM in test-ns1 (same name, same namespace)
-    run -0 apply_limavm "my-vm" "test-ns1" 'updated: "true"'
-    assert_output --partial "my-vm configured"
-
-    # Verify the label was added
-    run -0 rdd ctl get limavm my-vm -n test-ns1 -o jsonpath='{.metadata.labels.updated}'
-    assert_output "true"
-}
-
-@test "dry-run=server rejects duplicate names" {
+@test "dry-run validates duplicate names without creating resource" {
     # Try to create duplicate name with dry-run=server
-    run -0 create_limavm_yaml "my-vm" "test-ns2"
-    run -1 rdd ctl apply --dry-run=server -f - <<<"$output"
+    run -1 rdd ctl apply --dry-run=server -f - <<EOF
+apiVersion: lima.rancherdesktop.io/v1alpha1
+kind: LimaVM
+metadata:
+  name: my-vm
+  namespace: test-ns2
+spec: {}
+EOF
     assert_output --partial "Forbidden"
-    assert_output --partial 'LimaVM name "my-vm" is already used in namespace "test-ns1"'
+    assert_output --partial "already used"
 
-    # Verify the resource was not created
-    run -1 rdd ctl get limavm my-vm -n test-ns2
+    # Verify the resource was not created (dry-run should never create)
+    run -1 rdd ctl get limavm "my-vm" -n "test-ns2"
     assert_output --partial "not found"
 }
 
 @test "deletion allows recreation in different namespace" {
     # Delete the LimaVM from test-ns1
-    run -0 rdd ctl delete limavm my-vm -n test-ns1
+    run -0 rdd lima delete "my-vm"
     assert_output --partial "deleted"
 
     # Verify deletion succeeded
-    run -1 rdd ctl get limavm my-vm -n test-ns1
+    run -1 rdd ctl get limavm "my-vm" -n "test-ns1"
     assert_output --partial "not found"
 
     # Now we should be able to create a LimaVM with the same name in test-ns2
-    run -0 apply_limavm "my-vm" "test-ns2"
-    assert_output --partial "my-vm created"
+    run -0 rdd lima create "my-vm" -n "test-ns2"
+    assert_output --partial "created"
 
     # Verify the LimaVM was created in test-ns2
-    run -0 rdd ctl get limavm my-vm -n test-ns2
-    assert_output --partial "my-vm"
+    run -0 rdd ctl get limavm "my-vm" -n "test-ns2" -o name
+    assert_line "limavm.lima.rancherdesktop.io/my-vm"
 }
 
 @test "multiple unique VMs across namespaces are allowed" {
     # Create several LimaVMs with unique names across different namespaces
+    run -0 rdd lima create "vm1" -n "test-ns1"
+    assert_output --partial "created"
 
-    run -0 apply_limavm "vm1" "test-ns1"
-    assert_output --partial "vm1 created"
+    run -0 rdd lima create "vm2" -n "test-ns2"
+    assert_output --partial "created"
 
-    run -0 apply_limavm "vm2" "test-ns2"
-    assert_output --partial "vm2 created"
-
-    run -0 apply_limavm "vm3" "test-ns3"
-    assert_output --partial "vm3 created"
+    run -0 rdd lima create "vm3" -n "test-ns3"
+    assert_output --partial "created"
 
     # Verify all VMs exist
     run -0 rdd ctl get limavms -A

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
+	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
+)
+
+func newLimaCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:     "limavm",
+		Short:   "Manage LimaVM resources",
+		Long:    "Create, start, stop, and delete LimaVM virtual machines",
+		Aliases: []string{"lima"},
+	}
+	command.AddCommand(
+		newLimaCreateCommand(),
+		newLimaStartCommand(),
+		newLimaStopCommand(),
+		newLimaDeleteCommand(),
+	)
+	return command
+}
+
+func newLimaCreateCommand() *cobra.Command {
+	var namespace string
+	command := &cobra.Command{
+		Use:   "create NAME",
+		Short: "Create a new LimaVM resource",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return limaCreateAction(cmd.Context(), args[0], namespace)
+		},
+	}
+	command.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace for the LimaVM resource")
+	return command
+}
+
+func newLimaStartCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "start NAME",
+		Short: "Start a LimaVM by setting running=true",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return limaSetRunningAction(cmd.Context(), args[0], true)
+		},
+	}
+	return command
+}
+
+func newLimaStopCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "stop NAME",
+		Short: "Stop a LimaVM by setting running=false",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return limaSetRunningAction(cmd.Context(), args[0], false)
+		},
+	}
+	return command
+}
+
+func newLimaDeleteCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "delete NAME",
+		Short: "Delete a LimaVM resource",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return limaDeleteAction(cmd.Context(), args[0])
+		},
+	}
+	return command
+}
+
+// getKubeClient returns a controller-runtime client configured for the RDD control plane.
+func getKubeClient(ctx context.Context) (client.Client, error) {
+	if err := ensureServiceRunning(ctx); err != nil {
+		return nil, err
+	}
+	config, err := service.GetKubeRestConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+	runtimeScheme := runtime.NewScheme()
+	if err := limav1alpha1.AddToScheme(runtimeScheme); err != nil {
+		return nil, fmt.Errorf("failed to add LimaVM types to scheme: %w", err)
+	}
+	c, err := client.New(config, client.Options{Scheme: runtimeScheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+	return c, nil
+}
+
+// findLimaVM searches for a LimaVM with the given name across all namespaces.
+func findLimaVM(ctx context.Context, c client.Client, name string) (*limav1alpha1.LimaVM, error) {
+	vmList := &limav1alpha1.LimaVMList{}
+	if err := c.List(ctx, vmList); err != nil {
+		return nil, fmt.Errorf("failed to list LimaVMs: %w", err)
+	}
+
+	var found *limav1alpha1.LimaVM
+	for i := range vmList.Items {
+		if vmList.Items[i].Name == name {
+			if found != nil {
+				return nil, fmt.Errorf("multiple LimaVMs found with name %q in different namespaces", name)
+			}
+			found = &vmList.Items[i]
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("LimaVM %q not found in any namespace", name)
+	}
+	return found, nil
+}
+
+func limaCreateAction(ctx context.Context, name, namespace string) error {
+	c, err := getKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	running := false
+	limaVM := &limav1alpha1.LimaVM{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: limav1alpha1.LimaVMSpec{
+			Running: &running,
+		},
+	}
+
+	if err := c.Create(ctx, limaVM); err != nil {
+		return fmt.Errorf("failed to create LimaVM: %w", err)
+	}
+	logrus.Infof("LimaVM %q created in namespace %q", name, namespace)
+	return nil
+}
+
+func limaSetRunningAction(ctx context.Context, name string, running bool) error {
+	c, err := getKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+	limaVM, err := findLimaVM(ctx, c, name)
+	if err != nil {
+		return err
+	}
+
+	// Create a patch to update the running field
+	patch := client.MergeFrom(limaVM.DeepCopy())
+	limaVM.Spec.Running = &running
+
+	if err := c.Patch(ctx, limaVM, patch); err != nil {
+		return fmt.Errorf("failed to update LimaVM: %w", err)
+	}
+
+	action := "stopped"
+	if running {
+		action = "started"
+	}
+	logrus.Infof("LimaVM %q %s in namespace %q", name, action, limaVM.Namespace)
+	return nil
+}
+
+func limaDeleteAction(ctx context.Context, name string) error {
+	c, err := getKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	limaVM, err := findLimaVM(ctx, c, name)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Delete(ctx, limaVM); err != nil {
+		return fmt.Errorf("failed to delete LimaVM: %w", err)
+	}
+	logrus.Infof("LimaVM %q deleted from namespace %q", name, limaVM.Namespace)
+	return nil
+}

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -108,23 +108,13 @@ func getKubeClient(ctx context.Context) (client.Client, error) {
 // findLimaVM searches for a LimaVM with the given name across all namespaces.
 func findLimaVM(ctx context.Context, c client.Client, name string) (*limav1alpha1.LimaVM, error) {
 	vmList := &limav1alpha1.LimaVMList{}
-	if err := c.List(ctx, vmList); err != nil {
+	if err := c.List(ctx, vmList, client.MatchingFields{"metadata.name": name}); err != nil {
 		return nil, fmt.Errorf("failed to list LimaVMs: %w", err)
 	}
-
-	var found *limav1alpha1.LimaVM
-	for i := range vmList.Items {
-		if vmList.Items[i].Name == name {
-			if found != nil {
-				return nil, fmt.Errorf("multiple LimaVMs found with name %q in different namespaces", name)
-			}
-			found = &vmList.Items[i]
-		}
-	}
-	if found == nil {
+	if len(vmList.Items) == 0 {
 		return nil, fmt.Errorf("LimaVM %q not found in any namespace", name)
 	}
-	return found, nil
+	return &vmList.Items[0], nil
 }
 
 func limaCreateAction(ctx context.Context, name, namespace string) error {

--- a/cmd/rdd/main.go
+++ b/cmd/rdd/main.go
@@ -129,6 +129,10 @@ func main() {
 	ctlCmd.Hidden = !developer.Mode()
 	cmd.AddCommand(ctlCmd)
 
+	limaCmd := newLimaCommand()
+	limaCmd.Hidden = !developer.Mode()
+	cmd.AddCommand(limaCmd)
+
 	cmd.AddCommand(
 		newKubectlCommand(),
 		newServiceCommand(),

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -58,18 +59,25 @@ func newServiceConfigCommand() *cobra.Command {
 	return command
 }
 
-func serviceConfigAction(cmd *cobra.Command, _ []string) error {
+func ensureServiceRunning(ctx context.Context) error {
 	if !service.Exists() {
-		if err := service.Create(cmd.Context(), nil); err != nil {
+		if err := service.Create(ctx, nil); err != nil {
 			return err
 		}
 	}
 	if !service.Running() {
-		if err := service.Start(cmd.Context(), nil); err != nil {
+		if err := service.Start(ctx, nil); err != nil {
 			return err
 		}
 	}
-	if err := service.WaitWithTimeout(cmd.Context()); err != nil {
+	if err := service.WaitWithTimeout(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func serviceConfigAction(cmd *cobra.Command, _ []string) error {
+	if err := ensureServiceRunning(cmd.Context()); err != nil {
 		return err
 	}
 	contents, err := service.GetKubeconfig()


### PR DESCRIPTION
All take the VM name as an argument. "create" also takes a namespace.

Built on top of #30 and #31, so must be rebased once those are merged.