### PR TITLE
mock: Don't manual requeue after conflict

### DIFF
--- a/pkg/controllers/mock/container_reconciler.go
+++ b/pkg/controllers/mock/container_reconciler.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	mobycontainer "github.com/moby/moby/api/types/container"
 
@@ -47,20 +46,12 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	const crdName = "containers.containers.rancherdesktop.io"
 	var crd apiextensionsv1.CustomResourceDefinition
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: crdName}, &crd); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("CRD not found, requeuing", "crd", crdName)
-			return ctrl.Result{RequeueAfter: time.Second}, nil
-		}
 		log.Error(err, "Failed to get CRD", "crd", crdName)
 		return ctrl.Result{}, err
 	}
 
 	var rddNamespace corev1.Namespace
 	if err := r.Client.Get(ctx, req.NamespacedName, &rddNamespace); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("Namespace not found, requeuing", "namespace", req.NamespacedName)
-			return ctrl.Result{RequeueAfter: time.Second}, nil
-		}
 		log.Error(err, "Failed to get namespace", "namespace", req.NamespacedName)
 		return ctrl.Result{}, err
 	}
@@ -69,8 +60,6 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.Error(err, "Failed to get GVK for namespace", "namespace", &rddNamespace)
 		return ctrl.Result{}, err
 	}
-
-	reconcileResult := ctrl.Result{}
 
 	for _, inspect := range r.inspects {
 		namespacedName := types.NamespacedName{
@@ -134,32 +123,18 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			targetContainer.ResourceVersion = existingContainer.ResourceVersion
 			targetContainer.Status.Conditions = existingContainer.Status.Conditions
 			if err := r.Update(ctx, &targetContainer); err != nil {
-				if apierrors.IsConflict(err) {
-					log.V(5).Info("Conflict updating container, will retry on next reconcile", "name", namespacedName)
-					reconcileResult.RequeueAfter = time.Second
-				} else {
-					errs = append(errs, fmt.Errorf("failed to update static container %s: %w", namespacedName, err))
-				}
+				errs = append(errs, fmt.Errorf("failed to update static container %s: %w", namespacedName, err))
 				canUpdateStatus = false
 			}
 		}
 		if canUpdateStatus {
 			if err := r.Status().Update(ctx, &targetContainer); err != nil {
-				if apierrors.IsConflict(err) {
-					log.V(5).Info("Conflict updating container status, will retry on next reconcile", "name", namespacedName)
-					reconcileResult.RequeueAfter = time.Second
-				} else {
-					errs = append(errs, fmt.Errorf("failed to update status for static container %s: %w", namespacedName, err))
-				}
+				errs = append(errs, fmt.Errorf("failed to update status for static container %s: %w", namespacedName, err))
 			}
 		}
 	}
 
-	if len(errs) > 0 {
-		return ctrl.Result{}, errors.Join(errs...)
-	}
-
-	return reconcileResult, nil
+	return ctrl.Result{}, errors.Join(errs...)
 }
 
 func (r *containerReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controllers/mock/image_reconciler.go
+++ b/pkg/controllers/mock/image_reconciler.go
@@ -57,20 +57,12 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	const crdName = "images.containers.rancherdesktop.io"
 	var crd apiextensionsv1.CustomResourceDefinition
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: crdName}, &crd); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("CRD not found, requeuing", "crd", crdName)
-			return ctrl.Result{RequeueAfter: time.Second}, nil
-		}
 		log.Error(err, "Failed to get CRD", "crd", crdName)
 		return ctrl.Result{}, err
 	}
 
 	var rddNamespace corev1.Namespace
 	if err := r.Client.Get(ctx, req.NamespacedName, &rddNamespace); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("Namespace not found, requeuing", "namespace", req.NamespacedName)
-			return ctrl.Result{RequeueAfter: time.Second}, nil
-		}
 		log.Error(err, "Failed to get namespace", "namespace", req.NamespacedName)
 		return ctrl.Result{}, err
 	}
