### PR TITLE
rdd: implement `rdd svc log`

### DIFF
--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -15,6 +16,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/developer"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/tail"
 )
 
 // logrusLevelToKlog converts current logrus level to klog level.
@@ -45,6 +47,7 @@ func newServiceCommand(ctx context.Context) *cobra.Command {
 		newServiceStopCommand(),
 		newServiceDeleteCommand(),
 		newServiceStatusCommand(),
+		newServiceLogCommand(),
 	)
 	return command
 }
@@ -256,5 +259,28 @@ func newServiceStatusCommand() *cobra.Command {
 			return nil
 		},
 	}
+	return command
+}
+
+func newServiceLogCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:     "log",
+		Aliases: []string{"logs"},
+		Long:    "Show control plane logs",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			logrus.SetLevel(logrus.InfoLevel)
+
+			name := "rdd.stderr.log"
+			if ok, _ := cmd.Flags().GetBool("stdout"); ok {
+				name = "rdd.stdout.log"
+			}
+			logPath := filepath.Join(instance.Dir(), name)
+			follow, _ := cmd.Flags().GetBool("follow")
+
+			return tail.TailFile(cmd.Context(), cmd.OutOrStdout(), logPath, follow)
+		},
+	}
+	command.Flags().BoolP("stdout", "o", false, "Print stdout instead of stderr")
+	command.Flags().BoolP("follow", "f", false, "Follow log output")
 	return command
 }

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,13 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/k3s-io/kine v1.14.2
 	github.com/muesli/reflow v0.3.0
+	github.com/pulumi/pulumi/sdk/v3 v3.206.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.etcd.io/etcd/api/v3 v3.6.6
 	golang.org/x/mod v0.31.0
+	golang.org/x/sync v0.18.0
 	golang.org/x/sys v0.39.0
 	gotest.tools/v3 v3.5.2
 	k8s.io/api v0.34.3
