### PR TITLE
API: Add notes on API to manipulate containers &c

### DIFF
--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -10,6 +10,7 @@ mindepth
 mktemp
 moby
 netcat
+Trivy
 
 # golangci-lint & its linter / formatter names
 golangci

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -2,8 +2,8 @@
 
 # SHA1 hashes, for e.g. git commits.
 \b[0-9a-fA-F]{40}\b
-\bsha256:[0-9a-fA-F]{64}\b
-\bsha512:[0-9a-fA-F]{128}\b
+\bsha256[.:][0-9a-fA-F]{64}\b
+\bsha512[.:][0-9a-fA-F]{128}\b
 
 # Rancher Desktop domain
 \brancherdesktop\.io\b

--- a/docs/design/api_containers.md
+++ b/docs/design/api_containers.md
@@ -16,11 +16,14 @@ When running `containerd`, the containerd namespace is listed as the `namespace`
 label rather than re-using the Kubernetes namespace.  When running `dockerd`,
 namespaces are not supported and we always use `moby` as the value for that label.
 
-For the `*Request` resources, once they have successfully completed, they will
-be removed after some timeout; this will be at least one minute (so the caller
-can read any data).
+For the `*Request` resources, they use the `Complete` and `Failed` conditions to
+express state; those are mutually exclusive (only one of the two can be set to
+`True` at once).  Once either is set to `True`, the request object is considered
+to be in a terminal state and will be removed after some timeout.  This will be
+at least one minute (so the caller can read any data), but the precise timing is
+unspecified.
 
-This is mainly for use by the Rancher Desktop front end; all other users are
+This API is mainly for use by the Rancher Desktop front end; all other users are
 strongly urged to use the relevant CLI or other API instead.
 
 ## Containers
@@ -110,8 +113,10 @@ status:
   # same Kubernetes namespace as the ContainerCreateRequest.
   name: 8eb6f2cf72b6616aa743cf9187f350af84c9749dab65474db2530f26745d2ef3
   conditions:
-  - type: Finished
+  - type: Complete
     status: True
+  - type: Failed
+    status: False
 ```
 
 If `.metadata.labels.namespace` / `.metadata.labels.name` duplicates an existing
@@ -140,7 +145,9 @@ at which point the `Container` object will actually be deleted.
 
 `Image` objects reflect images in the container engine.  Each tag is represented
 as a new `Image` object; therefore, there may be multiple `Image` objects for
-the same image ID (one per tag).
+the same image ID (one per tag).  If an image without any tags exists, that will
+be represented by an `Image` object without `.status.repoTag` and
+`.metadata.labels.namespace`.
 
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
@@ -164,14 +171,12 @@ status:
   size: 45150437
   labels:
     org.opensuse.base.vendor: openSUSE Project
-  conditions:
-  - type: Pushed # Used to record last push time.
-    status: False
+  conditions: []
 ```
 
 ### Image Actions
 
-#### Fetch image
+#### Pull image
 Create an `ImagePullRequest` object:
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
@@ -182,7 +187,9 @@ spec:
   repoTag: 'registry.opensuse.org/opensuse/leap:latest'
 status:
   conditions:
-  - type: Pulled
+  - type: Complete
+    status: True
+  - type: Failed
     status: False
 ```
 
@@ -205,7 +212,9 @@ spec:
   imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345'
 status:
   conditions:
-  - type: Finished
+  - type: Complete
+    status: True
+  - type: Failed
     status: False
 ```
 
@@ -222,8 +231,10 @@ spec:
   imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345'
 status:
   conditions:
-  - type: Finished
+  - type: Complete
     status: True
+  - type: Failed
+    status: False
   result:
     # Just dump the raw Trivy result JSON here (without converting to YAML).
     '{ ... }'
@@ -279,7 +290,9 @@ spec:
   driver: local
 status:
   conditions:
-  - type: Processed
+  - type: Complete
+    status: True
+  - type: Failed
     status: False
 ```
 Only local volumes are supported initially.

--- a/docs/design/api_containers.md
+++ b/docs/design/api_containers.md
@@ -43,6 +43,7 @@ spec:
         hostPort: 32768
   labels:
     org.opensuse.base.vendor: openSUSE Project
+  state: Running # Desired state
 status:
   status: Running
   pid: 5059
@@ -64,21 +65,45 @@ status:
     status: False
 ```
 
