### PR TITLE
Refactor DeleteOwnedResources to check all resource types

### DIFF
--- a/pkg/controllers/base/finalizer.go
+++ b/pkg/controllers/base/finalizer.go
@@ -9,10 +9,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,9 +52,9 @@ func RemoveFinalizer(ctx context.Context, c client.Client, obj client.Object) er
 	return nil
 }
 
-// IsBeingDeleted checks if an object is being deleted (has deletion timestamp).
+// IsBeingDeleted checks if an object is being deleted (has non-zero deletion timestamp).
 func IsBeingDeleted(obj client.Object) bool {
-	return obj.GetDeletionTimestamp() != nil
+	return !obj.GetDeletionTimestamp().IsZero()
 }
 
 // ResourceNamespace is an optional interface that cluster-scoped resources can implement
@@ -60,20 +64,11 @@ type ResourceNamespace interface {
 	GetResourceNamespace() string
 }
 
-// CleanupOptions provides configuration for resource cleanup.
-type CleanupOptions struct {
-	// ResourceLists is a slice of empty list objects used to query different resource types.
-	// Each list object (e.g., &corev1.ConfigMapList{}) serves as a template that gets
-	// populated by Client.List(). Example: []client.ObjectList{&corev1.ConfigMapList{}, &corev1.SecretList{}}
-	ResourceLists []client.ObjectList
-	// LabelSelector to find resources to clean up (optional).
-	// If provided, uses efficient label-based filtering.
-	// If empty, lists all resources in namespace and filters by owner UID.
-	LabelSelector client.MatchingLabels
-}
-
 // DeleteOwnedResources finds and deletes all resources owned by the given object.
 // This is RDD's replacement for Kubernetes garbage collection.
+//
+// The function uses dynamic resource discovery to automatically find ALL namespaced
+// resource types in the cluster, eliminating the need to manually specify resource lists.
 //
 // The function attempts to delete all owned resources, collecting errors along the way.
 // If any deletions fail, it returns a combined error, but continues trying to delete
