### PR TITLE
readiness: Simplify checking CRD establishment

### DIFF
--- a/bats/Makefile
+++ b/bats/Makefile
@@ -83,11 +83,11 @@ bats-timeout: check-bats build-rdd
 # Run specific BATS test file
 # Usage: make bats-file FILE=bats/tests/31-rdd-controllers/configmapreplicaset.bats
 bats-file: check-bats build-rdd build-all-controllers
-	@if [ -z "$(FILE)" ]; then \
+	@if [ -z "$(FILE:bats/%=%)" ]; then \
 		echo "Usage: make bats-file FILE=path/to/test.bats"; \
 		exit 1; \
 	fi
-	$(BATS_CORE) "$(FILE)"
+	$(BATS_CORE) "$(FILE:bats/%=%)"
 .PHONY: bats-file
 
 # Run BATS tests with trace output for debugging

--- a/bats/tests/20-service/4-start-parameters.bats
+++ b/bats/tests/20-service/4-start-parameters.bats
@@ -2,52 +2,51 @@ load '../../helpers/load'
 
 # Controller testing using CRD presence validation
 
-assert_rdd_controllers() {
-    run -0 rdd ctl get CustomResourceDefinition notaries.rdd.rancherdesktop.io
-    assert_output --partial "notaries.rdd.rancherdesktop.io"
+CRD_GROUP=customresourcedefinition.apiextensions.k8s.io # spellchecker:ignore
 
-    run -0 rdd ctl get CustomResourceDefinition configmapreplicasets.rdd.rancherdesktop.io
-    assert_output --partial "configmapreplicasets.rdd.rancherdesktop.io"
+get_controllers() {
+    run -0 rdd ctl get CustomResourceDefinition --output=name
+    # If `$output` is empty, `refute_lines` will fail because `$lines` is unset.
+    if [[ -z "${output}" ]]; then
+        run -0 echo '<no output>'
+    fi
 }
 
-assert_app_controllers() {
-    run -0 rdd ctl get CustomResourceDefinition demos.app.rancherdesktop.io
-    assert_output --partial "demos.app.rancherdesktop.io"
+check_rdd_controllers() {
+    local assert=$1
+    "${assert}_line" "${CRD_GROUP}/notaries.rdd.rancherdesktop.io"
+    "${assert}_line" "${CRD_GROUP}/configmapreplicasets.rdd.rancherdesktop.io"
 }
 
-refute_rdd_controllers() {
-    run -1 rdd ctl get CustomResourceDefinition notaries.rdd.rancherdesktop.io
-    assert_output --partial "NotFound"
-
-    run -1 rdd ctl get CustomResourceDefinition configmapreplicasets.rdd.rancherdesktop.io
-    assert_output --partial "NotFound"
-}
-
-refute_app_controllers() {
-    run -1 rdd ctl get CustomResourceDefinition demos.app.rancherdesktop.io
-    assert_output --partial "NotFound"
+check_app_controllers() {
+    local assert=$1
+    "${assert}_line" "${CRD_GROUP}/demos.app.rancherdesktop.io"
 }
 
 assert_only_rdd_controllers() {
-    assert_rdd_controllers
-    refute_app_controllers
+    get_controllers
+    check_rdd_controllers assert
+    check_app_controllers refute
 }
 
 assert_only_app_controllers() {
-    assert_app_controllers
-    refute_rdd_controllers
+    get_controllers
+    check_app_controllers assert
+    check_rdd_controllers refute
 }
 
 assert_all_controllers() {
-    assert_rdd_controllers
-    assert_app_controllers
+    get_controllers
+    check_rdd_controllers assert
+    check_app_controllers assert
 }
 
 assert_no_controllers() {
     # Essential APIs should work but no controllers
     run -0 rdd ctl get namespaces
-    refute_rdd_controllers
-    refute_app_controllers
+    get_controllers
+    check_rdd_controllers refute
+    check_app_controllers refute
 }
 
 @test 'test instance with no controllers parameter' {

--- a/pkg/service/readiness/ready.go
+++ b/pkg/service/readiness/ready.go
@@ -168,66 +168,37 @@ func waitForCRDsEstablished(ctx context.Context, config *rest.Config, controller
 	establishedCRDs := sets.New[string]()
 
 	// First, check if any CRDs are already established
-	for _, crdName := range expectedCRDNames {
-		crd, err := crdClient.Get(ctx, crdName, metav1.GetOptions{})
-		if err != nil {
-			logger.V(2).Info("CRD not yet available, will watch for it", "crd", crdName)
-			continue // Will catch it in the watch
-		}
+	var initialCRDs *apiextensionsv1.CustomResourceDefinitionList
+	initialCRDs, err = crdClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list CRDs: %w", err)
+	}
 
-		if isCRDEstablished(crd) {
-			establishedCRDs.Insert(crdName)
-			logger.V(1).Info("CRD already established", "crd", crdName)
+	for _, crd := range initialCRDs.Items {
+		if expectedCRDs.Has(crd.Name) && isCRDEstablished(&crd) {
+			establishedCRDs.Insert(crd.Name)
+			logger.V(1).Info("CRD already established", "crd", crd.Name)
 		}
 	}
 
 	// Check if all are already established
-	allEstablished := establishedCRDs.IsSuperset(expectedCRDs)
-
-	if allEstablished {
+	if establishedCRDs.IsSuperset(expectedCRDs) {
 		logger.Info("All CRDs are already established")
 		return nil
 	}
 
 	// Watch for CRD changes
-	watchCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	const timeout = time.Minute
+	watchCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	watcher, err := crdClient.Watch(watchCtx, metav1.ListOptions{})
+	watcher, err := crdClient.Watch(watchCtx, metav1.ListOptions{ResourceVersion: initialCRDs.ResourceVersion})
 	if err != nil {
 		return fmt.Errorf("failed to start CRD watch: %w", err)
 	}
 	defer watcher.Stop()
 
-	klog.InfoS("Starting CRD watch", "timeout", "60s", "expected", expectedCRDNames)
-
-	// After starting the watch, do one more check to catch any CRDs that
-	// became established in the brief window between the initial check and watch start
-	for _, crdName := range expectedCRDNames {
-		if establishedCRDs.Has(crdName) {
-			continue // Already marked as established
-		}
-
-		crd, err := crdClient.Get(ctx, crdName, metav1.GetOptions{})
-		if err != nil {
-			continue // Will catch it in the watch
-		}
-
-		if isCRDEstablished(crd) {
-			wasNew := !establishedCRDs.Has(crdName)
-			establishedCRDs.Insert(crdName)
-			allEstablished = establishedCRDs.IsSuperset(expectedCRDs)
-
-			if wasNew {
-				logger.Info("CRD became established during watch setup", "crd", crdName)
-			}
-
-			if allEstablished {
-				logger.Info("All CRDs are established after watch setup")
-				return nil
-			}
-		}
-	}
+	klog.InfoS("Starting CRD watch", "timeout", timeout, "expected", expectedCRDNames)
 
 	for {
 		select {
@@ -252,16 +223,11 @@ func waitForCRDsEstablished(ctx context.Context, config *rest.Config, controller
 			}
 
 			if event.Type == watch.Added || event.Type == watch.Modified {
-				if isCRDEstablished(crd) {
-					wasNew := !establishedCRDs.Has(crd.Name)
+				if !establishedCRDs.Has(crd.Name) && isCRDEstablished(crd) {
+					logger.Info("CRD became established", "crd", crd.Name)
 					establishedCRDs.Insert(crd.Name)
-					allEstablished := establishedCRDs.IsSuperset(expectedCRDs)
 
-					if wasNew {
-						logger.Info("CRD became established", "crd", crd.Name)
-					}
-
-					if allEstablished {
+					if establishedCRDs.IsSuperset(expectedCRDs) {
 						logger.Info("All CRDs are established")
 						return nil
 					}


### PR DESCRIPTION
We are occasionally getting timeouts in CI when waiting for the CRDs to be established; try listing all CRDs and then watching based on that resource version to make sure we don't miss anything.