+If a `Container` object exists that does not actually exist in the container
+engine, it is automatically deleted.  Therefore, creating `Container` objects
+directly is not effective; to create containers, use `ContainerRequest`.
+
 ### Container actions
 
 We will need to support a variety of actions on containers:
 
 #### Create container
-Somehow we don't actually need this in the front end.  This will not be
-supported initially.
 
-If `.metadata.name` is the container ID (which we can't generate ahead of time),
-we can't actually create containers (because we don't know their name).
+To create a container, create a `ContainerRequest` object:
+```yaml
+apiVersion: containers.rancherdesktop.io/v1alpha1
+kind: ContainerRequest
+metadata:
+  generateName: whatever
+  namespace: rdd-system
+  labels:
+    name: magical_gates
+    namespace: k8s.io # containerd namespace
+spec:
+  # See Container.spec
+status:
+  # Resulting .metadata.name, which is the container ID.  It must be in the
+  # same Kubernetes namespace as the ContainerRequest.
+  name: 8eb6f2cf72b6616aa743cf9187f350af84c9749dab65474db2530f26745d2ef3
+  conditions:
+  - type: Finished
+    status: True
+```
+
+The `ContainerRequest` will be deleted soon after the `Finished` condition
+transitions to `True`.
+
+If multiple `ContainerRequest` objects exist at the same time for the same
+contained `name`/`namespace` pair, the result is undefined.
 
 #### Change container state
-Set an annotation? `containers.rancherdesktop.io/desiredStatus` perhaps?
-Alternatively, add a `.spec.state` and make that the desired state, which would
-match Kubernetes APIs better.
+Set `.spec.state` to match how Kubernetes resources normally work.
 
 #### Fetch container logs
 The `@kubernetes/client-node` package has some hand-written code to deal with
@@ -89,7 +114,12 @@ Same as logs; there's some special code in `@kubernetes/client-node` that we may
 be able to fork.
 
 #### Delete container
-Delete the Kubernetes API object.
+Create a `ContainerRequest` with `.spec.state` set to `deleted`.
+We can't just delete the Kubernetes object, because it will be recreated as a
+reflection of the containerd object.
+
+Once the container has been removed from the container engine, the Kubernetes
+object will be removed via normal reflection.
 
 ## Images
 
@@ -126,6 +156,7 @@ metadata:
 spec:
   # refers to `Image` objects, which are not namespaced.
   imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b'
+  push: false # If set to true, the image is pushed; see below.
 status:
   conditions:
   - type: PullStarted
@@ -151,15 +182,15 @@ Not sure; do something with the `Resource` API maybe?
 We may need an `ImageBuildRequest` job-thing or something?
 
 #### Push image
-Annotation? Spec?
-After push, probably set the `Pushed` condition to `True` (which will
-automatically get a time stamp).
+Set `.spec.push` to `true`.  The image will be pushed by `.metadata.labels.name`.
+After the push, `.status[?(@.type=="Pushed")]` will be set to `True`, and
+`.spec.push` will be set to `false`.
 
 #### Scan image
 We will need a new object type for this; maybe something like
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
-kind: ImageScan
+kind: ImageScanRequest
 metadata:
   generateName: imageScan-
   namespace: rdd-system # not containerd namespace
@@ -174,8 +205,9 @@ status:
     # Just dump the Trivy result JSON here (without converting to YAML).
 ```
 
-#### Delete image
-Delete the Kubernetes API object.
+#### Untag image
+Update the `ImageTag` with the `.spec.imageRef` set to `deleted`; once processed,
+the `ImageTag` will be removed to reflect the container engine state.
 
 ## Volumes
 
@@ -200,7 +232,21 @@ spec:
 ### Volume Actions
 
 #### Create volume
-Create a volume with a name.  To start with, only local volumes are supported.
+Create a `VolumeRequest`:
+```yaml
+apiVersion: containers.rancherdesktop.io/v1alpha1
+kind: Volume
+metadata: # same as Volume.metadata
+spec: # same as Volume.spec
+status:
+  conditions:
+  - type: Processed
+    status: False
+```
+Only local volumes are supported initially.
+Parts of `.spec` may be ignored.
 
 #### Delete volume
-Delete the Kubernetes object.
+Create a `VolumeRequest`, with `.spec.scope` set to `deleted`.
+Once the volume has been deleted, the `VolumeRequest` will also be deleted after
+a brief timeout.

--- a/docs/design/api_containers.md
+++ b/docs/design/api_containers.md
@@ -64,6 +64,33 @@ status:
     status: False
 ```
 