@@ -84,7 +79,7 @@ type CleanupOptions struct {
 //
 // Use opts.LabelSelector to efficiently filter the set of deletion candidates, if possible.
 // Resources not actually owned by the owner will not be touched.
-func DeleteOwnedResources(ctx context.Context, c client.Client, owner client.Object, opts CleanupOptions) error {
+func DeleteOwnedResources(ctx context.Context, c client.Client, owner client.Object, mgr ctrl.Manager) error {
 	logger := log.FromContext(ctx)
 
 	var namespace string
@@ -97,58 +92,123 @@ func DeleteOwnedResources(ctx context.Context, c client.Client, owner client.Obj
 			owner.GetName(), owner.GetObjectKind().GroupVersionKind())
 	}
 
-	listOpts := []client.ListOption{client.InNamespace(namespace)}
-	listOpts = append(listOpts, opts.LabelSelector)
-	var errs []error
-
-	for _, resourceList := range opts.ResourceLists {
-		// List() mutates resourceList by populating its Items field
-		if err := c.List(ctx, resourceList, listOpts...); err != nil {
-			gvk := resourceList.GetObjectKind().GroupVersionKind()
-			errs = append(errs, fmt.Errorf("failed to list %s resources for cleanup: %w", gvk, err))
-			continue // Try next resource type
-		}
-
-		// Use Kubernetes standard library to iterate over list items
-		_ = meta.EachListItem(resourceList, func(runtimeObj runtime.Object) error {
-			obj, ok := runtimeObj.(client.Object)
-			if !ok {
-				errs = append(errs, fmt.Errorf("item is not a client.Object: %s", runtimeObj.GetObjectKind().GroupVersionKind()))
-				return nil // Continue to next item
-			}
-			if !IsOwnedByUID(obj, owner.GetUID()) {
-				return nil // Skip this item, continue iteration
-			}
-			gvk := obj.GetObjectKind().GroupVersionKind()
-
-			// Remove only the RDD finalizer before deletion to allow other controllers to still perform their own cleanup.
-			if controllerutil.ContainsFinalizer(obj, FinalizerName) {
-				logger.Info("Removing RDD finalizer from owned resource",
-					"resourceType", gvk,
-					"resourceNamespace", obj.GetNamespace(),
-					"resourceName", obj.GetName(),
-					"finalizers", obj.GetFinalizers())
-
-				controllerutil.RemoveFinalizer(obj, FinalizerName)
-				if err := c.Update(ctx, obj); err != nil {
-					errs = append(errs, fmt.Errorf("failed to remove finalizers from %s %s/%s: %w", gvk, obj.GetNamespace(), obj.GetName(), err))
-					return nil // Continue to next item
-				}
-			}
-
-			logger.Info("Deleting owned resource",
-				"resourceType", obj.GetObjectKind().GroupVersionKind(),
-				"resourceNamespace", obj.GetNamespace(),
-				"resourceName", obj.GetName())
-
-			if err := c.Delete(ctx, obj); err != nil && client.IgnoreNotFound(err) != nil {
-				errs = append(errs, fmt.Errorf("failed to delete %s %s/%s during cleanup: %w", gvk, obj.GetNamespace(), obj.GetName(), err))
-			}
-			return nil // Always continue to next item
-		})
+	// Discover all namespaced resource types dynamically
+	resourceTypes, err := discoverNamespacedResources(ctx, mgr)
+	if err != nil {
+		return fmt.Errorf("failed to discover namespaced resources: %w", err)
 	}
 
+	// Use GetAPIReader() instead of cached client for listing resources to avoid
+	// setting up watches for dynamically discovered types that may not be in the scheme.
+	apiReader := mgr.GetAPIReader()
+	var errs []error
+	listOpts := []client.ListOption{client.InNamespace(namespace)}
+
+	for _, gvk := range resourceTypes {
+		// We use PartialObjectMetadata because we're doing dynamic resource discovery -
+		// we don't know at compile time what types we'll encounter, and those types may
+		// not be registered in the scheme. PartialObjectMetadata lets us work with ANY
+		// Kubernetes resource using just metadata fields (name, namespace, finalizers, etc.)
+		// without needing the full type definition.
+		list := &metav1.PartialObjectMetadataList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind + "List",
+		})
+
+		// List resources of this type in the namespace using API reader (bypasses cache)
+		if err := apiReader.List(ctx, list, listOpts...); err != nil {
+			logger.V(1).Info("Failed to list resources, skipping",
+				"gvk", gvk.String(),
+				"error", err.Error())
+			continue
+		}
+
+		// Process each resource
+		for _, item := range list.Items {
+			if !IsOwnedByUID(&item, owner.GetUID()) {
+				continue
+			}
+
+			// Remove only the RDD finalizer before deletion to allow other controllers to still perform their own cleanup.
+			patch := client.MergeFrom(item.DeepCopy())
+			if controllerutil.RemoveFinalizer(&item, FinalizerName) {
+				// Use Patch instead of Update for PartialObjectMetadata
+				if err := c.Patch(ctx, &item, patch); err != nil {
+					itemLogger := logger.V(1).WithValues("namespace", item.GetNamespace(), "name", item.GetName(), "gvk", gvk.String())
+					if apierrors.IsNotFound(err) {
+						itemLogger.Info("Resource already deleted during finalizer removal")
+						continue
+					}
+					// For other errors, log and collect error but proceed with deletion attempt
+					// The deletion might still succeed if there are no other blocking finalizers
+					itemLogger.Info("Failed to remove finalizer, will attempt deletion anyway", "error", err)
+					errs = append(errs, fmt.Errorf("failed to remove finalizers from %s %s/%s: %w", gvk, item.GetNamespace(), item.GetName(), err))
+				}
+			}
+			if err := c.Delete(ctx, &item); err != nil && client.IgnoreNotFound(err) != nil {
+				errs = append(errs, fmt.Errorf("failed to delete %s %s/%s during cleanup: %w", gvk, item.GetNamespace(), item.GetName(), err))
+			}
+		}
+	}
 	return errors.Join(errs...)
+}
+
+// discoverNamespacedResources discovers all namespaced resource types in the cluster.
+// Uses the Kubernetes discovery API to find all available namespaced resources dynamically.
+func discoverNamespacedResources(ctx context.Context, mgr ctrl.Manager) ([]schema.GroupVersionKind, error) {
+	logger := log.FromContext(ctx)
+
+	// Create discovery client from manager's config
+	config := mgr.GetConfig()
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
+	// Get all server resources
+	_, apiResourceLists, err := discoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		// ServerGroupsAndResources can return partial results with an error
+		// We'll use whatever we got and log the error
+		logger.V(1).Info("Discovery returned partial results", "error", err)
+	}
+
+	var resourceTypes []schema.GroupVersionKind
+
+	// Iterate through all API groups and resources
+	for _, apiResourceList := range apiResourceLists {
+		// Parse the GroupVersion from the list
+		gv, err := schema.ParseGroupVersion(apiResourceList.GroupVersion)
+		if err != nil {
+			logger.V(1).Info("Failed to parse group version, skipping",
+				"groupVersion", apiResourceList.GroupVersion,
+				"error", err)
+			continue
+		}
+		for _, apiResource := range apiResourceList.APIResources {
+			if !apiResource.Namespaced {
+				continue
+			}
+			// Skip subresources (e.g., namespaces/status, namespaces/finalize)
+			if strings.Contains(apiResource.Name, "/") {
+				continue
+			}
+			gvk := schema.GroupVersionKind{
+				Group:   gv.Group,
+				Version: gv.Version,
+				Kind:    apiResource.Kind,
+			}
+			resourceTypes = append(resourceTypes, gvk)
+		}
+	}
+
+	logger.V(1).Info("Discovered namespaced resources for cleanup",
+		"totalResources", len(resourceTypes),
+		"apiGroups", len(apiResourceLists))
+
+	return resourceTypes, nil
 }
 
 // HasFinalizer checks if a resource has the RDD finalizer.

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -101,8 +101,9 @@ func (c *Controller) GetCRDData() string {
 // setupReconciler sets up the LimaVMReconciler with the manager.
 func (c *Controller) setupReconciler(mgr ctrl.Manager) error {
 	return (&controllers.LimaVMReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Manager: mgr,
 	}).SetupWithManager(mgr)
 }
 

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -27,7 +27,8 @@ const (
 // LimaVMReconciler reconciles a LimaVM object.
 type LimaVMReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme  *runtime.Scheme
+	Manager ctrl.Manager
 }
 
 // +kubebuilder:rbac:groups=lima.rancherdesktop.io,resources=limavms,verbs=get;list;watch;create;update;patch;delete