@@ -136,6 +138,7 @@ require (
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect
@@ -237,6 +240,7 @@ require (
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.21.2 // indirect
+	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/selinux v1.11.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
@@ -332,7 +336,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
@@ -347,6 +350,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,7 @@ github.com/firefart/nonamedreturns v1.0.6 h1:vmiBcKV/3EqKY3ZiPxCINmpS431OcE1S47A
 github.com/firefart/nonamedreturns v1.0.6/go.mod h1:R8NisJnSIpvPWheCq0mNRXJok6D8h7fagJTF8EMEwCo=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
@@ -244,6 +245,8 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
+github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golangci/asciicheck v0.5.0 h1:jczN/BorERZwK8oiFBOGvlGPknhvq0bjnysTj4nUfo0=
@@ -479,8 +482,8 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nunnatsa/ginkgolinter v0.21.2 h1:khzWfm2/Br8ZemX8QM1pl72LwM+rMeW6VUbQ4rzh0Po=
 github.com/nunnatsa/ginkgolinter v0.21.2/go.mod h1:GItSI5fw7mCGLPmkvGYrr1kEetZe7B593jcyOpyabsY=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
-github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
+github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
@@ -522,6 +525,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
+github.com/pulumi/pulumi/sdk/v3 v3.206.0 h1:DvEn8GiYwSCraOv+RkGHYFOvA2m7Y3peWAdgmuYknUY=
+github.com/pulumi/pulumi/sdk/v3 v3.206.0/go.mod h1:UsBMdaUQ+WoKoQtF2PYbQIbo8ZRJuAo1axkyit9IQVE=
 github.com/quasilyte/go-ruleguard v0.4.5 h1:AGY0tiOT5hJX9BTdx/xBdoCubQUAE2grkqY2lSwvZcA=
 github.com/quasilyte/go-ruleguard v0.4.5/go.mod h1:Vl05zJ538vcEEwu16V/Hdu7IYZWyKSwIy4c88Ro1kRE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.23 h1:lxjt5B6ZCiBeeNO8/oQsegE6fLeCzuMRoVWSkXC4uvY=
@@ -558,8 +563,8 @@ github.com/sashamelentyev/usestdlibvars v1.29.0 h1:8J0MoRrw4/NAXtjQqTHrbW9NN+3iM
 github.com/sashamelentyev/usestdlibvars v1.29.0/go.mod h1:8PpnjHMk5VdeWlVb4wCdrB8PNbLqZ3wBZTZWkrpZZL8=
 github.com/securego/gosec/v2 v2.22.11-0.20251204091113-daccba6b93d7 h1:rZg6IGn0ySYZwCX8LHwZoYm03JhG/cVAJJ3O+u3Vclo=
 github.com/securego/gosec/v2 v2.22.11-0.20251204091113-daccba6b93d7/go.mod h1:9sr22NZO5Kfh7unW/xZxkGYTmj2484/fCiE54gw7UTY=
-github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
+github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shengdoushi/base58 v1.0.0 h1:tGe4o6TmdXFJWoI31VoSWvuaKxf0Px3gqa3sUWhAxBs=
 github.com/shengdoushi/base58 v1.0.0/go.mod h1:m5uIILfzcKMw6238iWAhP4l3s5+uXyF3+bJKUNhAL9I=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
@@ -793,6 +798,7 @@ golang.org/x/sys v0.0.0-20211105183446-c75c47738b0c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/util/tail/tail.go
+++ b/pkg/util/tail/tail.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+package tail
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tail"
+	"github.com/sirupsen/logrus"
+)
+
+// TailFile prints out all of the given file into the given writer.  If follow
+// is true, wait for more lines to be added to the file at end of file;
+// otherwise, just return at end of file.
+func TailFile(ctx context.Context, writer io.Writer, filePath string, follow bool) error {
+	config := tail.Config{
+		ReOpen:        follow,
+		Follow:        follow,
+		CompleteLines: true,
+		Logger:        logrus.StandardLogger(),
+	}
+	t, err := tail.File(filePath, config)
+	if err != nil {
+		return err
+	}
+
+	if !follow {
+		// Signal that we want to stop tailing at EOF.
+		go func() {
+			_ = t.StopAtEOF()
+		}()
+	}
+	go func() {
+		<-ctx.Done()
+		_ = t.Stop()
+	}()
+
+	for line := range t.Lines {
+		fmt.Fprintln(writer, line.Text)
+	}
+	return nil
+}

--- a/pkg/util/tail/tail_test.go
+++ b/pkg/util/tail/tail_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+package tail
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"gotest.tools/v3/assert"
+)
+
+func TestTailFile(t *testing.T) {
+	const expected = "This is the last line of text"
+
+	testCases := []struct {
+		name    string
+		follow  bool
+		prepare func(w io.WriteCloser) error
+		finish  func(w io.WriteCloser) error
+	}{
+		{
+			name:   "do not follow",
+			follow: false,
+			prepare: func(w io.WriteCloser) error {
+				for i := range 1000 {
+					_, err := fmt.Fprintf(w, "This is line %d with some length\n", i)
+					if err != nil {
+						return err
+					}
+				}
+				_, err := fmt.Fprintln(w, expected)
+				return err
+			},
+			finish: func(w io.WriteCloser) error {
+				return w.Close()
+			},
+		},
+		{
+			name:   "follow",
+			follow: true,
+			prepare: func(w io.WriteCloser) error {
+				for i := range 100 {
+					_, err := fmt.Fprintf(w, "This is line %d in the first block\n", i)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			finish: func(w io.WriteCloser) error {
+				defer w.Close()
+				for i := range 100 {
+					_, err := fmt.Fprintf(w, "This is line %d in the second block\n", i)
+					if err != nil {
+						return err
+					}
+				}
+				_, err := fmt.Fprintln(w, expected)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			n := filepath.Join(t.TempDir(), "output.log")
+			f, err := os.Create(n)
+			assert.NilError(t, err, "failed to create test file")
+			defer f.Close()
+			r, w := io.Pipe()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+
+			// Across a bunch of goroutines, we need to:
+			// - Set up the scanner
+			// - Run the `prepare` function
+			// - Run TailFile until it gets stuck
+			// - Run the `finish` function
+			// - Run TailFile until it gets stuck (again)
+			// - End the TailFile context (so it ends)
+			// - Check that the last line was the expected output
+
+			lastLine := "initial value"
+			lines := make(chan string)
+			scanner := bufio.NewScanner(r)
+			go func() {
+				defer close(lines)
+				for scanner.Scan() {
+					lines <- scanner.Text()
+				}
+			}()
+			// waitForStuck will run until there has been half a second without
+			// any lines being emitted.
+			waitForStuck := func() {
+				for {
+					select {
+					case lastLine = <-lines:
+					case <-time.After(100 * time.Millisecond):
+						return
+					}
+				}
+			}
+
+			tailCtx, done := context.WithCancel(ctx)
+			assert.NilError(t, tc.prepare(f))
+			wg, tailCtx := errgroup.WithContext(tailCtx)
+			wg.Go(func() error {
+				return TailFile(tailCtx, w, n, tc.follow)
+			})
+			waitForStuck()
+			assert.NilError(t, tc.finish(f))
+			waitForStuck()
+			done()
+
+			// Close the writer, so the scanner knows we're done.
+			assert.NilError(t, w.Close())
+			assert.NilError(t, wg.Wait(), "failed to wait for cleanup")
+			assert.Equal(t, expected, lastLine)
+		})
+	}
+}


### PR DESCRIPTION
This new command prints out the last known logs of the corresponding RDD instance.  By default, stderr logs are printed; `rdd svc log --stdout` can be used to print the stdout logs instead.  `rdd svc log --follow` can be used to tail the logs until the user interrupts it.

We are using the pulumi fork of `github.com/nxadm/tail` because that has some fixes around stopping at the end of the file that would be important for our use case (when not using `--follow`) that has pull requests upstream that have not been merged.

Fixes #71