+### Container actions
+
+We will need to support a variety of actions on containers:
+
+#### Create container
+Somehow we don't actually need this in the front end.  This will not be
+supported initially.
+
+If `.metadata.name` is the container ID (which we can't generate ahead of time),
+we can't actually create containers (because we don't know their name).
+
+#### Change container state
+Set an annotation? `containers.rancherdesktop.io/desiredStatus` perhaps?
+Alternatively, add a `.spec.state` and make that the desired state, which would
+match Kubernetes APIs better.
+
+#### Fetch container logs
+The `@kubernetes/client-node` package has some hand-written code to deal with
+logs; maybe we can make a copy of that (with a different endpoint) for this?
+
+#### Exec (shell) in container
+Same as logs; there's some special code in `@kubernetes/client-node` that we may
+be able to fork.
+
+#### Delete container
+Delete the Kubernetes API object.
+
 ## Images
 
 `Image` objects reflect images in the container engine.
@@ -72,13 +99,9 @@ status:
 apiVersion: containers.rancherdesktop.io/v1alpha1
 kind: Image
 metadata:
-  name: 'sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b' # Image ID
-  namespace: default # Not related to containerd namespace
-  labels:
-    namespace: k8s.io # containerd namespace, or `moby` if using dockerd
+  name: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b' # Image ID, colon replaced with dot.
+  namespace: rdd-system # not the containerd namespace
 spec:
-  repoTags:
-  - registry.opensuse.org/opensuse/leap:latest
   repoDigests:
   - registry.opensuse.org/opensuse/leap@sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b
   createdAt: "2025-11-17T03:14:16Z"
@@ -89,15 +112,81 @@ spec:
     org.opensuse.base.vendor: openSUSE Project
 ```
 
+`ImageTag` objects are names for each `Image`.
+
+```yaml
+apiVersion: containers.rancherdesktop.io/v1alpha1
+kind: ImageTag
+metadata:
+  generateName: registry.opensuse.org-opensuse-leap-latest-
+  namespace: rdd-system
+  labels:
+    name: 'registry.opensuse.org/opensuse/leap:latest'
+    namespace: moby # containerd namespace
+spec:
+  # refers to `Image` objects, which are not namespaced.
+  imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b'
+status:
+  conditions:
+  - type: PullStarted
+    status: True
+  - type: Ready
+    status: True
+  - type: Pushed
+    status: False
+```
+
+This is split into separate objects so that listing images by tag is easier,
+assuming we never want to list images with no tags.
+
+### Image Actions
+
+#### Fetch image
+Create an `ImageTag` object, but omit the `imageRef`.  The reconciler will pull
+the corresponding image and fill in the `imageRef` once available.
+
+#### Build image
+Not sure; do something with the `Resource` API maybe?
+
+We may need an `ImageBuildRequest` job-thing or something?
+
+#### Push image
+Annotation? Spec?
+After push, probably set the `Pushed` condition to `True` (which will
+automatically get a time stamp).
+
+#### Scan image
+We will need a new object type for this; maybe something like
+```yaml
+apiVersion: containers.rancherdesktop.io/v1alpha1
+kind: ImageScan
+metadata:
+  generateName: imageScan-
+  namespace: rdd-system # not containerd namespace
+spec:
+  # refers to `Image` objects, which are not namespaced.
+  imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b'
+status:
+  conditions:
+  - type: Finished
+    status: True
+  result:
+    # Just dump the Trivy result JSON here (without converting to YAML).
+```
+
+#### Delete image
+Delete the Kubernetes API object.
+
 ## Volumes
 
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
 kind: Volume
 metadata:
-  name: volume-name
+  generateName: volume-name- # Based on the containerd name
   namespace: default # Not related to containerd namespace
   labels:
+    name: volume-name
     namespace: k8s.io # containerd namespace, or `moby` if using dockerd
 spec:
   createdAt: "2025-11-17T03:14:16Z"
@@ -107,3 +196,11 @@ spec:
   scope: local
   options: {}
 ```
+
+### Volume Actions
+
+#### Create volume
+Create a volume with a name.  To start with, only local volumes are supported.
+
+#### Delete volume
+Delete the Kubernetes object.

