### PR TITLE
Allow multiple controller managers

### DIFF
--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -66,6 +66,7 @@ DSQLITE
 endef
 ifneq
 notdir
+patsubst
 VTAB
 
 # check-spelling

--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,10 @@ build-rdd: bin/rdd$(EXE)
 .PHONY: build-rdd
 
 # API Group Controller management - Auto-discovery of API groups
-API_GROUPS := $(notdir $(shell find pkg/controllers -mindepth 1 -maxdepth 1 -type d -not -name base -not -name builtin))
+CONTROLLERS := $(patsubst cmd/%-controller,%,$(wildcard cmd/*-controller))
 
 # Generate build targets for API group controllers
-define API_GROUP_CONTROLLER_TARGETS
+define CONTROLLER_TARGETS
 bin/$(1)-controller$$(EXE): $$(GOLANG_SOURCES)
 	WSLENV=${WSLENV}:CGO_ENABLED CGO_ENABLED=0 \
 	go$$(EXE) build -tags="$(TAGS)" -gcflags="all=$${GCFLAGS}" -ldflags="$(LDFLAGS)" -o $$@ ./cmd/$(1)-controller
@@ -77,16 +77,16 @@ run-$(1)-controller: bin/$(1)-controller$$(EXE)
 endef
 
 # Generate targets for each API group
-$(foreach apigroup,$(API_GROUPS),$(eval $(call API_GROUP_CONTROLLER_TARGETS,$(apigroup))))
+$(foreach controller,$(CONTROLLERS),$(eval $(call CONTROLLER_TARGETS,$(controller))))
 
 # Meta targets
-build-all-controllers: $(addprefix build-,$(addsuffix -controller,$(API_GROUPS)))
+build-all-controllers: $(addprefix build-,$(addsuffix -controller,$(CONTROLLERS)))
 .PHONY: build-all-controllers
 
-test-all-controllers: $(addprefix test-,$(addsuffix -controllers,$(API_GROUPS)))
+test-all-controllers: $(addprefix test-,$(addsuffix -controllers,$(CONTROLLERS)))
 .PHONY: test-all-controllers
 
-run-all-controllers: $(addprefix run-,$(addsuffix -controller,$(API_GROUPS)))
+run-all-controllers: $(addprefix run-,$(addsuffix -controller,$(CONTROLLERS)))
 .PHONY: run-all-controllers
 
 # Code generation targets
@@ -102,7 +102,7 @@ generate: generate-deepcopy generate-crds
 .PHONY: generate
 
 run: bin/rdd$(EXE)
-	$< start
+	$< service start
 .PHONY: run
 
 test: $(GOLANG_SOURCES)

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -134,3 +134,57 @@ EOF
     # External controllers check every 2 seconds, allow up to 3 failures (6 seconds), plus buffer
     try --max 15 --delay 1 -- assert_process_exited "${controller_pid}"
 }
+
+@test "control plane starts with different controller" {
+    rdd service delete
+    rdd service create --controllers="lima"
+    rdd service start
+}
+
+@test "control plane starts without rdd controller" {
+    # Confirm apiserver is working
+    run -0 rdd ctl get namespaces -o name
+    assert_line namespace/default
+
+    # Verify that the embedded lima controller is running
+    run -0 rdd ctl get configmap rdd-controller-manager --namespace rdd-system --output jsonpath='{.data.embedded}'
+    assert_output
+    jq_output '.enabledControllers[]'
+    assert_line "limavm"
+    refute_line "notary"
+
+    # Verify that the external rdd controller is not running
+    run -0 rdd ctl get configmap rdd-controller-manager --namespace rdd-system --output jsonpath='{.data.rdd}'
+    refute_output
+}
+
+@test "external controller runs and registers" {
+    # Start external rdd-controller binary in background
+    "rdd-controller${EXE}" &
+    # Store PID to verify it auto-exits later
+    echo "$!" >"${BATS_FILE_TMPDIR}/controller_pid"
+
+    # Wait for external controller to register in discovery system
+    try --max 20 --delay 1 -- rdd ctl get configmap rdd-controller-manager --namespace rdd-system --allow-missing-template-keys=false --output jsonpath='{.data.rdd}'
+
+    # Verify the discovery ConfigMap contains notary controller
+    run -0 --separate-stderr rdd ctl get configmap rdd-controller-manager --namespace rdd-system --output jsonpath='{.data.rdd}'
+    run -0 jq_output '.enabledControllers[]'
+    assert_output
+    assert_line "notary"
+}
+
+@test "shut down external controller" {
+    # Get the stored PID from the controller start test
+    controller_pid=$(cat "${BATS_FILE_TMPDIR}/controller_pid")
+
+    # Verify the external controller process is currently running
+    run -0 kill -0 "${controller_pid}"
+
+    # Stop the control plane - this should trigger auto-cleanup of external controllers
+    run -0 rdd svc stop
+
+    # Wait for external controller to detect control plane shutdown and exit
+    # External controllers check every 2 seconds, allow up to 3 failures (6 seconds), plus buffer
+    try --max 15 --delay 1 -- assert_process_exited "${controller_pid}"
+}

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -38,7 +38,7 @@ assert_process_exited() {
     try --max 20 --delay 1 -- rdd ctl get configmap rdd-controller-manager --namespace rdd-system
 
     # Verify the discovery ConfigMap contains notary controller
-    run -0 --separate-stderr rdd ctl get configmap rdd-controller-manager --namespace rdd-system -o jsonpath='{.data.rdd}'
+    run_e -0 rdd ctl get configmap rdd-controller-manager --namespace rdd-system -o jsonpath='{.data.rdd}'
     run -0 jq_output '.enabledControllers[]'
     assert_line "notary"
 }
@@ -179,10 +179,10 @@ EOF
     controller_pid=$(cat "${BATS_FILE_TMPDIR}/controller_pid")
 
     # Verify the external controller process is currently running
-    run -0 kill -0 "${controller_pid}"
+    kill -0 "${controller_pid}"
 
     # Stop the control plane - this should trigger auto-cleanup of external controllers
-    run -0 rdd svc stop
+    rdd service stop
 
     # Wait for external controller to detect control plane shutdown and exit
     # External controllers check every 2 seconds, allow up to 3 failures (6 seconds), plus buffer

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -38,8 +38,9 @@ assert_process_exited() {
     try --max 20 --delay 1 -- rdd ctl get configmap rdd-controller-manager --namespace rdd-system
 
     # Verify the discovery ConfigMap contains notary controller
-    run -0 rdd ctl get configmap rdd-controller-manager --namespace rdd-system -o jsonpath='{.data.enabledControllers}'
-    assert_output --partial "notary"
+    run -0 --separate-stderr rdd ctl get configmap rdd-controller-manager --namespace rdd-system -o jsonpath='{.data.rdd}'
+    run -0 jq_output '.enabledControllers[]'
+    assert_line "notary"
 }
 
 @test "webhook configuration is created" {

--- a/pkg/controllers/base/webhook_certificates.go
+++ b/pkg/controllers/base/webhook_certificates.go
@@ -22,12 +22,6 @@ import (
 )
 
 const (
-	// DefaultWebhookCertFileName is the default filename for webhook server certificates.
-	// Uses controller-runtime's expected filename for automatic discovery.
-	DefaultWebhookCertFileName = "tls.crt"
-	// DefaultWebhookKeyFileName is the default filename for webhook server private keys.
-	// Uses controller-runtime's expected filename for automatic discovery.
-	DefaultWebhookKeyFileName = "tls.key"
 	// DefaultWebhookCACertFileName is the default filename for webhook CA certificates.
 	DefaultWebhookCACertFileName = "webhook-ca.crt"
 )
@@ -36,14 +30,18 @@ const (
 // for multiple controllers sharing the same webhook server infrastructure.
 type SharedWebhookCertificateManager struct {
 	certDir      string
+	certName     string
+	keyName      string
 	serverIP     string
 	serviceNames []string // DNS names for all webhook services
 }
 
 // NewSharedWebhookCertificateManager creates a new shared certificate manager.
-func NewSharedWebhookCertificateManager(certDir, serverIP string, serviceNames []string) *SharedWebhookCertificateManager {
+func NewSharedWebhookCertificateManager(certDir, certName, keyName, serverIP string, serviceNames []string) *SharedWebhookCertificateManager {
 	return &SharedWebhookCertificateManager{
 		certDir:      certDir,
+		certName:     certName,
+		keyName:      keyName,
 		serverIP:     serverIP,
 		serviceNames: serviceNames,
 	}
@@ -138,13 +136,13 @@ func (cm *SharedWebhookCertificateManager) GenerateWebhookCertificates() error {
 	}
 
 	// Save webhook certificate
-	webhookCertPath := filepath.Join(cm.certDir, DefaultWebhookCertFileName)
+	webhookCertPath := filepath.Join(cm.certDir, cm.certName)
 	if err := cm.saveCertificate(webhookCertPath, webhookCertDER); err != nil {
 		return fmt.Errorf("failed to save webhook certificate: %w", err)
 	}
 
 	// Save webhook private key
-	webhookKeyPath := filepath.Join(cm.certDir, DefaultWebhookKeyFileName)
+	webhookKeyPath := filepath.Join(cm.certDir, cm.keyName)
 	if err := cm.savePrivateKey(webhookKeyPath, webhookKey); err != nil {
 		return fmt.Errorf("failed to save webhook private key: %w", err)
 	}
@@ -211,8 +209,8 @@ func (cm *SharedWebhookCertificateManager) GetCABundle() ([]byte, error) {
 
 // CertificatesExist checks if webhook certificates already exist and are valid.
 func (cm *SharedWebhookCertificateManager) CertificatesExist() bool {
-	certPath := filepath.Join(cm.certDir, DefaultWebhookCertFileName)
-	keyPath := filepath.Join(cm.certDir, DefaultWebhookKeyFileName)
+	certPath := filepath.Join(cm.certDir, cm.certName)
+	keyPath := filepath.Join(cm.certDir, cm.keyName)
 
 	// Check if both files exist
 	if _, err := os.Stat(certPath); os.IsNotExist(err) {
@@ -274,8 +272,8 @@ func (cm *SharedWebhookCertificateManager) certificateIncludesAllServiceNames(ce
 
 // GetWebhookCertPaths returns the file paths for webhook certificate and key.
 func (cm *SharedWebhookCertificateManager) GetWebhookCertPaths() (certPath, keyPath string) {
-	certPath = filepath.Join(cm.certDir, DefaultWebhookCertFileName)
-	keyPath = filepath.Join(cm.certDir, DefaultWebhookKeyFileName)
+	certPath = filepath.Join(cm.certDir, cm.certName)
+	keyPath = filepath.Join(cm.certDir, cm.keyName)
 	return certPath, keyPath
 }
 

--- a/pkg/external/main.go
+++ b/pkg/external/main.go
@@ -126,8 +126,8 @@ func RunControllers(apiGroupName string) int {
 
 // monitorControlPlane monitors the control plane lifecycle and cancels the context when it's no longer available.
 // This allows external controllers to automatically exit when `rdd svc stop` or `rdd svc delete` is called.
-func monitorControlPlane(ctx context.Context, name string, config *rest.Config, log klog.Logger, cancel context.CancelFunc) {
-	discovery, err := controllers.NewControllerManagerDiscovery(config, name)
+func monitorControlPlane(ctx context.Context, apiGroupName string, config *rest.Config, log klog.Logger, cancel context.CancelFunc) {
+	discovery, err := controllers.NewControllerManagerDiscoveryGroup(config, apiGroupName)
 	if err != nil {
 		log.Error(err, "Failed to create discovery service for monitoring")
 		return
@@ -198,7 +198,7 @@ func monitorControlPlane(ctx context.Context, name string, config *rest.Config, 
 // shouldStartController checks if an external controller should start based on RDD discovery.
 // Returns true if no RDD controller manager is running or the specific controller is not enabled.
 func shouldStartController(ctx context.Context, config *rest.Config, controllerName string, log klog.Logger) (bool, error) {
-	discovery, err := controllers.NewControllerManagerDiscovery(config, "")
+	discovery, err := controllers.NewControllerManagerDiscovery(config)
 	if err != nil {
 		return false, fmt.Errorf("failed to create discovery service: %w", err)
 	}

--- a/pkg/external/main.go
+++ b/pkg/external/main.go
@@ -78,7 +78,7 @@ func RunControllers(apiGroupName string) int {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		monitorControlPlane(monitorCtx, config, setupLog, cancelMonitor)
+		monitorControlPlane(monitorCtx, apiGroupName, config, setupLog, cancelMonitor)
 	}()
 
 	// Get available ports for metrics and health endpoints
@@ -95,7 +95,11 @@ func RunControllers(apiGroupName string) int {
 	}
 
 	// Create shared controller manager for this API group
-	sharedManager := controllers.NewSharedControllerManager(ctx, config, metricsPort, healthPort)
+	sharedManager, err := controllers.NewSharedControllerManager(ctx, apiGroupName, config, metricsPort, healthPort)
+	if err != nil {
+		setupLog.Error(err, "Failed to create shared controller manager")
+		return 1
+	}
 
 	// Register only the controllers that should start
 	for _, controller := range controllersToStart {
@@ -122,8 +126,8 @@ func RunControllers(apiGroupName string) int {
 
 // monitorControlPlane monitors the control plane lifecycle and cancels the context when it's no longer available.
 // This allows external controllers to automatically exit when `rdd svc stop` or `rdd svc delete` is called.
-func monitorControlPlane(ctx context.Context, config *rest.Config, log klog.Logger, cancel context.CancelFunc) {
-	discovery, err := controllers.NewControllerManagerDiscovery(config)
+func monitorControlPlane(ctx context.Context, name string, config *rest.Config, log klog.Logger, cancel context.CancelFunc) {
+	discovery, err := controllers.NewControllerManagerDiscovery(config, name)
 	if err != nil {
 		log.Error(err, "Failed to create discovery service for monitoring")
 		return
@@ -194,7 +198,7 @@ func monitorControlPlane(ctx context.Context, config *rest.Config, log klog.Logg
 // shouldStartController checks if an external controller should start based on RDD discovery.
 // Returns true if no RDD controller manager is running or the specific controller is not enabled.
 func shouldStartController(ctx context.Context, config *rest.Config, controllerName string, log klog.Logger) (bool, error) {
-	discovery, err := controllers.NewControllerManagerDiscovery(config)
+	discovery, err := controllers.NewControllerManagerDiscovery(config, "")
 	if err != nil {
 		return false, fmt.Errorf("failed to create discovery service: %w", err)
 	}

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -184,7 +184,7 @@ func getRuntimeControllersFromCluster(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("could not get kubeconfig to read running controllers: %w", err)
 	}
 
-	discovery, err := controllers.NewControllerManagerDiscovery(config, "")
+	discovery, err := controllers.NewControllerManagerDiscovery(config)
 	if err != nil {
 		klog.V(2).Infof("getRuntimeControllersFromCluster: discovery creation error: %v", err)
 		return nil, fmt.Errorf("could not create discovery client: %w", err)
@@ -284,16 +284,6 @@ func checkReadiness(ctx context.Context) error {
 	}
 
 	klog.V(2).Infof("Waiting for %d runtime controllers to be ready", len(runtimeControllers))
-	if len(runtimeControllers) == 0 {
-		// No controller managers are found.
-		// Check if API server is ready for basic operations
-		if err := readiness.WaitForReady(ctx, config, false); err == nil {
-			klog.V(2).Info("API server ready but no controllers registered - assuming no controllers mode")
-			return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
-		}
-		klog.V(2).Info("Waiting for controller manager to register in cluster...")
-		return errors.New("waiting for controller manager to register")
-	}
 
 	// Get the controller objects for the actually running controllers
 	allControllers := base.GetAllControllers()

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -23,8 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	apiextensionapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -76,9 +75,6 @@ var requiredAPIGroups = sets.NewString(
 	"admissionregistration.k8s.io", // Admission
 	"coordination.k8s.io",          // Coordination (for controller-runtime compatibility)
 )
-
-// ErrControllerManagerNotFound is returned when no controller manager is found.
-var ErrControllerManagerNotFound = errors.New("no running controller manager found")
 
 // GetKubeconfig returns the kubeconfig by reading it directly from disk.
 func GetKubeconfig() ([]byte, error) {
@@ -179,7 +175,7 @@ func Create(ctx context.Context, args []string) error {
 	return os.WriteFile(instance.ArgsFile(), data, 0o600)
 }
 
-// getRuntimeControllersFromCluster retrieves the actual running controller configuration from the cluster.
+// getRuntimeControllersFromCluster retrieves all enabled controllers from the cluster.
 func getRuntimeControllersFromCluster(ctx context.Context) ([]string, error) {
 	// Try to get the running controller configuration from the cluster
 	config, err := GetKubeRestConfig()
@@ -188,7 +184,7 @@ func getRuntimeControllersFromCluster(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("could not get kubeconfig to read running controllers: %w", err)
 	}
 
-	discovery, err := controllers.NewControllerManagerDiscovery(config)
+	discovery, err := controllers.NewControllerManagerDiscovery(config, "")
 	if err != nil {
 		klog.V(2).Infof("getRuntimeControllersFromCluster: discovery creation error: %v", err)
 		return nil, fmt.Errorf("could not create discovery client: %w", err)
@@ -197,19 +193,12 @@ func getRuntimeControllersFromCluster(ctx context.Context) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	info, err := discovery.DiscoverControllerManager(ctx)
+	enabledControllers, err := discovery.GetEnabledControllers(ctx)
 	if err != nil {
 		klog.V(2).Infof("getRuntimeControllersFromCluster: discovery error: %v", err)
-		return nil, fmt.Errorf("could not discover running controllers: %w", err)
+		return nil, fmt.Errorf("could not discover enabled controllers: %w", err)
 	}
-
-	if info == nil {
-		klog.V(2).Info("getRuntimeControllersFromCluster: no controller manager found")
-		return nil, ErrControllerManagerNotFound
-	}
-
-	klog.V(2).Infof("getRuntimeControllersFromCluster: found controllers: %v", info.EnabledControllers)
-	return info.EnabledControllers, nil
+	return enabledControllers, nil
 }
 
 func Start(ctx context.Context, args []string) error {
@@ -267,38 +256,36 @@ func checkReadiness(ctx context.Context) error {
 	// Wait for the controller manager to register with the actual running controllers
 	runtimeControllers, err := getRuntimeControllersFromCluster(ctx)
 	if err != nil {
-		// Check if this is a "no controller manager found" error, which indicates --controllers=""
-		if errors.Is(err, ErrControllerManagerNotFound) {
-			klog.V(2).Info("No controller manager found - checking if this is truly no-controllers mode")
-
-			// Check the original command args to see if --controllers="" was specified
-			serveArgs := ServeArgs()
-			isNoControllersMode := false
-			for i, arg := range serveArgs {
-				if arg == "--controllers" && i+1 < len(serveArgs) && serveArgs[i+1] == "" {
-					isNoControllersMode = true
-					break
-				}
-			}
-
-			if isNoControllersMode {
-				// Check if API server is ready for basic operations
-				if err := readiness.WaitForReady(ctx, config, false); err == nil {
-					klog.V(2).Info("API server ready and no controllers expected - no controllers mode")
-					return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
-				}
-				klog.V(2).Info("API server not ready yet, continuing to wait...")
-			} else {
-				klog.V(2).Info("Controllers expected but discovery configmap not found yet - waiting for external controllers to register...")
-			}
-		} else {
-			klog.V(2).Infof("getRuntimeControllersFromCluster: %v", err)
-		}
+		klog.V(2).Infof("getRuntimeControllersFromCluster: %v", err)
 		return err
 	}
+
+	if len(runtimeControllers) == 0 {
+		// If we found no controllers, check to see if we just need to wait longer
+		// for the controller manager to register.
+		klog.V(2).Info("No controller manager found - checking if this is truly no-controllers mode")
+
+		// Check the original command args to see if --controllers="" was specified
+		serveArgs := ServeArgs()
+		argIndex := slices.Index(serveArgs, "--controllers")
+		isNoControllersMode := argIndex >= 0 && argIndex+1 < len(serveArgs) && serveArgs[argIndex+1] == ""
+
+		if isNoControllersMode {
+			// Check if API server is ready for basic operations
+			if err := readiness.WaitForReady(ctx, config, false); err == nil {
+				klog.V(2).Info("API server ready and no controllers expected - no controllers mode")
+				return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
+			}
+			klog.V(2).Info("API server not ready yet, continuing to wait...")
+		} else {
+			klog.V(2).Info("Controllers expected but discovery configmap not found yet - waiting for external controllers to register...")
+		}
+		return errors.New("waiting for controller manager registration")
+	}
+
 	klog.V(2).Infof("Waiting for %d runtime controllers to be ready", len(runtimeControllers))
 	if len(runtimeControllers) == 0 {
-		// This shouldn't happen since we handle it above, but keeping as fallback
+		// No controller managers are found.
 		// Check if API server is ready for basic operations
 		if err := readiness.WaitForReady(ctx, config, false); err == nil {
 			klog.V(2).Info("API server ready but no controllers registered - assuming no controllers mode")
@@ -313,29 +300,26 @@ func checkReadiness(ctx context.Context) error {
 	var enabledControllers []base.Controller
 
 	for _, controller := range allControllers {
-		for _, enabledName := range runtimeControllers {
-			if controller.GetName() == enabledName {
-				enabledControllers = append(enabledControllers, controller)
-				break
-			}
+		if slices.Contains(runtimeControllers, controller.GetName()) {
+			enabledControllers = append(enabledControllers, controller)
 		}
 	}
 
-	klog.V(2).Infof("Discovery service found running controllers: %v", runtimeControllers)
+	klog.V(2).InfoS("Discovery service found running controllers", "controllers", runtimeControllers)
 
 	// Debug: Log all available controllers
 	allControllerNames := make([]string, len(allControllers))
 	for i, c := range allControllers {
 		allControllerNames[i] = c.GetName()
 	}
-	klog.V(2).Infof("All available controllers: %v", allControllerNames)
+	klog.V(2).InfoS("All available controllers", "controllers", allControllerNames)
 
 	// Debug: Log enabled controllers
 	enabledControllerNames := make([]string, len(enabledControllers))
 	for i, c := range enabledControllers {
 		enabledControllerNames[i] = c.GetName()
 	}
-	klog.V(2).Infof("Enabled controllers for readiness: %v", enabledControllerNames)
+	klog.V(2).InfoS("Enabled controllers for readiness", "controllers", enabledControllerNames)
 
 	return readiness.WaitForReadyWithCRDs(ctx, config, enabledControllers, false)
 }
@@ -422,18 +406,9 @@ func cleanupDiscoveryConfigMap() error {
 		return nil // Not a critical error during shutdown
 	}
 
-	configMapClient := client.CoreV1().ConfigMaps(controllers.RDDSystemNamespace)
-	discoveryConfigMapName := controllers.ControllerManagerConfigMapName
-
-	err = configMapClient.Delete(context.TODO(), discoveryConfigMapName, metav1.DeleteOptions{})
+	err = controllers.CleanupDiscovery(context.TODO(), client)
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			logrus.WithError(err).WithField("configmap", discoveryConfigMapName).Debug("Failed to delete discovery configmap")
-		} else {
-			logrus.WithField("configmap", discoveryConfigMapName).Debug("Discovery configmap not found, nothing to clean up")
-		}
-	} else {
-		logrus.WithField("configmap", discoveryConfigMapName).Debug("Successfully deleted stale discovery configmap")
+		logrus.WithError(err).Debug("Failed to delete discovery configmap")
 	}
 
 	return nil // Don't fail stop operation due to discovery cleanup issues
@@ -721,12 +696,17 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 			}
 
 			// Create shared controller manager with dynamic ports
-			sharedManager := controllers.NewSharedControllerManager(
+			sharedManager, err := controllers.NewSharedControllerManager(
 				ctx,
+				"embedded",
 				completed.ControlPlane.Generic.LoopbackClientConfig,
 				metricsPort,
 				healthPort,
 			)
+			if err != nil {
+				klog.Error(err, "Failed to create shared controller manager")
+				return
+			}
 
 			// Register all enabled controllers
 			for _, controller := range enabledControllers {

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -78,21 +79,36 @@ func (d *ControllerManagerDiscovery) RegisterControllerManager(ctx context.Conte
 		return fmt.Errorf("failed to serialize controller manager info: %w", err)
 	}
 
-	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	// Update the config map if it exists.
+	patchData, err := json.Marshal(map[string]any{
+		"data": map[string]string{
+			d.name: string(serializedInfo),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to serialize controller manager patch: %w", err)
+	}
+	_, err = d.client.CoreV1().ConfigMaps(d.namespace).Patch(
+		ctx,
+		controllerManagerConfigMapName,
+		types.StrategicMergePatchType,
+		patchData,
+		metav1.PatchOptions{},
+	)
 	if err == nil {
-		// Update existing ConfigMap as needed
-		configMap.Data[d.name] = string(serializedInfo)
-		_, err = d.client.CoreV1().ConfigMaps(d.namespace).Update(ctx, configMap, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to update existing controller manager configmap: %w", err)
-		}
+		klog.InfoS("Registered controller manager in cluster",
+			"namespace", d.namespace,
+			"configmap", controllerManagerConfigMapName,
+			"name", d.name,
+			"controllers", len(controllers))
 		return nil
-	} else if !errors.IsNotFound(err) {
-		return fmt.Errorf("failed to get existing controller manager configmap: %w", err)
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to patch existing controller manager configmap: %w", err)
 	}
 
 	// Create the config map
-	configMap = &corev1.ConfigMap{
+	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controllerManagerConfigMapName,
 			Namespace: d.namespace,
@@ -107,10 +123,16 @@ func (d *ControllerManagerDiscovery) RegisterControllerManager(ctx context.Conte
 	}
 	_, err = d.client.CoreV1().ConfigMaps(d.namespace).Create(ctx, configMap, metav1.CreateOptions{})
 	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			// We hit a race condition, and somebody else created it first.  Try again.
+			// We're not expecting to recurse more than once, because if the config map
+			// exists then we won't hit IsNotFound on the patch attempt.
+			return d.RegisterControllerManager(ctx, healthPort, metricsPort, controllers)
+		}
 		return fmt.Errorf("failed to register controller manager: %w", err)
 	}
 
-	klog.InfoS("Registered controller manager in cluster",
+	klog.InfoS("Registered initial controller manager in cluster",
 		"namespace", d.namespace,
 		"configmap", controllerManagerConfigMapName,
 		"name", d.name,
@@ -121,29 +143,50 @@ func (d *ControllerManagerDiscovery) RegisterControllerManager(ctx context.Conte
 
 // UnregisterControllerManager removes the controller manager ConfigMap.
 func (d *ControllerManagerDiscovery) UnregisterControllerManager(ctx context.Context) error {
-	cm, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	patchData, err := json.Marshal(map[string]any{
+		d.name: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to serialize controller manager patch: %w", err)
+	}
+
+	cm, err := d.client.CoreV1().ConfigMaps(d.namespace).Patch(
+		ctx,
+		controllerManagerConfigMapName,
+		types.StrategicMergePatchType,
+		patchData,
+		metav1.PatchOptions{},
+	)
 	if errors.IsNotFound(err) {
 		return nil // Already deleted, no error
 	}
 	if err != nil {
-		return fmt.Errorf("failed to get controller manager configmap: %w", err)
+		return fmt.Errorf("failed to patch controller manager configmap: %w", err)
 	}
 
-	if _, exists := cm.Data[d.name]; !exists {
-		return nil // No entry for this instance, nothing to do
-	}
-
-	delete(cm.Data, d.name)
-	if len(cm.Data) > 0 {
-		// Update the ConfigMap without this instance's entry
-		_, err = d.client.CoreV1().ConfigMaps(d.namespace).Update(ctx, cm, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to update controller manager configmap: %w", err)
-		}
-	} else {
+	if len(cm.Data) == 0 {
 		// No more entries, delete the ConfigMap
-		err = d.client.CoreV1().ConfigMaps(d.namespace).Delete(ctx, controllerManagerConfigMapName, metav1.DeleteOptions{})
-		if err != nil {
+		err = d.client.CoreV1().ConfigMaps(d.namespace).Delete(
+			ctx,
+			controllerManagerConfigMapName,
+			metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					ResourceVersion: &cm.ResourceVersion,
+				},
+			},
+		)
+
+		if err == nil {
+			klog.InfoS("Unregistered final controller manager from cluster",
+				"namespace", d.namespace,
+				"configmap", controllerManagerConfigMapName,
+				"name", d.name)
+			return nil
+		}
+
+		// If somebody else deleted the config map or modified it, the config
+		// map should stay in the state the other controller managers left it.
+		if !errors.IsNotFound(err) && !errors.IsConflict(err) {
 			return fmt.Errorf("failed to delete controller manager configmap: %w", err)
 		}
 	}

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -6,11 +6,10 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"slices"
-	"strconv"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -19,27 +18,35 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-
-	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
 const (
-	// ControllerManagerConfigMapName is the name of the ConfigMap that stores controller manager information.
-	ControllerManagerConfigMapName = "rdd-controller-manager"
+	// controllerManagerConfigMapName is the name of the ConfigMap that stores controller manager information.
+	controllerManagerConfigMapName = "rdd-controller-manager"
 
 	// RDDSystemNamespace is the namespace where RDD stores its control plane information.
 	RDDSystemNamespace = "rdd-system"
 )
 
+// ControllerManagerInfo contains discovered information about a running controller manager.
+type ControllerManagerInfo struct {
+	HealthPort         int         `json:"healthPort"`
+	MetricsPort        int         `json:"metricsPort"`
+	EnabledControllers []string    `json:"enabledControllers"`
+	StartTime          metav1.Time `json:"startTime"`
+	HealthEndpoint     string      `json:"healthEndpoint"`
+	MetricsEndpoint    string      `json:"metricsEndpoint"`
+}
+
 // ControllerManagerDiscovery handles service discovery for the shared controller manager.
 type ControllerManagerDiscovery struct {
 	client    kubernetes.Interface
 	namespace string
-	instance  string
+	name      string
 }
 
 // NewControllerManagerDiscovery creates a new discovery service.
-func NewControllerManagerDiscovery(config *rest.Config) (*ControllerManagerDiscovery, error) {
+func NewControllerManagerDiscovery(config *rest.Config, name string) (*ControllerManagerDiscovery, error) {
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
@@ -48,7 +55,7 @@ func NewControllerManagerDiscovery(config *rest.Config) (*ControllerManagerDisco
 	return &ControllerManagerDiscovery{
 		client:    client,
 		namespace: RDDSystemNamespace,
-		instance:  instance.Name(),
+		name:      name,
 	}, nil
 }
 
@@ -58,41 +65,55 @@ func (d *ControllerManagerDiscovery) RegisterControllerManager(ctx context.Conte
 		return fmt.Errorf("failed to ensure namespace: %w", err)
 	}
 
-	configMap := &corev1.ConfigMap{
+	info := ControllerManagerInfo{
+		HealthPort:         healthPort,
+		MetricsPort:        metricsPort,
+		EnabledControllers: controllers,
+		StartTime:          metav1.NewTime(time.Now().UTC()),
+		HealthEndpoint:     fmt.Sprintf("http://localhost:%d/healthz", healthPort),
+		MetricsEndpoint:    fmt.Sprintf("http://localhost:%d/metrics", metricsPort),
+	}
+	serializedInfo, err := json.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("failed to serialize controller manager info: %w", err)
+	}
+
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	if err == nil {
+		// Update existing ConfigMap as needed
+		configMap.Data[d.name] = string(serializedInfo)
+		_, err = d.client.CoreV1().ConfigMaps(d.namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update existing controller manager configmap: %w", err)
+		}
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get existing controller manager configmap: %w", err)
+	}
+
+	// Create the config map
+	configMap = &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ControllerManagerConfigMapName,
+			Name:      controllerManagerConfigMapName,
 			Namespace: d.namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/name":      "rancher-desktop-daemon",
 				"app.kubernetes.io/component": "controller-manager",
-				"app.kubernetes.io/instance":  d.instance,
 			},
 		},
 		Data: map[string]string{
-			"instance":           d.instance,
-			"healthPort":         strconv.Itoa(healthPort),
-			"metricsPort":        strconv.Itoa(metricsPort),
-			"enabledControllers": strings.Join(controllers, ","),
-			"startTime":          time.Now().UTC().Format(time.RFC3339),
-			"healthEndpoint":     fmt.Sprintf("http://localhost:%d/healthz", healthPort),
-			"metricsEndpoint":    fmt.Sprintf("http://localhost:%d/metrics", metricsPort),
+			d.name: string(serializedInfo),
 		},
 	}
-
-	// Try to update existing ConfigMap, create if it doesn't exist
-	_, err := d.client.CoreV1().ConfigMaps(d.namespace).Update(ctx, configMap, metav1.UpdateOptions{})
-	if errors.IsNotFound(err) {
-		_, err = d.client.CoreV1().ConfigMaps(d.namespace).Create(ctx, configMap, metav1.CreateOptions{})
-	}
-
+	_, err = d.client.CoreV1().ConfigMaps(d.namespace).Create(ctx, configMap, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to register controller manager: %w", err)
 	}
 
 	klog.InfoS("Registered controller manager in cluster",
 		"namespace", d.namespace,
-		"configmap", ControllerManagerConfigMapName,
-		"instance", d.instance,
+		"configmap", controllerManagerConfigMapName,
+		"name", d.name,
 		"controllers", len(controllers))
 
 	return nil
@@ -100,25 +121,44 @@ func (d *ControllerManagerDiscovery) RegisterControllerManager(ctx context.Conte
 
 // UnregisterControllerManager removes the controller manager ConfigMap.
 func (d *ControllerManagerDiscovery) UnregisterControllerManager(ctx context.Context) error {
-	err := d.client.CoreV1().ConfigMaps(d.namespace).Delete(ctx, ControllerManagerConfigMapName, metav1.DeleteOptions{})
+	cm, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil // Already deleted, no error
 	}
 	if err != nil {
-		return fmt.Errorf("failed to unregister controller manager: %w", err)
+		return fmt.Errorf("failed to get controller manager configmap: %w", err)
+	}
+
+	if _, exists := cm.Data[d.name]; !exists {
+		return nil // No entry for this instance, nothing to do
+	}
+
+	delete(cm.Data, d.name)
+	if len(cm.Data) > 0 {
+		// Update the ConfigMap without this instance's entry
+		_, err = d.client.CoreV1().ConfigMaps(d.namespace).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update controller manager configmap: %w", err)
+		}
+	} else {
+		// No more entries, delete the ConfigMap
+		err = d.client.CoreV1().ConfigMaps(d.namespace).Delete(ctx, controllerManagerConfigMapName, metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to delete controller manager configmap: %w", err)
+		}
 	}
 
 	klog.InfoS("Unregistered controller manager from cluster",
 		"namespace", d.namespace,
-		"configmap", ControllerManagerConfigMapName,
-		"instance", d.instance)
+		"configmap", controllerManagerConfigMapName,
+		"name", d.name)
 
 	return nil
 }
 
 // DiscoverControllerManager finds running controller manager information.
 func (d *ControllerManagerDiscovery) DiscoverControllerManager(ctx context.Context) (*ControllerManagerInfo, error) {
-	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, ControllerManagerConfigMapName, metav1.GetOptions{})
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil // No controller manager running
 	}
@@ -126,68 +166,68 @@ func (d *ControllerManagerDiscovery) DiscoverControllerManager(ctx context.Conte
 		return nil, fmt.Errorf("failed to discover controller manager: %w", err)
 	}
 
-	return d.parseControllerManagerInfo(configMap)
+	serializedInfo, exists := configMap.Data[d.name]
+	if !exists {
+		return nil, nil // No entry for this instance
+	}
+
+	var info ControllerManagerInfo
+	if err := json.Unmarshal([]byte(serializedInfo), &info); err != nil {
+		return nil, fmt.Errorf("failed to parse controller manager info: %w", err)
+	}
+	return &info, nil
 }
 
-// IsControllerRunning checks if a specific controller is running in the discovered controller manager.
+// GetEnabledControllers returns the list of all enabled controllers, across all
+// controller managers.  Note that the returned controllers may not be running.
+func (d *ControllerManagerDiscovery) GetEnabledControllers(ctx context.Context) ([]string, error) {
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil // No controller manager running
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover controller manager: %w", err)
+	}
+
+	var enabledControllers []string
+	for _, serializedInfo := range configMap.Data {
+		var info ControllerManagerInfo
+		if err := json.Unmarshal([]byte(serializedInfo), &info); err != nil {
+			return nil, fmt.Errorf("failed to parse controller manager info: %w", err)
+		}
+
+		enabledControllers = append(enabledControllers, info.EnabledControllers...)
+	}
+
+	return enabledControllers, nil
+}
+
+// IsControllerRunning checks if a specific controller is running in any of the
+// shared controller managers.
 func (d *ControllerManagerDiscovery) IsControllerRunning(ctx context.Context, controllerName string) (bool, *ControllerManagerInfo, error) {
-	info, err := d.DiscoverControllerManager(ctx)
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
 	if err != nil {
-		return false, nil, err
-	}
-	if info == nil {
-		return false, nil, nil // No controller manager running
-	}
-
-	// Check if the controller manager is actually accessible
-	if !d.isControllerManagerHealthy(ctx, info) {
-		return false, info, nil
+		if errors.IsNotFound(err) {
+			return false, nil, nil // No controller manager running
+		}
+		return false, nil, fmt.Errorf("failed to discover controller manager: %w", err)
 	}
 
-	// Check if the specific controller is enabled
-	return slices.Contains(info.EnabledControllers, controllerName), info, nil
-}
+	for _, serializedInfo := range configMap.Data {
+		var info ControllerManagerInfo
+		if err := json.Unmarshal([]byte(serializedInfo), &info); err != nil {
+			return false, nil, fmt.Errorf("failed to parse controller manager info: %w", err)
+		}
 
-// ControllerManagerInfo contains discovered information about a running controller manager.
-type ControllerManagerInfo struct {
-	HealthPort         int       `json:"healthPort"`
-	MetricsPort        int       `json:"metricsPort"`
-	EnabledControllers []string  `json:"enabledControllers"`
-	StartTime          time.Time `json:"startTime"`
-	HealthEndpoint     string    `json:"healthEndpoint"`
-	MetricsEndpoint    string    `json:"metricsEndpoint"`
-}
+		if !slices.Contains(info.EnabledControllers, controllerName) {
+			continue // This controller manager does not have the controller enabled.
+		}
 
-// parseControllerManagerInfo converts ConfigMap data to ControllerManagerInfo.
-func (d *ControllerManagerDiscovery) parseControllerManagerInfo(cm *corev1.ConfigMap) (*ControllerManagerInfo, error) {
-	healthPort, err := strconv.Atoi(cm.Data["healthPort"])
-	if err != nil {
-		return nil, fmt.Errorf("invalid healthPort: %w", err)
+		// Check if the controller manager is actually accessible
+		return d.isControllerManagerHealthy(ctx, &info), &info, nil
 	}
 
-	metricsPort, err := strconv.Atoi(cm.Data["metricsPort"])
-	if err != nil {
-		return nil, fmt.Errorf("invalid metricsPort: %w", err)
-	}
-
-	startTime, err := time.Parse(time.RFC3339, cm.Data["startTime"])
-	if err != nil {
-		return nil, fmt.Errorf("invalid startTime: %w", err)
-	}
-
-	var controllers []string
-	if controllersStr := cm.Data["enabledControllers"]; controllersStr != "" {
-		controllers = strings.Split(controllersStr, ",")
-	}
-
-	return &ControllerManagerInfo{
-		HealthPort:         healthPort,
-		MetricsPort:        metricsPort,
-		EnabledControllers: controllers,
-		StartTime:          startTime,
-		HealthEndpoint:     cm.Data["healthEndpoint"],
-		MetricsEndpoint:    cm.Data["metricsEndpoint"],
-	}, nil
+	return false, nil, nil // Controller not found in any controller manager.
 }
 
 // isControllerManagerHealthy checks if the controller manager is responding to health checks.
@@ -221,4 +261,20 @@ func (d *ControllerManagerDiscovery) ensureNamespace(ctx context.Context) error 
 		return nil // Namespace already exists, that's fine
 	}
 	return err
+}
+
+func CleanupDiscovery(ctx context.Context, client *kubernetes.Clientset) error {
+	err := client.CoreV1().ConfigMaps(RDDSystemNamespace).Delete(ctx, controllerManagerConfigMapName, metav1.DeleteOptions{})
+	if errors.IsNotFound(err) {
+		return nil // Already deleted, no error
+	}
+	if err != nil {
+		return fmt.Errorf("failed to delete controller manager configmap: %w", err)
+	}
+
+	klog.InfoS("Cleaned up stale controller manager discovery configmap",
+		"namespace", RDDSystemNamespace,
+		"configmap", controllerManagerConfigMapName)
+
+	return nil
 }

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -43,11 +43,17 @@ type ControllerManagerInfo struct {
 type ControllerManagerDiscovery struct {
 	client    kubernetes.Interface
 	namespace string
-	name      string
 }
 
-// NewControllerManagerDiscovery creates a new discovery service.
-func NewControllerManagerDiscovery(config *rest.Config, name string) (*ControllerManagerDiscovery, error) {
+// ControllerManagerDiscoveryGroup handles service discovery for a specific API
+// group.
+type ControllerManagerDiscoveryGroup struct {
+	ControllerManagerDiscovery
+	name string
+}
+
+// NewControllerManagerDiscovery creates a new read-only discovery service.
+func NewControllerManagerDiscovery(config *rest.Config) (*ControllerManagerDiscovery, error) {
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
@@ -56,12 +62,34 @@ func NewControllerManagerDiscovery(config *rest.Config, name string) (*Controlle
 	return &ControllerManagerDiscovery{
 		client:    client,
 		namespace: RDDSystemNamespace,
-		name:      name,
+	}, nil
+}
+
+// NewControllerManagerDiscoveryGroup creates a new discovery service that can
+// register and unregister controller managers for a given API group.
+func NewControllerManagerDiscoveryGroup(config *rest.Config, apiGroupName string) (*ControllerManagerDiscoveryGroup, error) {
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return &ControllerManagerDiscoveryGroup{
+		ControllerManagerDiscovery: ControllerManagerDiscovery{
+			client:    client,
+			namespace: RDDSystemNamespace,
+		},
+		name: apiGroupName,
 	}, nil
 }
 
 // RegisterControllerManager creates or updates the ConfigMap with controller manager information.
-func (d *ControllerManagerDiscovery) RegisterControllerManager(ctx context.Context, healthPort, metricsPort int, controllers []string) error {
+func (d *ControllerManagerDiscoveryGroup) RegisterControllerManager(ctx context.Context, healthPort, metricsPort int, controllers []string) error {
+	return d.registerControllerManagerImpl(ctx, healthPort, metricsPort, controllers, true)
+}
+
+// registerControllerManagerImpl is the internal implementation of RegisterControllerManager,
+// with an option to retry on conflict.
+func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx context.Context, healthPort, metricsPort int, controllers []string, allowRetry bool) error {
 	if err := d.ensureNamespace(ctx); err != nil {
 		return fmt.Errorf("failed to ensure namespace: %w", err)
 	}
@@ -123,11 +151,11 @@ func (d *ControllerManagerDiscovery) RegisterControllerManager(ctx context.Conte
 	}
 	_, err = d.client.CoreV1().ConfigMaps(d.namespace).Create(ctx, configMap, metav1.CreateOptions{})
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if allowRetry && errors.IsAlreadyExists(err) {
 			// We hit a race condition, and somebody else created it first.  Try again.
 			// We're not expecting to recurse more than once, because if the config map
 			// exists then we won't hit IsNotFound on the patch attempt.
-			return d.RegisterControllerManager(ctx, healthPort, metricsPort, controllers)
+			return d.registerControllerManagerImpl(ctx, healthPort, metricsPort, controllers, false)
 		}
 		return fmt.Errorf("failed to register controller manager: %w", err)
 	}
@@ -142,9 +170,11 @@ func (d *ControllerManagerDiscovery) RegisterControllerManager(ctx context.Conte
 }
 
 // UnregisterControllerManager removes the controller manager ConfigMap.
-func (d *ControllerManagerDiscovery) UnregisterControllerManager(ctx context.Context) error {
+func (d *ControllerManagerDiscoveryGroup) UnregisterControllerManager(ctx context.Context) error {
 	patchData, err := json.Marshal(map[string]any{
-		d.name: nil,
+		"data": map[string]any{
+			d.name: nil,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to serialize controller manager patch: %w", err)
@@ -200,7 +230,7 @@ func (d *ControllerManagerDiscovery) UnregisterControllerManager(ctx context.Con
 }
 
 // DiscoverControllerManager finds running controller manager information.
-func (d *ControllerManagerDiscovery) DiscoverControllerManager(ctx context.Context) (*ControllerManagerInfo, error) {
+func (d *ControllerManagerDiscoveryGroup) DiscoverControllerManager(ctx context.Context) (*ControllerManagerInfo, error) {
 	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil // No controller manager running

--- a/pkg/service/controllers/discovery_test.go
+++ b/pkg/service/controllers/discovery_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+package controllers
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestControllerManagerDiscoveryGroup(t *testing.T) {
+	env := &envtest.Environment{
+		DownloadBinaryAssets: true,
+	}
+	cfg, err := env.Start()
+	assert.NilError(t, err, "failed to start environment")
+
+	defer func() {
+		err := env.Stop()
+		// On Windows, `env.Stop()` will return an error because it can't kill
+		// etcd gracefully; this is not an issue for this test.
+		// Also, in CI only, ignore failure to stop kube-apiserver.
+		if runtime.GOOS != "windows" && err != nil {
+			checkError := os.Getenv("CI") == ""
+			checkError = checkError || !strings.Contains(err.Error(), "timeout waiting for process kube-apiserver to stop")
+			if checkError {
+				assert.NilError(t, err, "failed to stop environment")
+			}
+		}
+	}()
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer healthServer.Close()
+	port := healthServer.Listener.Addr().(*net.TCPAddr).Port
+
+	client, err := kubernetes.NewForConfig(cfg)
+	assert.NilError(t, err, "failed to create kubernetes client")
+
+	d1, err := NewControllerManagerDiscoveryGroup(cfg, "test-group")
+	assert.NilError(t, err, "failed to create ControllerManagerDiscoveryGroup")
+
+	// Register a controller manager.
+	assert.NilError(t, d1.RegisterControllerManager(t.Context(), 1234, 5678, nil), "failed to register controller manager")
+
+	// Check that the config map exists.
+	cm, err := client.CoreV1().ConfigMaps(d1.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
+	assert.NilError(t, err, "failed to get controller manager config map")
+	assert.Assert(t, cmp.Len(cm.Data, 1), "expected config map to have one entry")
+	assert.Check(t, cmp.Contains(cm.Data, d1.name))
+
+	// Check that we can read it back out.
+	info, err := d1.DiscoverControllerManager(t.Context())
+	assert.NilError(t, err, "failed to discover controller manager")
+	assert.DeepEqual(t, &ControllerManagerInfo{
+		HealthPort:         1234,
+		MetricsPort:        5678,
+		EnabledControllers: nil,
+		StartTime:          info.StartTime,
+		HealthEndpoint:     info.HealthEndpoint,
+		MetricsEndpoint:    info.MetricsEndpoint,
+	}, info)
+
+	controllers, err := d1.GetEnabledControllers(t.Context())
+	assert.NilError(t, err, "failed to get enabled controllers")
+	assert.Check(t, cmp.Len(controllers, 0), "expected no enabled controllers")
+
+	running, _, err := d1.IsControllerRunning(t.Context(), "hello")
+	assert.NilError(t, err, "failed to check if controller is running")
+	assert.Check(t, !running, "expected controller not to be running")
+
+	// Register a second controller manager to test unregister.
+	d2, err := NewControllerManagerDiscoveryGroup(cfg, "test-group-2")
+	assert.NilError(t, err, "failed to create second ControllerManagerDiscoveryGroup")
+	assert.NilError(t, d2.RegisterControllerManager(t.Context(), port, 8765, []string{"hello"}), "failed to register second controller manager")
+
+	// Check that the config map is updated.
+	cm, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
+	assert.NilError(t, err, "failed to get controller manager config map after second registration")
+	assert.Assert(t, cmp.Len(cm.Data, 2), "expected config map to have two entries after second registration")
+	assert.Check(t, cmp.Contains(cm.Data, d1.name))
+	assert.Check(t, cmp.Contains(cm.Data, d2.name))
+
+	// Check that we can read the second one back out.
+	info, err = d2.DiscoverControllerManager(t.Context())
+	assert.NilError(t, err, "failed to discover second controller manager")
+	assert.DeepEqual(t, &ControllerManagerInfo{
+		HealthPort:         port,
+		MetricsPort:        8765,
+		EnabledControllers: []string{"hello"},
+		StartTime:          info.StartTime,
+		HealthEndpoint:     info.HealthEndpoint,
+		MetricsEndpoint:    info.MetricsEndpoint,
+	}, info)
+
+	// Check that we can get controllers.
+	controllers, err = d2.GetEnabledControllers(t.Context())
+	assert.NilError(t, err, "failed to get enabled controllers")
+	assert.DeepEqual(t, []string{"hello"}, controllers)
+
+	running, _, err = d2.IsControllerRunning(t.Context(), "hello")
+	assert.NilError(t, err, "failed to check if controller is running")
+	assert.Check(t, running, "expected controller to be running")
+
+	// Unregister the first controller manager.
+	assert.NilError(t, d1.UnregisterControllerManager(t.Context()), "failed to unregister first controller manager")
+
+	// Check that discovering the first controller manager now fails.
+	info, err = d1.DiscoverControllerManager(t.Context())
+	assert.NilError(t, err, "unexpected error discovering unregistered controller manager")
+	assert.Assert(t, info == nil, "expected nil info for unregistered controller manager")
+
+	// Check that the second controller manager is still discoverable.
+	info, err = d2.DiscoverControllerManager(t.Context())
+	assert.NilError(t, err, "failed to discover second controller manager after first unregistered")
+	assert.Check(t, info != nil, "expected non-nil info for second controller manager")
+
+	// Check that the config map still exists with one entry.
+	cm, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
+	assert.NilError(t, err, "failed to get controller manager config map after first unregistered")
+	assert.Assert(t, cmp.Len(cm.Data, 1), "expected config map to have one entry after first unregistered")
+	assert.Check(t, cmp.Contains(cm.Data, d2.name))
+	assert.Check(t, cm.Data[d1.name] == "", "expected first controller manager entry to be removed")
+
+	// Unregister the second controller manager.
+	assert.NilError(t, d2.UnregisterControllerManager(t.Context()), "failed to unregister second controller manager")
+
+	// Check that the config map is removed.
+	_, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
+	assert.Assert(t, errors.IsNotFound(err), "expected config map to be deleted after all controller managers unregistered")
+}

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -17,10 +17,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -34,8 +32,14 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
+const (
+	// crdOwnerLabel is the label used to identify the SharedControllerManager that owns a CRD.
+	crdOwnerLabel = "org.rancherdesktop.rdd/shared-controller-manager"
+)
+
 // SharedControllerManager manages all embedded RDD controllers using a single controller-runtime manager.
 type SharedControllerManager struct {
+	name          string
 	manager       ctrl.Manager
 	registrations []base.Controller
 	kubeConfig    *rest.Config
@@ -47,19 +51,22 @@ type SharedControllerManager struct {
 }
 
 // NewSharedControllerManager creates a new shared controller manager.
-func NewSharedControllerManager(ctx context.Context, kubeConfig *rest.Config, metricsPort, healthPort int) *SharedControllerManager {
+func NewSharedControllerManager(ctx context.Context, name string, kubeConfig *rest.Config, metricsPort, healthPort int) (*SharedControllerManager, error) {
 	// Create discovery service (errors handled in Start method)
-	discovery, _ := NewControllerManagerDiscovery(kubeConfig)
+	discovery, err := NewControllerManagerDiscovery(kubeConfig, name)
+	if err != nil {
+		return nil, err
+	}
 
 	// Calculate webhook port with instance offset
 	desiredWebhookPort := 9443 + instance.Index()
 	webhookPort, err := GetAvailablePort(ctx, desiredWebhookPort)
 	if err != nil {
-		// Fallback to original port if GetAvailablePort fails
-		webhookPort = desiredWebhookPort
+		return nil, fmt.Errorf("failed to get available webhook port: %w", err)
 	}
 
 	return &SharedControllerManager{
+		name:          name,
 		kubeConfig:    kubeConfig,
 		metricsPort:   metricsPort,
 		healthPort:    healthPort,
@@ -67,7 +74,7 @@ func NewSharedControllerManager(ctx context.Context, kubeConfig *rest.Config, me
 		registrations: make([]base.Controller, 0),
 		started:       false,
 		discovery:     discovery,
-	}
+	}, nil
 }
 
 // RegisterController registers a controller with the shared manager.
@@ -76,7 +83,7 @@ func (scm *SharedControllerManager) RegisterController(registration base.Control
 		return fmt.Errorf("cannot register controller %s: shared manager already started", registration.GetName())
 	}
 
-	klog.V(2).InfoS("Registering controller with shared manager", "controller", registration.GetName())
+	klog.V(2).InfoS("Registering controller with shared manager", "controller", registration.GetName(), "shared manager", scm.name)
 	scm.registrations = append(scm.registrations, registration)
 	return nil
 }
@@ -84,7 +91,7 @@ func (scm *SharedControllerManager) RegisterController(registration base.Control
 // Start initializes the shared manager and starts all registered controllers.
 func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	if scm.started {
-		return errors.New("shared controller manager already started")
+		return fmt.Errorf("shared controller manager %s already started", scm.name)
 	}
 
 	log := klog.FromContext(ctx)
@@ -95,7 +102,7 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	}
 
 	// Clean up stale discovery configmap to prevent readiness check confusion
-	if err := scm.cleanupStaleDiscovery(ctx); err != nil {
+	if err := scm.discovery.UnregisterControllerManager(ctx); err != nil {
 		log.Error(err, "Failed to cleanup stale discovery configmap, continuing with startup")
 	}
 
@@ -105,27 +112,18 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to install controller CRDs: %w", err)
 	}
 
-	// Check if any controllers require webhooks before setting up certificates
-	var webhookCertDir string
-	hasWebhookControllers := scm.hasWebhookControllers()
-	if hasWebhookControllers {
-		// Use instance TLS directory for webhook certificates (persistent storage)
-		webhookCertDir = instance.TLSDir()
-
-		// Generate shared webhook certificates
-		if err := scm.setupSharedWebhookCertificates(webhookCertDir); err != nil {
-			return fmt.Errorf("failed to setup shared webhook certificates: %w", err)
-		}
-	}
-
 	// Configure controller-runtime to use klog
-	ctrllog.SetLogger(log.WithName("controller-runtime"))
+	ctrllog.SetLogger(log.WithName(fmt.Sprintf("controller-runtime-%s", scm.name)))
 
 	// Create and register scheme with required types
 	managerScheme := runtime.NewScheme()
-	utilruntime.Must(scheme.AddToScheme(managerScheme))
+	if err := scheme.AddToScheme(managerScheme); err != nil {
+		return fmt.Errorf("failed to add core scheme: %w", err)
+	}
 	// Add CRD types to support dynamic resource discovery
-	utilruntime.Must(apiextensionsv1.AddToScheme(managerScheme))
+	if err := apiextensionsv1.AddToScheme(managerScheme); err != nil {
+		return fmt.Errorf("failed to add apiextensions scheme: %w", err)
+	}
 
 	// Modify kubeconfig to force JSON content type to avoid protobuf issues
 	configCopy := *scm.kubeConfig
@@ -142,11 +140,23 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	}
 
 	// Only configure webhook server if controllers require it
-	if hasWebhookControllers {
-		managerOptions.WebhookServer = webhook.NewServer(webhook.Options{
-			Port:    scm.webhookPort,
-			CertDir: webhookCertDir,
-		})
+	if scm.hasWebhookControllers() {
+		// Use instance TLS directory for webhook certificates (persistent storage)
+		webhookCertDir := instance.TLSDir()
+
+		opts := webhook.Options{
+			Port:     scm.webhookPort,
+			CertDir:  webhookCertDir,
+			CertName: fmt.Sprintf("webhook-%s.crt", scm.name),
+			KeyName:  fmt.Sprintf("webhook-%s.key", scm.name),
+		}
+
+		// Generate shared webhook certificates
+		if err := scm.setupSharedWebhookCertificates(opts); err != nil {
+			return fmt.Errorf("failed to setup shared webhook certificates: %w", err)
+		}
+
+		managerOptions.WebhookServer = webhook.NewServer(opts)
 	}
 
 	mgr, err := ctrl.NewManager(&configCopy, managerOptions)
@@ -164,30 +174,19 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to set up ready check: %w", err)
 	}
 
-	// Register controller manager in cluster for service discovery FIRST
-	// Initialize discovery client now that the cluster is running
-	if scm.discovery == nil {
-		discovery, err := NewControllerManagerDiscovery(scm.kubeConfig)
-		if err != nil {
-			log.Error(err, "Failed to create controller manager discovery client")
-		} else {
-			scm.discovery = discovery
-		}
+	// Register controller manager in cluster for service discovery before
+	// running the controllers.
+	if err := scm.registerDiscovery(ctx); err != nil {
+		log.Error(err, "Failed to register controller manager for discovery")
+		// Don't fail startup for discovery registration errors
 	}
 
-	if scm.discovery != nil {
-		if err := scm.registerDiscovery(ctx); err != nil {
-			log.Error(err, "Failed to register controller manager for discovery")
-			// Don't fail startup for discovery registration errors
+	// Ensure cleanup on shutdown
+	defer func() {
+		if err := scm.discovery.UnregisterControllerManager(context.Background()); err != nil {
+			log.Error(err, "Failed to unregister controller manager")
 		}
-
-		// Ensure cleanup on shutdown
-		defer func() {
-			if err := scm.discovery.UnregisterControllerManager(context.Background()); err != nil {
-				log.Error(err, "Failed to unregister controller manager")
-			}
-		}()
-	}
+	}()
 
 	// Track webhook setup goroutines
 	var webhookWaitGroup sync.WaitGroup
@@ -244,6 +243,7 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	scm.started = true
 
 	klog.InfoS("Starting shared controller manager",
+		"name", scm.name,
 		"controllers", len(scm.registrations),
 		"metricsPort", scm.metricsPort,
 		"healthPort", scm.healthPort)
@@ -360,6 +360,10 @@ func (scm *SharedControllerManager) installControllerCRDs(ctx context.Context) e
 
 		// Create the CRD
 		klog.Infof("Installing %s CRD", controllerName)
+		if crd.Labels == nil {
+			crd.Labels = make(map[string]string)
+		}
+		crd.Labels[crdOwnerLabel] = scm.name
 		if _, err := crdClient.Create(ctx, &crd, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create CRD for controller %s: %w", controllerName, err)
 		}
@@ -469,8 +473,17 @@ func (scm *SharedControllerManager) cleanupUnusedCRDs(ctx context.Context, contr
 			continue
 		}
 
+		existingCRD, err := crdClient.Get(ctx, crd.Name, metav1.GetOptions{})
+		if err == nil && existingCRD.Labels != nil {
+			existingOwner := existingCRD.Labels[crdOwnerLabel]
+			if existingOwner != scm.name {
+				klog.V(2).InfoS("Skipping CRD owned by different controller manager", "crd", crd.Name, "manager", existingOwner)
+				continue
+			}
+		}
+
 		klog.InfoS("Deleting unused CRD", "crd", crd.Name, "controller", controller.GetName())
-		err := crdClient.Delete(ctx, crd.Name, metav1.DeleteOptions{})
+		err = crdClient.Delete(ctx, crd.Name, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			klog.ErrorS(err, "Failed to delete unused CRD", "crd", crd.Name, "controller", controller.GetName())
 		}
@@ -479,33 +492,8 @@ func (scm *SharedControllerManager) cleanupUnusedCRDs(ctx context.Context, contr
 	return nil
 }
 
-// cleanupStaleDiscovery removes the discovery configmap to prevent readiness check confusion.
-func (scm *SharedControllerManager) cleanupStaleDiscovery(ctx context.Context) error {
-	client, err := kubernetes.NewForConfig(scm.kubeConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create kubernetes client: %w", err)
-	}
-
-	configMapClient := client.CoreV1().ConfigMaps("rdd-system")
-
-	// Delete the discovery configmap if it exists
-	discoveryConfigMapName := "rdd-controller-manager"
-
-	err = configMapClient.Delete(ctx, discoveryConfigMapName, metav1.DeleteOptions{})
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete discovery configmap %s: %w", discoveryConfigMapName, err)
-		}
-		klog.InfoS("Discovery configmap not found, nothing to clean up", "configmap", discoveryConfigMapName)
-	} else {
-		klog.InfoS("Successfully deleted stale discovery configmap", "configmap", discoveryConfigMapName)
-	}
-
-	return nil
-}
-
 // setupSharedWebhookCertificates generates webhook certificates for all controllers that need them.
-func (scm *SharedControllerManager) setupSharedWebhookCertificates(webhookCertDir string) error {
+func (scm *SharedControllerManager) setupSharedWebhookCertificates(opts webhook.Options) error {
 	// Check if any controller requires webhook certificates
 	needsCertificates := false
 	serviceNames := []string{}
@@ -524,10 +512,16 @@ func (scm *SharedControllerManager) setupSharedWebhookCertificates(webhookCertDi
 		return nil
 	}
 
-	klog.InfoS("Setting up shared webhook certificates", "certDir", webhookCertDir, "serviceNames", serviceNames)
+	klog.InfoS("Setting up shared webhook certificates", "certDir", opts.CertDir, "serviceNames", serviceNames)
 
 	// Use the shared webhook certificate manager to generate certificates
-	certManager := base.NewSharedWebhookCertificateManager(webhookCertDir, "127.0.0.1", serviceNames)
+	certManager := base.NewSharedWebhookCertificateManager(
+		opts.CertDir,
+		opts.CertName,
+		opts.KeyName,
+		"127.0.0.1",
+		serviceNames,
+	)
 
 	// Skip certificate generation if valid certificates already exist
 	if certManager.CertificatesExist() {

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -47,13 +47,13 @@ type SharedControllerManager struct {
 	healthPort    int
 	webhookPort   int
 	started       bool
-	discovery     *ControllerManagerDiscovery
+	discovery     *ControllerManagerDiscoveryGroup
 }
 
 // NewSharedControllerManager creates a new shared controller manager.
 func NewSharedControllerManager(ctx context.Context, name string, kubeConfig *rest.Config, metricsPort, healthPort int) (*SharedControllerManager, error) {
 	// Create discovery service (errors handled in Start method)
-	discovery, err := NewControllerManagerDiscovery(kubeConfig, name)
+	discovery, err := NewControllerManagerDiscoveryGroup(kubeConfig, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -133,9 +133,9 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	managerOptions := ctrl.Options{
 		Scheme: managerScheme,
 		Metrics: server.Options{
-			BindAddress: ":" + strconv.Itoa(scm.metricsPort),
+			BindAddress: "127.0.0.1:" + strconv.Itoa(scm.metricsPort),
 		},
-		HealthProbeBindAddress: ":" + strconv.Itoa(scm.healthPort),
+		HealthProbeBindAddress: "127.0.0.1:" + strconv.Itoa(scm.healthPort),
 		LeaderElection:         false, // RDD controllers are single-instance
 	}
 
@@ -145,6 +145,7 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		webhookCertDir := instance.TLSDir()
 
 		opts := webhook.Options{
+			Host:     "127.0.0.1",
 			Port:     scm.webhookPort,
 			CertDir:  webhookCertDir,
 			CertName: fmt.Sprintf("webhook-%s.crt", scm.name),


### PR DESCRIPTION
This makes it possible to support multiple shared controller managers (each in a different process).  This is to make it easier to reuse the code; we can have multiple processes running different controllers in the future to e.g. allow testing-only controllers to be used with the normal build.

The config map is changed so that the key is the name of the controller process (with the default one named "embedded"), and the value is JSON-serialized `ControllerManagerInfo`.  JSON is chosen so that we can dig into it as part of the BATS tests.  We also no longer track the instance in the info, because that is fixed per Kubernetes API controller so it does not
actually provide any useful information.

To test:
- Build all the executable (with `make build`)
- Run the executable with a subset of controllers:
  `bin/rdd --controllers rdd,lima`
- Run the app controller externally:
  `bin/app-controller`

Everything should work as before, the only difference being multiple
controller processes co-existing.

#102 will be rebased on top of this once this lands.
