### PR TITLE
Switch to new events API

### DIFF
--- a/pkg/controllers/app/demo/controller.go
+++ b/pkg/controllers/app/demo/controller.go
@@ -59,6 +59,6 @@ func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 	return (&controllers.DemoReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor(ControllerName + "-controller"), //nolint:staticcheck // new API requires events.k8s.io
+		Recorder: mgr.GetEventRecorder(ControllerName + "-controller"),
 	}).SetupWithManager(mgr)
 }

--- a/pkg/controllers/app/demo/controllers/demo_controller.go
+++ b/pkg/controllers/app/demo/controllers/demo_controller.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -24,7 +24,7 @@ import (
 type DemoReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Recorder events.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=app.rancherdesktop.io,resources=demos,verbs=get;list;watch;create;update;patch;delete
@@ -78,14 +78,14 @@ func (r *DemoReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		r.setCondition(&demo, appv1alpha1.DemoConditionCompleted, metav1.ConditionFalse, "InProgress", "Processing is still in progress")
 
 		log.Info("Processing demo message", "message", demo.Spec.Message, "count", demo.Status.ProcessedCount)
-		r.Recorder.Eventf(&demo, "Normal", "Processing", "Processed message %d of %d: %s", demo.Status.ProcessedCount, demo.Spec.Count, demo.Spec.Message)
+		r.Recorder.Eventf(&demo, nil, corev1.EventTypeNormal, "Processing", "Process", "Processed message %d of %d: %s", demo.Status.ProcessedCount, demo.Spec.Count, demo.Spec.Message)
 	} else {
 		// Update conditions for completed state
 		r.setCondition(&demo, appv1alpha1.DemoConditionReady, metav1.ConditionTrue, "Ready", "Demo controller is ready")
 		r.setCondition(&demo, appv1alpha1.DemoConditionProcessing, metav1.ConditionFalse, "Completed", "Processing has completed")
 		r.setCondition(&demo, appv1alpha1.DemoConditionCompleted, metav1.ConditionTrue, "Completed", "All messages have been processed successfully")
 
-		r.Recorder.Event(&demo, "Normal", "Completed", "Demo processing completed successfully")
+		r.Recorder.Eventf(&demo, nil, corev1.EventTypeNormal, "Completed", "Process", "Demo processing completed successfully")
 	}
 
 	// Update status
@@ -124,7 +124,7 @@ func (r *DemoReconciler) setCondition(demo *appv1alpha1.Demo, conditionType stri
 			changed = true
 		}
 		if changed {
-			r.Recorder.Eventf(demo, corev1.EventTypeNormal, "ConditionChanged", conditionType, message)
+			r.Recorder.Eventf(demo, nil, corev1.EventTypeNormal, "ConditionChanged", conditionType, message)
 		}
 		return
 	}
@@ -137,7 +137,7 @@ func (r *DemoReconciler) setCondition(demo *appv1alpha1.Demo, conditionType stri
 		Reason:             reason,
 		Message:            message,
 	})
-	r.Recorder.Eventf(demo, corev1.EventTypeNormal, "ConditionChanged", conditionType, message)
+	r.Recorder.Eventf(demo, nil, corev1.EventTypeNormal, "ConditionChanged", conditionType, message)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controllers/rdd/notary/controller.go
+++ b/pkg/controllers/rdd/notary/controller.go
@@ -87,7 +87,7 @@ func (c *controller) setupReconciler(mgr ctrl.Manager) error {
 	return (&controllers.NotaryReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor(ControllerName + "-controller"), //nolint:staticcheck // new API requires events.k8s.io
+		Recorder: mgr.GetEventRecorder(ControllerName + "-controller"),
 		Manager:  mgr,
 	}).SetupWithManager(mgr)
 }

--- a/pkg/controllers/rdd/notary/controllers/notary_controller.go
+++ b/pkg/controllers/rdd/notary/controllers/notary_controller.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -28,7 +28,7 @@ import (
 type NotaryReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Recorder events.EventRecorder
 	Manager  ctrl.Manager
 }
 
@@ -74,7 +74,7 @@ func (r *NotaryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Record event for every reconcile with current spec value
-	r.Recorder.Eventf(&notary, "Normal", "SpecUpdate", "Notary spec updated with value: %s", notary.Spec.Value)
+	r.Recorder.Eventf(&notary, nil, corev1.EventTypeNormal, "Reconcile", "SpecUpdate", "Notary spec updated with value: %s", notary.Spec.Value)
 
 	// Check if the value has changed
 	oldValue := notary.Status.LastRecordedValue
@@ -86,7 +86,7 @@ func (r *NotaryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Record the change in the ConfigMap
 		if err := r.recordValueChange(ctx, &notary); err != nil {
 			log.Error(err, "Failed to record value change")
-			r.Recorder.Eventf(&notary, "Warning", "ConfigMapError", "Failed to record value change: %v", err)
+			r.Recorder.Eventf(&notary, nil, corev1.EventTypeWarning, "ConfigMapError", "SyncValue", "Failed to record value change: %v", err)
 			return ctrl.Result{}, err
 		}
 
@@ -97,13 +97,13 @@ func (r *NotaryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		if err := r.Status().Update(ctx, &notary); err != nil {
 			log.Error(err, "Failed to update Notary status")
-			r.Recorder.Eventf(&notary, "Warning", "StatusUpdateError", "Failed to update status: %v", err)
+			r.Recorder.Eventf(&notary, nil, corev1.EventTypeWarning, "StatusUpdateError", "SyncValue", "Failed to update status: %v", err)
 			return ctrl.Result{}, err
 		}
 
-		r.Recorder.Eventf(&notary, "Normal", "ValueRecorded", "Value change recorded in ConfigMap: %s -> %s", oldValue, notary.Spec.Value)
+		r.Recorder.Eventf(&notary, nil, corev1.EventTypeNormal, "ValueRecorded", "SyncValue", "Value change recorded in ConfigMap: %s -> %s", oldValue, notary.Spec.Value)
 	} else {
-		r.Recorder.Event(&notary, "Normal", "NoChange", "Spec update received but value unchanged, no ConfigMap update needed")
+		r.Recorder.Eventf(&notary, nil, corev1.EventTypeNormal, "NoChange", "SyncValue", "Spec update received but value unchanged, no ConfigMap update needed")
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -72,6 +72,7 @@ import (
 var requiredAPIGroups = sets.NewString(
 	"apiextensions.k8s.io",         // CRDs
 	"authorization.k8s.io",         // Authorization
+	"events.k8s.io",                // Events
 	"rbac.authorization.k8s.io",    // RBAC
 	"admissionregistration.k8s.io", // Admission
 	"coordination.k8s.io",          // Coordination (for controller-runtime compatibility)


### PR DESCRIPTION
The old events API has been deprecated; this switches to the new one.

Fixes #129