### PR TITLE
Implement namespace controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build-rdd: bin/rdd$(EXE)
 .PHONY: build-rdd
 
 # API Group Controller management - Auto-discovery of API groups
-API_GROUPS := $(notdir $(shell find pkg/controllers -mindepth 1 -maxdepth 1 -type d -not -name base))
+API_GROUPS := $(notdir $(shell find pkg/controllers -mindepth 1 -maxdepth 1 -type d -not -name base -not -name builtin))
 
 # Generate build targets for API group controllers
 define API_GROUP_CONTROLLER_TARGETS

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -43,6 +43,11 @@ bats-service: check-bats build-rdd
 	RDD_INSTANCE=bats-service $(BATS_CORE) tests/20-service/
 .PHONY: bats-service
 
+# Run builtin controller tests
+bats-builtin: check-bats build-rdd
+	RDD_INSTANCE=bats-builtin-controller $(BATS_CORE) tests/30-builtin-controllers/
+.PHONY: bats-builtin
+
 # Run rdd API group controller tests
 bats-rdd: check-bats build-rdd build-rdd-controller
 	RDD_INSTANCE=bats-rdd-controller $(BATS_CORE) tests/31-rdd-controllers/
@@ -59,7 +64,7 @@ bats-lima: check-bats build-rdd
 .PHONY: bats-lima
 
 # Run all controller tests
-bats-controllers: bats-rdd bats-app bats-lima
+bats-controllers: bats-builtin bats-rdd bats-app bats-lima
 .PHONY: bats-controllers
 
 # Run all BATS tests

--- a/bats/tests/30-builtin-controllers/namespace.bats
+++ b/bats/tests/30-builtin-controllers/namespace.bats
@@ -1,0 +1,66 @@
+load '../../helpers/load'
+
+# Namespace deletion tests - tests the built-in namespace controller
+# that handles cleanup of resources when a namespace is deleted.
+
+local_setup_file() {
+    setup_rdd_control_plane "*"
+}
+
+@test 'namespace deletion with multiple resource types' {
+    rdd ctl create namespace "multi-ns"
+
+    # Create various core resources
+    rdd ctl create configmap test-cm -n multi-ns --from-literal=key=value
+    rdd ctl create secret generic test-secret -n multi-ns --from-literal=password=secret
+
+    # Create custom resources from different API groups
+    # ConfigMapReplicaSet (rdd.rancherdesktop.io)
+    rdd ctl apply -f - <<EOF
+apiVersion: rdd.rancherdesktop.io/v1alpha1
+kind: ConfigMapReplicaSet
+metadata:
+  name: test-cmrs
+  namespace: multi-ns
+spec:
+  replicas: 2
+  data:
+    key: value
+EOF
+
+    # Notary (rdd.rancherdesktop.io)
+    rdd ctl apply -f - <<EOF
+apiVersion: rdd.rancherdesktop.io/v1alpha1
+kind: Notary
+metadata:
+  name: test-notary
+  namespace: multi-ns
+spec:
+  value: "test-value"
+  configMapName: "notary-history"
+EOF
+
+    # LimaVM (lima.rancherdesktop.io)
+    rdd ctl create configmap lima-template -n multi-ns --from-literal=template='{"vmType":"vz"}'
+    rdd ctl apply -f - <<EOF
+apiVersion: lima.rancherdesktop.io/v1alpha1
+kind: LimaVM
+metadata:
+  name: test-vm
+  namespace: multi-ns
+spec:
+  running: false
+  templateRef:
+    name: lima-template
+EOF
+
+    # Verify all resources exist
+    rdd ctl get configmap test-cm -n multi-ns
+    rdd ctl get secret test-secret -n multi-ns
+    rdd ctl get configmapreplicaset test-cmrs -n multi-ns
+    rdd ctl get notary test-notary -n multi-ns
+    rdd ctl get limavm test-vm -n multi-ns
+
+    # Delete namespace
+    rdd ctl delete namespace "multi-ns" --timeout=20s
+}

