### PR TITLE
Update lima API and command specs

### DIFF
--- a/docs/design/api_lima.md
+++ b/docs/design/api_lima.md
@@ -35,19 +35,19 @@ status:
 
 - **metadata.annotations**: Can be used to request "actions" from the reconciler, like resetting (deleting and recreating with the same settings), or restarting the instance. The `status.conditions` can be used to store the state machine information.
 
-- **running**: Set to `true` when the instance should be running, set to `false` when it should be stopped.
+- **spec.running**: Set to `true` when the instance should be running, set to `false` when it should be stopped.
 
-- **templateRef**: Specifies the `lima.yaml` template for the machine. The template must pass Lima validation or the `LimaVM` creation will fail. 
+- **spec.templateRef**: Specifies the `lima.yaml` template for the machine. The template must pass Lima validation or the `LimaVM` creation will fail. 
 
-    Initially the only way to specify a template is via a ConfigMap that will store the "fully embedded" template under the `template` key. It cannot reference external base templates or scripts. This will change eventually when `templateRef.name` can also be set to a URL. The default for `templateRef.namespace` is the same as `metadata.namespace`.
+    Initially the only way to specify a template is via a ConfigMap that will store the "fully embedded" template under the `template` key. It cannot reference external base templates or scripts. This will change eventually when `spec.templateRef.name` can also be set to a URL. The default for `spec.templateRef.namespace` is the same as `metadata.namespace`.
 
-    The `LimaVM` controller will create a new ConfigMap (in `metadata.namespace`) with the `metadata.name` and a `"-template"` suffix to store a copy of the validated template. This name is stored under `status.templateConfigMap`. The original `templateRef` source is never accessed again after this, and can be modified or deleted without affecting the `LimaVM` resource. The `spec.templateRef` is immutable after creation and only serves as documentation.
+    The `LimaVM` controller will create a new ConfigMap (in `metadata.namespace`) with the `metadata.name` and a `"-template"` suffix to store a copy of the validated template. This name is stored under `status.templateConfigMap`. The original `spec.templateRef` source is never accessed again after this, and can be modified or deleted without affecting the `LimaVM` resource. The `spec.templateRef` is immutable after creation and only serves as documentation.
 
-    The `templateConfigMap` can be modified, but must pass Lima validation for the update to succeed. If `spec.running` is `true` and the template has changed, then the instance will be restarted. The `templateConfigMap` cannot be deleted, except by deleting the `LimaVM` resource itself, which will clean up owned resources automatically.
+    The `status.templateConfigMap` can be modified, but must pass Lima validation for the update to succeed. If `spec.running` is `true` and the template has changed, then the instance will be restarted. The `status.templateConfigMap` cannot be deleted, except by deleting the `LimaVM` resource itself, which will clean up owned resources automatically.
 
-- **params**: Override `params` settings in the template. These values will be merged with the template before validation, and when creating/updating the `lima.yaml` file of the actual instance on disk.
+- **spec.params**: Override `spec.params` settings in the template. These values will be merged with the template before validation, and when creating/updating the `lima.yaml` file of the actual instance on disk.
 
-    If the template provisioning scripts are properly parameterized, then the instance settings can be modified by just updating `spec.params`, which is simpler than modifying the `template` inside the ConfigMap.
+    If the template provisioning scripts are properly parameterized, then the instance settings can be modified by just updating `spec.params`, which is simpler than modifying the `template` inside the ConfigMap. If `spec.running` is `true` then changing `spec.params` will restart the instance.
 
 ## LimaDisk
 

--- a/docs/design/api_lima.md
+++ b/docs/design/api_lima.md
@@ -18,14 +18,36 @@ kind: LimaVM
 metadata:
   name: alpine
   namespace: default
+  annotations:
+    lima.rancherdesktop.io/resetRequested: "2025-10-12T08:00:00Z"
+    lima.rancherdesktop.io/restartRequested: "2025-10-12T10:30:00Z"
 spec:
-  template: alpine
-  status: running
+  running: true
+  templateRef:
+    name: alpine
+    namespace: lima-templates
+  params:
+    DOCKER_ROOTFUL: "true"
 status:
-  status: stopped
+  templateConfigMap: alpine-template
+  conditions: []
 ```
 
-The `template` specifies a ConfigMap that contains the `lima.yaml` template for the machine. It must be "fully embedded"; it cannot reference external base templates or scripts.
+- **metadata.annotations**: Can be used to request "actions" from the reconciler, like resetting (deleting and recreating with the same settings), or restarting the instance. The `status.conditions` can be used to store the state machine information.
+
+- **running**: Set to `true` when the instance should be running, set to `false` when it should be stopped.
+
+- **templateRef**: Specifies the `lima.yaml` template for the machine. The template must pass Lima validation or the `LimaVM` creation will fail. 
+
+    Initially the only way to specify a template is via a ConfigMap that will store the "fully embedded" template under the `template` key. It cannot reference external base templates or scripts. This will change eventually when `templateRef.name` can also be set to a URL. The default for `templateRef.namespace` is the same as `metadata.namespace`.
+
+    The `LimaVM` controller will create a new ConfigMap (in `metadata.namespace`) with the `metadata.name` and a `"-template"` suffix to store a copy of the validated template. This name is stored under `status.templateConfigMap`. The original `templateRef` source is never accessed again after this, and can be modified or deleted without affecting the `LimaVM` resource. The `spec.templateRef` is immutable after creation and only serves as documentation.
+
+    The `templateConfigMap` can be modified, but must pass Lima validation for the update to succeed. If `spec.running` is `true` and the template has changed, then the instance will be restarted. The `templateConfigMap` cannot be deleted, except by deleting the `LimaVM` resource itself, which will clean up owned resources automatically.
+
+- **params**: Override `params` settings in the template. These values will be merged with the template before validation, and when creating/updating the `lima.yaml` file of the actual instance on disk.
+
+    If the template provisioning scripts are properly parameterized, then the instance settings can be modified by just updating `spec.params`, which is simpler than modifying the `template` inside the ConfigMap.
 
 ## LimaDisk
 

--- a/docs/design/cmd_lima.md
+++ b/docs/design/cmd_lima.md
@@ -1,13 +1,45 @@
-# Lima Commands
+# LimaVM Commands
 
-## `rdd lima`
+## `rdd limavm`
 
 This command is similar to `limactl`, but uses `rdd` to create/start/stop/delete VM instances. It is a convenience command to work with other VMs and not needed to operate the Rancher Desktop app.
 
-```bash
-rdd lima create --name my-vm --cpus 4 lima.yaml
-rdd lima start my-vm
-rdd lima stop my-vm
-rdd lima delete my-vm
-rdd lima shell my-vm
-```
+### `rdd limavm create NAME TEMPLATE --namespace NAMESPACE`
+
+Create a new `LimaVM` instance `NAME` in `NAMESPACE` (or `default`) using `TEMPLATE`.
+
+`TEMPLATE` should be the name of a ConfigMap inside the `NAMESPACE` where the resource should be created. It will be used as the `spec.templateRef.name` in the `LimaVM` resource. Referencing a ConfigMap in a different namespace is currently not supported and requires the use of `rdd ctl apply` instead.
+
+`TEMPLATE` will be treated as a local filename if it contains a `/`.  In that case the `create` command will create a ConfigMap in `NAMESPACE` called `NAME`. It will store the "fully embedded" template from the file inside that ConfigMap and use it as the `spec.templateRef`. If a ConfigMap of this name already exists, then the `create` command will fail. If `LimaVM` creation succeeds then ownership of this ConfigMap is transferred to the `LimaVM` resource, and it will be deleted when the `LimaVM` instance is deleted. But when the command fails, then the ConfigMap is deleted immediately.
+
+### `rdd limavm start NAME`
+
+Set `spec.running` of the specified instance to `true`. There is no `--namespace` option because `LimaVM` names are globally unique (within the controlplane).
+
+### `rdd limavm stop NAME`
+
+Set `spec.running` of the specified instance to `false`.
+
+### `rdd limavm delete NAME`
+
+This will stop and delete the instance. The `LimaVM` resource will be deleted, which in turn will delete all owned resources. Currently, this is the `status.templateConfigMap`, and potentially the `spec.templateRef.name` template if it was created by `rdd lima create`.
+
+### `rdd limavm params NAME1=VALUE1 NAME2=VALUE2`
+
+Create/update/delete `spec.params` values. New entries are created as needed. Assigning an empty string will remove the name.
+
+The `status.templateConfigMap` will be combined with the updated `spec.params` and needs to pass Lima validation. Otherwise, the update will be rejected.
+
+If `spec.running` is true, then the instance will be restarted if the `params` have changed.
+
+### `rdd limavm reset NAME`
+
+Set `lima.rancherdesktop.io/resetRequested` annotation to the current timestamp. This tells the reconciler to delete the existing instance (stopping it, if necessary), and then recreate it using the same `status.templateConfigMap` and `spec.params` template.
+
+### `rdd limavm restart NAME`
+
+Set `lima.rancherdesktop.io/restartRequested` annotation to the current timestamp. This tells the reconciler to stop the instance (if it is running), and then to start it again.
+
+### `rdd limavm shell NAME CMD`
+
+Runs `CMD` inside a shell in the `NAME` instance, or opens an interactive shell if `CMD` is omitted.

--- a/docs/design/cmd_lima.md
+++ b/docs/design/cmd_lima.md
@@ -2,7 +2,7 @@
 
 ## `rdd limavm`
 
-This command is similar to `limactl`, but uses `rdd` to create/start/stop/delete VM instances. It is a convenience command to work with other VMs and not needed to operate the Rancher Desktop app.
+This command is similar to `limactl`, but uses `rdd` to create/start/stop/delete VM instances. It is a convenience command to work with other VMs and not needed to operate the Rancher Desktop app. It is hidden (like `rdd ctl`) unless `rdd` is running in developer mode.
 
 ### `rdd limavm create NAME TEMPLATE --namespace NAMESPACE`
 
@@ -10,11 +10,11 @@ Create a new `LimaVM` instance `NAME` in `NAMESPACE` (or `default`) using `TEMPL
 
 `TEMPLATE` should be the name of a ConfigMap inside the `NAMESPACE` where the resource should be created. It will be used as the `spec.templateRef.name` in the `LimaVM` resource. Referencing a ConfigMap in a different namespace is currently not supported and requires the use of `rdd ctl apply` instead.
 
