### PR TITLE
limavm: Support `rdd limavm create --dry-run`

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-admission.bats
+++ b/bats/tests/33-lima-controllers/limavm-admission.bats
@@ -100,7 +100,7 @@ spec:
     name: invalid-template
   running: false
 EOF
-    assert_output --partial "template validation failed"
+    assert_output --partial "denied the request"
     assert_output --partial '"template" data cannot be empty'
 
     # Verify the LimaVM was not created (dry-run should never create)

--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -29,6 +29,21 @@ assert_created() {
     assert_info "${msg}"
 }
 
+@test "lima create with missing ConfigMap template" {
+    # Create VM with ConfigMap template
+    run_e -1 rdd limavm create "test-missing-vm" "test-missing-template" --namespace "$LIMA_TEST_NS"
+    assert_stderr_line --partial 'denied the request'
+    assert_stderr_line --partial 'ConfigMap \"test-missing-template\" not found'
+
+    # Verify the ConfigMap was not created, or at least deleted after.
+    run -1 rdd ctl get configmap "test-missing-template" --namespace "$LIMA_TEST_NS" --output=name
+    assert_output --partial NotFound
+
+    # Verify the VM was not created
+    run -0 rdd ctl get limavm --namespace "$LIMA_TEST_NS" --output=name
+    refute_output # There should be no output at all
+}
+
 @test "lima create/start/stop/delete with ConfigMap template" {
     # Create a template ConfigMap first
     rdd ctl create configmap "test-template" --namespace "${LIMA_TEST_NS}" --from-literal=template='{}'
@@ -62,6 +77,19 @@ assert_created() {
     # Create a temporary template file
     local template_file="${BATS_TEST_TMPDIR}/test-template.yaml"
     echo '{}' >"${template_file}"
+
+    # Create VM with file template (dry run)
+    run_e -0 rdd limavm create "test-vm-file" "$template_file" --namespace "$LIMA_TEST_NS" --dry-run
+    # Generated ConfigMap has the same name as the LimaVM
+    assert_created "test-vm-file" "$LIMA_TEST_NS" "test-vm-file"
+
+    # Verify the ConfigMap was not created, or at least deleted after.
+    run -1 rdd ctl get configmap "test-vm-file" --namespace "$LIMA_TEST_NS" --output=name
+    assert_output --partial NotFound
+
+    # Verify the VM was not created
+    run -0 rdd ctl get limavm --namespace "$LIMA_TEST_NS" --output=name
+    refute_output # There should be no output at all
 
     # Create VM with file template
     run_e -0 rdd limavm create "test-vm-file" "${template_file}" --namespace "${LIMA_TEST_NS}"

--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -31,16 +31,16 @@ assert_created() {
 
 @test "lima create with missing ConfigMap template" {
     # Create VM with ConfigMap template
-    run_e -1 rdd limavm create "test-missing-vm" "test-missing-template" --namespace "$LIMA_TEST_NS"
+    run_e -1 rdd limavm create "test-missing-vm" "test-missing-template" --namespace "${LIMA_TEST_NS}"
     assert_stderr_line --partial 'denied the request'
     assert_stderr_line --partial 'ConfigMap \"test-missing-template\" not found'
 
     # Verify the ConfigMap was not created, or at least deleted after.
-    run -1 rdd ctl get configmap "test-missing-template" --namespace "$LIMA_TEST_NS" --output=name
+    run -1 rdd ctl get configmap "test-missing-template" --namespace "${LIMA_TEST_NS}" --output=name
     assert_output --partial NotFound
 
     # Verify the VM was not created
-    run -0 rdd ctl get limavm --namespace "$LIMA_TEST_NS" --output=name
+    run -0 rdd ctl get limavm --namespace "${LIMA_TEST_NS}" --output=name
     refute_output # There should be no output at all
 }
 
@@ -79,16 +79,16 @@ assert_created() {
     echo '{}' >"${template_file}"
 
     # Create VM with file template (dry run)
-    run_e -0 rdd limavm create "test-vm-file" "$template_file" --namespace "$LIMA_TEST_NS" --dry-run
+    run_e -0 rdd limavm create "test-vm-file" "${template_file}" --namespace "${LIMA_TEST_NS}" --dry-run
     # Generated ConfigMap has the same name as the LimaVM
-    assert_created "test-vm-file" "$LIMA_TEST_NS" "test-vm-file"
+    assert_created "test-vm-file" "${LIMA_TEST_NS}" "test-vm-file"
 
     # Verify the ConfigMap was not created, or at least deleted after.
-    run -1 rdd ctl get configmap "test-vm-file" --namespace "$LIMA_TEST_NS" --output=name
+    run -1 rdd ctl get configmap "test-vm-file" --namespace "${LIMA_TEST_NS}" --output=name
     assert_output --partial NotFound
 
     # Verify the VM was not created
-    run -0 rdd ctl get limavm --namespace "$LIMA_TEST_NS" --output=name
+    run -0 rdd ctl get limavm --namespace "${LIMA_TEST_NS}" --output=name
     refute_output # There should be no output at all
 
     # Create VM with file template

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -44,6 +44,7 @@ func newLimaVMCommand() *cobra.Command {
 
 func newLimaVMCreateCommand() *cobra.Command {
 	var namespace string
+	var dryRun bool
 	command := &cobra.Command{
 		Use:   "create NAME TEMPLATE",
 		Short: "Create a new LimaVM resource",
@@ -54,10 +55,11 @@ TEMPLATE can be one of:
 - A file path (if it's not a valid ConfigMap name) - creates a ConfigMap with the VM name`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return limaVMCreateAction(cmd.Context(), args[0], args[1], namespace)
+			return limaVMCreateAction(cmd.Context(), args[0], args[1], namespace, dryRun)
 		},
 	}
 	command.Flags().StringVarP(&namespace, "namespace", "n", metav1.NamespaceDefault, "Namespace for the LimaVM resource")
+	command.Flags().BoolVar(&dryRun, "dry-run", false, "If set, do not commit any changes to the cluster")
 	return command
 }
 
@@ -185,7 +187,7 @@ func takeOwnership(ctx context.Context, c client.Client, limaVM *limav1alpha1.Li
 	return nil
 }
 
-func limaVMCreateAction(ctx context.Context, name, template, namespace string) error {
+func limaVMCreateAction(ctx context.Context, name, template, namespace string, dryRun bool) error {
 	c, err := getKubeClient(ctx)
 	if err != nil {
 		return err
@@ -205,6 +207,14 @@ func limaVMCreateAction(ctx context.Context, name, template, namespace string) e
 		}
 	}
 
+	// Delete createdConfigMap unless limaVM has been created and taken ownership of it.
+	defer func() {
+		if createdConfigMap != nil {
+			logrus.Warnf("Cleaning up created ConfigMap %q", createdConfigMap.Name)
+			_ = c.Delete(ctx, createdConfigMap)
+		}
+	}()
+
 	// Create the LimaVM resource with the template reference
 	running := false
 	limaVM := &limav1alpha1.LimaVM{
@@ -220,24 +230,23 @@ func limaVMCreateAction(ctx context.Context, name, template, namespace string) e
 		},
 	}
 
-	// Delete createdConfigMap unless limaVM has been created and taken ownership of it.
-	defer func() {
-		if createdConfigMap != nil {
-			logrus.Warnf("Cleaning up created ConfigMap %q", createdConfigMap.Name)
-			_ = c.Delete(ctx, createdConfigMap)
-		}
-	}()
+	var opts []client.CreateOption
+	if dryRun {
+		opts = append(opts, client.DryRunAll)
+	}
 
 	// Create LimaVM resource.
-	if err := c.Create(ctx, limaVM); err != nil {
+	if err := c.Create(ctx, limaVM, opts...); err != nil {
 		return fmt.Errorf("failed to create LimaVM: %w", err)
 	}
 	logrus.Infof("LimaVM %q created in namespace %q with template ConfigMap %q", name, namespace, configMapName)
 
 	// If we created a ConfigMap, set the LimaVM as its owner for auto-cleanup
-	if err := takeOwnership(ctx, c, limaVM, createdConfigMap); err == nil {
-		// Keep createdConfigMap until limaVM itself is deleted.
-		createdConfigMap = nil
+	if !dryRun {
+		if err := takeOwnership(ctx, c, limaVM, createdConfigMap); err == nil {
+			// Keep createdConfigMap until limaVM itself is deleted.
+			createdConfigMap = nil
+		}
 	}
 	return nil
 }

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -11,7 +11,6 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -196,33 +195,6 @@ func (d *LimaVMDefaulter) Default(ctx context.Context, obj runtime.Object) error
 		return fmt.Errorf("failed to fetch template data: %w", err)
 	}
 
-	// Check if this is a dry-run request
-	if base.IsDryRun(ctx) {
-		klog.V(1).Infof("[DryRun] Webhook validating LimaVM %s/%s (skipping ConfigMap creation)\n", limavm.Namespace, limavm.Name)
-
-		// Check if ConfigMap already exists (to match actual create behavior)
-		existingConfigMap := &corev1.ConfigMap{}
-		configMapKey := types.NamespacedName{
-			Name:      limavm.GetTemplateConfigMapName(),
-			Namespace: limavm.Namespace,
-		}
-		err := d.Client.Get(ctx, configMapKey, existingConfigMap)
-		if err == nil {
-			return fmt.Errorf("template ConfigMap %q already exists", configMapKey.Name)
-		}
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to check for existing ConfigMap: %w", err)
-		}
-
-		// Validate the template data
-		if _, err := validateTemplateData(map[string]string{v1alpha1.TemplateConfigMapKey: templateData}); err != nil {
-			return fmt.Errorf("template validation failed: %w", err)
-		}
-
-		// Don't create ConfigMap in dry-run mode
-		return nil
-	}
-
 	// Create template ConfigMap with label
 	templateConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -240,13 +212,20 @@ func (d *LimaVMDefaulter) Default(ctx context.Context, obj runtime.Object) error
 		},
 	}
 
+	var options []client.CreateOption
+	var dryRunText string
+	if base.IsDryRun(ctx) {
+		options = append(options, client.DryRunAll)
+		dryRunText = "[DryRun] "
+	}
+
 	// Create the ConfigMap (this triggers ConfigMap admission webhook for validation)
-	if err := d.Client.Create(ctx, templateConfigMap); err != nil {
+	if err := d.Client.Create(ctx, templateConfigMap, options...); err != nil {
 		return fmt.Errorf("failed to create template ConfigMap: %w", err)
 	}
 
-	klog.Infof("Created template ConfigMap %s/%s for LimaVM %s/%s",
-		limavm.Namespace, limavm.GetTemplateConfigMapName(), limavm.Namespace, limavm.Name)
+	klog.Infof("%sCreated template ConfigMap %s/%s for LimaVM %s/%s",
+		dryRunText, limavm.Namespace, limavm.GetTemplateConfigMapName(), limavm.Namespace, limavm.Name)
 
 	// Note: The reconciler will set owner reference and status after LimaVM creation:
 	// - Owner reference requires LimaVM UID (not available during admission)


### PR DESCRIPTION
This adds the option to use (server-side) dry-run to create lima vms with full validation.  It actually still creates the config map as needed, as that is required to pass validation; the config map is deleted after if it is a dry-run.

We may want to consider embedding the configuration into the LimaVM object instead in the future, so that this would not be an issue.

Hopefully this explains what I was requesting in #51. (At the time I wasn't thinking about server-side dry-run, but this is better.)