--- a/docs/design/api_containers.md
+++ b/docs/design/api_containers.md
@@ -10,9 +10,15 @@ be rejected by the controllers.
 
 All objects are in the `containers.rancherdesktop.io` API group.
 
+All times are in RFC3339 format, per usual Kubernetes conventions.
+
 When running `containerd`, the containerd namespace is listed as the `namespace`
 label rather than re-using the Kubernetes namespace.  When running `dockerd`,
 namespaces are not supported and we always use `moby` as the value for that label.
+
+For the `*Request` resources, once they have successfully completed, they will
+be removed after some timeout; this will be at least one minute (so the caller
+can read any data).
 
 This is mainly for use by the Rancher Desktop front end; all other users are
 strongly urged to use the relevant CLI or other API instead.
@@ -35,6 +41,7 @@ spec:
 status:
   path: /bin/sh
   args: [-c, 'sleep inf']
+  # Image ID; corresponds to `Image` object's `.status.id` field.
   image: "sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b"
   ports:
     - name: 80/tcp
@@ -45,7 +52,7 @@ status:
         hostPort: 32768
   labels:
     org.opensuse.base.vendor: openSUSE Project
-  status: Running
+  status: running
   pid: 5059
   exitCode: 0
   error: ""
@@ -92,13 +99,12 @@ spec:
   ports: # merged with image defaults
     - name: 80/tcp
       bindings:
-      - hostIp: 0.0.0.0
+      - hostIP: 0.0.0.0
         hostPort: 32768
-      - hostIp: '::'
+      - hostIP: '::'
         hostPort: 32768
   labels: # merged with image labels
     org.opensuse.base.vendor: openSUSE Project
-  state: running # initial desired state, either `running` or `created`; defaults to `running`.
 status:
   # Resulting .metadata.name, which is the container ID.  It must be in the
   # same Kubernetes namespace as the ContainerCreateRequest.
@@ -108,14 +114,12 @@ status:
     status: True
 ```
 
-The `ContainerCreateRequest` will be deleted soon after the `Finished` condition
-transitions to `True`.
-
 If `.metadata.labels.namespace` / `.metadata.labels.name` duplicates an existing
-container, an `CreateFailed` status is set with some details.
+container, a `CreateFailed` status is set with some details.
 
-If multiple `ContainerRequest` objects exist at the same time for the same
-contained `name`/`namespace` pair, the result is undefined.
+An admission controller will ensure that we cannot have multiple
+`ContainerRequest` objects at the same time for the same containerd
+`name`/`namespace` pair.
 
 #### Change container state
 Set `.spec.state` to match how Kubernetes resources normally work.
@@ -135,24 +139,25 @@ at which point the `Container` object will actually be deleted.
 ## Images
 
 `Image` objects reflect images in the container engine.  Each tag is represented
-as a new `Image` object (therefore there may be duplication).
+as a new `Image` object; therefore, there may be multiple `Image` objects for
+the same image ID (one per tag).
 
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
 kind: Image
 metadata:
-  name: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345' # Image ID, colon replaced with dot, with random suffix.
+  # Image ID, colon replaced with dot, with random suffix.
+  name: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345'
   namespace: rancher-desktop # not the containerd namespace
   labels:
-    # If an image is untagged, `name` and `namespace` are missing.
-    name: 'registry.opensuse.org/opensuse/leap:latest' # image tag
-    id: 'sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b' # image ID
-    namespace: moby # containerd namespace
-spec:
-  push: false
+    namespace: moby # containerd namespace; not set for untagged images.
 status:
+  # Image ID, in the raw form.
+  id: 'sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b'
   repoDigests:
   - registry.opensuse.org/opensuse/leap@sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b
+  # repoTag is unset if the image is not tagged
+  repoTag: 'registry.opensuse.org/opensuse/leap:latest'
   createdAt: "2025-11-17T03:14:16Z"
   architecture: arm64
   os: linux
@@ -160,11 +165,7 @@ status:
   labels:
     org.opensuse.base.vendor: openSUSE Project
   conditions:
-  - type: PullStarted
-    status: True
-  - type: Ready
-    status: True
-  - type: Pushed
+  - type: Pushed # Used to record last push time.
     status: False
 ```
 
@@ -180,6 +181,7 @@ metadata:
 spec:
   repoTag: 'registry.opensuse.org/opensuse/leap:latest'
 status:
