### PR TITLE
BATS: Turn on optional lints for shellcheck

### DIFF
--- a/bats/Makefile
+++ b/bats/Makefile
@@ -97,9 +97,9 @@ bats-trace: check-bats build-rdd build-all-controllers
 TEST_FILES := $(shell find helpers tests -name '*.bash' -o -name '*.bats')
 SC_EXCLUDES ?= SC1091,SC2034,SC2154
 lint: $(TEST_FILES)
-	shellcheck --shell=bats --exclude=$(SC_EXCLUDES) $(TEST_FILES)
+	shellcheck --shell=bats --enable=all --exclude=$(SC_EXCLUDES) $(TEST_FILES)
 	go tool shfmt --language-dialect=bats --indent=4 --diff $(TEST_FILES)
 lint-fix: $(TEST_FILES)
-	shellcheck --shell=bats --exclude=$(SC_EXCLUDES) $(TEST_FILES)
+	shellcheck --shell=bats --enable=all --exclude=$(SC_EXCLUDES) $(TEST_FILES)
 	go tool shfmt --language-dialect=bats --indent=4 --write $(TEST_FILES)
 .PHONY: lint lint-fix

--- a/bats/helpers/commands.bash
+++ b/bats/helpers/commands.bash
@@ -39,7 +39,7 @@ rdd() {
         mapfile -t envs < <({
             tr : '\n' <<<"${WSLENV}"
             env | awk -F= '/^RDD_/ { print $1 }'
-        } | sort -u)
+        } | sort -u || true)
         WSLENV=""
         for env in "${envs[@]}"; do
             WSLENV="${WSLENV}:${env}"

--- a/bats/helpers/commands.bash
+++ b/bats/helpers/commands.bash
@@ -1,5 +1,5 @@
 EXE=""
-PLATFORM=$OS
+PLATFORM=${OS}
 if is_windows; then
     PLATFORM=linux
     if using_windows_exe; then
