### PR TITLE
`rdd service serve`: Set up controller-runtime loggers

### DIFF
--- a/pkg/external/main.go
+++ b/pkg/external/main.go
@@ -12,11 +12,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-logr/logr"
-
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
@@ -32,16 +31,14 @@ func RunControllers(apiGroupName string) int {
 	flag.IntVar(&desiredMetricsPort, "metrics-port", 8080, "The desired port the metric endpoint binds to.")
 	flag.IntVar(&desiredHealthPort, "health-port", 8081, "The desired port the health probe endpoint binds to.")
 
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
+	klog.InitFlags(nil)
 	flag.Parse()
 
-	ctx := ctrl.SetupSignalHandler()
+	log := klog.NewKlogr()
+	ctx := klog.NewContext(ctrl.SetupSignalHandler(), log)
 
-	setupLog := ctrl.Log.WithName("setup")
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrllog.SetLogger(log)
+	setupLog := log.WithName("setup")
 
 	// Get Kubernetes configuration from `rdd svc config`
 	config, err := base.GetKubeConfigFromRDD(ctx)
@@ -124,7 +121,7 @@ func RunControllers(apiGroupName string) int {
 
 // monitorControlPlane monitors the control plane lifecycle and cancels the context when it's no longer available.
 // This allows external controllers to automatically exit when `rdd svc stop` or `rdd svc delete` is called.
-func monitorControlPlane(ctx context.Context, config *rest.Config, log logr.Logger, cancel context.CancelFunc) {
+func monitorControlPlane(ctx context.Context, config *rest.Config, log klog.Logger, cancel context.CancelFunc) {
 	discovery, err := controllers.NewControllerManagerDiscovery(config)
 	if err != nil {
 		log.Error(err, "Failed to create discovery service for monitoring")
@@ -195,7 +192,7 @@ func monitorControlPlane(ctx context.Context, config *rest.Config, log logr.Logg
 
 // shouldStartController checks if an external controller should start based on RDD discovery.
 // Returns true if no RDD controller manager is running or the specific controller is not enabled.
-func shouldStartController(ctx context.Context, config *rest.Config, controllerName string, log logr.Logger) (bool, error) {
+func shouldStartController(ctx context.Context, config *rest.Config, controllerName string, log klog.Logger) (bool, error) {
 	discovery, err := controllers.NewControllerManagerDiscovery(config)
 	if err != nil {
 		return false, fmt.Errorf("failed to create discovery service: %w", err)

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -87,18 +87,20 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		return errors.New("shared controller manager already started")
 	}
 
+	log := klog.FromContext(ctx)
+
 	// Clean up unused resources from previous controller runs
 	if err := scm.cleanupUnusedResources(ctx); err != nil {
-		klog.ErrorS(err, "Failed to cleanup unused resources, continuing with startup")
+		log.Error(err, "Failed to cleanup unused resources, continuing with startup")
 	}
 
 	// Clean up stale discovery configmap to prevent readiness check confusion
 	if err := scm.cleanupStaleDiscovery(ctx); err != nil {
-		klog.ErrorS(err, "Failed to cleanup stale discovery configmap, continuing with startup")
+		log.Error(err, "Failed to cleanup stale discovery configmap, continuing with startup")
 	}
 
 	// Install CRDs for all registered controllers in parallel
-	klog.InfoS("Installing CRDs for all controllers in parallel", "controllers", len(scm.registrations))
+	log.Info("Installing CRDs for all controllers in parallel", "controllers", len(scm.registrations))
 	if err := scm.installControllerCRDs(ctx); err != nil {
 		return fmt.Errorf("failed to install controller CRDs: %w", err)
 	}
@@ -116,6 +118,9 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		}
 	}
 
+	// Configure controller-runtime to use klog
+	ctrllog.SetLogger(log.WithName("controller-runtime"))
+
 	// Create and register scheme with required types
 	managerScheme := runtime.NewScheme()
 	utilruntime.Must(scheme.AddToScheme(managerScheme))
@@ -132,7 +137,6 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		},
 		HealthProbeBindAddress: ":" + strconv.Itoa(scm.healthPort),
 		LeaderElection:         false, // RDD controllers are single-instance
-		Logger:                 zap.New(zap.UseDevMode(false)),
 	}
 
 	// Only configure webhook server if controllers require it
@@ -163,7 +167,7 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	if scm.discovery == nil {
 		discovery, err := NewControllerManagerDiscovery(scm.kubeConfig)
 		if err != nil {
-			klog.ErrorS(err, "Failed to create controller manager discovery client")
+			log.Error(err, "Failed to create controller manager discovery client")
 		} else {
 			scm.discovery = discovery
 		}
@@ -171,14 +175,14 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 
 	if scm.discovery != nil {
 		if err := scm.registerDiscovery(ctx); err != nil {
-			klog.ErrorS(err, "Failed to register controller manager for discovery")
+			log.Error(err, "Failed to register controller manager for discovery")
 			// Don't fail startup for discovery registration errors
 		}
 
 		// Ensure cleanup on shutdown
 		defer func() {
 			if err := scm.discovery.UnregisterControllerManager(context.Background()); err != nil {
-				klog.ErrorS(err, "Failed to unregister controller manager")
+				log.Error(err, "Failed to unregister controller manager")
 			}
 		}()
 	}


### PR DESCRIPTION
Otherwise the log messages will never get displayed.

Without this, we can end up with this in the logs:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 3439 [running]:
        >  runtime/debug.Stack()
        >       …/go/1.25.1/src/runtime/debug/stack.go:26 +0x5e
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       …/sigs.k8s.io/controller-runtime@v0.22.2/pkg/log/log.go:60 +0xcd
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0xc0002e7440, 0x7)
        >       …/sigs.k8s.io/controller-runtime@v0.22.2/pkg/log/deleg.go:111 +0x32
        >  github.com/go-logr/logr.Logger.Info({{0x7ff651f2dd68?, 0xc0002e7440?}, 0x0?}, {0x7ff651591d06, 0x1a}, {0x0, 0x0, 0x0})
        >       …/github.com/go-logr/logr@v1.4.3/logr.go:276 +0x6e
        >  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).updateCachedCertificate(0xc003f46120, 0xc005357e80, {0xc003888e00, 0x68b, 0x68c})
        >       …/sigs.k8s.io/controller-runtime@v0.22.2/pkg/certwatcher/certwatcher.go:180 +0x1ce
        >  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).ReadCertificate(0xc003f46120)
        >       …/sigs.k8s.io/controller-runtime@v0.22.2/pkg/certwatcher/certwatcher.go:210 +0x265
        >  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Start(0xc003f46120, {0x7ff651f20ba0, 0xc00248a2d0})
        >       …/sigs.k8s.io/controller-runtime@v0.22.2/pkg/certwatcher/certwatcher.go:142 +0x3d7
        >  sigs.k8s.io/controller-runtime/pkg/webhook.(*DefaultServer).Start.func1()
        >       …/sigs.k8s.io/controller-runtime@v0.22.2/pkg/webhook/server.go:214 +0x1f
        >  created by sigs.k8s.io/controller-runtime/pkg/webhook.(*DefaultServer).Start in goroutine 3436
        >       …/sigs.k8s.io/controller-runtime@v0.22.2/pkg/webhook/server.go:213 +0x31f
```