@@ -80,7 +72,6 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	var reconcileResult ctrl.Result
 	for _, inspect := range r.inspects {
 		imageName := inspect.ID
 		if len(inspect.RepoTags) > 0 {
@@ -115,24 +106,14 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				targetImage.Labels["namespace"] = "moby"
 				targetImage.Status.RepoTag = tag
 				if err := r.upsertImage(ctx, targetImage); err != nil {
-					if apierrors.IsConflict(err) {
-						log.V(5).Info("Conflict updating image, will retry on next reconcile", "image", tag)
-						reconcileResult.RequeueAfter = time.Second
-					} else {
-						errs = append(errs, err)
-					}
+					errs = append(errs, err)
 				}
 			}
 		} else {
 			// No tags; create a single dangling image.
 			templateImage.ObjectMeta.Name = sanitizeKubernetesObjectName(inspect.ID)
 			if err := r.upsertImage(ctx, &templateImage); err != nil {
-				if apierrors.IsConflict(err) {
-					log.V(5).Info("Conflict updating image, will retry on next reconcile", "image", imageName)
-					reconcileResult.RequeueAfter = time.Second
-				} else {
-					errs = append(errs, err)
-				}
+				errs = append(errs, err)
 			}
 		}
 	}
@@ -142,7 +123,7 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, errors.Join(errs...)
 	}
 
-	return reconcileResult, nil
+	return ctrl.Result{}, nil
 }
 
 // upsertImage creates or updates the given Image resource.  The passed in image

--- a/pkg/controllers/mock/volume_reconciler.go
+++ b/pkg/controllers/mock/volume_reconciler.go
@@ -47,20 +47,12 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	const crdName = "volumes.containers.rancherdesktop.io"
 	var crd apiextensionsv1.CustomResourceDefinition
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: crdName}, &crd); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("CRD not found, requeuing", "crd", crdName)
-			return ctrl.Result{RequeueAfter: time.Second}, nil
-		}
 		log.Error(err, "Failed to get CRD", "crd", crdName)
 		return ctrl.Result{}, err
 	}
 
 	var rddNamespace corev1.Namespace
 	if err := r.Client.Get(ctx, req.NamespacedName, &rddNamespace); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("Namespace not found, requeuing", "namespace", req.NamespacedName)
-			return ctrl.Result{RequeueAfter: time.Second}, nil
-		}
 		log.Error(err, "Failed to get namespace", "namespace", req.NamespacedName)
 		return ctrl.Result{}, err
 	}
@@ -70,7 +62,6 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
-	var reconcileResult ctrl.Result
 	for _, inspect := range r.inspects {
 		namespacedName := types.NamespacedName{
 			Namespace: metav1.NamespaceDefault,
@@ -111,12 +102,7 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			} else {
 				existingVolume.Status = targetVolume.Status
 				if err := r.Status().Update(ctx, &existingVolume); err != nil {
-					if apierrors.IsConflict(err) {
-						log.V(5).Info("Conflict updating volume status, will retry on next reconcile", "name", namespacedName)
-						reconcileResult.RequeueAfter = time.Second
-					} else {
-						errs = append(errs, fmt.Errorf("failed to update status for static volume %s: %w", namespacedName, err))
-					}
+					errs = append(errs, fmt.Errorf("failed to update status for static volume %s: %w", namespacedName, err))
 				}
 			}
 		} else if err != nil {
@@ -125,30 +111,16 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		} else {
 			targetVolume.ResourceVersion = existingVolume.ResourceVersion
 			if err := r.Update(ctx, &targetVolume); err != nil {
-				if apierrors.IsConflict(err) {
-					log.V(5).Info("Conflict updating volume, will retry on next reconcile", "name", namespacedName)
-					reconcileResult.RequeueAfter = time.Second
-				} else {
-					errs = append(errs, fmt.Errorf("failed to update static volume %s: %w", namespacedName, err))
-				}
+				errs = append(errs, fmt.Errorf("failed to update static volume %s: %w", namespacedName, err))
 			} else {
 				if err := r.Status().Update(ctx, &targetVolume); err != nil {
-					if apierrors.IsConflict(err) {
-						log.V(5).Info("Conflict updating volume status, will retry on next reconcile", "name", namespacedName)
-						reconcileResult.RequeueAfter = time.Second
-					} else {
-						errs = append(errs, fmt.Errorf("failed to update status for static volume %s: %w", namespacedName, err))
-					}
+					errs = append(errs, fmt.Errorf("failed to update status for static volume %s: %w", namespacedName, err))
 				}
 			}
 		}
 	}
 
-	if len(errs) > 0 {
-		return ctrl.Result{}, errors.Join(errs...)
-	}
-
-	return reconcileResult, nil
+	return ctrl.Result{}, errors.Join(errs...)
 }
 
 func (r *volumeReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
If we get a conflict when updating a resource, do not manually requeue; instead, just pass the error back to get the normal exponential backoff behaviour.

Also drop manual requeuing if we fail to find CRDs or namespaces; in those cases we also did not progress on the reconcile.