@@ -19,7 +19,7 @@ ctrctl() {
     fi
 }
 curl() {
-    command "curl$EXE" "$@"
+    command "curl${EXE}" "$@"
 }
 rdd() {
     local arg
@@ -30,14 +30,14 @@ rdd() {
         args=()
         for arg in "$@"; do
             if [[ "${arg}" != "${arg#/mnt/}" ]]; then
-                args+=("$(wslpath -w "$arg")")
+                args+=("$(wslpath -w "${arg}")")
             else
-                args+=("$arg")
+                args+=("${arg}")
             fi
         done
         # Adjust WSLENV to include everything starting with RDD_
         mapfile -t envs < <({
-            tr : '\n' <<<"$WSLENV"
+            tr : '\n' <<<"${WSLENV}"
             env | awk -F= '/^RDD_/ { print $1 }'
         } | sort -u)
         WSLENV=""
@@ -48,5 +48,5 @@ rdd() {
 
         export WSLENV
     fi
-    "$PATH_REPO_ROOT/bin/rdd${EXE}" "${args[@]}"
+    "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${args[@]}"
 }

--- a/bats/helpers/controller.bash
+++ b/bats/helpers/controller.bash
@@ -19,12 +19,12 @@ assert_resource_count() {
     local expected=$4
 
     run rdd ctl get "${resource_type}" -n "${RDD_NAMESPACE}" -l "app.kubernetes.io/managed-by=${controller_name},app.kubernetes.io/instance=${name}" -o json
-    if [ "$status" -eq 0 ]; then
-        run -0 jq '.items | length' <<<"$output"
+    if [[ "${status}" -eq 0 ]]; then
+        run -0 jq '.items | length' <<<"${output}"
     else
         output="0"
     fi
-    assert_output "$expected"
+    assert_output "${expected}"
 }
 
 # Wait for resources to reach expected count
@@ -52,7 +52,7 @@ assert_resource_status() {
     local expected=$4
 
     run -0 get_resource_status "${resource_type}" "${name}" "${field}"
-    assert_output "$expected"
+    assert_output "${expected}"
 }
 
 wait_for_resource_status() {

--- a/bats/helpers/instance.bash
+++ b/bats/helpers/instance.bash
@@ -16,5 +16,7 @@ get_instance_index() {
 # Calculate the expected port for the current RDD_INSTANCE
 get_expected_port() {
     local base_port="${1:-6443}"
-    echo $((base_port + $(get_instance_index)))
+    local instance_index
+    instance_index=$(get_instance_index)
+    echo $((base_port + instance_index))
 }

--- a/bats/helpers/instance.bash
+++ b/bats/helpers/instance.bash
@@ -1,14 +1,14 @@
 # Calculate the RDD_INSTANCE index for the current RDD_INSTANCE
 # This mirrors the Index() function in pkg/RDD_INSTANCE/RDD_INSTANCE.go
 get_instance_index() {
-    if [[ $RDD_INSTANCE =~ ^[0-9]+$ ]] && ((RDD_INSTANCE > 0)) && ((RDD_INSTANCE < 100)); then
-        echo "$RDD_INSTANCE"
+    if [[ ${RDD_INSTANCE} =~ ^[0-9]+$ ]] && ((RDD_INSTANCE > 0)) && ((RDD_INSTANCE < 100)); then
+        echo "${RDD_INSTANCE}"
         return
     fi
 
     local i sum
     for ((i = 0, sum = 0; i < ${#RDD_INSTANCE}; i++)); do
-        sum=$((sum + $(printf "%d" "'${RDD_INSTANCE:$i:1}")))
+        sum=$((sum + $(printf "%d" "'${RDD_INSTANCE:${i}:1}")))
     done
     echo $((100 + (sum % 100)))
 }

--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -13,66 +13,66 @@ absolute_path() {
 }
 
 PATH_BATS_HELPERS=$(absolute_path "$(dirname "${BASH_SOURCE[0]}")")
-PATH_BATS_ROOT=$(absolute_path "$PATH_BATS_HELPERS/..")
-PATH_BATS_LOGS=$PATH_BATS_ROOT/logs
+PATH_BATS_ROOT=$(absolute_path "${PATH_BATS_HELPERS}/..")
+PATH_BATS_LOGS=${PATH_BATS_ROOT}/logs
 
 # Use fatal() to abort loading helpers; don't run any tests
 fatal() {
     local fd=2
     # fd 3 might not be open if we're not fully under bats yet; detect that.
     [[ -e /dev/fd/3 ]] && fd=3
-    echo "   $1" >&$fd
+    echo "   $1" >&"${fd}"
 
     # Print (ugly) stack trace if we are outside any @test function
-    if [ -z "${BATS_SUITE_TEST_NUMBER:-}" ]; then
-        echo >&$fd
+    if [[ -z "${BATS_SUITE_TEST_NUMBER:-}" ]]; then
+        echo >&"${fd}"
         local frame=0
-        while caller $frame >&$fd; do
+        while caller "${frame}" >&"${fd}"; do
             ((frame++))
         done
     fi
     exit 1
 }
 
-source "$PATH_BATS_ROOT/lib/bats-support/load.bash"
-source "$PATH_BATS_ROOT/lib/bats-assert/load.bash"
-source "$PATH_BATS_ROOT/lib/bats-file/load.bash"
+source "${PATH_BATS_ROOT}/lib/bats-support/load.bash"
+source "${PATH_BATS_ROOT}/lib/bats-assert/load.bash"
+source "${PATH_BATS_ROOT}/lib/bats-file/load.bash"
 
-source "$PATH_BATS_HELPERS/os.bash"
-source "$PATH_BATS_HELPERS/utils.bash"
-source "$PATH_BATS_HELPERS/controller.bash"
-source "$PATH_BATS_HELPERS/instance.bash"
-source "$PATH_BATS_HELPERS/logs.bash"
-source "$PATH_BATS_HELPERS/numeric.bash"
+source "${PATH_BATS_HELPERS}/os.bash"
+source "${PATH_BATS_HELPERS}/utils.bash"
+source "${PATH_BATS_HELPERS}/controller.bash"
+source "${PATH_BATS_HELPERS}/instance.bash"
+source "${PATH_BATS_HELPERS}/logs.bash"
+source "${PATH_BATS_HELPERS}/numeric.bash"
 
 # defaults.bash uses is_windows() from os.bash and
 # validate_enum() and is_true() from utils.bash.
-source "$PATH_BATS_HELPERS/defaults.bash"
+source "${PATH_BATS_HELPERS}/defaults.bash"
 
-source "$PATH_BATS_HELPERS/paths.bash"
+source "${PATH_BATS_HELPERS}/paths.bash"
 
 # commands.bash uses is_containerd() from defaults.bash,
 # is_windows() etc from os.bash,
 # and PATH_* variables from paths.bash
-source "$PATH_BATS_HELPERS/commands.bash"
+source "${PATH_BATS_HELPERS}/commands.bash"
 
 # Add repo-root/bin directory to the PATH. This is where the Makefile puts all compiled programs.
-export PATH="$PATH_BATS_ROOT/../bin:$PATH"
+export PATH="${PATH_BATS_ROOT}/../bin:${PATH}"
 
 # If called from foo() this function will call local_foo() if it exist.
 call_local_function() {
     local func
     func="local_$(calling_function)"
-    if [ "$(type -t "$func")" = "function" ]; then
-        "$func"
+    if [[ "$(type -t "${func}")" = "function" ]]; then
+        "${func}"
     fi
 }
 
 setup_file() {
     # We require bash 4; bash 3.2 (as shipped by macOS) seems to have
     # compatibility issues.
-    if semver_gt 4.0.0 "$(semver "$BASH_VERSION")"; then
-        fail "Bash 4.0.0 is required; you have $BASH_VERSION"
+    if semver_gt 4.0.0 "$(semver "${BASH_VERSION}")"; then
+        fail "Bash 4.0.0 is required; you have ${BASH_VERSION}"
     fi
 
     call_local_function

--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -63,7 +63,7 @@ export PATH="${PATH_BATS_ROOT}/../bin:${PATH}"
 call_local_function() {
     local func
     func="local_$(calling_function)"
-    if [[ "$(type -t "${func}")" = "function" ]]; then
+    if [[ "$(type -t "${func}" || true)" = "function" ]]; then
         "${func}"
     fi
 }
@@ -71,7 +71,9 @@ call_local_function() {
 setup_file() {
     # We require bash 4; bash 3.2 (as shipped by macOS) seems to have
     # compatibility issues.
-    if semver_gt 4.0.0 "$(semver "${BASH_VERSION}")"; then
+    local bash_version
+    bash_version=$(semver "${BASH_VERSION}")
+    if semver_gt 4.0.0 "${bash_version}"; then
         fail "Bash 4.0.0 is required; you have ${BASH_VERSION}"
     fi
 

--- a/bats/helpers/logs.bash
+++ b/bats/helpers/logs.bash
@@ -16,17 +16,27 @@ quote_msg() {
 }
 
 assert_fatal() {
-    assert_stderr_line --partial "level=fatal msg=$(quote_msg "$1")"
+    local quoted
+    quoted=$(quote_msg "$1")
+    assert_stderr_line --partial "level=fatal msg=${quoted}"
 }
 assert_error() {
-    assert_stderr_line --partial "level=error msg=$(quote_msg "$1")"
+    local quoted
+    quoted=$(quote_msg "$1")
+    assert_stderr_line --partial "level=error msg=${quoted}"
 }
 assert_warning() {
-    assert_stderr_line --partial "level=warning msg=$(quote_msg "$1")"
+    local quoted
+    quoted=$(quote_msg "$1")
+    assert_stderr_line --partial "level=warning msg=${quoted}"
 }
 assert_info() {
-    assert_stderr_line --partial "level=info msg=$(quote_msg "$1")"
+    local quoted
+    quoted=$(quote_msg "$1")
+    assert_stderr_line --partial "level=info msg=${quoted}"
 }
 assert_debug() {
-    assert_stderr_line --partial "level=debug msg=$(quote_msg "$1")"
+    local quoted
+    quoted=$(quote_msg "$1")
+    assert_stderr_line --partial "level=debug msg=${quoted}"
 }

--- a/bats/helpers/logs.bash
+++ b/bats/helpers/logs.bash
@@ -8,7 +8,7 @@
 quote_msg() {
     local quoted
     quoted=$(sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' <<<"$1")
-    if [[ $quoted == *… ]]; then
+    if [[ ${quoted} == *… ]]; then
         echo "${quoted%…}"
     else
         echo "${quoted}\""

--- a/bats/helpers/numeric.bash
+++ b/bats/helpers/numeric.bash
@@ -5,12 +5,12 @@ assert_output_ge() {
     local -i expected=$1
     local -i actual
 
-    if [[ $output =~ ^-?[0-9]+$ ]]; then
-        actual="$output"
+    if [[ ${output} =~ ^-?[0-9]+$ ]]; then
+        actual="${output}"
     else
         batslib_print_kv_single_or_multi 8 \
-            'expected' ">= $expected" \
-            'actual' "$output (not a valid integer)" |
+            'expected' ">= ${expected}" \
+            'actual' "${output} (not a valid integer)" |
             batslib_decorate 'output does not contain a valid integer' |
             fail
         return $?
@@ -18,8 +18,8 @@ assert_output_ge() {
 
     if ((actual < expected)); then
         batslib_print_kv_single_or_multi 8 \
-            'expected' ">= $expected" \
-            'actual' "$actual" |
+            'expected' ">= ${expected}" \
+            'actual' "${actual}" |
             batslib_decorate 'output is less than expected minimum' |
             fail
     fi
@@ -30,12 +30,12 @@ assert_output_lt() {
     local -i expected=$1
     local -i actual
 
-    if [[ $output =~ ^-?[0-9]+$ ]]; then
-        actual="$output"
+    if [[ ${output} =~ ^-?[0-9]+$ ]]; then
+        actual="${output}"
     else
         batslib_print_kv_single_or_multi 8 \
-            'expected' "< $expected" \
-            'actual' "$output (not a valid integer)" |
+            'expected' "< ${expected}" \
+            'actual' "${output} (not a valid integer)" |
             batslib_decorate 'output does not contain a valid integer' |
             fail
         return $?
@@ -43,8 +43,8 @@ assert_output_lt() {
 
     if ((actual >= expected)); then
         batslib_print_kv_single_or_multi 8 \
-            'expected' "< $expected" \
-            'actual' "$actual" |
+            'expected' "< ${expected}" \
+            'actual' "${actual}" |
             batslib_decorate 'output is not less than expected maximum' |
             fail
     fi

--- a/bats/helpers/numeric.bash
+++ b/bats/helpers/numeric.bash
@@ -8,6 +8,7 @@ assert_output_ge() {
     if [[ ${output} =~ ^-?[0-9]+$ ]]; then
         actual="${output}"
     else
+        # shellcheck disable=SC2312 # We're intentionally failing anyway.
         batslib_print_kv_single_or_multi 8 \
             'expected' ">= ${expected}" \
             'actual' "${output} (not a valid integer)" |
@@ -17,6 +18,7 @@ assert_output_ge() {
     fi
 
     if ((actual < expected)); then
+        # shellcheck disable=SC2312 # We're intentionally failing anyway.
         batslib_print_kv_single_or_multi 8 \
             'expected' ">= ${expected}" \
             'actual' "${actual}" |
@@ -33,6 +35,7 @@ assert_output_lt() {
     if [[ ${output} =~ ^-?[0-9]+$ ]]; then
         actual="${output}"
     else
+        # shellcheck disable=SC2312 # We're intentionally failing anyway.
         batslib_print_kv_single_or_multi 8 \
             'expected' "< ${expected}" \
             'actual' "${output} (not a valid integer)" |
@@ -42,6 +45,7 @@ assert_output_lt() {
     fi
 
     if ((actual >= expected)); then
+        # shellcheck disable=SC2312 # We're intentionally failing anyway.
         batslib_print_kv_single_or_multi 8 \
             'expected' "< ${expected}" \
             'actual' "${actual}" |

--- a/bats/helpers/os.bash
+++ b/bats/helpers/os.bash
@@ -11,7 +11,7 @@ Darwin)
     OS=darwin
     ;;
 Linux)
-    if [[ $(uname -a) =~ microsoft ]]; then
+    if grep --quiet WSL2 </proc/sys/kernel/osrelease; then # spellchecker:ignore
         OS=windows
     else
         OS=linux
@@ -66,9 +66,11 @@ skip_on_unix() {
 needs_port() {
     local port=$1
     if is_linux; then
-        if [[ "$(sysctl -n net.ipv4.ip_unprivileged_port_start)" -gt "${port}" ]]; then
+        local port_start
+        read -r port_start </proc/sys/net/ipv4/ip_unprivileged_port_start
+        if [[ "${port_start}" -gt "${port}" ]]; then
             # Run sudo non-interactive, so don't prompt for password
-            run sudo -n sysctl -w "net.ipv4.ip_unprivileged_port_start=${port}"
+            run sudo -n /bin/sh -c "echo '${port}' > /proc/sys/net/ipv4/ip_unprivileged_port_start"
             if ((status > 0)); then
                 skip "net.ipv4.ip_unprivileged_port_start must be ${port} or less"
             fi

--- a/bats/helpers/os.bash
+++ b/bats/helpers/os.bash
@@ -4,7 +4,7 @@ UNAME=$(uname)
 ARCH=$(uname -m)
 ARCH=${ARCH/arm64/aarch64}
 
-case $UNAME in
+case ${UNAME} in
 Darwin)
     # OS matches the directory name of the PATH_RESOURCES directory,
     # so uses "darwin" and not "macos".
@@ -18,32 +18,32 @@ Linux)
     fi
     ;;
 *)
-    echo "Unexpected uname: $UNAME" >&2
+    echo "Unexpected uname: ${UNAME}" >&2
     exit 1
     ;;
 esac
 
 is_linux() {
-    if [ -z "${1:-}" ]; then
-        test "$OS" = linux
+    if [[ -z "${1:-}" ]]; then
+        test "${OS}" = linux
     else
-        test "$OS" = linux -a "$ARCH" = "$1"
+        test "${OS}" = linux -a "${ARCH}" = "$1"
     fi
 }
 
 is_macos() {
-    if [ -z "${1:-}" ]; then
-        test "$OS" = darwin
+    if [[ -z "${1:-}" ]]; then
+        test "${OS}" = darwin
     else
-        test "$OS" = darwin -a "$ARCH" = "$1"
+        test "${OS}" = darwin -a "${ARCH}" = "$1"
     fi
 }
 
 is_windows() {
-    if [ -z "${1:-}" ]; then
-        test "$OS" = windows
+    if [[ -z "${1:-}" ]]; then
+        test "${OS}" = windows
     else
-        test "$OS" = windows -a "$ARCH" = "$1"
+        test "${OS}" = windows -a "${ARCH}" = "$1"
     fi
 }
 
@@ -66,11 +66,11 @@ skip_on_unix() {
 needs_port() {
     local port=$1
     if is_linux; then
-        if [ "$(sysctl -n net.ipv4.ip_unprivileged_port_start)" -gt "$port" ]; then
+        if [[ "$(sysctl -n net.ipv4.ip_unprivileged_port_start)" -gt "${port}" ]]; then
             # Run sudo non-interactive, so don't prompt for password
-            run sudo -n sysctl -w "net.ipv4.ip_unprivileged_port_start=$port"
+            run sudo -n sysctl -w "net.ipv4.ip_unprivileged_port_start=${port}"
             if ((status > 0)); then
-                skip "net.ipv4.ip_unprivileged_port_start must be $port or less"
+                skip "net.ipv4.ip_unprivileged_port_start must be ${port} or less"
             fi
         fi
     fi

--- a/bats/helpers/paths.bash
+++ b/bats/helpers/paths.bash
@@ -1,23 +1,23 @@
 # PATH_BATS_ROOT, PATH_BATS_LOGS, and PATH_BATS_HELPERS are already set by load.bash
 
-PATH_REPO_ROOT=$(absolute_path "$PATH_BATS_ROOT/..")
+PATH_REPO_ROOT=$(absolute_path "${PATH_BATS_ROOT}/..")
 
 inside_repo_clone() {
-    [ -d "$PATH_REPO_ROOT/pkg/rancher-desktop-daemon" ]
+    [[ -d "${PATH_REPO_ROOT}/pkg/rancher-desktop-daemon" ]]
 }
 
 if is_macos; then
-    PATH_APP_HOME="$HOME/Library/Application Support/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CONFIG="$HOME/Library/Preferences/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CACHE="$HOME/Library/Caches/rancher-desktop-${RDD_INSTANCE}"
-    PATH_LOGS="$HOME/Library/Logs/rancher-desktop-${RDD_INSTANCE}"
+    PATH_APP_HOME="${HOME}/Library/Application Support/rancher-desktop-${RDD_INSTANCE}"
+    PATH_CONFIG="${HOME}/Library/Preferences/rancher-desktop-${RDD_INSTANCE}"
+    PATH_CACHE="${HOME}/Library/Caches/rancher-desktop-${RDD_INSTANCE}"
+    PATH_LOGS="${HOME}/Library/Logs/rancher-desktop-${RDD_INSTANCE}"
 fi
 
 if is_linux; then
-    PATH_APP_HOME="$HOME/.local/share/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CONFIG="$HOME/.config/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CACHE="$HOME/.cache/rancher-desktop-${RDD_INSTANCE}"
-    PATH_LOGS="$PATH_APP_HOME/logs"
+    PATH_APP_HOME="${HOME}/.local/share/rancher-desktop-${RDD_INSTANCE}"
+    PATH_CONFIG="${HOME}/.config/rancher-desktop-${RDD_INSTANCE}"
+    PATH_CACHE="${HOME}/.cache/rancher-desktop-${RDD_INSTANCE}"
+    PATH_LOGS="${PATH_APP_HOME}/logs"
 fi
 
 wslpath_from_win32_env() {
@@ -32,12 +32,12 @@ if is_windows; then
     PROGRAMFILES="$(wslpath_from_win32_env ProgramFiles)"
     SYSTEMROOT="$(wslpath_from_win32_env SystemRoot)"
 
-    PATH_APP_HOME="$LOCALAPPDATA/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CONFIG="$LOCALAPPDATA/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CACHE="$PATH_APP_HOME/cache"
-    PATH_LOGS="$PATH_APP_HOME/logs"
-    PATH_DISTRO="$PATH_APP_HOME/distro"
-    PATH_DISTRO_DATA="$PATH_APP_HOME/distro-data"
+    PATH_APP_HOME="${LOCALAPPDATA}/rancher-desktop-${RDD_INSTANCE}"
+    PATH_CONFIG="${LOCALAPPDATA}/rancher-desktop-${RDD_INSTANCE}"
+    PATH_CACHE="${PATH_APP_HOME}/cache"
+    PATH_LOGS="${PATH_APP_HOME}/logs"
+    PATH_DISTRO="${PATH_APP_HOME}/distro"
+    PATH_DISTRO_DATA="${PATH_APP_HOME}/distro-data"
 fi
 
-LIMA_HOME="$PATH_APP_HOME/lima"
+LIMA_HOME="${PATH_APP_HOME}/lima"

--- a/bats/helpers/paths.bash
+++ b/bats/helpers/paths.bash
@@ -20,17 +20,20 @@ if is_linux; then
     PATH_LOGS="${PATH_APP_HOME}/logs"
 fi
 
-wslpath_from_win32_env() {
-    # The cmd.exe _sometimes_ returns an empty string when invoked in a subshell
-    # wslpath "$(cmd.exe /c "echo %$1%" 2>/dev/null)" | tr -d "\r"
-    # Let's see if powershell.exe avoids this issue
-    wslpath "$(powershell.exe -Command "Write-Output \${Env:$1}")" | tr -d "\r"
+# Get the WSL (Unix) path for a Windows shell folder id; for a list of valid ids,
+# see https://learn.microsoft.com/en-us/dotnet/api/system.environment.specialfolder
+wslpath_from_win32_folder_id() {
+    local folder_id=$1
+    local windows_path
+    windows_path=$(powershell.exe -Command "[System.Environment]::GetFolderPath(${folder_id})")
+    local unix_path
+    unix_path=$(wslpath -u "${windows_path}")
+    tr -d "\r" <<<"${unix_path}"
 }
 
 if is_windows; then
-    LOCALAPPDATA="$(wslpath_from_win32_env LOCALAPPDATA)"
-    PROGRAMFILES="$(wslpath_from_win32_env ProgramFiles)"
-    SYSTEMROOT="$(wslpath_from_win32_env SystemRoot)"
+    LOCALAPPDATA="$(wslpath_from_win32_folder_id 28)"
+    PROGRAMFILES="$(wslpath_from_win32_folder_id 38)"
 
     PATH_APP_HOME="${LOCALAPPDATA}/rancher-desktop-${RDD_INSTANCE}"
     PATH_CONFIG="${LOCALAPPDATA}/rancher-desktop-${RDD_INSTANCE}"

--- a/bats/helpers/utils.bash
+++ b/bats/helpers/utils.bash
@@ -91,7 +91,7 @@ refute_file_contains() {
 ########################################################################
 
 extract_msg() {
-    echo "${output}" | sed -n 's/.*msg="\(.*\)"$/\1/p' | sed 's/\\"/"/g'
+    sed -n '/.*msg="\(.*\)"$/{ s//\1/; s/\\"/"/g; p; }' <<<"${output}"
 }
 
 # Convert raw string into properly quoted JSON string
@@ -139,6 +139,7 @@ jq_raw() {
     elif ((status == 0)); then
         # The command succeeded, so we should be able to run it again without error
         # If the jq command emitted a newline, then we want to emit a newline too.
+        # shellcheck disable=SC2312 # wc can't fail
         if [[ "$(jq --raw-output "${args[@]}" <<<"${json}" | wc -c)" -gt 0 ]]; then
             echo ""
         fi
@@ -188,6 +189,7 @@ semver_is_valid() {
 # (semver_eq and semver_neq don't really depend on the arguments being versions).
 # `A = B = C`
 semver_eq() {
+    # shellcheck disable=SC2312 # sort and wc can't fail.
     [[ $# -gt 0 ]] && [[ $(printf "%s\n" "$@" | sort --unique | wc -l) -eq 1 ]]
 }
 
@@ -195,6 +197,7 @@ semver_eq() {
 # `A ≠ B ≠ C` because semver_neq will also return a failure if `A = C`.
 # `(A ≠ B) & (A ≠ C) & (B ≠ C)`
 semver_neq() {
+    # shellcheck disable=SC2312 # sort can't fail.
     [[ $# -gt 0 ]] && printf "%s\n" "$@" | sort | sort --check=silent --unique
 }
 
@@ -256,7 +259,9 @@ comment() {
 # Set CALLER to print a calling function higher up in the call stack.
 trace() {
     if is_true "${RDD_TRACE}"; then
-        CALLER=${CALLER:-$(calling_function)} comment "$@"
+        local calling_function
+        calling_function=$(calling_function)
+        CALLER=${CALLER:-${calling_function}} comment "$@"
     fi
 }
 
@@ -344,7 +349,9 @@ update_allowed_patterns() {
     # If the enabled state changes, then the container engine will be restarted.
     # Record PID of the current daemon process so we can wait for it to be ready again.
     local pid
-    if [[ "${enabled}" != "$(get_setting .containerEngine.allowedImages.enabled)" ]]; then
+    local patterns_enabled
+    patterns_enabled=$(get_setting .containerEngine.allowedImages.enabled)
+    if [[ "${enabled}" != "${patterns_enabled}" ]]; then
         pid=$(get_service_pid "${CONTAINER_ENGINE_SERVICE}")
     fi
 
@@ -363,7 +370,8 @@ EOF
     if [[ -n ${pid:-} ]]; then
         try --max 15 --delay 5 refute_service_pid "${CONTAINER_ENGINE_SERVICE}" "${pid}"
         wait_for_container_engine
-        if [[ $(get_setting .kubernetes.enabled) == "true" ]]; then
+        enabled=$(get_setting .kubernetes.enabled)
+        if [[ "${enabled}" == "true" ]]; then
             wait_for_kubelet
         fi
     fi

--- a/bats/helpers/utils.bash
+++ b/bats/helpers/utils.bash
@@ -10,7 +10,7 @@ is_true() {
     # case-insensitive check; false values: '', '0', 'no', and 'false'
     local value
     value=$(to_lower "$1")
-    [[ ! $value =~ ^(0|no|false)?$ ]]
+    [[ ! ${value} =~ ^(0|no|false)?$ ]]
 }
 
 is_false() {
@@ -35,11 +35,11 @@ validate_enum() {
     local var=$1
     shift
     for value in "$@"; do
-        if [[ ${!var} == "$value" ]]; then
+        if [[ ${!var} == "${value}" ]]; then
             return
         fi
     done
-    fatal "$var=${!var} is not a valid setting; select from [$*]"
+    fatal "${var}=${!var} is not a valid setting; select from [$*]"
 }
 
 # Ensure that the variable contains a valid semver (major.minor.path) version, e.g.
@@ -47,7 +47,7 @@ validate_enum() {
 validate_semver() {
     local var=$1
     if ! semver_is_valid "${!var}"; then
-        fatal "$var=${!var} is not a valid semver value (major.minor.patch)"
+        fatal "${var}=${!var} is not a valid semver value (major.minor.patch)"
     fi
 }
 
@@ -91,7 +91,7 @@ refute_file_contains() {
 ########################################################################
 
 extract_msg() {
-    echo "$output" | sed -n 's/.*msg="\(.*\)"$/\1/p' | sed 's/\\"/"/g'
+    echo "${output}" | sed -n 's/.*msg="\(.*\)"$/\1/p' | sed 's/\\"/"/g'
 }
 
 # Convert raw string into properly quoted JSON string
@@ -111,14 +111,14 @@ join_map() {
     local elem
     local result=""
     for elem in "$@"; do
-        elem=$(eval "$map" '"$elem"')
-        if [[ -z $result ]]; then
-            result=$elem
+        elem=$(eval "${map}" '"$elem"')
+        if [[ -z ${result} ]]; then
+            result=${elem}
         else
             result="${result}${sep}${elem}"
         fi
     done
-    echo "$result"
+    echo "${result}"
 }
 
 # Extract raw value from a JSON object in a string (last argument).
@@ -127,28 +127,28 @@ join_map() {
 jq_raw() {
     local args=("$@")
     local last=$((${#args[@]} - 1))
-    local json=${args[$last]}
-    unset "args[$last]"
+    local json=${args[${last}]}
+    unset "args[${last}]"
 
     run jq --raw-output "${args[@]}" <<<"${json}"
-    if [[ -n $output ]]; then
-        echo "$output"
-        if [[ $output == null ]]; then
+    if [[ -n ${output} ]]; then
+        echo "${output}"
+        if [[ ${output} == null ]]; then
             status=1
         fi
     elif ((status == 0)); then
         # The command succeeded, so we should be able to run it again without error
         # If the jq command emitted a newline, then we want to emit a newline too.
-        if [ "$(jq --raw-output "${args[@]}" <<<"${json}" | wc -c)" -gt 0 ]; then
+        if [[ "$(jq --raw-output "${args[@]}" <<<"${json}" | wc -c)" -gt 0 ]]; then
             echo ""
         fi
     fi
-    return "$status"
+    return "${status}"
 }
 
 # Run jq_raw on the current $output
 jq_output() {
-    jq_raw "$@" "$output"
+    jq_raw "$@" "${output}"
 }
 
 # semver returns the first semver version from its first argument (which may be multiple lines).
@@ -160,20 +160,20 @@ jq_output() {
 semver() {
     local input=$1
     local semver
-    semver=$(awk 'match($0, /([0-9]+\.[0-9]+\.[0-9]+)/) {print substr($0, RSTART, RLENGTH); exit}' <<<"$input")
-    if [[ -z $semver ]]; then
-        semver=$(awk 'match($0, /([0-9]+\.[0-9]+)/) {print substr($0, RSTART, RLENGTH); exit}' <<<"$input")
+    semver=$(awk 'match($0, /([0-9]+\.[0-9]+\.[0-9]+)/) {print substr($0, RSTART, RLENGTH); exit}' <<<"${input}")
+    if [[ -z ${semver} ]]; then
+        semver=$(awk 'match($0, /([0-9]+\.[0-9]+)/) {print substr($0, RSTART, RLENGTH); exit}' <<<"${input}")
     fi
-    if [[ -z $semver ]]; then
-        semver=$(awk 'match($0, /([0-9]+)/) {print substr($0, RSTART, RLENGTH); exit}' <<<"$input")
+    if [[ -z ${semver} ]]; then
+        semver=$(awk 'match($0, /([0-9]+)/) {print substr($0, RSTART, RLENGTH); exit}' <<<"${input}")
     fi
-    if [[ -z $semver ]]; then
+    if [[ -z ${semver} ]]; then
         return 1
     fi
-    until [[ $semver =~ \..+\. ]]; do
+    until [[ ${semver} =~ \..+\. ]]; do
         semver="${semver}.0"
     done
-    sed -E 's/^0*([0-9])/\1/; s/\.0*([0-9])/.\1/g' <<<"$semver"
+    sed -E 's/^0*([0-9])/\1/; s/\.0*([0-9])/.\1/g' <<<"${semver}"
 }
 
 # Check if the argument is a valid 3-tuple version number with no leading 0s and no newlines
@@ -238,16 +238,16 @@ calling_function() {
 # Set CALLER to print a calling function higher up in the call stack.
 comment() {
     local prefix=""
-    if is_true "$RDD_TRACE"; then
+    if is_true "${RDD_TRACE}"; then
         local caller="${CALLER:-$(calling_function)}"
         prefix="($(date -u +"%FT%TZ"): ${caller}): "
     fi
     local line
     while IFS= read -r line; do
         if [[ -e /dev/fd/3 ]]; then
-            printf "# %s%s\n" "$prefix" "$line" >&3
+            printf "# %s%s\n" "${prefix}" "${line}" >&3
         else
-            printf "# %s%s\n" "$prefix" "$line" >&2
+            printf "# %s%s\n" "${prefix}" "${line}" >&2
         fi
     done <<<"$*"
 }
@@ -255,7 +255,7 @@ comment() {
 # Write a comment to the TAP stream if RDD_TRACE is set.
 # Set CALLER to print a calling function higher up in the call stack.
 trace() {
-    if is_true "$RDD_TRACE"; then
+    if is_true "${RDD_TRACE}"; then
         CALLER=${CALLER:-$(calling_function)} comment "$@"
     fi
 }
@@ -307,20 +307,20 @@ try() {
             success=$((status == 0))
         fi
         if ((success || ++count >= max)); then
-            trace "$count/$max tries: $*"
+            trace "${count}/${max} tries: $*"
             break
         fi
-        sleep "$delay"
+        sleep "${delay}"
     done
-    echo "$output"
-    if [ -n "${stderr:-}" ]; then
-        echo "$stderr" >&2
+    echo "${output}"
+    if [[ -n "${stderr:-}" ]]; then
+        echo "${stderr}" >&2
     fi
     # When using --until-fail, return 0 if we successfully waited for failure, 1 if we timed out
     if ((until_fail)); then
         return $((success ? 0 : 1))
     fi
-    return "$status"
+    return "${status}"
 }
 
 image_without_tag_as_json_string() {
@@ -328,7 +328,7 @@ image_without_tag_as_json_string() {
     # If the tag looks like a port number and follows something that looks
     # like a domain name, then don't strip the tag (e.g. foo.io:5000).
     if [[ ${image##*:} =~ ^[0-9]+(/|$) && ${image%:*} =~ \.[a-z]+$ ]]; then
-        json_string "$image"
+        json_string "${image}"
     else
         json_string "${image%:*}"
     fi
@@ -344,8 +344,8 @@ update_allowed_patterns() {
     # If the enabled state changes, then the container engine will be restarted.
     # Record PID of the current daemon process so we can wait for it to be ready again.
     local pid
-    if [ "$enabled" != "$(get_setting .containerEngine.allowedImages.enabled)" ]; then
-        pid=$(get_service_pid "$CONTAINER_ENGINE_SERVICE")
+    if [[ "${enabled}" != "$(get_setting .containerEngine.allowedImages.enabled)" ]]; then
+        pid=$(get_service_pid "${CONTAINER_ENGINE_SERVICE}")
     fi
 
     rdctl api settings -X PUT --input - <<EOF
@@ -353,15 +353,15 @@ update_allowed_patterns() {
   "version": 8,
   "containerEngine": {
     "allowedImages": {
-      "enabled": $enabled,
-      "patterns": [$patterns]
+      "enabled": ${enabled},
+      "patterns": [${patterns}]
     }
   }
 }
 EOF
     # Wait for container engine (and Kubernetes) to be ready again
     if [[ -n ${pid:-} ]]; then
-        try --max 15 --delay 5 refute_service_pid "$CONTAINER_ENGINE_SERVICE" "$pid"
+        try --max 15 --delay 5 refute_service_pid "${CONTAINER_ENGINE_SERVICE}" "${pid}"
         wait_for_container_engine
         if [[ $(get_setting .kubernetes.enabled) == "true" ]]; then
             wait_for_kubelet
@@ -379,8 +379,8 @@ create_file() {
     # where the WSL view of the filesystem is desynchronized from the Windows
     # view, so we end up having ghost files that can't be deleted from Windows.
     if ! is_windows; then
-        mkdir -p "$(dirname "$dest")"
-        cat >"$dest"
+        mkdir -p "$(dirname "${dest}")"
+        cat >"${dest}"
         return
     fi
 
@@ -389,11 +389,11 @@ create_file() {
 
     local winParent
     local winDest
-    winParent="$(wslpath -w "$(dirname "$dest")")"
-    winDest="$(wslpath -w "$dest")"
-    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "New-Item -ItemType Directory -ErrorAction SilentlyContinue '$winParent'" || true
-    local command="[IO.File]::WriteAllBytes('$winDest', \$([System.Convert]::FromBase64String('$contents')))"
-    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "$command"
+    winParent="$(wslpath -w "$(dirname "${dest}")")"
+    winDest="$(wslpath -w "${dest}")"
+    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "New-Item -ItemType Directory -ErrorAction SilentlyContinue '${winParent}'" || true
+    local command="[IO.File]::WriteAllBytes('${winDest}', \$([System.Convert]::FromBase64String('${contents}')))"
+    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "${command}"
 }
 
 # unique_filename /tmp/image .png
@@ -406,8 +406,8 @@ unique_filename() {
 
     while true; do
         local filename="${basename}${suffix}${extension}"
-        if [[ ! -e $filename ]]; then
-            echo "$filename"
+        if [[ ! -e ${filename} ]]; then
+            echo "${filename}"
             return
         fi
         suffix="_$((++index))"
@@ -419,14 +419,14 @@ skip_unless_host_ip() {
         # Make sure the exit code is 0 even when netsh.exe or grep fails, in case errexit is in effect
         HOST_IP=$(netsh.exe interface ip show addresses 'vEthernet (WSL)' | grep -Po 'IP Address:\s+\K[\d.]+' || :)
         # The veth interface name changed at some time on Windows 11, so try the new name if the old one doesn't exist
-        if [[ -z $HOST_IP ]]; then
+        if [[ -z ${HOST_IP} ]]; then
             HOST_IP=$(netsh.exe interface ip show addresses 'vEthernet (WSL (Hyper-V firewall))' | grep -Po 'IP Address:\s+\K[\d.]+' || :)
         fi
     else
         # TODO determine if the Lima VM has its own IP address
         HOST_IP=""
     fi
-    if [[ -z $HOST_IP ]]; then
+    if [[ -z ${HOST_IP} ]]; then
         skip "Test requires a routable host ip address"
     fi
 }
@@ -437,11 +437,11 @@ skip_unless_host_ip() {
 # Versions can be filtered by RD_K3S_MIN and RD_K3S_MAX.
 foreach_k3s_version() {
     local k3s_version
-    for k3s_version in $RD_K3S_VERSIONS; do
-        if semver_lte "$RD_K3S_MIN" "$k3s_version" "$RD_K3S_MAX"; then
+    for k3s_version in ${RD_K3S_VERSIONS}; do
+        if semver_lte "${RD_K3S_MIN}" "${k3s_version}" "${RD_K3S_MAX}"; then
             local cmd
             for cmd in "$@"; do
-                bats_test_function --description "$cmd $k3s_version" -- _foreach_k3s_version "$k3s_version" "$cmd"
+                bats_test_function --description "${cmd} ${k3s_version}" -- _foreach_k3s_version "${k3s_version}" "${cmd}"
             done
         fi
     done
@@ -451,8 +451,8 @@ _foreach_k3s_version() {
     local RD_KUBERNETES_VERSION=$1
     local skip_kubernetes_version
     skip_kubernetes_version=$(cat "${BATS_FILE_TMPDIR}/skip-kubernetes-version" 2>/dev/null || echo none)
-    if [[ $skip_kubernetes_version == "$RD_KUBERNETES_VERSION" ]]; then
-        skip "All remaining tests for Kubernetes $RD_KUBERNETES_VERSION are skipped"
+    if [[ ${skip_kubernetes_version} == "${RD_KUBERNETES_VERSION}" ]]; then
+        skip "All remaining tests for Kubernetes ${RD_KUBERNETES_VERSION} are skipped"
     fi
     "$2"
 }
@@ -460,7 +460,7 @@ _foreach_k3s_version() {
 # Tests can call mark_k3s_version_skipped to skip the rest of the tests within
 # this iteration of foreach_k3s_version.
 mark_k3s_version_skipped() {
-    echo "$RD_KUBERNETES_VERSION" >"${BATS_FILE_TMPDIR}/skip-kubernetes-version"
+    echo "${RD_KUBERNETES_VERSION}" >"${BATS_FILE_TMPDIR}/skip-kubernetes-version"
 }
 
 ########################################################################
@@ -479,13 +479,13 @@ save_var() {
     local var
     for var in "$@"; do
         # Using [[ -v $var ]] requires bash 4.2 but macOS only ships with 3.2
-        if [ -n "${!var+exists}" ]; then
-            printf "%s=%q\n" "$var" "${!var}" >"$(_var_filename "$var")"
+        if [[ -n "${!var+exists}" ]]; then
+            printf "%s=%q\n" "${var}" "${!var}" >"$(_var_filename "${var}")"
         else
             res=1
         fi
     done
-    return $res
+    return "${res}"
 }
 
 # Load env variables saved by `save_var`. Returns an error if any of the variables
@@ -496,13 +496,13 @@ load_var() {
     local var
     for var in "$@"; do
         local file
-        file=$(_var_filename "$var")
-        if [[ -r $file ]]; then
+        file=$(_var_filename "${var}")
+        if [[ -r ${file} ]]; then
             # shellcheck disable=SC1090 # Can't follow non-constant source
-            source "$file"
+            source "${file}"
         else
             res=1
         fi
     done
-    return $res
+    return "${res}"
 }

--- a/bats/helpers/utils.bats
+++ b/bats/helpers/utils.bats
@@ -221,7 +221,9 @@ get_json_test_data() {
 }
 
 @test 'jq must be version 1.7.1 or newer' {
-    run semver "$(jq --version)"
+    local version
+    version=$(jq --version)
+    run semver "${version}"
     assert_success
     semver_gte "${output}" 1.7.1
 }

--- a/bats/helpers/utils.bats
+++ b/bats/helpers/utils.bats
@@ -10,15 +10,15 @@ local_setup() {
 }
 
 reset_counter() {
-    echo 0 >"$COUNTER"
+    echo 0 >"${COUNTER}"
     SECONDS=0
 }
 
 # Increment counter file. Return success when counter >= max.
 inc_counter() {
     local max=${1-9999}
-    local counter=$(($(cat "$COUNTER") + 1))
-    echo $counter >"$COUNTER"
+    local counter=$(($(cat "${COUNTER}") + 1))
+    echo "${counter}" >"${COUNTER}"
     ((counter >= max))
 }
 
@@ -32,7 +32,7 @@ is() {
     # shellcheck disable=SC2086 # we want to split on whitespace
     run ${BATS_TEST_DESCRIPTION}
     assert_success
-    assert_output "$expect"
+    assert_output "${expect}"
 }
 
 is_quoted() {
@@ -89,13 +89,13 @@ check_truthiness() {
 
     # test true values
     for value in 1 true True TRUE yes Yes YES any; do
-        run "$predicate" "$value"
+        run "${predicate}" "${value}"
         "${assert}_success"
     done
 
     # test false values
     for value in 0 false False FALSE no No NO ''; do
-        run "$predicate" "$value"
+        run "${predicate}" "${value}"
         "${assert}_failure"
     done
 }
@@ -138,7 +138,7 @@ check_truthiness() {
     # Exactly one of the is_xxx functions should return true
     count=0
     for os in linux macos windows; do
-        if "is_$os"; then
+        if "is_${os}"; then
             ((++count))
         fi
     done
@@ -223,7 +223,7 @@ get_json_test_data() {
 @test 'jq must be version 1.7.1 or newer' {
     run semver "$(jq --version)"
     assert_success
-    semver_gte "$output" 1.7.1
+    semver_gte "${output}" 1.7.1
 }
 
 ########################################################################
@@ -499,7 +499,7 @@ get_json_test_data() {
 
 @test 'try returns stdout and stderr together' {
     run try --max 1 sh -c 'echo foo; echo bar >&2; echo baz'
-    trace "output=$output"
+    trace "output=${output}"
     trace "stderr=${stderr:-}"
     assert_success
     # output is currently re-ordered that all stderr follows all stdout
@@ -512,11 +512,11 @@ get_json_test_data() {
 
 @test 'try supports --separate-stderr' {
     run --separate-stderr try --max 1 sh -c 'echo foo; echo bar >&2; echo baz'
-    trace "output=$output"
+    trace "output=${output}"
     trace "stderr=${stderr:-}"
     assert_success
     assert_output foo$'\n'baz
-    output=$stderr assert_output bar
+    output=${stderr} assert_output bar
 }
 
 @test 'try will run command at least once' {
@@ -641,28 +641,28 @@ get_json_test_data() {
 ########################################################################
 
 @test 'unique_filename without extension' {
-    run unique_filename "$COUNTER"
+    run unique_filename "${COUNTER}"
     assert_success
     assert_output "${COUNTER}_2"
-    touch "$output"
+    touch "${output}"
 
-    run unique_filename "$COUNTER"
+    run unique_filename "${COUNTER}"
     assert_success
     assert_output "${COUNTER}_3"
 }
 
 @test 'unique_filename with extension' {
-    run unique_filename "$COUNTER" .png
+    run unique_filename "${COUNTER}" .png
     assert_success
     assert_output "${COUNTER}.png"
-    touch "$output"
+    touch "${output}"
 
-    run unique_filename "$COUNTER" .png
+    run unique_filename "${COUNTER}" .png
     assert_success
     assert_output "${COUNTER}_2.png"
-    touch "$output"
+    touch "${output}"
 
-    run unique_filename "$COUNTER" .png
+    run unique_filename "${COUNTER}" .png
     assert_success
     assert_output "${COUNTER}_3.png"
 }
@@ -678,8 +678,8 @@ get_json_test_data() {
     # shellcheck disable=SC2030
     FOO=bar BAR=bar
     load_var FOO BAR
-    [[ $FOO == baz ]]
-    [[ $BAR == foo ]]
+    [[ ${FOO} == baz ]]
+    [[ ${BAR} == foo ]]
 }
 
 @test 'save_var mix of existing and non-existing variables' {
@@ -687,18 +687,18 @@ get_json_test_data() {
     FAILED=false
     # Don't use run because it may mask errexit failures
     save_var ONE DOES_NOT_EXIST TWO || FAILED=true
-    [[ $FAILED == true ]]
-    [[ $ONE == one ]]
-    [[ $TWO == two ]]
+    [[ ${FAILED} == true ]]
+    [[ ${ONE} == one ]]
+    [[ ${TWO} == two ]]
 }
 
 @test 'load_var mix of existing and non-existing variables' {
     DOES_NOT_EXIST=false
     # Can't use `run` because variable would be loaded in a subshell
     load_var FOO DOES_NOT_EXIST BAR || DOES_NOT_EXIST=true
-    [[ $DOES_NOT_EXIST == true ]]
+    [[ ${DOES_NOT_EXIST} == true ]]
     # shellcheck disable=SC2031
-    [[ $FOO == baz ]]
+    [[ ${FOO} == baz ]]
     # shellcheck disable=SC2031
-    [[ $BAR == foo ]]
+    [[ ${BAR} == foo ]]
 }

--- a/bats/tests/10-cli/1-version.bats
+++ b/bats/tests/10-cli/1-version.bats
@@ -37,8 +37,8 @@ assert_version() {
 
 @test 'rdd --version and rdd version produce same output' {
     run -0 rdd --version
-    local version_flag_output="$output"
+    local version_flag_output="${output}"
 
     run -0 rdd version
-    assert_output "$version_flag_output"
+    assert_output "${version_flag_output}"
 }

--- a/bats/tests/10-cli/2-instance.bats
+++ b/bats/tests/10-cli/2-instance.bats
@@ -7,14 +7,14 @@ load '../../helpers/load'
 }
 
 @test 'RDD_INSTANCE overrides default instance' {
-    [[ $RDD_INSTANCE != "2" ]]
+    [[ ${RDD_INSTANCE} != "2" ]]
     run -0 rdd svc status
     assert_line --partial "rancher-desktop-${RDD_INSTANCE}"
     refute_line --partial "rancher-desktop-2"
 }
 
 @test '--instance overrides RDD_INSTANCE' {
-    [[ $RDD_INSTANCE != "vampire" ]]
+    [[ ${RDD_INSTANCE} != "vampire" ]]
     run -0 rdd --instance vampire svc status
     assert_line --partial "rancher-desktop-vampire"
     refute_line --partial "rancher-desktop-${RDD_INSTANCE}"

--- a/bats/tests/10-cli/4-log-level.bats
+++ b/bats/tests/10-cli/4-log-level.bats
@@ -2,8 +2,8 @@ load '../../helpers/load'
 
 assert_klog_level() {
     local level=$1
-    run -0 jq --compact-output . "$PATH_APP_HOME/args.json"
-    assert_line --partial "\"-v\",\"$level\""
+    run -0 jq --compact-output . "${PATH_APP_HOME}/args.json"
+    assert_line --partial "\"-v\",\"${level}\""
 }
 
 # Test log level validation

--- a/bats/tests/20-service/2-create.bats
+++ b/bats/tests/20-service/2-create.bats
@@ -4,7 +4,7 @@ load '../../helpers/load'
 
 @test 'Make sure instance does not exist' {
     rdd svc delete || :
-    assert_dir_not_exist "$PATH_APP_HOME"
+    assert_dir_not_exist "${PATH_APP_HOME}"
 }
 
 @test 'Delete instance succeeds even when the instance does not exist' {
@@ -23,7 +23,7 @@ load '../../helpers/load'
     run -0 rdd svc create
     run -0 extract_msg
     assert_output "successfully created \"rancher-desktop-${RDD_INSTANCE}\" control plane"
-    assert_dir_exist "$PATH_APP_HOME"
+    assert_dir_exist "${PATH_APP_HOME}"
 }
 
 @test 'verify instance does exist but has not been started' {
@@ -55,7 +55,7 @@ EOT
     run -0 rdd svc stop
     run -0 extract_msg
     assert_output "successfully stopped \"rancher-desktop-${RDD_INSTANCE}\" control plane"
-    assert_dir_exist "$PATH_APP_HOME"
+    assert_dir_exist "${PATH_APP_HOME}"
 }
 
 @test 'verify instance has been stopped' {
@@ -70,7 +70,7 @@ EOT
     run -0 rdd svc delete
     run -0 extract_msg
     assert_output "successfully deleted \"rancher-desktop-${RDD_INSTANCE}\" control plane"
-    assert_dir_not_exist "$PATH_APP_HOME"
+    assert_dir_not_exist "${PATH_APP_HOME}"
 }
 
 @test 'verify instance has been deleted' {

--- a/bats/tests/20-service/4-start-parameters.bats
+++ b/bats/tests/20-service/4-start-parameters.bats
@@ -63,9 +63,9 @@ assert_no_controllers() {
 
     # Verify parameters were saved
     ARGS_JSON="${PATH_APP_HOME}/args.json"
-    assert_file_exist "$ARGS_JSON"
-    assert_file_contains "$ARGS_JSON" '"--controllers"'
-    assert_file_contains "$ARGS_JSON" '"rdd"'
+    assert_file_exist "${ARGS_JSON}"
+    assert_file_contains "${ARGS_JSON}" '"--controllers"'
+    assert_file_contains "${ARGS_JSON}" '"rdd"'
 }
 
 @test 'start instance uses saved parameters by default' {

--- a/bats/tests/20-service/5-port-fallback.bats
+++ b/bats/tests/20-service/5-port-fallback.bats
@@ -16,7 +16,7 @@ local_teardown() {
 get_kubeconfig_port() {
     run -0 rdd ctl config view --output='jsonpath={.clusters[0].cluster.server}'
     # shellcheck disable=SC2001 # shell replace doesn't do captures.
-    sed 's/.*127\.0\.0\.1:\([0-9]*\).*/\1/' <<<"$output"
+    sed 's/.*127\.0\.0\.1:\([0-9]*\).*/\1/' <<<"${output}"
 }
 
 # Get the status of a port on localhost; e,g, "LISTEN", "TIME_WAIT"
@@ -25,17 +25,17 @@ get_port_status() {
     # some Linux distros no longer include netstat, but ss is not available on macOS
     if command -v ss &>/dev/null; then
         run -0 ss -an -f inet
-        awk "/^tcp.*127\.0\.0\.1:${port} / { print \$2; exit }" <<<"$output"
+        awk "/^tcp.*127\.0\.0\.1:${port} / { print \$2; exit }" <<<"${output}"
     else
         run -0 netstat -an -f inet
-        awk "/^tcp.*127\.0\.0\.1\.${port} / { print \$NF; exit }" <<<"$output"
+        awk "/^tcp.*127\.0\.0\.1\.${port} / { print \$NF; exit }" <<<"${output}"
     fi
 }
 
 # Check if a port is available on localhost
 is_port_available() {
     local port=$1
-    [[ -z $(get_port_status "$port") ]]
+    [[ -z $(get_port_status "${port}") ]]
 }
 
 # Test basic functionality without port conflicts
@@ -46,20 +46,20 @@ is_port_available() {
     expected_port=$(get_expected_port 6443)
 
     # Skip test if the expected port is not available
-    if ! is_port_available "$expected_port"; then
-        skip "Port $expected_port is not available for testing"
+    if ! is_port_available "${expected_port}"; then
+        skip "Port ${expected_port} is not available for testing"
     fi
 
     ARGS_JSON="${PATH_APP_HOME}/args.json"
-    assert_file_exist "$ARGS_JSON"
-    assert_file_contains "$ARGS_JSON" '"--secure-port"'
-    assert_file_contains "$ARGS_JSON" "\"$expected_port\""
+    assert_file_exist "${ARGS_JSON}"
+    assert_file_contains "${ARGS_JSON}" '"--secure-port"'
+    assert_file_contains "${ARGS_JSON}" "\"${expected_port}\""
 
     rdd svc start
 
     # Verify kubeconfig uses the expected port
     run -0 get_kubeconfig_port
-    assert_output "$expected_port"
+    assert_output "${expected_port}"
 
     # Verify API works
     run -0 rdd ctl get namespaces
@@ -72,26 +72,26 @@ is_port_available() {
     # Calculate expected port dynamically and occupy it
     expected_port=$(get_expected_port)
 
-    try --max 30 --delay 1 is_port_available "$expected_port" || :
-    if ! is_port_available "$expected_port"; then
-        skip "Port $expected_port is not available for testing"
+    try --max 30 --delay 1 is_port_available "${expected_port}" || :
+    if ! is_port_available "${expected_port}"; then
+        skip "Port ${expected_port} is not available for testing"
     fi
 
-    nc -l 127.0.0.1 "$expected_port" &
+    nc -l 127.0.0.1 "${expected_port}" &
     NETCAT_PIDS+=($!)
 
     # Give netcat time to bind
     sleep 1
 
     # Verify the port is actually occupied
-    run is_port_available "$expected_port"
+    run is_port_available "${expected_port}"
     assert_failure
 
     # Start RDD - it should fall back to a different port
     rdd svc start
 
     run -0 get_kubeconfig_port
-    refute_output "$expected_port"
+    refute_output "${expected_port}"
 
     # Verify API works on the fallback port
     run -0 rdd ctl get namespaces
@@ -108,7 +108,7 @@ is_port_available() {
     # Occupy both the desired port and default fallback (6443) on localhost
     nc -l 127.0.0.1 6443 &
     NETCAT_PIDS+=($!)
-    nc -l 127.0.0.1 "$expected_port" &
+    nc -l 127.0.0.1 "${expected_port}" &
     NETCAT_PIDS+=($!)
 
     # Give netcat time to bind
@@ -117,7 +117,7 @@ is_port_available() {
     # Verify both ports are occupied
     run is_port_available 6443
     assert_failure
-    run is_port_available "$expected_port"
+    run is_port_available "${expected_port}"
     assert_failure
 
     # Start RDD - it should fall back to a random available port
@@ -126,10 +126,10 @@ is_port_available() {
     # Get the port from kubeconfig
     run -0 get_kubeconfig_port
     refute_output "6443"
-    refute_output "$expected_port"
+    refute_output "${expected_port}"
 
     # Should be a high random port (typically > 1024)
-    [[ $output -gt 1024 ]]
+    [[ ${output} -gt 1024 ]]
 
     # Verify API works on the random fallback port
     run -0 rdd ctl get namespaces
@@ -176,9 +176,9 @@ is_port_available() {
 
     # Verify the port is saved in args.json
     ARGS_JSON="${PATH_APP_HOME}/args.json"
-    assert_file_exist "$ARGS_JSON"
-    assert_file_contains "$ARGS_JSON" '"--secure-port"'
-    assert_file_contains "$ARGS_JSON" '"7777"'
+    assert_file_exist "${ARGS_JSON}"
+    assert_file_contains "${ARGS_JSON}" '"--secure-port"'
+    assert_file_contains "${ARGS_JSON}" '"7777"'
 
     # Start the service
     rdd svc start

--- a/bats/tests/20-service/5-port-fallback.bats
+++ b/bats/tests/20-service/5-port-fallback.bats
@@ -35,7 +35,9 @@ get_port_status() {
 # Check if a port is available on localhost
 is_port_available() {
     local port=$1
-    [[ -z $(get_port_status "${port}") ]]
+    local port_status
+    port_status=$(get_port_status "${port}")
+    [[ -z "${port_status}" ]]
 }
 
 # Test basic functionality without port conflicts

--- a/bats/tests/31-rdd-controllers/configmapreplicaset.bats
+++ b/bats/tests/31-rdd-controllers/configmapreplicaset.bats
@@ -42,7 +42,7 @@ delete_configmapreplicaset() {
 wait_for_configmaps() {
     local name=$1
     local expected=$2
-    wait_for_resource_count "configmaps" "$CONFIGMAP_CONTROLLER_NAME" "${name}" "${expected}"
+    wait_for_resource_count "configmaps" "${CONFIGMAP_CONTROLLER_NAME}" "${name}" "${expected}"
 }
 
 @test 'create ConfigMapReplicaSet resource' {
@@ -68,17 +68,17 @@ wait_for_configmaps() {
 @test 'verify ConfigMap content includes original data plus index' {
     # Check first ConfigMap contains original data plus index
     run -0 rdd ctl get configmap basic-0 -o json
-    local basic0_json="$output"
+    local basic0_json="${output}"
 
-    run -0 jq -r '.data | keys[]' <<<"$basic0_json"
+    run -0 jq -r '.data | keys[]' <<<"${basic0_json}"
     assert_line "config.yaml"
     assert_line "app.properties"
     assert_line "index"
 
-    run -0 jq -r '.data."config.yaml"' <<<"$basic0_json"
+    run -0 jq -r '.data."config.yaml"' <<<"${basic0_json}"
     assert_output --partial "test-app"
 
-    run -0 jq -r '.data."app.properties"' <<<"$basic0_json"
+    run -0 jq -r '.data."app.properties"' <<<"${basic0_json}"
     assert_output --partial "server.port=8080"
 
     run -0 rdd ctl get configmap basic-0 -o jsonpath='{.data.index}'
@@ -91,53 +91,53 @@ wait_for_configmaps() {
 
 @test 'verify ConfigMap owner references are set' {
     run -0 rdd ctl get configmap basic-0 -o json
-    local configmap_json="$output"
+    local configmap_json="${output}"
 
     # Verify owner reference exists and has correct kind
-    run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"$configmap_json"
+    run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"${configmap_json}"
     assert_output "ConfigMapReplicaSet"
 
-    run -0 jq -r '.metadata.ownerReferences[0].name' <<<"$configmap_json"
+    run -0 jq -r '.metadata.ownerReferences[0].name' <<<"${configmap_json}"
     assert_output "basic"
 
     # Verify the controller reference is set for garbage collection
-    run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"$configmap_json"
+    run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"${configmap_json}"
     assert_output "true"
 
-    run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion' <<<"$configmap_json"
+    run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion' <<<"${configmap_json}"
     assert_output "true"
 }
 
 @test 'debug owner references before deletion' {
     # Extract and validate complete owner reference structure
     run -0 rdd ctl get ConfigMapReplicaSet basic -o json
-    local parent_json="$output"
+    local parent_json="${output}"
 
-    run -0 jq -r '.metadata.uid' <<<"$parent_json"
-    local parent_uid=$output
+    run -0 jq -r '.metadata.uid' <<<"${parent_json}"
+    local parent_uid=${output}
 
-    run -0 jq -r '.apiVersion' <<<"$parent_json"
-    local parent_api_version=$output
+    run -0 jq -r '.apiVersion' <<<"${parent_json}"
+    local parent_api_version=${output}
 
     # Verify owner reference structure
     run -0 rdd ctl get configmap basic-0 -o json
-    local configmap="$output"
+    local configmap="${output}"
 
     # Verify critical owner reference fields
-    run -0 jq -r '.metadata.ownerReferences[0].uid // empty' <<<"$configmap"
-    local ref_uid=$output
-    run -0 jq -r '.metadata.ownerReferences[0].controller // false' <<<"$configmap"
-    local ref_controller=$output
-    run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion // false' <<<"$configmap"
-    local ref_block_deletion=$output
-    run -0 jq -r '.metadata.ownerReferences[0].apiVersion // empty' <<<"$configmap"
-    local ref_api_version=$output
+    run -0 jq -r '.metadata.ownerReferences[0].uid // empty' <<<"${configmap}"
+    local ref_uid=${output}
+    run -0 jq -r '.metadata.ownerReferences[0].controller // false' <<<"${configmap}"
+    local ref_controller=${output}
+    run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion // false' <<<"${configmap}"
+    local ref_block_deletion=${output}
+    run -0 jq -r '.metadata.ownerReferences[0].apiVersion // empty' <<<"${configmap}"
+    local ref_api_version=${output}
 
     # Validate all fields are correct
-    [ "$ref_uid" = "$parent_uid" ]
-    [ "$ref_controller" = "true" ]
-    [ "$ref_block_deletion" = "true" ]
-    [ "$ref_api_version" = "$parent_api_version" ]
+    [[ "${ref_uid}" = "${parent_uid}" ]]
+    [[ "${ref_controller}" = "true" ]]
+    [[ "${ref_block_deletion}" = "true" ]]
+    [[ "${ref_api_version}" = "${parent_api_version}" ]]
 }
 
 @test 'scale ConfigMapReplicaSet up to 5 replicas' {
@@ -150,14 +150,14 @@ wait_for_configmaps() {
 
 @test 'verify all 5 ConfigMaps exist after scaling up' {
     run -0 rdd ctl get configmaps -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=basic -o json
-    local configmaps="$output"
+    local configmaps="${output}"
 
     # Verify we have exactly 5 ConfigMaps
-    run -0 jq '.items | length' <<<"$configmaps"
+    run -0 jq '.items | length' <<<"${configmaps}"
     assert_output "5"
 
     # Verify correct names
-    run -0 jq -r '.items | map(.metadata.name) | sort | .[]' <<<"$configmaps"
+    run -0 jq -r '.items | map(.metadata.name) | sort | .[]' <<<"${configmaps}"
     assert_line "basic-0"
     assert_line "basic-1"
     assert_line "basic-2"
@@ -175,14 +175,14 @@ wait_for_configmaps() {
 
 @test 'verify only 2 ConfigMaps remain after scaling down' {
     run -0 rdd ctl get configmaps -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=basic -o json
-    local configmaps="$output"
+    local configmaps="${output}"
 
     # Verify we have exactly 2 ConfigMaps
-    run -0 jq '.items | length' <<<"$configmaps"
+    run -0 jq '.items | length' <<<"${configmaps}"
     assert_output "2"
 
     # Verify the remaining ConfigMaps are the first two
-    run -0 jq -r '.items | map(.metadata.name) | sort | .[]' <<<"$configmaps"
+    run -0 jq -r '.items | map(.metadata.name) | sort | .[]' <<<"${configmaps}"
     assert_line "basic-0"
     assert_line "basic-1"
 }
@@ -199,64 +199,64 @@ wait_for_configmaps() {
 
     # Verify old ConfigMaps (0,1) still have original data
     run -0 rdd ctl get configmap basic-0 -o json
-    local basic0_json="$output"
+    local basic0_json="${output}"
 
-    run -0 jq -r '.data."config.yaml"' <<<"$basic0_json"
+    run -0 jq -r '.data."config.yaml"' <<<"${basic0_json}"
     assert_output --partial "test-app"
     refute_output --partial "updated: true"
     refute_output --partial "version: 2.0.0"
 
-    run -0 jq -r '.data."app.properties"' <<<"$basic0_json"
+    run -0 jq -r '.data."app.properties"' <<<"${basic0_json}"
     assert_output --partial "server.port=8080"
 
-    run -0 jq -r '.data.index' <<<"$basic0_json"
+    run -0 jq -r '.data.index' <<<"${basic0_json}"
     assert_output "0"
 
-    run -0 jq -r '.data | has("new-file.txt")' <<<"$basic0_json"
+    run -0 jq -r '.data | has("new-file.txt")' <<<"${basic0_json}"
     assert_output "false"
 
     run -0 rdd ctl get configmap basic-1 -o json
-    local basic1_json="$output"
+    local basic1_json="${output}"
 
-    run -0 jq -r '.data."config.yaml"' <<<"$basic1_json"
+    run -0 jq -r '.data."config.yaml"' <<<"${basic1_json}"
     assert_output --partial "test-app"
     refute_output --partial "updated: true"
     refute_output --partial "version: 2.0.0"
 
-    run -0 jq -r '.data."app.properties"' <<<"$basic1_json"
+    run -0 jq -r '.data."app.properties"' <<<"${basic1_json}"
     assert_output --partial "server.port=8080"
 
-    run -0 jq -r '.data.index' <<<"$basic1_json"
+    run -0 jq -r '.data.index' <<<"${basic1_json}"
     assert_output "1"
 
-    run -0 jq -r '.data | has("new-file.txt")' <<<"$basic1_json"
+    run -0 jq -r '.data | has("new-file.txt")' <<<"${basic1_json}"
     assert_output "false"
 
     # Verify new ConfigMaps (2,3) have updated data
     run -0 rdd ctl get configmap basic-2 -o json
-    local basic2_json="$output"
+    local basic2_json="${output}"
 
-    run -0 jq -r '.data."config.yaml"' <<<"$basic2_json"
+    run -0 jq -r '.data."config.yaml"' <<<"${basic2_json}"
     assert_output --partial "updated: true"
     assert_output --partial "version: 2.0.0"
 
-    run -0 jq -r '.data."new-file.txt"' <<<"$basic2_json"
+    run -0 jq -r '.data."new-file.txt"' <<<"${basic2_json}"
     assert_output "This is a new file"
 
-    run -0 jq -r '.data.index' <<<"$basic2_json"
+    run -0 jq -r '.data.index' <<<"${basic2_json}"
     assert_output "2"
 
     run -0 rdd ctl get configmap basic-3 -o json
-    local basic3_json="$output"
+    local basic3_json="${output}"
 
-    run -0 jq -r '.data."config.yaml"' <<<"$basic3_json"
+    run -0 jq -r '.data."config.yaml"' <<<"${basic3_json}"
     assert_output --partial "updated: true"
     assert_output --partial "version: 2.0.0"
 
-    run -0 jq -r '.data."new-file.txt"' <<<"$basic3_json"
+    run -0 jq -r '.data."new-file.txt"' <<<"${basic3_json}"
     assert_output "This is a new file"
 
-    run -0 jq -r '.data.index' <<<"$basic3_json"
+    run -0 jq -r '.data.index' <<<"${basic3_json}"
     assert_output "3"
 }
 
@@ -294,7 +294,7 @@ wait_for_configmaps() {
 }
 
 @test 'verify no ConfigMaps are created for zero replicas' {
-    assert_resource_count "configmaps" "$CONFIGMAP_CONTROLLER_NAME" "zero" 0
+    assert_resource_count "configmaps" "${CONFIGMAP_CONTROLLER_NAME}" "zero" 0
 }
 
 @test 'create ConfigMapReplicaSet with single replica' {
@@ -307,14 +307,14 @@ wait_for_configmaps() {
 
 @test 'verify single ConfigMap has correct name' {
     run -0 rdd ctl get configmaps -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=single -o json
-    local configmaps="$output"
+    local configmaps="${output}"
 
     # Verify we have exactly 1 ConfigMap
-    run -0 jq '.items | length' <<<"$configmaps"
+    run -0 jq '.items | length' <<<"${configmaps}"
     assert_output "1"
 
     # Verify correct name
-    run -0 jq -r '.items[0].metadata.name' <<<"$configmaps"
+    run -0 jq -r '.items[0].metadata.name' <<<"${configmaps}"
     assert_output "single-0"
 }
 
@@ -331,6 +331,6 @@ wait_for_configmaps() {
 
     # Check the status of the ConfigMapReplicaSet
     run -0 rdd ctl get ConfigMapReplicaSet status -o json
-    run -0 jq -r 'has("status")' <<<"$output"
+    run -0 jq -r 'has("status")' <<<"${output}"
     assert_output "true"
 }

--- a/bats/tests/31-rdd-controllers/notary-admission.bats
+++ b/bats/tests/31-rdd-controllers/notary-admission.bats
@@ -31,7 +31,7 @@ apply_notary() {
     local value=$2
 
     run -0 create_notary_yaml "${name}" "${value}"
-    rdd ctl apply -f - <<<"$output"
+    rdd ctl apply -f - <<<"${output}"
 }
 
 @test "webhook configuration has correct structure" {
@@ -39,24 +39,24 @@ apply_notary() {
     try --max 20 --delay 3 -- rdd ctl get ValidatingWebhookConfiguration notary-validator
 
     run -0 rdd ctl get ValidatingWebhookConfiguration notary-validator -o jsonpath='{.webhooks[0]}'
-    local json=$output
+    local json=${output}
 
-    run -0 jq_raw '.failurePolicy' "$json"
+    run -0 jq_raw '.failurePolicy' "${json}"
     assert_output "Fail"
 
-    run -0 jq_raw '.name' "$json"
+    run -0 jq_raw '.name' "${json}"
     assert_output "notary.rdd.rancherdesktop.io"
 
-    run -0 jq_raw '.rules[0].apiGroups[0]' "$json"
+    run -0 jq_raw '.rules[0].apiGroups[0]' "${json}"
     assert_output "rdd.rancherdesktop.io"
 
-    run -0 jq_raw '.rules[0].apiVersions[0]' "$json"
+    run -0 jq_raw '.rules[0].apiVersions[0]' "${json}"
     assert_output "v1alpha1"
 
-    run -0 jq_raw '.rules[0].resources[0]' "$json"
+    run -0 jq_raw '.rules[0].resources[0]' "${json}"
     assert_output "notaries"
 
-    run -0 jq_raw '.rules[0].operations[]' "$json"
+    run -0 jq_raw '.rules[0].operations[]' "${json}"
     assert_line "CREATE"
     assert_line "UPDATE"
 }
@@ -89,7 +89,7 @@ apply_notary() {
 @test "dry-run=server rejects invalid values" {
     # Create an invalid notary resource for dry-run testing
     run -0 create_notary_yaml "test-dry-run-server-invalid" "invalid-dry-run-test"
-    run -1 rdd ctl apply --dry-run=server -f - <<<"$output"
+    run -1 rdd ctl apply --dry-run=server -f - <<<"${output}"
     assert_output --partial "Forbidden"
     assert_output --partial "spec.value cannot start with 'invalid' (case-insensitive)"
 
@@ -109,7 +109,7 @@ apply_notary() {
 
     # Apply invalid update with --dry-run=server - should be rejected by admission controllers
     run -0 create_notary_yaml "test-dry-run-update-invalid" "invalid-updated-value"
-    run -1 rdd ctl apply --dry-run=server -f - <<<"$output"
+    run -1 rdd ctl apply --dry-run=server -f - <<<"${output}"
     assert_output --partial "Forbidden"
     assert_output --partial "spec.value cannot start with 'invalid' (case-insensitive)"
 

--- a/bats/tests/31-rdd-controllers/notary-events.bats
+++ b/bats/tests/31-rdd-controllers/notary-events.bats
@@ -49,7 +49,7 @@ assert_events_exist() {
     local reason=$2
 
     run -0 rdd ctl get events --field-selector involvedObject.name="${resource_name}" -o json
-    run -0 jq ".items | map(select(.reason == \"$reason\")) | length" <<<"$output"
+    run -0 jq ".items | map(select(.reason == \"${reason}\")) | length" <<<"${output}"
     refute_output 0
 }
 
@@ -67,12 +67,12 @@ get_events_after_timestamp() {
     local reason=$3
 
     run rdd ctl get events --field-selector involvedObject.name="${resource_name}" -o json
-    if [ "$status" -ne 0 ]; then
+    if [[ "${status}" -ne 0 ]]; then
         echo "[]"
         return 0
     fi
 
-    jq -r ".items | map(select(.lastTimestamp > \"$timestamp\" and .reason == \"$reason\"))" <<<"$output"
+    jq -r ".items | map(select(.lastTimestamp > \"${timestamp}\" and .reason == \"${reason}\"))" <<<"${output}"
 }
 
 assert_events_after_timestamp() {
@@ -80,8 +80,8 @@ assert_events_after_timestamp() {
     local timestamp=$2
     local reason=$3
 
-    run -0 get_events_after_timestamp "$resource_name" "$timestamp" "$reason"
-    run -0 jq 'length' <<<"$output"
+    run -0 get_events_after_timestamp "${resource_name}" "${timestamp}" "${reason}"
+    run -0 jq 'length' <<<"${output}"
     refute_output 0
 }
 
@@ -97,19 +97,19 @@ get_latest_event_timestamp() {
     local resource_name=$1
 
     run rdd ctl get events --field-selector involvedObject.name="${resource_name}" -o json
-    if [ "$status" -ne 0 ]; then
+    if [[ "${status}" -ne 0 ]]; then
         echo ""
         return 1
     fi
 
-    jq -r ".items | sort_by(.lastTimestamp) | .[-1].lastTimestamp // empty" <<<"$output"
+    jq -r ".items | sort_by(.lastTimestamp) | .[-1].lastTimestamp // empty" <<<"${output}"
 }
 
 @test 'verify event generation for spec updates' {
     create_notary "events" "initial-event-value" "events-history"
 
     # Wait for initial ConfigMap creation and events
-    wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "events" 1
+    wait_for_resource_count "configmaps" "${NOTARY_CONTROLLER_NAME}" "events" 1
     wait_for_events "events" "SpecUpdate"
     wait_for_events "events" "ValueRecorded"
 
@@ -121,20 +121,20 @@ get_latest_event_timestamp() {
 
     # Get the timestamp of the most recent event before update
     run -0 get_latest_event_timestamp "events"
-    timestamp=$output
+    timestamp=${output}
 
     # Update with a different value
     update_notary_value "events" "new-event-value"
 
     # Wait for status update and new events
     wait_for_notary_status "events" "new-event-value"
-    wait_for_events_after_timestamp "events" "$timestamp" "SpecUpdate"
-    wait_for_events_after_timestamp "events" "$timestamp" "ValueRecorded"
+    wait_for_events_after_timestamp "events" "${timestamp}" "SpecUpdate"
+    wait_for_events_after_timestamp "events" "${timestamp}" "ValueRecorded"
 
     # Verify we have new SpecUpdate and ValueRecorded events containing the new value
-    run -0 get_events_after_timestamp "events" "$timestamp" "SpecUpdate"
+    run -0 get_events_after_timestamp "events" "${timestamp}" "SpecUpdate"
     assert_output --partial "new-event-value"
-    run -0 get_events_after_timestamp "events" "$timestamp" "ValueRecorded"
+    run -0 get_events_after_timestamp "events" "${timestamp}" "ValueRecorded"
     assert_output --partial "new-event-value"
 }
 
@@ -143,13 +143,13 @@ get_latest_event_timestamp() {
     create_notary "dupe" "constant-value" "dupe-history"
 
     # Wait for initial ConfigMap creation and events
-    wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "dupe" 1
+    wait_for_resource_count "configmaps" "${NOTARY_CONTROLLER_NAME}" "dupe" 1
     wait_for_events "dupe" "SpecUpdate"
     wait_for_events "dupe" "ValueRecorded"
 
     # Get the timestamp before triggering multiple identical reconciles
     run -0 get_latest_event_timestamp "dupe"
-    timestamp=$output
+    timestamp=${output}
 
     # Trigger multiple reconciles with identical spec.value by changing annotations
     # Each will generate identical SpecUpdate and NoChange events that Kubernetes should deduplicate
@@ -164,19 +164,19 @@ get_latest_event_timestamp() {
 
     # Count events after the timestamp - should be deduplicated by Kubernetes
     # It is not clear if Kubernetes will always catch all duplicates, but it should get at least 1
-    run -0 get_events_after_timestamp "dupe" "$timestamp" "SpecUpdate"
+    run -0 get_events_after_timestamp "dupe" "${timestamp}" "SpecUpdate"
     assert_output --partial "constant-value"
 
-    run -0 jq 'length' <<<"$output"
+    run -0 jq 'length' <<<"${output}"
     assert_output_lt 4
 
-    run -0 get_events_after_timestamp "dupe" "$timestamp" "NoChange"
+    run -0 get_events_after_timestamp "dupe" "${timestamp}" "NoChange"
     assert_output --partial "value unchanged"
 
-    run -0 jq 'length' <<<"$output"
+    run -0 jq 'length' <<<"${output}"
     assert_output_lt 4
 
-    run -0 get_events_after_timestamp "dupe" "$timestamp" "ValueRecorded"
-    run -0 jq 'length' <<<"$output"
+    run -0 get_events_after_timestamp "dupe" "${timestamp}" "ValueRecorded"
+    run -0 jq 'length' <<<"${output}"
     assert_output 0
 }

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -15,7 +15,7 @@ local_setup_file() {
 assert_process_exited() {
     local pid=$1
     # Return 0 (success) if process has exited, 1 (failure) if still running
-    ! kill -0 "$pid" 2>/dev/null
+    ! kill -0 "${pid}" 2>/dev/null
 }
 
 @test "control plane starts without embedded controllers" {
@@ -51,7 +51,7 @@ assert_process_exited() {
     assert_output "notary.rdd.rancherdesktop.io"
 
     run -0 rdd ctl get ValidatingWebhookConfiguration notary-validator -o json
-    run -0 jq -r '.webhooks[0].clientConfig.url' <<<"$output"
+    run -0 jq -r '.webhooks[0].clientConfig.url' <<<"${output}"
     assert_output --partial "https://127.0.0.1:"
     assert_output --partial "/validate-rdd-rancherdesktop-io-v1alpha1-notary"
 
@@ -105,7 +105,7 @@ EOF
     try --max 30 --delay 1 -- rdd ctl get configmap test-config
     # Verify ConfigMap was created with correct content
     run -0 rdd ctl get configmap test-config -o json
-    run -0 jq -r '.data.change_000' <<<"$output"
+    run -0 jq -r '.data.change_000' <<<"${output}"
     assert_output --partial "value=valid-external-test"
 
     run -0 rdd ctl get configmap test-config -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}'
@@ -124,12 +124,12 @@ EOF
     controller_pid=$(cat "${BATS_FILE_TMPDIR}/controller_pid")
 
     # Verify the external controller process is currently running
-    run -0 kill -0 "$controller_pid"
+    run -0 kill -0 "${controller_pid}"
 
     # Stop the control plane - this should trigger auto-cleanup of external controllers
     run -0 rdd svc stop
 
     # Wait for external controller to detect control plane shutdown and exit
     # External controllers check every 2 seconds, allow up to 3 failures (6 seconds), plus buffer
-    try --max 15 --delay 1 -- assert_process_exited "$controller_pid"
+    try --max 15 --delay 1 -- assert_process_exited "${controller_pid}"
 }

--- a/bats/tests/31-rdd-controllers/notary.bats
+++ b/bats/tests/31-rdd-controllers/notary.bats
@@ -54,62 +54,62 @@ wait_for_notary_status() {
 }
 
 @test 'wait for controller to create ConfigMap' {
-    wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "basic" 1
+    wait_for_resource_count "configmaps" "${NOTARY_CONTROLLER_NAME}" "basic" 1
 }
 
 @test 'verify ConfigMap has correct name and content' {
     run -0 rdd ctl get configmap "basic-history" -o json
-    local json="$output"
+    local json="${output}"
 
-    run -0 jq -r '.data.change_000' <<<"$json"
+    run -0 jq -r '.data.change_000' <<<"${json}"
     assert_output --partial "value=initial-value"
 
-    run -0 jq -r '.data.latest_change' <<<"$json"
+    run -0 jq -r '.data.latest_change' <<<"${json}"
     assert_output --partial "value=initial-value"
 
-    run -0 jq -r '.data.change_count' <<<"$json"
+    run -0 jq -r '.data.change_count' <<<"${json}"
     assert_output 0
 }
 
 @test 'verify ConfigMap has correct labels and owner references' {
     run -0 rdd ctl get configmap "basic-history" -o json
-    local json="$output"
+    local json="${output}"
 
     # Check labels
-    run -0 jq -r '.metadata.labels."app.kubernetes.io/managed-by"' <<<"$json"
+    run -0 jq -r '.metadata.labels."app.kubernetes.io/managed-by"' <<<"${json}"
     assert_output "notary-controller"
 
-    run -0 jq -r '.metadata.labels."app.kubernetes.io/instance"' <<<"$json"
+    run -0 jq -r '.metadata.labels."app.kubernetes.io/instance"' <<<"${json}"
     assert_output "basic"
 
     # Check owner references
-    run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"$json"
+    run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"${json}"
     assert_output "Notary"
 
-    run -0 jq -r '.metadata.ownerReferences[0].name' <<<"$json"
+    run -0 jq -r '.metadata.ownerReferences[0].name' <<<"${json}"
     assert_output "basic"
 
-    run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"$json"
+    run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"${json}"
     assert_output "true"
 
-    run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion' <<<"$json"
+    run -0 jq -r '.metadata.ownerReferences[0].blockOwnerDeletion' <<<"${json}"
     assert_output "true"
 }
 
 @test 'verify Notary status is updated' {
     run -0 rdd ctl get notary basic -o json
-    local json="$output"
+    local json="${output}"
 
-    run -0 jq -r 'has("status")' <<<"$json"
+    run -0 jq -r 'has("status")' <<<"${json}"
     assert_output "true"
 
-    run -0 jq -r '.status.lastRecordedValue' <<<"$json"
+    run -0 jq -r '.status.lastRecordedValue' <<<"${json}"
     assert_output "initial-value"
 
-    run -0 jq -r '.status.configMapStatus' <<<"$json"
+    run -0 jq -r '.status.configMapStatus' <<<"${json}"
     assert_output "Updated"
 
-    run -0 jq -r '.status.changeCount' <<<"$json"
+    run -0 jq -r '.status.changeCount' <<<"${json}"
     assert_output 1
 }
 
@@ -123,32 +123,32 @@ wait_for_notary_status() {
 
 @test 'verify ConfigMap records the change' {
     run -0 rdd ctl get configmap "basic-history" -o json
-    local json="$output"
+    local json="${output}"
 
-    run -0 jq -r '.data.change_000' <<<"$json"
+    run -0 jq -r '.data.change_000' <<<"${json}"
     assert_output --partial "value=initial-value"
 
-    run -0 jq -r '.data.change_001' <<<"$json"
+    run -0 jq -r '.data.change_001' <<<"${json}"
     assert_output --partial "value=updated-value"
 
-    run -0 jq -r '.data.latest_change' <<<"$json"
+    run -0 jq -r '.data.latest_change' <<<"${json}"
     assert_output --partial "value=updated-value"
 
-    run -0 jq -r '.data.change_count' <<<"$json"
+    run -0 jq -r '.data.change_count' <<<"${json}"
     assert_output 1
 }
 
 @test 'verify Notary status shows updated change count' {
     run -0 rdd ctl get notary basic -o json
-    local json="$output"
+    local json="${output}"
 
-    run -0 jq -r '.status.lastRecordedValue' <<<"$json"
+    run -0 jq -r '.status.lastRecordedValue' <<<"${json}"
     assert_output "updated-value"
 
-    run -0 jq -r '.status.configMapStatus' <<<"$json"
+    run -0 jq -r '.status.configMapStatus' <<<"${json}"
     assert_output "Updated"
 
-    run -0 jq -r '.status.changeCount' <<<"$json"
+    run -0 jq -r '.status.changeCount' <<<"${json}"
     assert_output 2
 }
 
@@ -162,26 +162,26 @@ wait_for_notary_status() {
 
 @test 'verify ConfigMap records multiple changes' {
     run -0 rdd ctl get configmap "basic-history" -o json
-    local json="$output"
+    local json="${output}"
 
     # Verify all changes are recorded
-    run -0 jq -r '.data.change_000' <<<"$json"
+    run -0 jq -r '.data.change_000' <<<"${json}"
     assert_output --partial "value=initial-value"
 
-    run -0 jq -r '.data.change_001' <<<"$json"
+    run -0 jq -r '.data.change_001' <<<"${json}"
     assert_output --partial "value=updated-value"
 
-    run -0 jq -r '.data.change_002' <<<"$json"
+    run -0 jq -r '.data.change_002' <<<"${json}"
     assert_output --partial "value=third-value"
 
-    run -0 jq -r '.data.change_003' <<<"$json"
+    run -0 jq -r '.data.change_003' <<<"${json}"
     assert_output --partial "value=fourth-value"
 
     # Verify latest change and count
-    run -0 jq -r '.data.latest_change' <<<"$json"
+    run -0 jq -r '.data.latest_change' <<<"${json}"
     assert_output --partial "value=fourth-value"
 
-    run -0 jq -r '.data.change_count' <<<"$json"
+    run -0 jq -r '.data.change_count' <<<"${json}"
     assert_output 3
 }
 
@@ -194,16 +194,16 @@ wait_for_notary_status() {
 
     # Check that no new change was recorded
     run -0 rdd ctl get configmap "basic-history" -o json
-    local json="$output"
+    local json="${output}"
 
-    run -0 jq -r '.data.change_003' <<<"$json"
+    run -0 jq -r '.data.change_003' <<<"${json}"
     assert_output --partial "value=fourth-value"
 
-    run -0 jq -r '.data.change_count' <<<"$json"
+    run -0 jq -r '.data.change_count' <<<"${json}"
     assert_output 3
 
     # Should NOT have change_004
-    run -0 jq -r '.data | has("change_004")' <<<"$json"
+    run -0 jq -r '.data | has("change_004")' <<<"${json}"
     assert_output "false"
 }
 
@@ -221,5 +221,5 @@ wait_for_notary_status() {
 }
 
 @test 'wait for ConfigMaps to be cleaned up by finalizer' {
-    wait_for_resource_count "configmaps" "$NOTARY_CONTROLLER_NAME" "basic" 0
+    wait_for_resource_count "configmaps" "${NOTARY_CONTROLLER_NAME}" "basic" 0
 }

--- a/bats/tests/32-app-controllers/demo.bats
+++ b/bats/tests/32-app-controllers/demo.bats
@@ -42,21 +42,21 @@ assert_demo_condition() {
     run rdd ctl get demo "demo" -o json
     assert_success
 
-    run -0 jq -r ".status.conditions[] | select(.type == \"${condition_type}\") | .status" <<<"$output"
-    assert_output "$expected_status"
+    run -0 jq -r ".status.conditions[] | select(.type == \"${condition_type}\") | .status" <<<"${output}"
+    assert_output "${expected_status}"
 }
 
 wait_for_demo_condition() {
     local condition_type=${1:-Ready}
     local expected_status=${2:-True}
 
-    try --max 12 --delay 5 -- assert_demo_condition "$condition_type" "$expected_status"
+    try --max 12 --delay 5 -- assert_demo_condition "${condition_type}" "${expected_status}"
 }
 
 wait_for_demo_completion() {
     local expected=$1
 
-    try --max 20 --delay 2 -- assert_demo_status "processedCount" "$expected"
+    try --max 20 --delay 2 -- assert_demo_status "processedCount" "${expected}"
     wait_for_demo_condition "Completed" "True"
 }
 
@@ -88,40 +88,40 @@ local_setup_file() {
     # Processing condition might be True briefly or False if already completed
     # So just verify we have the Ready condition and some processing has occurred
     run -0 get_demo_status "processedCount"
-    [ "$output" -ge 0 ] # Should have some status
+    [[ "${output}" -ge 0 ]] # Should have some status
 }
 
 @test 'verify initial Demo status' {
     run -0 rdd ctl get demo demo -o json
-    local demo_json="$output"
+    local demo_json="${output}"
 
-    run -0 jq -r 'has("status")' <<<"$demo_json"
+    run -0 jq -r 'has("status")' <<<"${demo_json}"
     assert_output "true"
 
-    run -0 jq -r '.status | has("processedCount")' <<<"$demo_json"
+    run -0 jq -r '.status | has("processedCount")' <<<"${demo_json}"
     assert_output "true"
 
     # Should have at least started processing (processedCount >= 1)
     run -0 get_demo_status "processedCount"
-    [ "$output" -ge 1 ]
+    [[ "${output}" -ge 1 ]]
 }
 
 @test 'verify Demo conditions are properly set during processing' {
     run -0 rdd ctl get demo demo -o json
-    local demo_json="$output"
+    local demo_json="${output}"
 
     # Should have conditions array
-    run -0 jq -r '.status | has("conditions")' <<<"$demo_json"
+    run -0 jq -r '.status | has("conditions")' <<<"${demo_json}"
     assert_output "true"
 
     # Check for all three condition types
-    run -0 jq -r '.status.conditions | map(.type) | @json' <<<"$demo_json"
+    run -0 jq -r '.status.conditions | map(.type) | @json' <<<"${demo_json}"
     assert_output --partial "Ready"
     assert_output --partial "Processing"
     assert_output --partial "Completed"
 
     # Ready should be True during processing
-    run -0 jq -r '.status.conditions[] | select(.type == "Ready") | .status' <<<"$demo_json"
+    run -0 jq -r '.status.conditions[] | select(.type == "Ready") | .status' <<<"${demo_json}"
     assert_output "True"
 }
 
@@ -131,26 +131,26 @@ local_setup_file() {
 
 @test 'verify Demo status after completion' {
     run -0 rdd ctl get demo demo -o json
-    local demo_json="$output"
+    local demo_json="${output}"
 
     # Should have processed all 3 messages
-    run -0 jq -r '.status.processedCount' <<<"$demo_json"
+    run -0 jq -r '.status.processedCount' <<<"${demo_json}"
     assert_output "3"
 
     # Should have lastProcessed timestamp
-    run -0 jq -r '.status | has("lastProcessed")' <<<"$demo_json"
+    run -0 jq -r '.status | has("lastProcessed")' <<<"${demo_json}"
     assert_output "true"
 
     # Ready should be True
-    run -0 jq -r '.status.conditions[] | select(.type == "Ready") | .status' <<<"$demo_json"
+    run -0 jq -r '.status.conditions[] | select(.type == "Ready") | .status' <<<"${demo_json}"
     assert_output "True"
 
     # Processing should be False (completed)
-    run -0 jq -r '.status.conditions[] | select(.type == "Processing") | .status' <<<"$demo_json"
+    run -0 jq -r '.status.conditions[] | select(.type == "Processing") | .status' <<<"${demo_json}"
     assert_output "False"
 
     # Completed should be True
-    run -0 jq -r '.status.conditions[] | select(.type == "Completed") | .status' <<<"$demo_json"
+    run -0 jq -r '.status.conditions[] | select(.type == "Completed") | .status' <<<"${demo_json}"
     assert_output "True"
 }
 
@@ -197,7 +197,7 @@ EOF
     # ProcessedCount might not be explicitly set to 0, or could be missing
     run -0 rdd ctl get demo demo -o json
     # Just verify completed condition is True for zero count
-    run -0 jq -r '.status.conditions[] | select(.type == "Completed") | .status' <<<"$output"
+    run -0 jq -r '.status.conditions[] | select(.type == "Completed") | .status' <<<"${output}"
     assert_output "True"
 }
 
@@ -213,8 +213,8 @@ EOF
 
     # Verify we have a Processing condition (might be True or False)
     local processing_exists
-    processing_exists=$(echo "$output" | jq -r '.status.conditions[] | select(.type == "Processing") | .type')
-    [ "$processing_exists" = "Processing" ]
+    processing_exists=$(echo "${output}" | jq -r '.status.conditions[] | select(.type == "Processing") | .type')
+    [[ "${processing_exists}" = "Processing" ]]
 }
 
 @test 'test Demo update during processing' {
@@ -231,12 +231,12 @@ EOF
 
     # Verify final state
     run -0 rdd ctl get demo demo -o json
-    local demo_json="$output"
+    local demo_json="${output}"
 
-    run -0 jq -r '.status.processedCount' <<<"$demo_json"
+    run -0 jq -r '.status.processedCount' <<<"${demo_json}"
     assert_output "15"
 
-    run -0 jq -r '.spec.message' <<<"$demo_json"
+    run -0 jq -r '.spec.message' <<<"${demo_json}"
     assert_output "Updated message"
 }
 
@@ -265,12 +265,12 @@ EOF
 
     # Verify it works
     run -0 rdd ctl get demo demo -o json
-    local demo_json="$output"
+    local demo_json="${output}"
 
-    run -0 jq -r '.status.processedCount' <<<"$demo_json"
+    run -0 jq -r '.status.processedCount' <<<"${demo_json}"
     assert_output "2"
 
-    run -0 jq -r '.spec.message' <<<"$demo_json"
+    run -0 jq -r '.spec.message' <<<"${demo_json}"
     assert_output "Recreation test"
 }
 
@@ -283,7 +283,7 @@ EOF
     # Check that no finalizers are set (Demo controller doesn't use finalizers)
     run rdd ctl get demo demo -o jsonpath='{.metadata.finalizers}'
     # Should be empty or null
-    [ -z "$output" ] || [ "$output" = "null" ]
+    [[ -z "${output}" ]] || [[ "${output}" = "null" ]]
 }
 
 @test 'demo status reflects current processing state' {
@@ -294,31 +294,31 @@ EOF
 
     # Check comprehensive status
     run -0 rdd ctl get demo demo -o json
-    local demo_json="$output"
+    local demo_json="${output}"
 
-    run -0 jq -r 'has("status")' <<<"$demo_json"
+    run -0 jq -r 'has("status")' <<<"${demo_json}"
     assert_output "true"
 
-    run -0 jq -r '.status.processedCount' <<<"$demo_json"
+    run -0 jq -r '.status.processedCount' <<<"${demo_json}"
     assert_output "2"
 
-    run -0 jq -r '.status | has("lastProcessed")' <<<"$demo_json"
+    run -0 jq -r '.status | has("lastProcessed")' <<<"${demo_json}"
     assert_output "true"
 
-    run -0 jq -r '.status | has("conditions")' <<<"$demo_json"
+    run -0 jq -r '.status | has("conditions")' <<<"${demo_json}"
     assert_output "true"
 
     # Extract condition statuses using jq
-    run -0 jq -r '.status.conditions[] | select(.type == "Ready") | .status' <<<"$demo_json"
-    local ready_status="$output"
+    run -0 jq -r '.status.conditions[] | select(.type == "Ready") | .status' <<<"${demo_json}"
+    local ready_status="${output}"
 
-    run -0 jq -r '.status.conditions[] | select(.type == "Processing") | .status' <<<"$demo_json"
-    local processing_status="$output"
+    run -0 jq -r '.status.conditions[] | select(.type == "Processing") | .status' <<<"${demo_json}"
+    local processing_status="${output}"
 
-    run -0 jq -r '.status.conditions[] | select(.type == "Completed") | .status' <<<"$demo_json"
-    local completed_status="$output"
+    run -0 jq -r '.status.conditions[] | select(.type == "Completed") | .status' <<<"${demo_json}"
+    local completed_status="${output}"
 
-    [ "$ready_status" = "True" ]
-    [ "$processing_status" = "False" ]
-    [ "$completed_status" = "True" ]
+    [[ "${ready_status}" = "True" ]]
+    [[ "${processing_status}" = "False" ]]
+    [[ "${completed_status}" = "True" ]]
 }

--- a/bats/tests/33-lima-controllers/limavm-admission.bats
+++ b/bats/tests/33-lima-controllers/limavm-admission.bats
@@ -20,24 +20,24 @@ local_setup_file() {
     try --max 20 --delay 3 -- rdd ctl get MutatingWebhookConfiguration "limavm-defaulter"
 
     run -0 rdd ctl get MutatingWebhookConfiguration limavm-defaulter -o jsonpath='{.webhooks[0]}'
-    local json=$output
+    local json=${output}
 
-    run -0 jq_raw '.failurePolicy' "$json"
+    run -0 jq_raw '.failurePolicy' "${json}"
     assert_output "Fail"
 
-    run -0 jq_raw '.name' "$json"
+    run -0 jq_raw '.name' "${json}"
     assert_output "limavm-defaulter.lima.rancherdesktop.io"
 
-    run -0 jq_raw '.rules[0].apiGroups[0]' "$json"
+    run -0 jq_raw '.rules[0].apiGroups[0]' "${json}"
     assert_output "lima.rancherdesktop.io"
 
-    run -0 jq_raw '.rules[0].apiVersions[0]' "$json"
+    run -0 jq_raw '.rules[0].apiVersions[0]' "${json}"
     assert_output "v1alpha1"
 
-    run -0 jq_raw '.rules[0].resources[0]' "$json"
+    run -0 jq_raw '.rules[0].resources[0]' "${json}"
     assert_output "limavms"
 
-    run -0 jq_raw '.rules[0].operations[0]' "$json"
+    run -0 jq_raw '.rules[0].operations[0]' "${json}"
     assert_output "CREATE"
 }
 

--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -6,14 +6,14 @@ LIMA_TEST_NS="lima-test-ns"
 
 local_setup_file() {
     setup_rdd_control_plane "lima"
-    rdd ctl create namespace "$LIMA_TEST_NS"
+    rdd ctl create namespace "${LIMA_TEST_NS}"
 }
 
 # assert_running verifies the "test-vm" running state, must be "true" or "false"
 assert_running() {
     local state=$1
-    run -0 rdd ctl get limavm "test-vm" --namespace "$LIMA_TEST_NS" -o jsonpath='{.spec.running}'
-    assert_output "$state"
+    run -0 rdd ctl get limavm "test-vm" --namespace "${LIMA_TEST_NS}" -o jsonpath='{.spec.running}'
+    assert_output "${state}"
 }
 
 # assert_created verifies the $name VM has been created in $namespace from $template
@@ -25,17 +25,17 @@ assert_created() {
     local template=$3
 
     local msg
-    printf -v msg 'LimaVM "%s" created in namespace "%s" with template ConfigMap "%s"' "$name" "$namespace" "$template"
-    assert_info "$msg"
+    printf -v msg 'LimaVM "%s" created in namespace "%s" with template ConfigMap "%s"' "${name}" "${namespace}" "${template}"
+    assert_info "${msg}"
 }
 
 @test "lima create/start/stop/delete with ConfigMap template" {
     # Create a template ConfigMap first
-    rdd ctl create configmap "test-template" --namespace "$LIMA_TEST_NS" --from-literal=template='{}'
+    rdd ctl create configmap "test-template" --namespace "${LIMA_TEST_NS}" --from-literal=template='{}'
 
     # Create VM with ConfigMap template
-    run_e -0 rdd limavm create "test-vm" "test-template" --namespace "$LIMA_TEST_NS"
-    assert_created "test-vm" "$LIMA_TEST_NS" "test-template"
+    run_e -0 rdd limavm create "test-vm" "test-template" --namespace "${LIMA_TEST_NS}"
+    assert_created "test-vm" "${LIMA_TEST_NS}" "test-template"
     assert_running "false"
 
     # Start the VM (cross-namespace lookup: no --namespace flag needed)
@@ -51,29 +51,29 @@ assert_created() {
     # Delete the VM
     run -0 rdd limavm delete "test-vm"
     assert_output --partial 'deleted'
-    run -1 rdd ctl get limavm "test-vm" --namespace "$LIMA_TEST_NS"
+    run -1 rdd ctl get limavm "test-vm" --namespace "${LIMA_TEST_NS}"
     assert_output --partial "not found"
 
     # Clean up the template ConfigMap
-    rdd ctl delete configmap "test-template" --namespace "$LIMA_TEST_NS"
+    rdd ctl delete configmap "test-template" --namespace "${LIMA_TEST_NS}"
 }
 
 @test "lima create with file template" {
     # Create a temporary template file
     local template_file="${BATS_TEST_TMPDIR}/test-template.yaml"
-    echo '{}' >"$template_file"
+    echo '{}' >"${template_file}"
 
     # Create VM with file template
-    run_e -0 rdd limavm create "test-vm-file" "$template_file" --namespace "$LIMA_TEST_NS"
+    run_e -0 rdd limavm create "test-vm-file" "${template_file}" --namespace "${LIMA_TEST_NS}"
     # Generated ConfigMap has the same name as the LimaVM
-    assert_created "test-vm-file" "$LIMA_TEST_NS" "test-vm-file"
+    assert_created "test-vm-file" "${LIMA_TEST_NS}" "test-vm-file"
 
     # Verify the ConfigMap was created
-    run -0 rdd ctl get configmap "test-vm-file" --namespace "$LIMA_TEST_NS" -o jsonpath='{.data.template}'
+    run -0 rdd ctl get configmap "test-vm-file" --namespace "${LIMA_TEST_NS}" -o jsonpath='{.data.template}'
     assert_output '{}'
 
     # Try creating another VM with same name - should fail because ConfigMap exists
-    run -1 rdd limavm create "test-vm-file" "$template_file" --namespace "$LIMA_TEST_NS"
+    run -1 rdd limavm create "test-vm-file" "${template_file}" --namespace "${LIMA_TEST_NS}"
     assert_output --partial 'already exists'
 
     # Delete the LimaVM
@@ -81,29 +81,29 @@ assert_created() {
     assert_output --partial 'deleted'
 
     # Wait for LimaVM to be fully deleted
-    rdd ctl wait --for=delete "limavm/test-vm-file" --namespace "$LIMA_TEST_NS" --timeout="30s"
+    rdd ctl wait --for=delete "limavm/test-vm-file" --namespace "${LIMA_TEST_NS}" --timeout="30s"
 
     # Verify ConfigMap was auto-deleted by controller finalizer
-    run -1 rdd ctl get configmap "test-vm-file" --namespace "$LIMA_TEST_NS"
+    run -1 rdd ctl get configmap "test-vm-file" --namespace "${LIMA_TEST_NS}"
     assert_output --partial "not found"
 }
 
 @test "lima create cleans up ConfigMap on LimaVM creation failure" {
     # Create a LimaVM in the default namespace to trigger uniqueness constraint
     local template_file="${BATS_TEST_TMPDIR}/test-template.yaml"
-    echo '{}' >"$template_file"
-    rdd limavm create duplicate-vm "$template_file" --namespace "default"
+    echo '{}' >"${template_file}"
+    rdd limavm create duplicate-vm "${template_file}" --namespace "default"
 
     # Try to create another LimaVM with the same name in a different namespace
     # This should fail due to cross-namespace uniqueness enforcement by admission webhook
     local template_file2="${BATS_TEST_TMPDIR}/test-template2.yaml"
-    echo '{}' >"$template_file2"
-    run -1 rdd limavm create duplicate-vm "$template_file2" --namespace "$LIMA_TEST_NS"
+    echo '{}' >"${template_file2}"
+    run -1 rdd limavm create duplicate-vm "${template_file2}" --namespace "${LIMA_TEST_NS}"
     assert_output --partial "admission webhook"
     assert_output --partial "Cleaning up created ConfigMap"
 
     # Verify the ConfigMap was cleaned up (should not exist in $LIMA_TEST_NS)
-    run -1 rdd ctl get configmap "duplicate-vm" --namespace "$LIMA_TEST_NS"
+    run -1 rdd ctl get configmap "duplicate-vm" --namespace "${LIMA_TEST_NS}"
     assert_output --partial "not found"
 
     # Clean up the first LimaVM
@@ -111,7 +111,7 @@ assert_created() {
 }
 
 @test "lima create fails with non-existent file" {
-    run -1 rdd limavm create "test-vm" "${BATS_TEST_TMPDIR}/nonexistent/template.yaml" --namespace "$LIMA_TEST_NS"
+    run -1 rdd limavm create "test-vm" "${BATS_TEST_TMPDIR}/nonexistent/template.yaml" --namespace "${LIMA_TEST_NS}"
     assert_output --partial 'failed to read template file'
 }
 
@@ -119,13 +119,13 @@ assert_created() {
     local not_found='LimaVM "nonexistent" not found in any namespace'
 
     run_e -1 rdd limavm start "nonexistent"
-    assert_fatal "$not_found"
+    assert_fatal "${not_found}"
 
     run_e -1 rdd limavm stop "nonexistent"
-    assert_fatal "$not_found"
+    assert_fatal "${not_found}"
 
     run_e -1 rdd limavm delete "nonexistent"
-    assert_fatal "$not_found"
+    assert_fatal "${not_found}"
 }
 
 @test "lima help text is displayed" {

--- a/bats/tests/33-lima-controllers/limavm-lifecycle.bats
+++ b/bats/tests/33-lima-controllers/limavm-lifecycle.bats
@@ -11,7 +11,7 @@ TEMPLATE='{"memory":"2GB"}'
 
 local_setup_file() {
     setup_rdd_control_plane "lima"
-    rdd ctl create namespace "$NAMESPACE"
+    rdd ctl create namespace "${NAMESPACE}"
 }
 
 # Helper function to create a LimaVM
@@ -34,129 +34,129 @@ EOF
 }
 
 @test "create source-template ConfigMap" {
-    rdd ctl create configmap "source-template" --namespace "$NAMESPACE" --from-literal="template=${TEMPLATE}"
+    rdd ctl create configmap "source-template" --namespace "${NAMESPACE}" --from-literal="template=${TEMPLATE}"
 
     # Verify the template was created
-    run -0 rdd ctl get configmap "source-template" --namespace "$NAMESPACE" -o jsonpath='{.data.template}'
-    assert_output "$TEMPLATE"
+    run -0 rdd ctl get configmap "source-template" --namespace "${NAMESPACE}" -o jsonpath='{.data.template}'
+    assert_output "${TEMPLATE}"
 }
 
 @test "create LimaVM resource" {
-    create_limavm "$VM_NAME" "source-template"
+    create_limavm "${VM_NAME}" "source-template"
 
     # Verify the LimaVM was created
-    run -0 rdd ctl get limavm "$VM_NAME" --namespace "$NAMESPACE" -o name
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" -o name
     assert_output "limavm.lima.rancherdesktop.io/${VM_NAME}"
 }
 
 @test "verify LimaVM has finalizer for cleanup" {
-    run -0 rdd ctl get limavm "$VM_NAME" --namespace "$NAMESPACE" -o jsonpath='{.metadata.finalizers}'
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.metadata.finalizers}'
     assert_output --partial "rdd.rancherdesktop.io/cleanup"
 }
 
 @test "wait for template ConfigMap to be created" {
     rdd ctl wait --for=jsonpath='{.status.templateConfigMap}' \
-        "limavm/${VM_NAME}" --namespace "$NAMESPACE" --timeout="30s"
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout="30s"
 }
 
 @test "verify copied ConfigMap has correct data" {
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" -o jsonpath='{.data.template}'
-    assert_output "$TEMPLATE"
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.data.template}'
+    assert_output "${TEMPLATE}"
 }
 
 @test "verify template ConfigMap has correct label" {
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" \
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" \
         -o jsonpath='{.metadata.labels.lima\.rancherdesktop\.io/template-configmap}'
     assert_output "true"
 }
 
 @test "verify template ConfigMap has protection finalizer" {
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" -o jsonpath='{.metadata.finalizers}'
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.metadata.finalizers}'
     assert_output --partial "rdd.rancherdesktop.io/cleanup"
 }
 
 @test "verify template ConfigMap has owner reference" {
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" -o json
-    local json=$output
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o json
+    local json=${output}
 
-    run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"$json"
+    run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"${json}"
     assert_output "LimaVM"
 
-    run -0 jq -r '.metadata.ownerReferences[0].name' <<<"$json"
-    assert_output "$VM_NAME"
+    run -0 jq -r '.metadata.ownerReferences[0].name' <<<"${json}"
+    assert_output "${VM_NAME}"
 
-    run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"$json"
+    run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"${json}"
     assert_output "true"
 }
 
 @test "verify LimaVM status has template ConfigMap name" {
-    run -0 rdd ctl get limavm "$VM_NAME" --namespace "$NAMESPACE" -o jsonpath='{.status.templateConfigMap}'
-    assert_output "$TEMPLATE_NAME"
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.status.templateConfigMap}'
+    assert_output "${TEMPLATE_NAME}"
 }
 
 @test "template ConfigMap modification is allowed if template key exists" {
-    run -0 rdd ctl patch configmap "$TEMPLATE_NAME" --namespace $NAMESPACE --type='merge' \
+    run -0 rdd ctl patch configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --type='merge' \
         --patch='{"data":{"template":"{\"memory\":\"4GB\"}"}}'
 
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" -o jsonpath='{.data.template}'
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.data.template}'
     assert_output '{"memory":"4GB"}'
 }
 
 @test "template ConfigMap modification without template key is rejected" {
-    run -1 rdd ctl patch configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" --type='json' \
+    run -1 rdd ctl patch configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --type='json' \
         --patch='[{"op":"remove","path":"/data/template"}]'
     assert_output --partial "Forbidden"
     assert_output --partial 'template ConfigMap must have a "template" data entry'
 
     # Verify the template key still exists
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" -o jsonpath='{.data.template}'
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.data.template}'
     assert_output '{"memory":"4GB"}'
 }
 
 @test "template ConfigMap modification with empty template is rejected" {
-    run -1 rdd ctl patch configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" --type='merge' \
+    run -1 rdd ctl patch configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --type='merge' \
         --patch='{"data":{"template":""}}'
     assert_output --partial "Forbidden"
     assert_output --partial '"template" data cannot be empty'
 
     # Verify the template data is unchanged
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" -o jsonpath='{.data.template}'
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.data.template}'
     assert_output '{"memory":"4GB"}'
 }
 
 @test "template ConfigMap cannot be deleted independently" {
-    run -1 rdd ctl delete configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" --grace-period=0
+    run -1 rdd ctl delete configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --grace-period=0
     assert_output --partial "Forbidden"
     assert_output --partial "cannot delete template ConfigMap"
     assert_output --partial "protected by the LimaVM controller"
     assert_output --partial "delete the owning LimaVM resource instead"
 
     # Verify the ConfigMap still exists
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE"
-    assert_output --partial "$TEMPLATE_NAME"
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}"
+    assert_output --partial "${TEMPLATE_NAME}"
 }
 
 @test "dry-run deletion of template ConfigMap is also rejected" {
-    run -1 rdd ctl delete configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE" --dry-run=server
+    run -1 rdd ctl delete configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --dry-run=server
     assert_output --partial "Forbidden"
     assert_output --partial "cannot delete template ConfigMap"
 
     # Verify the ConfigMap still exists
-    run -0 rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE"
-    assert_output --partial "$TEMPLATE_NAME"
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}"
+    assert_output --partial "${TEMPLATE_NAME}"
 }
 
 @test "delete LimaVM resource" {
-    rdd ctl delete limavm "$VM_NAME" --namespace "$NAMESPACE" --grace-period=0
+    rdd ctl delete limavm "${VM_NAME}" --namespace "${NAMESPACE}" --grace-period=0
 }
 
 @test "verify LimaVM is deleted" {
-    run -1 rdd ctl get limavm "$VM_NAME" --namespace "$NAMESPACE"
+    run -1 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}"
     assert_output --partial "not found"
 }
 
 @test "wait for template ConfigMap to be automatically deleted" {
-    try --max 30 --delay 1 --until-fail -- rdd ctl get configmap "$TEMPLATE_NAME" --namespace "$NAMESPACE"
+    try --max 30 --delay 1 --until-fail -- rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}"
 }
 
 @test "create LimaVM with nonexistent template ConfigMap fails" {
@@ -165,7 +165,7 @@ EOF
 }
 
 @test "create LimaVM with ConfigMap missing template key fails" {
-    rdd ctl create configmap "invalid-template" --namespace "$NAMESPACE" --from-literal="foo=bar"
+    rdd ctl create configmap "invalid-template" --namespace "${NAMESPACE}" --from-literal="foo=bar"
 
     run -1 create_limavm "test-vm-invalid" "invalid-template"
     # Mutating webhook tries to create template ConfigMap, ConfigMap webhook validates and rejects
@@ -177,12 +177,12 @@ EOF
 
     # Wait for template ConfigMap to be created
     rdd ctl wait --for=jsonpath='{.status.templateConfigMap}' \
-        "limavm/test-vm-running" --namespace "$NAMESPACE" --timeout="30s"
+        "limavm/test-vm-running" --namespace "${NAMESPACE}" --timeout="30s"
 
     # Update the running state
-    run -0 rdd ctl patch limavm "test-vm-running" --namespace "$NAMESPACE" --type='merge' --patch='{"spec":{"running":true}}'
+    run -0 rdd ctl patch limavm "test-vm-running" --namespace "${NAMESPACE}" --type='merge' --patch='{"spec":{"running":true}}'
 
     # Verify the template ConfigMap still exists and is unchanged
-    run -0 rdd ctl get configmap test-vm-running-template --namespace "$NAMESPACE" -o jsonpath='{.data.template}'
-    assert_output "$TEMPLATE"
+    run -0 rdd ctl get configmap test-vm-running-template --namespace "${NAMESPACE}" -o jsonpath='{.data.template}'
+    assert_output "${TEMPLATE}"
 }


### PR DESCRIPTION
This enables optional shellcheck checks, to further constrain how we can write the BATS tests to get better uniformity across our scripts.  It is recommended to review commit-by-commit, as one of the commits is done with automated fixes (using `shellcheck … --format=diff` and applying the output).