### PR TITLE
CI: Lint: Use platform runners

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,5 @@
+name: Lint
+
 on:
   push:
   pull_request:
@@ -32,12 +34,18 @@ jobs:
   golangci-lint:
     name: golangci-lint
     needs: get-pr-number
-    runs-on: ubuntu-latest
-    if: ${{ ! needs.get-pr-number.outputs.number }}
     strategy:
       matrix:
-        os: [darwin, linux, windows]
+        runs-on: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.runs-on }}
+    if: ${{ ! needs.get-pr-number.outputs.number }}
     steps:
+    - name: "Windows: Set up line endings"
+      if: runner.os == 'Windows'
+      run: |
+        git config --global --replace-all core.autocrlf false # spellchecker:ignore
+        git config --global --replace-all core.eol lf # spellchecker:ignore
+        git config --global --replace-all core.longpath true #spellchecker:ignore
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         persist-credentials: false
@@ -45,8 +53,6 @@ jobs:
       with:
         go-version-file: go.mod
     - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-      env:
-        GOOS: ${{ matrix.os }}
   bats:
     name: Lint BATS
     needs: get-pr-number


### PR DESCRIPTION
We tried to use Linux runners to run lint (overriding GOOS) to save costs, but that turned out to mess with the cache and took even longer to run. Use the default strategy of using the matching host OS in the hopes of getting faster runs.