-`TEMPLATE` will be treated as a local filename if it contains a `/`.  In that case the `create` command will create a ConfigMap in `NAMESPACE` called `NAME`. It will store the "fully embedded" template from the file inside that ConfigMap and use it as the `spec.templateRef`. If a ConfigMap of this name already exists, then the `create` command will fail. If `LimaVM` creation succeeds then ownership of this ConfigMap is transferred to the `LimaVM` resource, and it will be deleted when the `LimaVM` instance is deleted. But when the command fails, then the ConfigMap is deleted immediately.
+`TEMPLATE` will be treated as a local filename or template URL if it contains a `/` or a `:`.  In that case the `create` command will create a ConfigMap in `NAMESPACE` called `NAME`. It will store the "fully embedded" template from the file or URL inside that ConfigMap and use it as the `spec.templateRef`. If a ConfigMap of this name already exists, then the `create` command will fail. If `LimaVM` creation succeeds then ownership of this ConfigMap is transferred to the `LimaVM` resource, and it will be deleted when the `LimaVM` instance is deleted. But when the command fails, then any ConfigMap created from a file or URL is deleted immediately.
 
 ### `rdd limavm start NAME`
 
-Set `spec.running` of the specified instance to `true`. There is no `--namespace` option because `LimaVM` names are globally unique (within the controlplane).
+Set `spec.running` of the specified instance to `true`. There is no `--namespace` option because `LimaVM` names are globally unique (within the control plane).
 
 ### `rdd limavm stop NAME`
 
@@ -22,7 +22,7 @@ Set `spec.running` of the specified instance to `false`.
 
 ### `rdd limavm delete NAME`
 
-This will stop and delete the instance. The `LimaVM` resource will be deleted, which in turn will delete all owned resources. Currently, this is the `status.templateConfigMap`, and potentially the `spec.templateRef.name` template if it was created by `rdd lima create`.
+This will stop and delete the instance. The `LimaVM` resource will be deleted, which in turn will delete all owned resources. Currently, this is the `status.templateConfigMap`, and potentially the `spec.templateRef.name` template if it was created by `rdd limavm create`.
 
 ### `rdd limavm params NAME1=VALUE1 NAME2=VALUE2`
 
@@ -30,7 +30,7 @@ Create/update/delete `spec.params` values. New entries are created as needed. As
 
 The `status.templateConfigMap` will be combined with the updated `spec.params` and needs to pass Lima validation. Otherwise, the update will be rejected.
 
-If `spec.running` is true, then the instance will be restarted if the `params` have changed.
+If `spec.running` is true, then the instance will be restarted if `spec.params` have changed.
 
 ### `rdd limavm reset NAME`
 
@@ -38,7 +38,7 @@ Set `lima.rancherdesktop.io/resetRequested` annotation to the current timestamp.
 
 ### `rdd limavm restart NAME`
 
-Set `lima.rancherdesktop.io/restartRequested` annotation to the current timestamp. This tells the reconciler to stop the instance (if it is running), and then to start it again.
+Set `lima.rancherdesktop.io/restartRequested` annotation to the current timestamp. This tells the reconciler to stop the instance, if it is running. Then it will start the instance, even if it had been stopped initially.
 
 ### `rdd limavm shell NAME CMD`
 


### PR DESCRIPTION
I already have a local branch implementing the `templateRef` changes and corresponding `rdd limavm` updates.

The annotations and the `params` stuff does not exist at all yet.