### PR TITLE
Increase unit test timeouts for CI

### DIFF
--- a/pkg/controllers/base/finalizer_test.go
+++ b/pkg/controllers/base/finalizer_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
@@ -24,7 +25,8 @@ import (
 
 func TestDeleteOwnedResources(t *testing.T) {
 	env := &envtest.Environment{
-		DownloadBinaryAssets: true,
+		DownloadBinaryAssets:    true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 	cfg, err := env.Start()
 	assert.NilError(t, err, "failed to start environment")


### PR DESCRIPTION
Saw multiple failures to clean up after tests:

```
--- FAIL: TestDeleteOwnedResources (25.88s)
    finalizer_test.go:37: assertion failed: error is not nil: timeout waiting for process kube-apiserver to stop: failed to stop environment
FAIL
```

Only on CI; could not repro locally