--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -6,7 +6,14 @@ LIMA_TEST_NS="lima-test-ns"
 
 local_setup_file() {
     setup_rdd_control_plane "lima"
+}
+
+local_setup() {
     rdd ctl create namespace "${LIMA_TEST_NS}"
+}
+
+local_teardown() {
+    rdd ctl delete namespace "${LIMA_TEST_NS}"
 }
 
 # assert_running verifies the "test-vm" running state, must be "true" or "false"
@@ -68,9 +75,6 @@ assert_created() {
     assert_output --partial 'deleted'
     run -1 rdd ctl get limavm "test-vm" --namespace "${LIMA_TEST_NS}"
     assert_output --partial "not found"
-
-    # Clean up the template ConfigMap
-    rdd ctl delete configmap "test-template" --namespace "${LIMA_TEST_NS}"
 }
 
 @test "lima create with file template" {
@@ -133,9 +137,6 @@ assert_created() {
     # Verify the ConfigMap was cleaned up (should not exist in $LIMA_TEST_NS)
     run -1 rdd ctl get configmap "duplicate-vm" --namespace "${LIMA_TEST_NS}"
     assert_output --partial "not found"
-
-    # Clean up the first LimaVM
-    rdd limavm delete "duplicate-vm"
 }
 
 @test "lima create fails with non-existent file" {

--- a/pkg/controllers/app/demo/controller.go
+++ b/pkg/controllers/app/demo/controller.go
@@ -10,12 +10,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
-	controller "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/demo/controllers"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/demo/controllers"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 )
 
 func init() {
-	base.RegisterController(NewController())
+	base.RegisterController(&controller{})
 }
 
 // ControllerName is the name of this controller.
@@ -27,41 +27,36 @@ const APIGroup = "app"
 //go:embed crd.yaml
 var demoCRD string
 
-// Controller implements the base.Controller interface for demo.
-type Controller struct{}
+// controller implements the base.Controller interface for demo.
+type controller struct{}
 
-// Verify that Controller implements base.Controller interface.
-var _ base.Controller = &Controller{}
-
-// NewController creates a new Controller instance.
-func NewController() *Controller {
-	return &Controller{}
-}
+// Verify that controller implements base.Controller interface.
+var _ base.Controller = &controller{}
 
 // GetName returns the controller name.
-func (c *Controller) GetName() string {
+func (c *controller) GetName() string {
 	return ControllerName
 }
 
 // GetAPIGroup returns the API group this controller belongs to.
-func (c *Controller) GetAPIGroup() string {
+func (c *controller) GetAPIGroup() string {
 	return APIGroup
 }
 
 // GetCRDData returns the embedded CRD YAML data.
-func (c *Controller) GetCRDData() string {
+func (c *controller) GetCRDData() string {
 	return demoCRD
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *Controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
 
 	// Create and set up the controller with the manager
-	return (&controller.DemoReconciler{
+	return (&controllers.DemoReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor(ControllerName + "-controller"),

--- a/pkg/controllers/app/demo/controllers/demo_controller.go
+++ b/pkg/controllers/app/demo/controllers/demo_controller.go
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-package controller
+package controllers
 
 import (
 	"context"

--- a/pkg/controllers/base/finalizer.go
+++ b/pkg/controllers/base/finalizer.go
@@ -93,7 +93,7 @@ func DeleteOwnedResources(ctx context.Context, c client.Client, owner client.Obj
 	}
 
 	// Discover all namespaced resource types dynamically
-	resourceTypes, err := discoverNamespacedResources(ctx, mgr)
+	resourceTypes, err := DiscoverNamespacedResources(ctx, mgr)
 	if err != nil {
 		return fmt.Errorf("failed to discover namespaced resources: %w", err)
 	}
@@ -155,9 +155,9 @@ func DeleteOwnedResources(ctx context.Context, c client.Client, owner client.Obj
 	return errors.Join(errs...)
 }
 
-// discoverNamespacedResources discovers all namespaced resource types in the cluster.
+// DiscoverNamespacedResources discovers all namespaced resource types in the cluster.
 // Uses the Kubernetes discovery API to find all available namespaced resources dynamically.
-func discoverNamespacedResources(ctx context.Context, mgr ctrl.Manager) ([]schema.GroupVersionKind, error) {
+func DiscoverNamespacedResources(ctx context.Context, mgr ctrl.Manager) ([]schema.GroupVersionKind, error) {
 	logger := log.FromContext(ctx)
 
 	// Create discovery client from manager's config

--- a/pkg/controllers/builtin/namespace/controller.go
+++ b/pkg/controllers/builtin/namespace/controller.go
@@ -20,37 +20,32 @@ const ControllerName = "namespace"
 const APIGroup = "builtin"
 
 func init() {
-	base.RegisterController(NewController())
+	base.RegisterController(&controller{})
 }
 
-// Controller implements the base.Controller interface for namespace lifecycle management.
-type Controller struct{}
+// controller implements the base.Controller interface for namespace lifecycle management.
+type controller struct{}
 
-// Verify that Controller implements base.Controller interface.
-var _ base.Controller = &Controller{}
-
-// NewController creates a new Controller instance.
-func NewController() *Controller {
-	return &Controller{}
-}
+// Verify that controller implements base.Controller interface.
+var _ base.Controller = &controller{}
 
 // GetName returns the controller name.
-func (c *Controller) GetName() string {
+func (c *controller) GetName() string {
 	return ControllerName
 }
 
 // GetAPIGroup returns the API group this controller belongs to.
-func (c *Controller) GetAPIGroup() string {
+func (c *controller) GetAPIGroup() string {
 	return APIGroup
 }
 
 // GetCRDData returns empty string since namespace is a built-in Kubernetes resource.
-func (c *Controller) GetCRDData() string {
+func (c *controller) GetCRDData() string {
 	return ""
 }
 
 // RegisterWithManager implements the complete controller registration.
-func (c *Controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 	klog.InfoS("Setting up namespace controller watch", "controller", ControllerName)
 
 	// Register the controller

--- a/pkg/controllers/builtin/namespace/controller.go
+++ b/pkg/controllers/builtin/namespace/controller.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package namespace
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/builtin/namespace/controllers"
+)
+
+// ControllerName is the name of this controller.
+const ControllerName = "namespace"
+
+// APIGroup is the API group this controller belongs to.
+const APIGroup = "builtin"
+
+func init() {
+	base.RegisterController(NewController())
+}
+
+// Controller implements the base.Controller interface for namespace lifecycle management.
+type Controller struct{}
+
+// Verify that Controller implements base.Controller interface.
+var _ base.Controller = &Controller{}
+
+// NewController creates a new Controller instance.
+func NewController() *Controller {
+	return &Controller{}
+}
+
+// GetName returns the controller name.
+func (c *Controller) GetName() string {
+	return ControllerName
+}
+
+// GetAPIGroup returns the API group this controller belongs to.
+func (c *Controller) GetAPIGroup() string {
+	return APIGroup
+}
+
+// GetCRDData returns empty string since namespace is a built-in Kubernetes resource.
+func (c *Controller) GetCRDData() string {
+	return ""
+}
+
+// RegisterWithManager implements the complete controller registration.
+func (c *Controller) RegisterWithManager(mgr ctrl.Manager) error {
+	klog.InfoS("Setting up namespace controller watch", "controller", ControllerName)
+
+	// Register the controller
+	// Note: Resource discovery happens dynamically during each reconciliation
+	// to ensure we always have the most up-to-date list of namespaced resources
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		Complete(&controllers.NamespaceReconciler{
+			Client:  mgr.GetClient(),
+			Scheme:  mgr.GetScheme(),
+			Manager: mgr,
+		})
+	if err != nil {
+		klog.ErrorS(err, "Failed to setup namespace controller", "controller", ControllerName)
+		return err
+	}
+	klog.InfoS("Namespace controller watch setup complete", "controller", ControllerName)
+	return nil
+}

--- a/pkg/controllers/builtin/namespace/controllers/namespace_controller.go
+++ b/pkg/controllers/builtin/namespace/controllers/namespace_controller.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+)
+
+const (
+	// kubernetesFinalizer is the standard Kubernetes namespace finalizer.
+	// This finalizer is automatically added to all namespaces by the upstream NamespaceLifecycle
+	// admission plugin (enabled in pkg/service/admission/config.go). The admission plugin
+	// adds it during CREATE, ensuring all namespaces (including system namespaces like
+	// default and rdd-system) have the finalizer from the start.
+	//
+	// This controller is responsible for removing the finalizer after cleaning up all
+	// resources in the namespace during deletion.
+	kubernetesFinalizer = "kubernetes"
+)
+
+// NamespaceReconciler reconciles Namespace objects to handle deletion lifecycle.
+//
+// This controller replicates the behavior of the standard Kubernetes namespace controller,
+// which RDD cannot use because controller-manager requires kubelet.
+//
+// Namespace deletion in Kubernetes is a two-part process:
+// 1. NamespaceLifecycle admission plugin adds the "kubernetes" finalizer during CREATE.
+// 2. Namespace controller (this controller) deletes all resources and removes the finalizer.
+type NamespaceReconciler struct {
+	client.Client
+	Scheme  *runtime.Scheme
+	Manager ctrl.Manager
+}
+
+// Reconcile implements the reconciliation loop for namespace deletion.
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Fetch the namespace
+	var namespace corev1.Namespace
+	if err := r.Get(ctx, req.NamespacedName, &namespace); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !base.IsBeingDeleted(&namespace) {
+		return ctrl.Result{}, nil
+	}
+	// Check if the namespace has the kubernetes finalizer
+	// Can't use controllerutil.ContainsFinalizer() because namespaces use Spec.Finalizers instead of Metadata.Finalizers.
+	if !slices.Contains(namespace.Spec.Finalizers, kubernetesFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Processing namespace deletion", "namespace", namespace.Name)
+
+	resourceTypes, err := base.DiscoverNamespacedResources(ctx, r.Manager)
+	if err != nil {
+		log.Error(err, "Failed to discover namespaced resources")
+		return ctrl.Result{}, err
+	}
+
+	// Loop internally until all resources are deleted or no progress can be made.
+	// This avoids re-queueing and rate limiter delays when making progress.
+	previousCount := -1 // Start with -1 to indicate first iteration
+
+	for {
+		remainingCount, err := r.deleteAllResources(ctx, namespace.Name, resourceTypes)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Check if all resources are deleted
+		if remainingCount == 0 {
+			break
+		}
+
+		// Check if we made progress
+		if previousCount > 0 && remainingCount >= previousCount {
+			log.Error(nil, "Namespace deletion stuck - no progress made",
+				"namespace", namespace.Name,
+				"remaining", remainingCount)
+			// Requeue with longer delay to give finalizers more time
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		previousCount = remainingCount
+		// Brief delay to allow API server to process delete requests
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// All resources deleted, remove the kubernetes finalizer
+	// Re-fetch the namespace to get the latest resourceVersion
+	if err := r.Get(ctx, req.NamespacedName, &namespace); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := r.removeFinalizer(ctx, &namespace, kubernetesFinalizer); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// deleteAllResources deletes resources from the namespace.
+// Returns the count of remaining resources.
+func (r *NamespaceReconciler) deleteAllResources(ctx context.Context, namespaceName string, resourceTypes []schema.GroupVersionKind) (int, error) {
+	// IMPORTANT: This function uses GetAPIReader() instead of the cached client (r.Client) because:
+	// - The cached client automatically sets up informers/watches for every resource type it lists
+	// - With dynamic discovery, we don't know what resource types exist until runtime
+	// - The controller manager's scheme may not have all discovered types registered for watching
+	// - Attempting to list unknown types with the cached client causes the reflector to fail
+	// - GetAPIReader() bypasses the cache and reads directly from the API server, avoiding watches
+	apiReader := r.Manager.GetAPIReader()
+
+	totalRemaining := 0
+	for _, gvk := range resourceTypes {
+		list := &metav1.PartialObjectMetadataList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind + "List",
+		})
+
+		// List resources of this type in the namespace using API reader (bypasses cache)
+		if err := apiReader.List(ctx, list, client.InNamespace(namespaceName)); err != nil {
+			continue
+		}
+
+		if len(list.Items) > 0 {
+			// Try to delete each resource
+			for _, item := range list.Items {
+				_ = r.Delete(ctx, &item) // Ignore errors, will retry on next iteration
+			}
+
+			// Re-list to count remaining
+			listAfter := &metav1.PartialObjectMetadataList{}
+			listAfter.SetGroupVersionKind(list.GroupVersionKind())
+			if err := apiReader.List(ctx, listAfter, client.InNamespace(namespaceName)); err == nil {
+				totalRemaining += len(listAfter.Items)
+			}
+		}
+	}
+
+	return totalRemaining, nil
+}
+
+// removeFinalizer removes the specified finalizer from the namespace.
+// IMPORTANT: Namespaces require using the "finalize" subresource to update spec.finalizers.
+// A regular Update() call will appear to succeed but won't actually persist the change.
+func (r *NamespaceReconciler) removeFinalizer(ctx context.Context, namespace *corev1.Namespace, finalizer string) error {
+	namespace.Spec.Finalizers = slices.DeleteFunc(namespace.Spec.Finalizers, func(f corev1.FinalizerName) bool {
+		return string(f) == finalizer
+	})
+	if err := r.SubResource("finalize").Update(ctx, namespace); err != nil {
+		return fmt.Errorf("failed to remove namespace finalizer: %w", err)
+	}
+	return nil
+}

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	base.RegisterController(NewController())
+	base.RegisterController(&controller{})
 }
 
 // ControllerName is the name of this controller.
@@ -51,55 +51,50 @@ const (
 //go:embed crd.yaml
 var limaCRD string
 
-// Controller implements the base.Controller interface for limavm.
-type Controller struct {
+// controller implements the base.Controller interface for limavm.
+type controller struct {
 	webhookPort     int                    // The actual webhook port allocated by SharedControllerManager
 	webhookManagers []*base.WebhookManager // WebhookManagers for parallel setup
 }
 
-// Verify that Controller implements base.Controller and base.WebhookController interfaces.
+// Verify that controller implements base.Controller and base.WebhookController interfaces.
 var (
-	_ base.Controller        = &Controller{}
-	_ base.WebhookController = &Controller{}
+	_ base.Controller        = &controller{}
+	_ base.WebhookController = &controller{}
 )
 
-// NewController creates a new Controller instance.
-func NewController() *Controller {
-	return &Controller{}
-}
-
 // GetName returns the controller name.
-func (c *Controller) GetName() string {
+func (c *controller) GetName() string {
 	return ControllerName
 }
 
 // GetAPIGroup returns the API group this controller belongs to.
-func (c *Controller) GetAPIGroup() string {
+func (c *controller) GetAPIGroup() string {
 	return APIGroup
 }
 
 // SetWebhookPort sets the webhook port allocated by SharedControllerManager.
-func (c *Controller) SetWebhookPort(port int) {
+func (c *controller) SetWebhookPort(port int) {
 	c.webhookPort = port
 }
 
 // GetWebhookServiceName returns the DNS service name for webhook certificates.
-func (c *Controller) GetWebhookServiceName() string {
+func (c *controller) GetWebhookServiceName() string {
 	return ControllerName + "-webhook"
 }
 
 // GetWebhookManagers returns all WebhookManagers for parallel setup.
-func (c *Controller) GetWebhookManagers() []*base.WebhookManager {
+func (c *controller) GetWebhookManagers() []*base.WebhookManager {
 	return c.webhookManagers
 }
 
 // GetCRDData returns the embedded CRD YAML data.
-func (c *Controller) GetCRDData() string {
+func (c *controller) GetCRDData() string {
 	return limaCRD
 }
 
 // setupReconciler sets up the LimaVMReconciler with the manager.
-func (c *Controller) setupReconciler(mgr ctrl.Manager) error {
+func (c *controller) setupReconciler(mgr ctrl.Manager) error {
 	return (&controllers.LimaVMReconciler{
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
@@ -108,7 +103,7 @@ func (c *Controller) setupReconciler(mgr ctrl.Manager) error {
 }
 
 // setupWebhookWithRuntimeConfig sets up webhooks with shared certificate configuration.
-func (c *Controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
+func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 	// Set up LimaVM mutating webhook (validates uniqueness and creates template ConfigMap during admission)
 	sideEffectsNoneOnDryRun := admissionregistrationv1.SideEffectClassNoneOnDryRun
 	mutatingConfig := base.WebhookConfig{
@@ -156,7 +151,7 @@ func (c *Controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *Controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/pkg/controllers/rdd/configmapreplicaset/controller.go
+++ b/pkg/controllers/rdd/configmapreplicaset/controller.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	base.RegisterController(NewController())
+	base.RegisterController(&controller{})
 }
 
 // ControllerName is the name of this controller.
@@ -27,34 +27,29 @@ const APIGroup = "rdd"
 //go:embed crd.yaml
 var configMapReplicaSetCRD string
 
-// Controller implements the base.Controller interface for configmapreplicaset.
-type Controller struct{}
+// controller implements the base.Controller interface for configmapreplicaset.
+type controller struct{}
 
-// Verify that Controller implements base.Controller interface.
-var _ base.Controller = &Controller{}
-
-// NewController creates a new Controller instance.
-func NewController() *Controller {
-	return &Controller{}
-}
+// Verify that controller implements base.Controller interface.
+var _ base.Controller = &controller{}
 
 // GetName returns the controller name.
-func (c *Controller) GetName() string {
+func (c *controller) GetName() string {
 	return ControllerName
 }
 
 // GetAPIGroup returns the API group this controller belongs to.
-func (c *Controller) GetAPIGroup() string {
+func (c *controller) GetAPIGroup() string {
 	return APIGroup
 }
 
 // GetCRDData returns the embedded CRD YAML data.
-func (c *Controller) GetCRDData() string {
+func (c *controller) GetCRDData() string {
 	return configMapReplicaSetCRD
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *Controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/pkg/controllers/rdd/notary/controller.go
+++ b/pkg/controllers/rdd/notary/controller.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	base.RegisterController(NewController())
+	base.RegisterController(&controller{})
 }
 
 // ControllerName is the name of this controller.
@@ -40,55 +40,50 @@ const (
 //go:embed crd.yaml
 var notaryCRD string
 
-// Controller implements the base.Controller interface for notary.
-type Controller struct {
+// controller implements the base.Controller interface for notary.
+type controller struct {
 	webhookPort     int                    // The actual webhook port allocated by SharedControllerManager
 	webhookManagers []*base.WebhookManager // WebhookManagers for parallel setup
 }
 
-// Verify that Controller implements base.Controller and base.WebhookController interfaces.
+// Verify that controller implements base.Controller and base.WebhookController interfaces.
 var (
-	_ base.Controller        = &Controller{}
-	_ base.WebhookController = &Controller{}
+	_ base.Controller        = &controller{}
+	_ base.WebhookController = &controller{}
 )
 
-// NewController creates a new Controller instance.
-func NewController() *Controller {
-	return &Controller{}
-}
-
 // GetName returns the controller name.
-func (c *Controller) GetName() string {
+func (c *controller) GetName() string {
 	return ControllerName
 }
 
 // GetAPIGroup returns the API group this controller belongs to.
-func (c *Controller) GetAPIGroup() string {
+func (c *controller) GetAPIGroup() string {
 	return APIGroup
 }
 
 // SetWebhookPort sets the webhook port allocated by SharedControllerManager.
-func (c *Controller) SetWebhookPort(port int) {
+func (c *controller) SetWebhookPort(port int) {
 	c.webhookPort = port
 }
 
 // GetWebhookServiceName returns the DNS service name for webhook certificates.
-func (c *Controller) GetWebhookServiceName() string {
+func (c *controller) GetWebhookServiceName() string {
 	return ControllerName + "-webhook"
 }
 
 // GetWebhookManagers returns all WebhookManagers for parallel setup.
-func (c *Controller) GetWebhookManagers() []*base.WebhookManager {
+func (c *controller) GetWebhookManagers() []*base.WebhookManager {
 	return c.webhookManagers
 }
 
 // GetCRDData returns the embedded CRD YAML data.
-func (c *Controller) GetCRDData() string {
+func (c *controller) GetCRDData() string {
 	return notaryCRD
 }
 
 // setupReconciler sets up the NotaryReconciler with the manager.
-func (c *Controller) setupReconciler(mgr ctrl.Manager) error {
+func (c *controller) setupReconciler(mgr ctrl.Manager) error {
 	return (&controllers.NotaryReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
@@ -98,7 +93,7 @@ func (c *Controller) setupReconciler(mgr ctrl.Manager) error {
 }
 
 // setupWebhookWithRuntimeConfig sets up webhook with shared certificate configuration.
-func (c *Controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
+func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 	webhookConfig := base.WebhookConfig{
 		Name:        validatorConfigName,
 		WebhookName: webhookName,
@@ -116,7 +111,7 @@ func (c *Controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *Controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -55,6 +55,8 @@ import (
 	// Import controller packages to trigger init() functions for embedded mode.
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/demo"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	// Import built-in system controllers.
+	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/builtin/namespace"
 	// Import controller packages to trigger init() functions for embedded mode.
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/lima/limavm"
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/rdd/configmapreplicaset"
@@ -458,7 +460,10 @@ func ServeArgs() []string {
 
 // shouldEnableController determines if a controller should be enabled based on the controller's specification.
 func shouldEnableController(controller base.Controller, spec string) bool {
-	// Handle empty spec - no controllers should be enabled
+	if controller.GetAPIGroup() == "builtin" {
+		return true
+	}
+	// Empty spec: only builtin controllers are enabled
 	if spec == "" {
 		return false
 	}
@@ -687,9 +692,9 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 
 	// Get all registered controllers from the registry
 	allControllers := base.GetAllControllers()
-
-	// Get enabled controllers from the --controllers flag directly
 	controllersSpec := completed.Controllers.Controllers
+
+	// Enable controllers: builtin controllers are always enabled, others based on --controllers flag
 	for _, controller := range allControllers {
 		if shouldEnableController(controller, controllersSpec) {
 			enabledControllers = append(enabledControllers, controller)

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -124,6 +124,8 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	// Create and register scheme with required types
 	managerScheme := runtime.NewScheme()
 	utilruntime.Must(scheme.AddToScheme(managerScheme))
+	// Add CRD types to support dynamic resource discovery
+	utilruntime.Must(apiextensionsv1.AddToScheme(managerScheme))
 
 	// Modify kubeconfig to force JSON content type to avoid protobuf issues
 	configCopy := *scm.kubeConfig
@@ -291,8 +293,19 @@ func (scm *SharedControllerManager) hasWebhookControllers() bool {
 
 // registerDiscovery registers the controller manager information in the cluster.
 func (scm *SharedControllerManager) registerDiscovery(ctx context.Context) error {
-	// Get controller names
-	controllerNames := scm.GetRegisteredControllers()
+	// Get controller names, filtering out builtin controllers.
+	// Builtin controllers are internal system controllers and should not be registered in discovery.
+	var controllerNames []string
+	for _, registration := range scm.registrations {
+		if registration.GetAPIGroup() != "builtin" {
+			controllerNames = append(controllerNames, registration.GetName())
+		}
+	}
+
+	// Only register if there are non-builtin controllers.
+	if len(controllerNames) == 0 {
+		return nil
+	}
 
 	return scm.discovery.RegisterControllerManager(ctx, scm.healthPort, scm.metricsPort, controllerNames)
 }
@@ -322,6 +335,12 @@ func (scm *SharedControllerManager) installControllerCRDs(ctx context.Context) e
 	for _, controller := range scm.registrations {
 		controllerName := controller.GetName()
 		crdData := controller.GetCRDData()
+
+		// Skip controllers without CRDs (e.g., built-in controllers for Kubernetes resources)
+		if crdData == "" {
+			klog.V(2).InfoS("Controller has no CRD, skipping CRD installation", "controller", controllerName)
+			continue
+		}
 
 		var crd apiextensionsv1.CustomResourceDefinition
 		if err := yaml.Unmarshal([]byte(crdData), &crd); err != nil {


### PR DESCRIPTION
We can use the Kubernetes NamespaceLifecycle admission controller to set the finalizer on namespaces as they are being created, but we cannot use the Namespaces controller because it requires controller-manager/kubelet.