### PR TITLE
Speed up readiness checks

### DIFF
--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -81,8 +81,9 @@ setup_file() {
 }
 
 teardown_file() {
-    # Need to stop the control plane, otherwise bats will hang
-    rdd svc delete
+    # Stop the control plane but don't delete it, to preserve logs for debugging.
+    # The next test run's setup will clean up and create a fresh instance.
+    rdd svc stop 2>/dev/null || true
 
     call_local_function
 }

--- a/bats/tests/31-rdd-controllers/notary-events.bats
+++ b/bats/tests/31-rdd-controllers/notary-events.bats
@@ -151,6 +151,9 @@ get_latest_event_timestamp() {
     run -0 get_latest_event_timestamp "dupe"
     timestamp=${output}
 
+    # Sleep to ensure timestamp ordering (events created after this will have later timestamps)
+    sleep 1
+
     # Trigger multiple reconciles with identical spec.value by changing annotations
     # Each will generate identical SpecUpdate and NoChange events that Kubernetes should deduplicate
     run -0 rdd ctl annotate notary dupe test-annotation-1=value1
@@ -158,9 +161,10 @@ get_latest_event_timestamp() {
     run -0 rdd ctl annotate notary dupe test-annotation-3=value3
     run -0 rdd ctl annotate notary dupe test-annotation-4=value4
 
-    # Wait for events to be processed
-    wait_for_events "dupe" "SpecUpdate"
-    wait_for_events "dupe" "NoChange"
+    # Wait for NEW events to be generated after the timestamp
+    # This ensures the controller has processed the annotation updates
+    wait_for_events_after_timestamp "dupe" "${timestamp}" "SpecUpdate"
+    wait_for_events_after_timestamp "dupe" "${timestamp}" "NoChange"
 
     # Count events after the timestamp - should be deduplicated by Kubernetes
     # It is not clear if Kubernetes will always catch all duplicates, but it should get at least 1

--- a/bats/tests/33-lima-controllers/limavm-admission.bats
+++ b/bats/tests/33-lima-controllers/limavm-admission.bats
@@ -157,9 +157,8 @@ EOF
     run -0 rdd lima delete "my-vm"
     assert_output --partial "deleted"
 
-    # Verify deletion succeeded
-    run -1 rdd ctl get limavm "my-vm" --namespace "test-ns1"
-    assert_output --partial "not found"
+    # Wait for deletion to complete (asynchronous Kubernetes deletion)
+    try --max 10 --delay 1 --until-fail -- rdd ctl get limavm "my-vm" --namespace "test-ns1"
 
     # Now we should be able to create a LimaVM with the same name in test-ns2
     run -0 rdd lima create "my-vm" "test-template" --namespace "test-ns2"

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -236,10 +236,6 @@ func Start(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if err != nil {
-		return err
-	}
-
 	cmdArgs := []string{"service", "serve"}
 	// Always start with saved args from create (contains --secure-port)
 	savedArgs := ServeArgs()
@@ -258,7 +254,95 @@ func Start(ctx context.Context, args []string) error {
 	return cmd.Start()
 }
 
+// checkReadiness performs a single readiness check.
+func checkReadiness(ctx context.Context) error {
+	config, err := GetKubeRestConfig()
+	if err != nil {
+		klog.V(2).Infof("Waiting for kubeconfig to be available: %v", err)
+		return err
+	}
+
+	// Wait for the controller manager to register with the actual running controllers
+	runtimeControllers, err := getRuntimeControllersFromCluster(ctx)
+	if err != nil {
+		// Check if this is a "no controller manager found" error, which indicates --controllers=""
+		if errors.Is(err, ErrControllerManagerNotFound) {
+			klog.V(2).Info("No controller manager found - checking if this is truly no-controllers mode")
+
+			// Check the original command args to see if --controllers="" was specified
+			serveArgs := ServeArgs()
+			isNoControllersMode := false
+			for i, arg := range serveArgs {
+				if arg == "--controllers" && i+1 < len(serveArgs) && serveArgs[i+1] == "" {
+					isNoControllersMode = true
+					break
+				}
+			}
+
+			if isNoControllersMode {
+				// Check if API server is ready for basic operations
+				if err := readiness.WaitForReady(ctx, config, false); err == nil {
+					klog.V(2).Info("API server ready and no controllers expected - no controllers mode")
+					return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
+				}
+				klog.V(2).Info("API server not ready yet, continuing to wait...")
+			} else {
+				klog.V(2).Info("Controllers expected but discovery configmap not found yet - waiting for external controllers to register...")
+			}
+		} else {
+			klog.V(2).Infof("getRuntimeControllersFromCluster: %v", err)
+		}
+		return err
+	}
+	klog.V(2).Infof("Waiting for %d runtime controllers to be ready", len(runtimeControllers))
+	if len(runtimeControllers) == 0 {
+		// This shouldn't happen since we handle it above, but keeping as fallback
+		// Check if API server is ready for basic operations
+		if err := readiness.WaitForReady(ctx, config, false); err == nil {
+			klog.V(2).Info("API server ready but no controllers registered - assuming no controllers mode")
+			return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
+		}
+		klog.V(2).Info("Waiting for controller manager to register in cluster...")
+		return errors.New("waiting for controller manager to register")
+	}
+
+	// Get the controller objects for the actually running controllers
+	allControllers := base.GetAllControllers()
+	var enabledControllers []base.Controller
+
+	for _, controller := range allControllers {
+		for _, enabledName := range runtimeControllers {
+			if controller.GetName() == enabledName {
+				enabledControllers = append(enabledControllers, controller)
+				break
+			}
+		}
+	}
+
+	klog.V(2).Infof("Discovery service found running controllers: %v", runtimeControllers)
+
+	// Debug: Log all available controllers
+	allControllerNames := make([]string, len(allControllers))
+	for i, c := range allControllers {
+		allControllerNames[i] = c.GetName()
+	}
+	klog.V(2).Infof("All available controllers: %v", allControllerNames)
+
+	// Debug: Log enabled controllers
+	enabledControllerNames := make([]string, len(enabledControllers))
+	for i, c := range enabledControllers {
+		enabledControllerNames[i] = c.GetName()
+	}
+	klog.V(2).Infof("Enabled controllers for readiness: %v", enabledControllerNames)
+
+	return readiness.WaitForReadyWithCRDs(ctx, config, enabledControllers, false)
+}
+
 func Wait(ctx context.Context) error {
+	if err := checkReadiness(ctx); err == nil {
+		return nil
+	}
+
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -267,87 +351,9 @@ func Wait(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			config, err := GetKubeRestConfig()
-			if err != nil {
-				klog.V(2).Infof("Waiting for kubeconfig to be available: %v", err)
-				continue
+			if err := checkReadiness(ctx); err == nil {
+				return nil
 			}
-
-			// Wait for the controller manager to register with the actual running controllers
-			// Discovery service is the single source of truth - no fallbacks
-			runtimeControllers, err := getRuntimeControllersFromCluster(ctx)
-			if err != nil {
-				// Check if this is a "no controller manager found" error, which indicates --controllers=""
-				if errors.Is(err, ErrControllerManagerNotFound) {
-					klog.V(2).Info("No controller manager found - checking if this is truly no-controllers mode")
-
-					// Check the original command args to see if --controllers="" was specified
-					serveArgs := ServeArgs()
-					isNoControllersMode := false
-					for i, arg := range serveArgs {
-						if arg == "--controllers" && i+1 < len(serveArgs) && serveArgs[i+1] == "" {
-							isNoControllersMode = true
-							break
-						}
-					}
-
-					if isNoControllersMode {
-						// Check if API server is ready for basic operations
-						if err := readiness.WaitForReady(ctx, config, false); err == nil {
-							klog.V(2).Info("API server ready and no controllers expected - no controllers mode")
-							return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
-						}
-						klog.V(2).Info("API server not ready yet, continuing to wait...")
-					} else {
-						klog.V(2).Info("Controllers expected but discovery configmap not found yet - waiting for external controllers to register...")
-					}
-				} else {
-					klog.V(2).Infof("getRuntimeControllersFromCluster: %v", err)
-				}
-				continue
-			}
-			klog.V(2).Infof("Waiting for %d runtime controllers to be ready", len(runtimeControllers))
-			if len(runtimeControllers) == 0 {
-				// This shouldn't happen since we handle it above, but keeping as fallback
-				// Check if API server is ready for basic operations
-				if err := readiness.WaitForReady(ctx, config, false); err == nil {
-					klog.V(2).Info("API server ready but no controllers registered - assuming no controllers mode")
-					return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
-				}
-				klog.V(2).Info("Waiting for controller manager to register in cluster...")
-				continue
-			}
-
-			// Get the controller objects for the actually running controllers
-			allControllers := base.GetAllControllers()
-			var enabledControllers []base.Controller
-
-			for _, controller := range allControllers {
-				for _, enabledName := range runtimeControllers {
-					if controller.GetName() == enabledName {
-						enabledControllers = append(enabledControllers, controller)
-						break
-					}
-				}
-			}
-
-			klog.V(2).Infof("Discovery service found running controllers: %v", runtimeControllers)
-
-			// Debug: Log all available controllers
-			allControllerNames := make([]string, len(allControllers))
-			for i, c := range allControllers {
-				allControllerNames[i] = c.GetName()
-			}
-			klog.V(2).Infof("All available controllers: %v", allControllerNames)
-
-			// Debug: Log enabled controllers
-			enabledControllerNames := make([]string, len(enabledControllers))
-			for i, c := range enabledControllers {
-				enabledControllerNames[i] = c.GetName()
-			}
-			klog.V(2).Infof("Enabled controllers for readiness: %v", enabledControllerNames)
-
-			return readiness.WaitForReadyWithCRDs(ctx, config, enabledControllers, false)
 		}
 	}
 }
@@ -450,7 +456,7 @@ func ServeArgs() []string {
 	return nil
 }
 
-// shouldEnableController determines if a controller should be enabled based on the controllers specification.
+// shouldEnableController determines if a controller should be enabled based on the controller's specification.
 func shouldEnableController(controller base.Controller, spec string) bool {
 	// Handle empty spec - no controllers should be enabled
 	if spec == "" {

--- a/pkg/service/readiness/ready.go
+++ b/pkg/service/readiness/ready.go
@@ -44,8 +44,6 @@ func WaitForReady(ctx context.Context, config *rest.Config, logging bool) error 
 	}
 
 	for {
-		time.Sleep(100 * time.Millisecond)
-
 		select {
 		case <-ctx.Done():
 			return errors.New("context canceled")
@@ -76,9 +74,9 @@ func WaitForReady(ctx context.Context, config *rest.Config, logging bool) error 
 			logger.Info("Control plane is ready")
 			break
 		}
-
-		// Always log non-ready status for debugging
 		klog.V(1).InfoS("Control plane not ready", "status", rc, "unreadyComponents", sets.List[string](lastSeenUnready))
+
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	return nil
@@ -175,7 +173,7 @@ func waitForCRDsEstablished(ctx context.Context, config *rest.Config, controller
 	}
 
 	// Check if all are already established
-	allEstablished := establishedCRDs.Equal(expectedCRDs)
+	allEstablished := establishedCRDs.IsSuperset(expectedCRDs)
 
 	if allEstablished {
 		logger.Info("All CRDs are already established")
@@ -209,7 +207,7 @@ func waitForCRDsEstablished(ctx context.Context, config *rest.Config, controller
 		if isCRDEstablished(crd) {
 			wasNew := !establishedCRDs.Has(crdName)
 			establishedCRDs.Insert(crdName)
-			allEstablished = establishedCRDs.Equal(expectedCRDs)
+			allEstablished = establishedCRDs.IsSuperset(expectedCRDs)
 
 			if wasNew {
 				logger.Info("CRD became established during watch setup", "crd", crdName)
@@ -248,7 +246,7 @@ func waitForCRDsEstablished(ctx context.Context, config *rest.Config, controller
 				if isCRDEstablished(crd) {
 					wasNew := !establishedCRDs.Has(crd.Name)
 					establishedCRDs.Insert(crd.Name)
-					allEstablished := establishedCRDs.Equal(expectedCRDs)
+					allEstablished := establishedCRDs.IsSuperset(expectedCRDs)
 
 					if wasNew {
 						logger.Info("CRD became established", "crd", crd.Name)
@@ -350,7 +348,7 @@ func waitForWebhookConfigurations(ctx context.Context, config *rest.Config, cont
 	}
 
 	// Check if all are already created
-	allFound := foundWebhooks.Equal(expectedWebhookSet)
+	allFound := foundWebhooks.IsSuperset(expectedWebhookSet)
 
 	if allFound {
 		logger.Info("All webhook configurations already exist")
@@ -364,6 +362,34 @@ func waitForWebhookConfigurations(ctx context.Context, config *rest.Config, cont
 
 	logger.Info("Polling for webhook configuration creation")
 
+	// Helper function to check webhook status
+	checkWebhooks := func() bool {
+		for _, webhook := range expectedWebhooks {
+			if foundWebhooks.Has(webhook.name) {
+				continue
+			}
+
+			var err error
+			if webhook.webhookType == base.MutatingWebhook {
+				_, err = mutatingClient.Get(ctx, webhook.name, metav1.GetOptions{})
+			} else {
+				_, err = validatingClient.Get(ctx, webhook.name, metav1.GetOptions{})
+			}
+			if err == nil {
+				foundWebhooks.Insert(webhook.name)
+				logger.Info("Webhook configuration became available", "webhook", webhook.name, "type", webhook.webhookType)
+			}
+		}
+		return foundWebhooks.IsSuperset(expectedWebhookSet)
+	}
+
+	// Check immediately first - don't waste 500ms waiting for ticker
+	if checkWebhooks() {
+		logger.Info("All webhook configurations are ready")
+		return nil
+	}
+
+	// Not all ready yet, start polling
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -373,26 +399,9 @@ func waitForWebhookConfigurations(ctx context.Context, config *rest.Config, cont
 			missing := expectedWebhookSet.Difference(foundWebhooks)
 			return fmt.Errorf("timeout waiting for webhook configurations to be created: missing %v", sets.List(missing))
 		case <-ticker.C:
-			// Check for any missing webhook configurations
-			for _, webhook := range expectedWebhooks {
-				if foundWebhooks.Has(webhook.name) {
-					continue
-				}
-
-				var err error
-				if webhook.webhookType == base.MutatingWebhook {
-					_, err = mutatingClient.Get(ctx, webhook.name, metav1.GetOptions{})
-				} else {
-					_, err = validatingClient.Get(ctx, webhook.name, metav1.GetOptions{})
-				}
-				if err == nil {
-					logger.Info("Webhook configuration became available", "webhook", webhook.name, "type", webhook.webhookType)
-					foundWebhooks.Insert(webhook.name)
-					if foundWebhooks.IsSuperset(expectedWebhookSet) {
-						logger.Info("All webhook configurations are ready")
-						return nil
-					}
-				}
+			if checkWebhooks() {
+				logger.Info("All webhook configurations are ready")
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
Don't sleep before the first check; most times the control plane is already ready. This can reduce total runtime for an `rdd ctl` command from 700ms to just 100ms, speeding up BATS tests.

Some tests had to be updated because they started failing with faster readiness checks.

You want to review this while hiding whitespace changes because some large code blocks just got moved around and changed indentation.