### PR TITLE
Increase event wait timeout to fix flaky CI tests

### DIFF
--- a/bats/tests/31-rdd-controllers/notary-events.bats
+++ b/bats/tests/31-rdd-controllers/notary-events.bats
@@ -58,7 +58,7 @@ wait_for_events() {
     local reason=$2
 
     # couldn't figure out a way to use `wait` for events
-    try --max 10 --delay 1 -- assert_events_exist "${resource_name}" "${reason}"
+    try --max 20 --delay 1 -- assert_events_exist "${resource_name}" "${reason}"
 }
 
 get_events_after_timestamp() {
@@ -106,10 +106,6 @@ get_latest_event_timestamp() {
 }
 
 @test 'verify event generation for spec updates' {
-    if is_ci && is_linux; then
-        skip "This test randomly fails in GitHub CI on Linux"
-    fi
-
     create_notary "events" "initial-event-value" "events-history"
 
     # Wait for initial ConfigMap creation and events

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -131,8 +131,8 @@ EOF
     run -0 rdd svc stop
 
     # Wait for external controller to detect control plane shutdown and exit
-    # External controllers check every 2 seconds, allow up to 3 failures (6 seconds), plus buffer
-    try --max 15 --delay 1 -- assert_process_exited "${controller_pid}"
+    # Worst case: 9s detection (3 failures × 3s timeout) + 5s cleanup timeout + buffer
+    try --max 17 --delay 1 -- assert_process_exited "${controller_pid}"
 }
 
 @test "control plane starts with different controller" {
@@ -185,6 +185,6 @@ EOF
     rdd service stop
 
     # Wait for external controller to detect control plane shutdown and exit
-    # External controllers check every 2 seconds, allow up to 3 failures (6 seconds), plus buffer
-    try --max 15 --delay 1 -- assert_process_exited "${controller_pid}"
+    # Worst case: 9s detection (3 failures × 3s timeout) + 5s cleanup timeout + buffer
+    try --max 17 --delay 1 -- assert_process_exited "${controller_pid}"
 }

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -184,9 +184,11 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		// Don't fail startup for discovery registration errors
 	}
 
-	// Ensure cleanup on shutdown
+	// Ensure cleanup on shutdown with a timeout to avoid blocking if apiserver is gone
 	defer func() {
-		if err := scm.discovery.UnregisterControllerManager(context.Background()); err != nil {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		if err := scm.discovery.UnregisterControllerManager(cleanupCtx); err != nil {
 			log.Error(err, "Failed to unregister controller manager")
 		}
 	}()


### PR DESCRIPTION
`wait_for_events` used 10 retries while `wait_for_events_after_timestamp` used 20. Slow GitHub runners need the longer timeout.