@@ -114,13 +115,7 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 	logger := log.FromContext(ctx)
 
 	// Clean up all owned resources using the base helper
-	// DeleteOwnedResources automatically removes any finalizers before deletion
-	cleanupOpts := base.CleanupOptions{
-		ResourceLists: []client.ObjectList{
-			&corev1.ConfigMapList{},
-		},
-	}
-	if err := base.DeleteOwnedResources(ctx, r.Client, limaVM, cleanupOpts); err != nil {
+	if err := base.DeleteOwnedResources(ctx, r.Client, limaVM, r.Manager); err != nil {
 		logger.Error(err, "Failed to delete owned resources")
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/lima/limavm/validation.go
+++ b/pkg/controllers/lima/limavm/validation.go
@@ -53,7 +53,7 @@ func ValidateLimaVM(ctx context.Context, c client.Client, limavm *v1alpha1.LimaV
 
 	// Skip validation if the object is being deleted
 	// During deletion, the controller removes finalizers and may have already deleted owned resources
-	if limavm.DeletionTimestamp != nil {
+	if !limavm.DeletionTimestamp.IsZero() {
 		return warnings, nil
 	}
 

--- a/pkg/controllers/rdd/configmapreplicaset/controller.go
+++ b/pkg/controllers/rdd/configmapreplicaset/controller.go
@@ -62,7 +62,8 @@ func (c *Controller) RegisterWithManager(mgr ctrl.Manager) error {
 
 	// Create and set up the controller with the manager
 	return (&controllers.ConfigMapReplicaSetReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Manager: mgr,
 	}).SetupWithManager(mgr)
 }

--- a/pkg/controllers/rdd/configmapreplicaset/controllers/configmapreplicaset_controller.go
+++ b/pkg/controllers/rdd/configmapreplicaset/controllers/configmapreplicaset_controller.go
@@ -30,7 +30,8 @@ import (
 // minimalist controller pattern.
 type ConfigMapReplicaSetReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme  *runtime.Scheme
+	Manager ctrl.Manager
 }
 
 //+kubebuilder:rbac:groups=rdd.rancherdesktop.io,resources=configmapreplicasets,verbs=get;list;watch;create;update;patch;delete
@@ -153,13 +154,8 @@ func (r *ConfigMapReplicaSetReconciler) handleDeletion(ctx context.Context, conf
 	logger := log.FromContext(ctx)
 
 	// Clean up all owned ConfigMaps using the helper
-	cleanupOpts := base.CleanupOptions{
-		ResourceLists: []client.ObjectList{&corev1.ConfigMapList{}},
-		LabelSelector: labelsForConfigMap(configMapReplicaSet.Name),
-	}
-
-	if err := base.DeleteOwnedResources(ctx, r.Client, configMapReplicaSet, cleanupOpts); err != nil {
-		logger.Error(err, "Failed to delete owned ConfigMaps")
+	if err := base.DeleteOwnedResources(ctx, r.Client, configMapReplicaSet, r.Manager); err != nil {
+		logger.Error(err, "Failed to delete owned resources")
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/controllers/rdd/notary/controller.go
+++ b/pkg/controllers/rdd/notary/controller.go
@@ -93,6 +93,7 @@ func (c *Controller) setupReconciler(mgr ctrl.Manager) error {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor(ControllerName + "-controller"),
+		Manager:  mgr,
 	}).SetupWithManager(mgr)
 }
 

--- a/pkg/controllers/rdd/notary/controllers/notary_controller.go
+++ b/pkg/controllers/rdd/notary/controllers/notary_controller.go
@@ -29,6 +29,7 @@ type NotaryReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+	Manager  ctrl.Manager
 }
 
 // +kubebuilder:rbac:groups=rdd.rancherdesktop.io,resources=notaries,verbs=get;list;watch;create;update;patch;delete
@@ -115,16 +116,8 @@ func (r *NotaryReconciler) handleDeletion(ctx context.Context, notary *v1alpha1.
 	log := logf.FromContext(ctx)
 
 	// Clean up all owned ConfigMaps using the helper
-	cleanupOpts := base.CleanupOptions{
-		ResourceLists: []client.ObjectList{&corev1.ConfigMapList{}},
-		LabelSelector: map[string]string{
-			"app.kubernetes.io/managed-by": "notary-controller",
-			"app.kubernetes.io/instance":   notary.Name,
-		},
-	}
-
-	if err := base.DeleteOwnedResources(ctx, r.Client, notary, cleanupOpts); err != nil {
-		log.Error(err, "Failed to delete owned ConfigMaps")
+	if err := base.DeleteOwnedResources(ctx, r.Client, notary, r.Manager); err != nil {
+		log.Error(err, "Failed to delete owned resources")
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Enumerating resource types and resources inside a namspace is just a local sqlite database query, and iterating over the results should be just as quick as filtering stuff "server-side", which is the same process on the same computer.

Not requiring the caller to pass in a list of resource types is more maintenance friendly and the additional time required should be small, given that resources are not constantly being deleted.

Label selectors are used only for setting up reconcilers and general watches, and deletion is only controlled by owner references now.