+  conditions:
   - type: Pulled
     status: False
 ```
@@ -190,9 +192,22 @@ Not sure; do something with the `Resource` API maybe?
 We may need an `ImageBuildRequest` job-thing or something?
 
 #### Push image
-Set `.spec.push` to `true`.  The image will be pushed by `.metadata.labels.name`.
-After the push, `.status[?(@.type=="Pushed")]` will be set to `True`, and
-`.spec.push` will be set to `false`.
+Create an `ImagePushRequest` object; it will be removed some time after the push
+has completed:
+```yaml
+apiVersion: containers.rancherdesktop.io/v1alpha1
+kind: ImagePushRequest
+metadata:
+  name: image-push-12345
+  namespace: rancher-desktop
+spec:
+  # `.metadata.name` of the image tag to push.
+  imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345'
+status:
+  conditions:
+  - type: Finished
+    status: False
+```
 
 #### Scan image
 We will need a new object type for this; maybe something like
@@ -201,7 +216,7 @@ apiVersion: containers.rancherdesktop.io/v1alpha1
 kind: ImageScanRequest
 metadata:
   name: image-scan-12345
-  namespace: rdd-system # not containerd namespace
+  namespace: rancher-desktop # not containerd namespace
 spec:
   # The `.metadata.name` of an `Image` object.
   imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345'
@@ -210,13 +225,22 @@ status:
   - type: Finished
     status: True
   result:
-    # Just dump the Trivy result JSON here (without converting to YAML).
+    # Just dump the raw Trivy result JSON here (without converting to YAML).
+    '{ ... }'
 ```
 
 #### Untag image
 Delete the `Image` object; the finalizer will untag the image.  If all tags of
 an image are removed, _and_ it is not in use by a container (running or not),
 then the image itself is removed.
+
+If a container is using an image via a tag, then removing that tag may end up
+creating a new `Image` object to represent the untagged image.
+
+#### Delete untagged image
+Delete the `Image` object (which does not have any `.status.repoTag` set).  An
+admission controller must be set up so that this is not allowed if there is a
+running container that uses that image.
 
 ## Volumes
 
@@ -229,7 +253,7 @@ metadata:
   labels:
     name: volume-name
     namespace: k8s.io # containerd namespace, or `moby` if using dockerd
-spec:
+status:
   createdAt: "2025-11-17T03:14:16Z"
   driver: local
   mountpoint: /var/lib/docker/volumes/volume-name/_data
@@ -251,15 +275,15 @@ metadata:
   labels:
     name: volume-name
     namespace: k8s.io # containerd namespace, or `moby` if using dockerd
-spec: # same as Volume.spec
+spec:
+  driver: local
 status:
   conditions:
   - type: Processed
     status: False
 ```
 Only local volumes are supported initially.
-Parts of `.spec` may be ignored.
-The request is removed some time after the volume has been created.
+The `.spec` is expected to expand in the future, as more options are supported.
 
 #### Delete volume
 Delete the `Volume` object; finalizers will cause deletion of the container

--- a/docs/design/api_containers.md
+++ b/docs/design/api_containers.md
@@ -31,6 +31,8 @@ metadata:
     name: magical_gates
     namespace: k8s.io # containerd namespace, or `moby` if using dockerd
 spec:
+  state: running # Desired state
+status:
   path: /bin/sh
   args: [-c, 'sleep inf']
   image: "sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b"
@@ -43,8 +45,6 @@ spec:
         hostPort: 32768
   labels:
     org.opensuse.base.vendor: openSUSE Project
-  state: Running # Desired state
-status:
   status: Running
   pid: 5059
   exitCode: 0
@@ -65,9 +65,8 @@ status:
     status: False
 ```
 
-If a `Container` object exists that does not actually exist in the container
-engine, it is automatically deleted.  Therefore, creating `Container` objects
-directly is not effective; to create containers, use `ContainerRequest`.
+Deleting a `Container` object causes the finalizer to delete the matching
+container in the container engine.
 
 ### Container actions
 
@@ -75,29 +74,44 @@ We will need to support a variety of actions on containers:
 
 #### Create container
 
-To create a container, create a `ContainerRequest` object:
+To create a container, create a `ContainerCreateRequest` object:
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
-kind: ContainerRequest
+kind: ContainerCreateRequest
 metadata:
-  generateName: whatever
-  namespace: rdd-system
+  name: whatever-12345
+  namespace: rancher-desktop
   labels:
-    name: magical_gates
-    namespace: k8s.io # containerd namespace
+    name: magical_gates # If unset, generate one randomly
+    namespace: k8s.io # containerd namespace; defaults to `default` / `moby`.
 spec:
-  # See Container.spec
+  state: running # Default to `running`
+  path: /bin/sh # defaults to image entry point / command
+  args: [-c, 'sleep inf'] # defaults to image entry point / command
+  image: "sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b" # accepts image tag
+  ports: # merged with image defaults
+    - name: 80/tcp
+      bindings:
+      - hostIp: 0.0.0.0
+        hostPort: 32768
+      - hostIp: '::'
+        hostPort: 32768
+  labels: # merged with image labels
+    org.opensuse.base.vendor: openSUSE Project
 status:
   # Resulting .metadata.name, which is the container ID.  It must be in the
-  # same Kubernetes namespace as the ContainerRequest.
+  # same Kubernetes namespace as the ContainerCreateRequest.
   name: 8eb6f2cf72b6616aa743cf9187f350af84c9749dab65474db2530f26745d2ef3
   conditions:
   - type: Finished
     status: True
 ```
 
-The `ContainerRequest` will be deleted soon after the `Finished` condition
+The `ContainerCreateRequest` will be deleted soon after the `Finished` condition
 transitions to `True`.
+
+If `.metadata.labels.namespace` / `.metadata.labels.name` duplicates an existing
+container, an `CreateFailed` status is set with some details.
 
 If multiple `ContainerRequest` objects exist at the same time for the same
 contained `name`/`namespace` pair, the result is undefined.
@@ -114,49 +128,26 @@ Same as logs; there's some special code in `@kubernetes/client-node` that we may
 be able to fork.
 
 #### Delete container
-Create a `ContainerRequest` with `.spec.state` set to `deleted`.
-We can't just delete the Kubernetes object, because it will be recreated as a
-reflection of the containerd object.
-
-Once the container has been removed from the container engine, the Kubernetes
-object will be removed via normal reflection.
+Delete the `Container` object; a finalizer will be used to delete the container,
+at which point the `Container` object will actually be deleted.
 
 ## Images
 
-`Image` objects reflect images in the container engine.
+`Image` objects reflect images in the container engine.  Each tag is represented
+as a new `Image` object (therefore there may be duplication).
 
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
 kind: Image
 metadata:
-  name: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b' # Image ID, colon replaced with dot.
-  namespace: rdd-system # not the containerd namespace
-spec:
-  repoDigests:
-  - registry.opensuse.org/opensuse/leap@sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b
-  createdAt: "2025-11-17T03:14:16Z"
-  architecture: arm64
-  os: linux
-  size: 45150437
+  name: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345' # Image ID, colon replaced with dot, with random suffix.
+  namespace: rancher-desktop # not the containerd namespace
   labels:
-    org.opensuse.base.vendor: openSUSE Project
-```
-
-`ImageTag` objects are names for each `Image`.
-
-```yaml
-apiVersion: containers.rancherdesktop.io/v1alpha1
-kind: ImageTag
-metadata:
-  generateName: registry.opensuse.org-opensuse-leap-latest-
-  namespace: rdd-system
-  labels:
-    name: 'registry.opensuse.org/opensuse/leap:latest'
+    # If an image is untagged, `name` and `namespace` are missing.
+    name: 'registry.opensuse.org/opensuse/leap:latest' # image tag
     namespace: moby # containerd namespace
 spec:
-  # refers to `Image` objects, which are not namespaced.
-  imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b'
-  push: false # If set to true, the image is pushed; see below.
+  push: false
 status:
   conditions:
   - type: PullStarted
@@ -167,14 +158,21 @@ status:
     status: False
 ```
 
-This is split into separate objects so that listing images by tag is easier,
-assuming we never want to list images with no tags.
-
 ### Image Actions
 
 #### Fetch image
-Create an `ImageTag` object, but omit the `imageRef`.  The reconciler will pull
-the corresponding image and fill in the `imageRef` once available.
+Create an `ImagePullRequest` object:
+```yaml
+apiVersion: containers.rancherdesktop.io/v1alpha1
+kind: ImagePullRequest
+metadata:
+  name: image-fetch-12345
+spec:
+  repoTag: 'registry.opensuse.org/opensuse/leap:latest'
+status:
+  - type: Pulled
+    status: False
+```
 
 #### Build image
 Not sure; do something with the `Resource` API maybe?
