### PR TITLE
CI: BATS: Use Leap 16 instead of Tumbleweed

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -94,8 +94,7 @@ jobs:
         wsl --set-default-version 2
 
         # Install WSL2 Distribution
-        # TODO: switch to Leap 16 once that is available
-        wsl --install --no-launch --version 2 --name openSUSE openSUSE-Tumbleweed
+        wsl --install --no-launch --version 2 --name openSUSE openSUSE-Leap-16.0
         # Disable first-boot script
         wsl --distribution openSUSE --exec sed -i '/^command =/d' /etc/wsl-distribution.conf
 


### PR DESCRIPTION
Now that it's released, we should use Leap because its repository is more stable.