@@ -192,11 +190,11 @@ We will need a new object type for this; maybe something like
 apiVersion: containers.rancherdesktop.io/v1alpha1
 kind: ImageScanRequest
 metadata:
-  generateName: imageScan-
+  name: image-scan-12345
   namespace: rdd-system # not containerd namespace
 spec:
-  # refers to `Image` objects, which are not namespaced.
-  imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b'
+  # The `.metadata.name` of an `Image` object.
+  imageRef: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345'
 status:
   conditions:
   - type: Finished
@@ -206,8 +204,9 @@ status:
 ```
 
 #### Untag image
-Update the `ImageTag` with the `.spec.imageRef` set to `deleted`; once processed,
-the `ImageTag` will be removed to reflect the container engine state.
+Delete the `Image` object; the finalizer will untag the image.  If all tags of
+an image are removed, _and_ it is not in use by a container (running or not),
+then the image itself is removed.
 
 ## Volumes
 
@@ -215,7 +214,7 @@ the `ImageTag` will be removed to reflect the container engine state.
 apiVersion: containers.rancherdesktop.io/v1alpha1
 kind: Volume
 metadata:
-  generateName: volume-name- # Based on the containerd name
+  name: volume-name-12345 # based on containerd name / namespace?
   namespace: default # Not related to containerd namespace
   labels:
     name: volume-name
@@ -232,11 +231,16 @@ spec:
 ### Volume Actions
 
 #### Create volume
-Create a `VolumeRequest`:
+Create a `VolumeCreateRequest`:
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
-kind: Volume
-metadata: # same as Volume.metadata
+kind: VolumeCreateRequest
+metadata:
+  name: volume-create-12345
+  namespace: default
+  labels:
+    name: volume-name
+    namespace: k8s.io # containerd namespace, or `moby` if using dockerd
 spec: # same as Volume.spec
 status:
   conditions:
@@ -245,8 +249,10 @@ status:
 ```
 Only local volumes are supported initially.
 Parts of `.spec` may be ignored.
+The request is removed some time after the volume has been created.
 
 #### Delete volume
-Create a `VolumeRequest`, with `.spec.scope` set to `deleted`.
-Once the volume has been deleted, the `VolumeRequest` will also be deleted after
-a brief timeout.
+Delete the `Volume` object; finalizers will cause deletion of the container
+engine side volume.
+Webhooks will be needed for validation to reject deleting volumes that are in
+use.

--- a/docs/design/api_containers.md
+++ b/docs/design/api_containers.md
@@ -39,9 +39,9 @@ status:
   ports:
     - name: 80/tcp
       bindings:
-      - hostIp: 0.0.0.0
+      - hostIP: 0.0.0.0
         hostPort: 32768
-      - hostIp: '::'
+      - hostIP: '::'
         hostPort: 32768
   labels:
     org.opensuse.base.vendor: openSUSE Project
@@ -98,6 +98,7 @@ spec:
         hostPort: 32768
   labels: # merged with image labels
     org.opensuse.base.vendor: openSUSE Project
+  state: running # initial desired state, either `running` or `created`; defaults to `running`.
 status:
   # Resulting .metadata.name, which is the container ID.  It must be in the
   # same Kubernetes namespace as the ContainerCreateRequest.
@@ -145,10 +146,19 @@ metadata:
   labels:
     # If an image is untagged, `name` and `namespace` are missing.
     name: 'registry.opensuse.org/opensuse/leap:latest' # image tag
+    id: 'sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b' # image ID
     namespace: moby # containerd namespace
 spec:
   push: false
 status:
+  repoDigests:
+  - registry.opensuse.org/opensuse/leap@sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b
+  createdAt: "2025-11-17T03:14:16Z"
+  architecture: arm64
+  os: linux
+  size: 45150437
+  labels:
+    org.opensuse.base.vendor: openSUSE Project
   conditions:
   - type: PullStarted
     status: True


### PR DESCRIPTION
Jan brings up a good point that we don't have a single source of truth, so it's not clear if a containerd-side resource without a Kubernetes-side resource would mean the containerd-side needs to be deleted or the Kubernetes-side one needs to be created.