### PR TITLE
Implement API pass through support

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,4 +1,6 @@
 cooldown #https://en.wiktionary.org/wiki/cooldown#English
+passthrough #https://en.wiktionary.org/wiki/passthrough
+passthroughs #https://en.wiktionary.org/wiki/passthrough
 routable #https://en.wiktionary.org/wiki/routable#English
 standalone #https://en.wiktionary.org/wiki/standalone#English
 startable #https://en.wiktionary.org/wiki/startable

--- a/bats/tests/32-app-controllers/passthrough.bats
+++ b/bats/tests/32-app-controllers/passthrough.bats
@@ -1,0 +1,31 @@
+load '../../helpers/load'
+
+local_setup_file() {
+    setup_rdd_control_plane
+}
+
+@test 'Check that passthrough controllers work' {
+    run -0 rdd ctl get --raw '/passthrough/hello/'
+    assert_line 'Hello, world!'
+    assert_line --regexp 'X-Forwarded-For = .*127\.0\.0\.1.*'
+}
+
+@test 'Check that passthrough to web socket works' {
+    # We need to use curl for websocket support; however, some versions of curl
+    # do not support ws:// URLs directly, so we check for that and skip the
+    # test if not supported.
+    run -0 curl --version
+    if ! [[ "${output} " =~ Protocols:.*\ ws ]]; then
+        skip "curl does not support websockets"
+    fi
+    run -0 rdd ctl config view --minify --flatten --output=jsonpath='{.clusters[].cluster.server}'
+    local server_url="${output}"
+    run -0 rdd ctl config view --minify --flatten --output=jsonpath='{.users[].user.token}'
+    local token="${output}"
+    run -0 curl --silent --verbose --header "Authorization: Bearer ${token}" --insecure \
+        "ws${server_url#http}/passthrough/websocket/"
+    assert_line 'hello from websocket'
+    assert_line --partial 'HTTP/1.1 101 Switching Protocols'
+    assert_line --partial 'Connection: Upgrade'
+    assert_line --partial 'Upgrade: websocket'
+}

--- a/bats/tests/32-app-controllers/passthrough.bats
+++ b/bats/tests/32-app-controllers/passthrough.bats
@@ -5,9 +5,10 @@ local_setup_file() {
 }
 
 @test 'Check that passthrough controllers work' {
-    run -0 rdd ctl get --raw '/passthrough/hello/'
+    run -0 rdd ctl get --raw '/passthrough/demo/hello/thing'
     assert_line 'Hello, world!'
     assert_line --regexp 'X-Forwarded-For = .*127\.0\.0\.1.*'
+    assert_line 'Path = "/thing"'
 }
 
 @test 'Check that passthrough to web socket works' {
@@ -15,15 +16,17 @@ local_setup_file() {
     # do not support ws:// URLs directly, so we check for that and skip the
     # test if not supported.
     run -0 curl --version
-    if ! [[ "${output} " =~ Protocols:.*\ ws ]]; then
+    # `ws` may be the last protocol and precede a new line, so we only test for
+    # space to the left of it.
+    if ! [[ "${output}" =~ Protocols:.*\ ws ]]; then
         skip "curl does not support WebSocket"
     fi
     run -0 rdd ctl config view --minify --flatten --output=jsonpath='{.clusters[].cluster.server}'
-    local server_url="${output}"
+    local server_url=${output}
     run -0 rdd ctl config view --minify --flatten --output=jsonpath='{.users[].user.token}'
-    local token="${output}"
+    local token=${output}
     run -0 curl --silent --verbose --header "Authorization: Bearer ${token}" --insecure \
-        "ws${server_url#http}/passthrough/websocket/"
+        "${server_url/http/ws}/passthrough/demo/websocket/"
     assert_line --partial 'hello from websocket'
     assert_line --partial 'HTTP/1.1 101 Switching Protocols'
     assert_line --partial 'Connection: Upgrade'

--- a/bats/tests/32-app-controllers/passthrough.bats
+++ b/bats/tests/32-app-controllers/passthrough.bats
@@ -11,12 +11,12 @@ local_setup_file() {
 }
 
 @test 'Check that passthrough to web socket works' {
-    # We need to use curl for websocket support; however, some versions of curl
+    # We need to use curl for WebSocket support; however, some versions of curl
     # do not support ws:// URLs directly, so we check for that and skip the
     # test if not supported.
     run -0 curl --version
     if ! [[ "${output} " =~ Protocols:.*\ ws ]]; then
-        skip "curl does not support websockets"
+        skip "curl does not support WebSocket"
     fi
     run -0 rdd ctl config view --minify --flatten --output=jsonpath='{.clusters[].cluster.server}'
     local server_url="${output}"
@@ -24,7 +24,7 @@ local_setup_file() {
     local token="${output}"
     run -0 curl --silent --verbose --header "Authorization: Bearer ${token}" --insecure \
         "ws${server_url#http}/passthrough/websocket/"
-    assert_line 'hello from websocket'
+    assert_line --partial 'hello from websocket'
     assert_line --partial 'HTTP/1.1 101 Switching Protocols'
     assert_line --partial 'Connection: Upgrade'
     assert_line --partial 'Upgrade: websocket'

--- a/pkg/controllers/app/demo/controller.go
+++ b/pkg/controllers/app/demo/controller.go
@@ -43,7 +43,7 @@ func newController() base.Controller {
 	c := &controller{}
 	c.passthroughs = map[string]http.Handler{
 		"hello":     http.HandlerFunc(c.handleHello),
-		"websocket": http.HandlerFunc(c.handleWebsocket),
+		"websocket": http.HandlerFunc(c.handleWebSocket),
 	}
 	return c
 }
@@ -51,7 +51,7 @@ func newController() base.Controller {
 // Verify that controller implements base.Controller interface.
 var (
 	_ base.Controller            = &controller{}
-	_ base.PassThroughController = &controller{}
+	_ base.PassthroughController = &controller{}
 )
 
 // GetName returns the controller name.
@@ -69,11 +69,11 @@ func (c *controller) GetCRDData() string {
 	return demoCRD
 }
 
-func (c *controller) GetPassThroughEndpoints() []string {
+func (c *controller) GetPassthroughEndpoints() []string {
 	return slices.Collect(maps.Keys(c.passthroughs))
 }
 
-func (c *controller) GetPassThroughHandler(endpoint string) http.Handler {
+func (c *controller) GetPassthroughHandler(endpoint string) http.Handler {
 	return c.passthroughs[endpoint]
 }
 
@@ -84,22 +84,22 @@ func (c *controller) handleHello(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (c *controller) handleWebsocket(w http.ResponseWriter, r *http.Request) {
+func (c *controller) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	log := ctrl.LoggerFrom(r.Context())
 	upgrader := &websocket.Upgrader{
 		CheckOrigin: func(_ *http.Request) bool { return true },
 	}
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.V(5).Info("Failed to upgrade to websocket", "error", err)
-		http.Error(w, "Failed to upgrade to websocket: "+err.Error(), http.StatusBadRequest)
+		log.V(5).Info("Failed to upgrade to WebSocket", "error", err)
+		http.Error(w, "Failed to upgrade to WebSocket: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	defer conn.Close()
 
-	err = conn.WriteMessage(websocket.TextMessage, []byte("hello from websocket"))
+	err = conn.WriteMessage(websocket.TextMessage, []byte("\nhello from websocket\n"))
 	if err != nil {
-		log.V(5).Info("Failed to write websocket message", "error", err)
+		log.V(5).Info("Failed to write WebSocket message", "error", err)
 	}
 }
 

--- a/pkg/controllers/app/demo/controller.go
+++ b/pkg/controllers/app/demo/controller.go
@@ -6,6 +6,13 @@ package demo
 
 import (
 	_ "embed"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"slices"
+
+	"github.com/gorilla/websocket"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -15,7 +22,7 @@ import (
 )
 
 func init() {
-	base.RegisterController(&controller{})
+	base.RegisterController(newController())
 }
 
 // ControllerName is the name of this controller.
@@ -28,10 +35,24 @@ const APIGroup = "app"
 var demoCRD string
 
 // controller implements the base.Controller interface for demo.
-type controller struct{}
+type controller struct {
+	passthroughs map[string]http.Handler
+}
+
+func newController() base.Controller {
+	c := &controller{}
+	c.passthroughs = map[string]http.Handler{
+		"hello":     http.HandlerFunc(c.handleHello),
+		"websocket": http.HandlerFunc(c.handleWebsocket),
+	}
+	return c
+}
 
 // Verify that controller implements base.Controller interface.
-var _ base.Controller = &controller{}
+var (
+	_ base.Controller            = &controller{}
+	_ base.PassThroughController = &controller{}
+)
 
 // GetName returns the controller name.
 func (c *controller) GetName() string {
@@ -46,6 +67,40 @@ func (c *controller) GetAPIGroup() string {
 // GetCRDData returns the embedded CRD YAML data.
 func (c *controller) GetCRDData() string {
 	return demoCRD
+}
+
+func (c *controller) GetPassThroughEndpoints() []string {
+	return slices.Collect(maps.Keys(c.passthroughs))
+}
+
+func (c *controller) GetPassThroughHandler(endpoint string) http.Handler {
+	return c.passthroughs[endpoint]
+}
+
+func (c *controller) handleHello(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.WriteString(w, "Hello, world!\n")
+	for k, v := range r.Header {
+		_, _ = fmt.Fprintf(w, "%s = %q\n", k, v)
+	}
+}
+
+func (c *controller) handleWebsocket(w http.ResponseWriter, r *http.Request) {
+	log := ctrl.LoggerFrom(r.Context())
+	upgrader := &websocket.Upgrader{
+		CheckOrigin: func(_ *http.Request) bool { return true },
+	}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.V(5).Info("Failed to upgrade to websocket", "error", err)
+		http.Error(w, "Failed to upgrade to websocket: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer conn.Close()
+
+	err = conn.WriteMessage(websocket.TextMessage, []byte("hello from websocket"))
+	if err != nil {
+		log.V(5).Info("Failed to write websocket message", "error", err)
+	}
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.

--- a/pkg/controllers/app/demo/controller.go
+++ b/pkg/controllers/app/demo/controller.go
@@ -82,6 +82,7 @@ func (c *controller) handleHello(w http.ResponseWriter, r *http.Request) {
 	for k, v := range r.Header {
 		_, _ = fmt.Fprintf(w, "%s = %q\n", k, v)
 	}
+	_, _ = fmt.Fprintf(w, "Path = %q\n", r.URL.Path)
 }
 
 func (c *controller) handleWebSocket(w http.ResponseWriter, r *http.Request) {
@@ -97,7 +98,7 @@ func (c *controller) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 	defer conn.Close()
 
-	err = conn.WriteMessage(websocket.TextMessage, []byte("\nhello from websocket\n"))
+	err = conn.WriteMessage(websocket.TextMessage, []byte("hello from websocket\n"))
 	if err != nil {
 		log.V(5).Info("Failed to write WebSocket message", "error", err)
 	}

--- a/pkg/controllers/base/controller.go
+++ b/pkg/controllers/base/controller.go
@@ -53,26 +53,26 @@ type WebhookController interface {
 	GetWebhookManagers() []*WebhookManager
 }
 
-// PassThroughController is an optional interface that controllers can implement
+// PassthroughController is an optional interface that controllers can implement
 // to provide custom HTTP handlers.  These handlers will be exposed on the API
 // server under the `/passthrough/<endpoint>` path.
 //
 // This is intended for controllers that need to provide more complex HTTP
 // functionality that cannot be provided using custom resources, such as
-// handling websocket connections to stream data.
-type PassThroughController interface {
-	// GetPassThroughEndpoints returns the list of HTTP endpoints provided by
+// handling WebSocket connections to stream data.
+type PassthroughController interface {
+	// GetPassthroughEndpoints returns the list of HTTP endpoints provided by
 	// this controller.  These endpoints will be exposed on the API server under
 	// the `/passthrough/<endpoint>` path; for example, an endpoint named "logs"
 	// will be accessible at `/passthrough/logs`.  The endpoint names must be
 	// unique across the API server, and must be a valid path segment (i.e.,
 	// no slashes).
-	GetPassThroughEndpoints() []string
+	GetPassthroughEndpoints() []string
 
-	// GetPassThroughHandler returns the HTTP handler for the given endpoint.
+	// GetPassthroughHandler returns the HTTP handler for the given endpoint.
 	// The handler does not get the `/passthrough/` prefix; for example, for
 	// an endpoint "logs", the handler will receive requests to `/logs`.
-	GetPassThroughHandler(endpoint string) http.Handler
+	GetPassthroughHandler(endpoint string) http.Handler
 }
 
 // Registry holds all registered controllers.

--- a/pkg/controllers/base/controller.go
+++ b/pkg/controllers/base/controller.go
@@ -6,6 +6,7 @@ package base
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,6 +51,28 @@ type WebhookController interface {
 	// GetWebhookManagers returns all WebhookManagers for parallel setup.
 	// Returns nil or empty slice if the controller doesn't use webhooks.
 	GetWebhookManagers() []*WebhookManager
+}
+
+// PassThroughController is an optional interface that controllers can implement
+// to provide custom HTTP handlers.  These handlers will be exposed on the API
+// server under the `/passthrough/<endpoint>` path.
+//
+// This is intended for controllers that need to provide more complex HTTP
+// functionality that cannot be provided using custom resources, such as
+// handling websocket connections to stream data.
+type PassThroughController interface {
+	// GetPassThroughEndpoints returns the list of HTTP endpoints provided by
+	// this controller.  These endpoints will be exposed on the API server under
+	// the `/passthrough/<endpoint>` path; for example, an endpoint named "logs"
+	// will be accessible at `/passthrough/logs`.  The endpoint names must be
+	// unique across the API server, and must be a valid path segment (i.e.,
+	// no slashes).
+	GetPassThroughEndpoints() []string
+
+	// GetPassThroughHandler returns the HTTP handler for the given endpoint.
+	// The handler does not get the `/passthrough/` prefix; for example, for
+	// an endpoint "logs", the handler will receive requests to `/logs`.
+	GetPassThroughHandler(endpoint string) http.Handler
 }
 
 // Registry holds all registered controllers.

--- a/pkg/controllers/base/controller.go
+++ b/pkg/controllers/base/controller.go
@@ -55,7 +55,7 @@ type WebhookController interface {
 
 // PassthroughController is an optional interface that controllers can implement
 // to provide custom HTTP handlers.  These handlers will be exposed on the API
-// server under the `/passthrough/<endpoint>` path.
+// server under the `/passthrough/<controller>/<endpoint>` path.
 //
 // This is intended for controllers that need to provide more complex HTTP
 // functionality that cannot be provided using custom resources, such as
@@ -63,15 +63,17 @@ type WebhookController interface {
 type PassthroughController interface {
 	// GetPassthroughEndpoints returns the list of HTTP endpoints provided by
 	// this controller.  These endpoints will be exposed on the API server under
-	// the `/passthrough/<endpoint>` path; for example, an endpoint named "logs"
-	// will be accessible at `/passthrough/logs`.  The endpoint names must be
-	// unique across the API server, and must be a valid path segment (i.e.,
-	// no slashes).
+	// the `/passthrough/<controller>/<endpoint>/` path; for example, an
+	// endpoint named "logs" on the "example" controller will be accessible at
+	// `/passthrough/example/logs/`.  The endpoint names returned must not
+	// contain duplicates, and must be a valid path segment (i.e., no slashes).
 	GetPassthroughEndpoints() []string
 
 	// GetPassthroughHandler returns the HTTP handler for the given endpoint.
-	// The handler does not get the `/passthrough/` prefix; for example, for
-	// an endpoint "logs", the handler will receive requests to `/logs`.
+	// The handler does not get the `/passthrough/<controller>/<endpoint>`
+	// prefix; for example, for an endpoint "logs" on the "example" controller,
+	// if the client requests `/passthrough/example/logs/id` the handler will
+	// receive requests to `/id`.
 	GetPassthroughHandler(endpoint string) http.Handler
 }
 

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -737,8 +737,8 @@ func createServerChain(config options.CompletedConfig) (*aggregatorapiserver.API
 	// Basic not found handler
 	notFoundHandler := notfoundhandler.New(config.ControlPlane.Generic.Serializer, genericapifilters.NoMuxAndDiscoveryIncompleteKey)
 
-	// Mux for use with [base.PassthroughController] controllers; see the
-	// documentation for that interface.
+	// Mux exists so we can set up [base.PassthroughController] controllers later
+	// if needed; see the documentation for that interface.
 	mux := http.NewServeMux()
 	mux.Handle("/", notFoundHandler)
 

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -733,8 +734,13 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 
 // createServerChain creates the apiserver instances connected via delegation.
 func createServerChain(config options.CompletedConfig) (*aggregatorapiserver.APIAggregator, error) {
-	// 1. Basic not found handler
+	// Basic not found handler
 	notFoundHandler := notfoundhandler.New(config.ControlPlane.Generic.Serializer, genericapifilters.NoMuxAndDiscoveryIncompleteKey)
+
+	// Mux for use with [base.PassThroughController] controllers; see the
+	// documentation for that interface.
+	mux := http.NewServeMux()
+	mux.Handle("/", notFoundHandler)
 
 	var aggregatorServer *aggregatorapiserver.APIAggregator
 	var apiExtensionsServer *apiextensionapiserver.CustomResourceDefinitions
@@ -742,7 +748,7 @@ func createServerChain(config options.CompletedConfig) (*aggregatorapiserver.API
 	var err error
 
 	// CRDs are always enabled - create extension server
-	apiExtensionsServer, err = config.APIExtensions.New(genericapiserver.NewEmptyDelegateWithCustomHandler(notFoundHandler))
+	apiExtensionsServer, err = config.APIExtensions.New(genericapiserver.NewEmptyDelegateWithCustomHandler(mux))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create apiextensions-apiserver: %w", err)
 	}
@@ -778,13 +784,20 @@ func createServerChain(config options.CompletedConfig) (*aggregatorapiserver.API
 		klog.Infof("Serving %s", storageProvider.GroupName())
 	}
 
-	// 3. Aggregator for APIServices, discovery and OpenAPI
+	// Aggregator for APIServices, discovery and OpenAPI
 	// CRDs are always enabled - wire in aggregator server
 	aggregatorServer, err = controlplaneapiserver.CreateAggregatorServer(config.Aggregator, nativeAPIs.GenericAPIServer, apiExtensionsServer.Informers.Apiextensions().V1().CustomResourceDefinitions(), false, controlplaneapiserver.DefaultGenericAPIServicePriorities())
 	if err != nil {
 		// we don't need special handling for innerStopCh because the aggregator server doesn't create any go routines
 		return nil, fmt.Errorf("failed to create kube-aggregator: %w", err)
 	}
+
+	// Set up the passthrough handler
+	discovery, err := controllers.NewControllerManagerDiscovery(config.ControlPlane.Generic.LoopbackClientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not create discovery client: %w", err)
+	}
+	mux.Handle("/passthrough/", http.StripPrefix("/passthrough", controllers.NewPassThroughHandler(discovery)))
 
 	return aggregatorServer, nil
 }

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -737,7 +737,7 @@ func createServerChain(config options.CompletedConfig) (*aggregatorapiserver.API
 	// Basic not found handler
 	notFoundHandler := notfoundhandler.New(config.ControlPlane.Generic.Serializer, genericapifilters.NoMuxAndDiscoveryIncompleteKey)
 
-	// Mux for use with [base.PassThroughController] controllers; see the
+	// Mux for use with [base.PassthroughController] controllers; see the
 	// documentation for that interface.
 	mux := http.NewServeMux()
 	mux.Handle("/", notFoundHandler)
@@ -797,7 +797,7 @@ func createServerChain(config options.CompletedConfig) (*aggregatorapiserver.API
 	if err != nil {
 		return nil, fmt.Errorf("could not create discovery client: %w", err)
 	}
-	mux.Handle("/passthrough/", http.StripPrefix("/passthrough", controllers.NewPassThroughHandler(discovery)))
+	mux.Handle("/passthrough/", http.StripPrefix("/passthrough", controllers.NewPassthroughHandler(discovery)))
 
 	return aggregatorServer, nil
 }

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -29,14 +29,22 @@ const (
 	RDDSystemNamespace = "rdd-system"
 )
 
+// ControllerManagerInput contains the input parameters for registering a controller manager.
+type ControllerManagerInput struct {
+	HealthPort          int      `json:"healthPort"`
+	MetricsPort         int      `json:"metricsPort"`
+	PassThroughPort     int      `json:"-"`
+	EnabledControllers  []string `json:"enabledControllers"`
+	EnabledPassThroughs []string `json:"enabledPassThroughs"`
+}
+
 // ControllerManagerInfo contains discovered information about a running controller manager.
 type ControllerManagerInfo struct {
-	HealthPort         int         `json:"healthPort"`
-	MetricsPort        int         `json:"metricsPort"`
-	EnabledControllers []string    `json:"enabledControllers"`
-	StartTime          metav1.Time `json:"startTime"`
-	HealthEndpoint     string      `json:"healthEndpoint"`
-	MetricsEndpoint    string      `json:"metricsEndpoint"`
+	ControllerManagerInput `json:",inline"`
+	StartTime              metav1.Time `json:"startTime"`
+	HealthEndpoint         string      `json:"healthEndpoint"`
+	MetricsEndpoint        string      `json:"metricsEndpoint"`
+	PassThroughEndpoint    string      `json:"passThroughEndpoint"`
 }
 
 // ControllerManagerDiscovery handles service discovery for the shared controller manager.
@@ -83,24 +91,23 @@ func NewControllerManagerDiscoveryGroup(config *rest.Config, apiGroupName string
 }
 
 // RegisterControllerManager creates or updates the ConfigMap with controller manager information.
-func (d *ControllerManagerDiscoveryGroup) RegisterControllerManager(ctx context.Context, healthPort, metricsPort int, controllers []string) error {
-	return d.registerControllerManagerImpl(ctx, healthPort, metricsPort, controllers, true)
+func (d *ControllerManagerDiscoveryGroup) RegisterControllerManager(ctx context.Context, input ControllerManagerInput) error {
+	return d.registerControllerManagerImpl(ctx, input, true)
 }
 
 // registerControllerManagerImpl is the internal implementation of RegisterControllerManager,
 // with an option to retry on conflict.
-func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx context.Context, healthPort, metricsPort int, controllers []string, allowRetry bool) error {
+func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx context.Context, input ControllerManagerInput, allowRetry bool) error {
 	if err := d.ensureNamespace(ctx); err != nil {
 		return fmt.Errorf("failed to ensure namespace: %w", err)
 	}
 
 	info := ControllerManagerInfo{
-		HealthPort:         healthPort,
-		MetricsPort:        metricsPort,
-		EnabledControllers: controllers,
-		StartTime:          metav1.NewTime(time.Now().UTC()),
-		HealthEndpoint:     fmt.Sprintf("http://localhost:%d/healthz", healthPort),
-		MetricsEndpoint:    fmt.Sprintf("http://localhost:%d/metrics", metricsPort),
+		ControllerManagerInput: input,
+		StartTime:              metav1.NewTime(time.Now().UTC()),
+		HealthEndpoint:         fmt.Sprintf("http://localhost:%d/healthz", input.HealthPort),
+		MetricsEndpoint:        fmt.Sprintf("http://localhost:%d/metrics", input.MetricsPort),
+		PassThroughEndpoint:    fmt.Sprintf("http://localhost:%d/", input.PassThroughPort),
 	}
 	serializedInfo, err := json.Marshal(info)
 	if err != nil {
@@ -128,7 +135,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 			"namespace", d.namespace,
 			"configmap", controllerManagerConfigMapName,
 			"name", d.name,
-			"controllers", len(controllers))
+			"controllers", len(info.EnabledControllers))
 		return nil
 	}
 	if !errors.IsNotFound(err) {
@@ -155,7 +162,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 			// We hit a race condition, and somebody else created it first.  Try again.
 			// We're not expecting to recurse more than once, because if the config map
 			// exists then we won't hit IsNotFound on the patch attempt.
-			return d.registerControllerManagerImpl(ctx, healthPort, metricsPort, controllers, false)
+			return d.registerControllerManagerImpl(ctx, input, false)
 		}
 		return fmt.Errorf("failed to register controller manager: %w", err)
 	}
@@ -164,7 +171,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 		"namespace", d.namespace,
 		"configmap", controllerManagerConfigMapName,
 		"name", d.name,
-		"controllers", len(controllers))
+		"controllers", len(info.EnabledControllers))
 
 	return nil
 }
@@ -301,6 +308,37 @@ func (d *ControllerManagerDiscovery) IsControllerRunning(ctx context.Context, co
 	}
 
 	return false, nil, nil // Controller not found in any controller manager.
+}
+
+// LookupPassThroughEndpoint looks up the endpoint URL for a given passthrough
+// endpoint name across all controller managers.  If the endpoint is not found,
+// an empty string is returned.
+func (d *ControllerManagerDiscovery) LookupPassThroughEndpoint(ctx context.Context, endpointName string) (string, error) {
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil // No controller manager running
+		}
+		return "", fmt.Errorf("failed to discover controller manager: %w", err)
+	}
+
+	for _, serializedInfo := range configMap.Data {
+		var info ControllerManagerInfo
+		if err := json.Unmarshal([]byte(serializedInfo), &info); err != nil {
+			return "", fmt.Errorf("failed to parse controller manager info: %w", err)
+		}
+
+		if !slices.Contains(info.EnabledPassThroughs, endpointName) {
+			continue // This controller manager does not have the endpoint enabled.
+		}
+
+		// Check if the controller manager is actually accessible
+		if d.isControllerManagerHealthy(ctx, &info) {
+			return info.PassThroughEndpoint, nil
+		}
+	}
+
+	return "", nil // Endpoint not found in any controller manager.
 }
 
 // isControllerManagerHealthy checks if the controller manager is responding to health checks.

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -33,9 +33,9 @@ const (
 type ControllerManagerInput struct {
 	HealthPort          int      `json:"healthPort"`
 	MetricsPort         int      `json:"metricsPort"`
-	PassThroughPort     int      `json:"-"`
+	PassthroughPort     int      `json:"-"`
 	EnabledControllers  []string `json:"enabledControllers"`
-	EnabledPassThroughs []string `json:"enabledPassThroughs"`
+	EnabledPassthroughs []string `json:"enabledPassthroughs"`
 }
 
 // ControllerManagerInfo contains discovered information about a running controller manager.
@@ -44,7 +44,7 @@ type ControllerManagerInfo struct {
 	StartTime              metav1.Time `json:"startTime"`
 	HealthEndpoint         string      `json:"healthEndpoint"`
 	MetricsEndpoint        string      `json:"metricsEndpoint"`
-	PassThroughEndpoint    string      `json:"passThroughEndpoint"`
+	PassthroughEndpoint    string      `json:"passthroughEndpoint"`
 }
 
 // ControllerManagerDiscovery handles service discovery for the shared controller manager.
@@ -107,7 +107,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 		StartTime:              metav1.NewTime(time.Now().UTC()),
 		HealthEndpoint:         fmt.Sprintf("http://localhost:%d/healthz", input.HealthPort),
 		MetricsEndpoint:        fmt.Sprintf("http://localhost:%d/metrics", input.MetricsPort),
-		PassThroughEndpoint:    fmt.Sprintf("http://localhost:%d/", input.PassThroughPort),
+		PassthroughEndpoint:    fmt.Sprintf("http://localhost:%d/", input.PassthroughPort),
 	}
 	serializedInfo, err := json.Marshal(info)
 	if err != nil {
@@ -310,10 +310,10 @@ func (d *ControllerManagerDiscovery) IsControllerRunning(ctx context.Context, co
 	return false, nil, nil // Controller not found in any controller manager.
 }
 
-// LookupPassThroughEndpoint looks up the endpoint URL for a given passthrough
+// LookupPassthroughEndpoint looks up the endpoint URL for a given passthrough
 // endpoint name across all controller managers.  If the endpoint is not found,
 // an empty string is returned.
-func (d *ControllerManagerDiscovery) LookupPassThroughEndpoint(ctx context.Context, endpointName string) (string, error) {
+func (d *ControllerManagerDiscovery) LookupPassthroughEndpoint(ctx context.Context, endpointName string) (string, error) {
 	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -328,13 +328,13 @@ func (d *ControllerManagerDiscovery) LookupPassThroughEndpoint(ctx context.Conte
 			return "", fmt.Errorf("failed to parse controller manager info: %w", err)
 		}
 
-		if !slices.Contains(info.EnabledPassThroughs, endpointName) {
+		if !slices.Contains(info.EnabledPassthroughs, endpointName) {
 			continue // This controller manager does not have the endpoint enabled.
 		}
 
 		// Check if the controller manager is actually accessible
 		if d.isControllerManagerHealthy(ctx, &info) {
-			return info.PassThroughEndpoint, nil
+			return info.PassthroughEndpoint, nil
 		}
 	}
 

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -31,11 +31,11 @@ const (
 
 // ControllerManagerInput contains the input parameters for registering a controller manager.
 type ControllerManagerInput struct {
-	HealthPort          int      `json:"healthPort"`
-	MetricsPort         int      `json:"metricsPort"`
-	PassthroughPort     int      `json:"-"`
-	EnabledControllers  []string `json:"enabledControllers"`
-	EnabledPassthroughs []string `json:"enabledPassthroughs"`
+	HealthPort          int                 `json:"healthPort"`
+	MetricsPort         int                 `json:"metricsPort"`
+	PassthroughPort     int                 `json:"-"`
+	EnabledControllers  []string            `json:"enabledControllers"`
+	EnabledPassthroughs map[string][]string `json:"enabledPassthroughs"`
 }
 
 // ControllerManagerInfo contains discovered information about a running controller manager.
@@ -313,7 +313,7 @@ func (d *ControllerManagerDiscovery) IsControllerRunning(ctx context.Context, co
 // LookupPassthroughEndpoint looks up the endpoint URL for a given passthrough
 // endpoint name across all controller managers.  If the endpoint is not found,
 // an empty string is returned.
-func (d *ControllerManagerDiscovery) LookupPassthroughEndpoint(ctx context.Context, endpointName string) (string, error) {
+func (d *ControllerManagerDiscovery) LookupPassthroughEndpoint(ctx context.Context, controllerName, endpointName string) (string, error) {
 	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -328,8 +328,9 @@ func (d *ControllerManagerDiscovery) LookupPassthroughEndpoint(ctx context.Conte
 			return "", fmt.Errorf("failed to parse controller manager info: %w", err)
 		}
 
-		if !slices.Contains(info.EnabledPassthroughs, endpointName) {
-			continue // This controller manager does not have the endpoint enabled.
+		enabledPassthroughs := info.EnabledPassthroughs[controllerName]
+		if !slices.Contains(enabledPassthroughs, endpointName) {
+			continue
 		}
 
 		// Check if the controller manager is actually accessible

--- a/pkg/service/controllers/discovery_test.go
+++ b/pkg/service/controllers/discovery_test.go
@@ -102,7 +102,7 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 		MetricsPort:         8765,
 		EnabledControllers:  []string{"hello"},
 		PassthroughPort:     passthroughPort,
-		EnabledPassthroughs: []string{"foo", "bar"},
+		EnabledPassthroughs: map[string][]string{"hello": {"foo", "bar"}},
 	}), "failed to register second controller manager")
 
 	// Check that the config map is updated.
@@ -120,7 +120,7 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 			HealthPort:          port,
 			MetricsPort:         8765,
 			EnabledControllers:  []string{"hello"},
-			EnabledPassthroughs: []string{"foo", "bar"},
+			EnabledPassthroughs: map[string][]string{"hello": {"foo", "bar"}},
 		},
 		StartTime:           info.StartTime,
 		HealthEndpoint:      info.HealthEndpoint,
@@ -158,20 +158,25 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	assert.Check(t, cm.Data[d1.name] == "", "expected first controller manager entry to be removed")
 
 	// LookupPassthroughEndpoint should return the endpoint for enabled passthroughs
-	endpoint, err := d2.LookupPassthroughEndpoint(t.Context(), "foo")
+	endpoint, err := d2.LookupPassthroughEndpoint(t.Context(), "hello", "foo")
 	assert.NilError(t, err, "failed to lookup passthrough endpoint")
 	assert.Check(t, endpoint != "", "expected non-empty endpoint for enabled passthrough")
 	assert.Equal(t, endpoint, info.PassthroughEndpoint, "expected endpoint to match PassthroughEndpoint")
 
 	// Should return empty string for non-existent passthrough
-	endpoint, err = d2.LookupPassthroughEndpoint(t.Context(), "notfound")
+	endpoint, err = d2.LookupPassthroughEndpoint(t.Context(), "hello", "notfound")
 	assert.NilError(t, err, "failed to lookup non-existent passthrough endpoint")
 	assert.Equal(t, endpoint, "", "expected empty endpoint for non-existent passthrough")
 
 	// Should return endpoint for another enabled passthrough
-	endpoint, err = d2.LookupPassthroughEndpoint(t.Context(), "bar")
+	endpoint, err = d2.LookupPassthroughEndpoint(t.Context(), "hello", "bar")
 	assert.NilError(t, err, "failed to lookup second passthrough endpoint")
 	assert.Equal(t, endpoint, info.PassthroughEndpoint, "expected endpoint to match PassthroughEndpoint for 'bar'")
+
+	// Should not return endpoint for the wrong controller
+	endpoint, err = d2.LookupPassthroughEndpoint(t.Context(), "another", "foo")
+	assert.NilError(t, err, "failed to lookup second passthrough endpoint")
+	assert.Equal(t, endpoint, "", "expected empty endpoint for wrong controller")
 
 	// Unregister the second controller manager.
 	assert.NilError(t, d2.UnregisterControllerManager(t.Context()), "failed to unregister second controller manager")

--- a/pkg/service/controllers/discovery_test.go
+++ b/pkg/service/controllers/discovery_test.go
@@ -61,7 +61,7 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	assert.NilError(t, d1.RegisterControllerManager(t.Context(), ControllerManagerInput{
 		HealthPort:         1234,
 		MetricsPort:        5678,
-		PassThroughPort:    passthroughPort,
+		PassthroughPort:    passthroughPort,
 		EnabledControllers: nil,
 	}), "failed to register controller manager")
 
@@ -83,7 +83,7 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 		StartTime:           info.StartTime,
 		HealthEndpoint:      info.HealthEndpoint,
 		MetricsEndpoint:     info.MetricsEndpoint,
-		PassThroughEndpoint: fmt.Sprintf("http://localhost:%d/", passthroughPort),
+		PassthroughEndpoint: fmt.Sprintf("http://localhost:%d/", passthroughPort),
 	}, info)
 
 	controllers, err := d1.GetEnabledControllers(t.Context())
@@ -101,8 +101,8 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 		HealthPort:          port,
 		MetricsPort:         8765,
 		EnabledControllers:  []string{"hello"},
-		PassThroughPort:     passthroughPort,
-		EnabledPassThroughs: []string{"foo", "bar"},
+		PassthroughPort:     passthroughPort,
+		EnabledPassthroughs: []string{"foo", "bar"},
 	}), "failed to register second controller manager")
 
 	// Check that the config map is updated.
@@ -120,12 +120,12 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 			HealthPort:          port,
 			MetricsPort:         8765,
 			EnabledControllers:  []string{"hello"},
-			EnabledPassThroughs: []string{"foo", "bar"},
+			EnabledPassthroughs: []string{"foo", "bar"},
 		},
 		StartTime:           info.StartTime,
 		HealthEndpoint:      info.HealthEndpoint,
 		MetricsEndpoint:     info.MetricsEndpoint,
-		PassThroughEndpoint: fmt.Sprintf("http://localhost:%d/", passthroughPort),
+		PassthroughEndpoint: fmt.Sprintf("http://localhost:%d/", passthroughPort),
 	}, info)
 
 	// Check that we can get controllers.
@@ -157,21 +157,21 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	assert.Check(t, cmp.Contains(cm.Data, d2.name))
 	assert.Check(t, cm.Data[d1.name] == "", "expected first controller manager entry to be removed")
 
-	// LookupPassThroughEndpoint should return the endpoint for enabled passthroughs
-	endpoint, err := d2.LookupPassThroughEndpoint(t.Context(), "foo")
+	// LookupPassthroughEndpoint should return the endpoint for enabled passthroughs
+	endpoint, err := d2.LookupPassthroughEndpoint(t.Context(), "foo")
 	assert.NilError(t, err, "failed to lookup passthrough endpoint")
 	assert.Check(t, endpoint != "", "expected non-empty endpoint for enabled passthrough")
-	assert.Equal(t, endpoint, info.PassThroughEndpoint, "expected endpoint to match PassThroughEndpoint")
+	assert.Equal(t, endpoint, info.PassthroughEndpoint, "expected endpoint to match PassthroughEndpoint")
 
 	// Should return empty string for non-existent passthrough
-	endpoint, err = d2.LookupPassThroughEndpoint(t.Context(), "notfound")
+	endpoint, err = d2.LookupPassthroughEndpoint(t.Context(), "notfound")
 	assert.NilError(t, err, "failed to lookup non-existent passthrough endpoint")
 	assert.Equal(t, endpoint, "", "expected empty endpoint for non-existent passthrough")
 
 	// Should return endpoint for another enabled passthrough
-	endpoint, err = d2.LookupPassThroughEndpoint(t.Context(), "bar")
+	endpoint, err = d2.LookupPassthroughEndpoint(t.Context(), "bar")
 	assert.NilError(t, err, "failed to lookup second passthrough endpoint")
-	assert.Equal(t, endpoint, info.PassThroughEndpoint, "expected endpoint to match PassThroughEndpoint for 'bar'")
+	assert.Equal(t, endpoint, info.PassthroughEndpoint, "expected endpoint to match PassthroughEndpoint for 'bar'")
 
 	// Unregister the second controller manager.
 	assert.NilError(t, d2.UnregisterControllerManager(t.Context()), "failed to unregister second controller manager")

--- a/pkg/service/controllers/discovery_test.go
+++ b/pkg/service/controllers/discovery_test.go
@@ -4,6 +4,7 @@
 package controllers
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,8 @@ import (
 )
 
 func TestControllerManagerDiscoveryGroup(t *testing.T) {
+	const passthroughPort = 4321
+
 	env := &envtest.Environment{
 		DownloadBinaryAssets: true,
 	}
@@ -55,7 +58,12 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	assert.NilError(t, err, "failed to create ControllerManagerDiscoveryGroup")
 
 	// Register a controller manager.
-	assert.NilError(t, d1.RegisterControllerManager(t.Context(), 1234, 5678, nil), "failed to register controller manager")
+	assert.NilError(t, d1.RegisterControllerManager(t.Context(), ControllerManagerInput{
+		HealthPort:         1234,
+		MetricsPort:        5678,
+		PassThroughPort:    passthroughPort,
+		EnabledControllers: nil,
+	}), "failed to register controller manager")
 
 	// Check that the config map exists.
 	cm, err := client.CoreV1().ConfigMaps(d1.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
@@ -67,12 +75,15 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	info, err := d1.DiscoverControllerManager(t.Context())
 	assert.NilError(t, err, "failed to discover controller manager")
 	assert.DeepEqual(t, &ControllerManagerInfo{
-		HealthPort:         1234,
-		MetricsPort:        5678,
-		EnabledControllers: nil,
-		StartTime:          info.StartTime,
-		HealthEndpoint:     info.HealthEndpoint,
-		MetricsEndpoint:    info.MetricsEndpoint,
+		ControllerManagerInput: ControllerManagerInput{
+			HealthPort:         1234,
+			MetricsPort:        5678,
+			EnabledControllers: nil,
+		},
+		StartTime:           info.StartTime,
+		HealthEndpoint:      info.HealthEndpoint,
+		MetricsEndpoint:     info.MetricsEndpoint,
+		PassThroughEndpoint: fmt.Sprintf("http://localhost:%d/", passthroughPort),
 	}, info)
 
 	controllers, err := d1.GetEnabledControllers(t.Context())
@@ -86,7 +97,13 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	// Register a second controller manager to test unregister.
 	d2, err := NewControllerManagerDiscoveryGroup(cfg, "test-group-2")
 	assert.NilError(t, err, "failed to create second ControllerManagerDiscoveryGroup")
-	assert.NilError(t, d2.RegisterControllerManager(t.Context(), port, 8765, []string{"hello"}), "failed to register second controller manager")
+	assert.NilError(t, d2.RegisterControllerManager(t.Context(), ControllerManagerInput{
+		HealthPort:          port,
+		MetricsPort:         8765,
+		EnabledControllers:  []string{"hello"},
+		PassThroughPort:     passthroughPort,
+		EnabledPassThroughs: []string{"foo", "bar"},
+	}), "failed to register second controller manager")
 
 	// Check that the config map is updated.
 	cm, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
@@ -99,12 +116,16 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	info, err = d2.DiscoverControllerManager(t.Context())
 	assert.NilError(t, err, "failed to discover second controller manager")
 	assert.DeepEqual(t, &ControllerManagerInfo{
-		HealthPort:         port,
-		MetricsPort:        8765,
-		EnabledControllers: []string{"hello"},
-		StartTime:          info.StartTime,
-		HealthEndpoint:     info.HealthEndpoint,
-		MetricsEndpoint:    info.MetricsEndpoint,
+		ControllerManagerInput: ControllerManagerInput{
+			HealthPort:          port,
+			MetricsPort:         8765,
+			EnabledControllers:  []string{"hello"},
+			EnabledPassThroughs: []string{"foo", "bar"},
+		},
+		StartTime:           info.StartTime,
+		HealthEndpoint:      info.HealthEndpoint,
+		MetricsEndpoint:     info.MetricsEndpoint,
+		PassThroughEndpoint: fmt.Sprintf("http://localhost:%d/", passthroughPort),
 	}, info)
 
 	// Check that we can get controllers.
@@ -135,6 +156,22 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	assert.Assert(t, cmp.Len(cm.Data, 1), "expected config map to have one entry after first unregistered")
 	assert.Check(t, cmp.Contains(cm.Data, d2.name))
 	assert.Check(t, cm.Data[d1.name] == "", "expected first controller manager entry to be removed")
+
+	// LookupPassThroughEndpoint should return the endpoint for enabled passthroughs
+	endpoint, err := d2.LookupPassThroughEndpoint(t.Context(), "foo")
+	assert.NilError(t, err, "failed to lookup passthrough endpoint")
+	assert.Check(t, endpoint != "", "expected non-empty endpoint for enabled passthrough")
+	assert.Equal(t, endpoint, info.PassThroughEndpoint, "expected endpoint to match PassThroughEndpoint")
+
+	// Should return empty string for non-existent passthrough
+	endpoint, err = d2.LookupPassThroughEndpoint(t.Context(), "notfound")
+	assert.NilError(t, err, "failed to lookup non-existent passthrough endpoint")
+	assert.Equal(t, endpoint, "", "expected empty endpoint for non-existent passthrough")
+
+	// Should return endpoint for another enabled passthrough
+	endpoint, err = d2.LookupPassThroughEndpoint(t.Context(), "bar")
+	assert.NilError(t, err, "failed to lookup second passthrough endpoint")
+	assert.Equal(t, endpoint, info.PassThroughEndpoint, "expected endpoint to match PassThroughEndpoint for 'bar'")
 
 	// Unregister the second controller manager.
 	assert.NilError(t, d2.UnregisterControllerManager(t.Context()), "failed to unregister second controller manager")

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -323,13 +323,13 @@ func (scm *SharedControllerManager) registerDiscovery(ctx context.Context) error
 	// Get controller names, filtering out builtin controllers.
 	// Builtin controllers are internal system controllers and should not be registered in discovery.
 	var controllerNames []string
-	var passthroughNames []string
+	passthroughEndpoints := make(map[string][]string)
 	for _, registration := range scm.registrations {
 		if registration.GetAPIGroup() != "builtin" {
 			controllerNames = append(controllerNames, registration.GetName())
 		}
 		if httpController, ok := registration.(base.PassthroughController); ok {
-			passthroughNames = append(passthroughNames, httpController.GetPassthroughEndpoints()...)
+			passthroughEndpoints[registration.GetName()] = httpController.GetPassthroughEndpoints()
 		}
 	}
 
@@ -343,7 +343,7 @@ func (scm *SharedControllerManager) registerDiscovery(ctx context.Context) error
 		MetricsPort:         scm.metricsPort,
 		PassthroughPort:     scm.passthroughPort,
 		EnabledControllers:  controllerNames,
-		EnabledPassthroughs: passthroughNames,
+		EnabledPassthroughs: passthroughEndpoints,
 	})
 }
 
@@ -468,9 +468,10 @@ func (scm *SharedControllerManager) runPassthroughServer(ctx context.Context) er
 			hasPassthroughServers = true
 			for _, endpoint := range httpController.GetPassthroughEndpoints() {
 				handler := httpController.GetPassthroughHandler(endpoint)
-				fullPath := fmt.Sprintf("/%s/", endpoint)
-				log.V(2).Info("Registering pass through endpoint", "controller", registration.GetName(), "endpoint", fullPath)
-				mux.Handle(fullPath, handler)
+				prefix := fmt.Sprintf("/%s/%s", registration.GetName(), endpoint)
+				log.V(2).Info("Registering passthrough endpoint",
+					"controller", registration.GetName(), "endpoint", prefix)
+				mux.Handle(prefix+"/", http.StripPrefix(prefix, handler))
 			}
 		}
 	}

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -54,7 +54,7 @@ type SharedControllerManager struct {
 	metricsPort     int
 	healthPort      int
 	webhookPort     int
-	passThroughPort int
+	passthroughPort int
 	started         bool
 	discovery       *ControllerManagerDiscoveryGroup
 }
@@ -74,8 +74,8 @@ func NewSharedControllerManager(ctx context.Context, name string, kubeConfig *re
 		return nil, fmt.Errorf("failed to get available webhook port: %w", err)
 	}
 
-	desiredPassThroughPort := 9090 + instance.Index()
-	passThroughPort, err := GetAvailablePort(ctx, desiredPassThroughPort)
+	desiredPassthroughPort := 9090 + instance.Index()
+	passthroughPort, err := GetAvailablePort(ctx, desiredPassthroughPort)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get available pass through port: %w", err)
 	}
@@ -86,7 +86,7 @@ func NewSharedControllerManager(ctx context.Context, name string, kubeConfig *re
 		metricsPort:     metricsPort,
 		healthPort:      healthPort,
 		webhookPort:     webhookPort,
-		passThroughPort: passThroughPort,
+		passthroughPort: passthroughPort,
 		registrations:   make([]base.Controller, 0),
 		started:         false,
 		discovery:       discovery,
@@ -211,7 +211,7 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	}()
 
 	// Add pass through server
-	if err := mgr.Add(manager.RunnableFunc(scm.runPassThroughServer)); err != nil {
+	if err := mgr.Add(manager.RunnableFunc(scm.runPassthroughServer)); err != nil {
 		return fmt.Errorf("failed to add pass through server to manager: %w", err)
 	}
 
@@ -323,13 +323,13 @@ func (scm *SharedControllerManager) registerDiscovery(ctx context.Context) error
 	// Get controller names, filtering out builtin controllers.
 	// Builtin controllers are internal system controllers and should not be registered in discovery.
 	var controllerNames []string
-	var passThroughNames []string
+	var passthroughNames []string
 	for _, registration := range scm.registrations {
 		if registration.GetAPIGroup() != "builtin" {
 			controllerNames = append(controllerNames, registration.GetName())
 		}
-		if httpController, ok := registration.(base.PassThroughController); ok {
-			passThroughNames = append(passThroughNames, httpController.GetPassThroughEndpoints()...)
+		if httpController, ok := registration.(base.PassthroughController); ok {
+			passthroughNames = append(passthroughNames, httpController.GetPassthroughEndpoints()...)
 		}
 	}
 
@@ -341,9 +341,9 @@ func (scm *SharedControllerManager) registerDiscovery(ctx context.Context) error
 	return scm.discovery.RegisterControllerManager(ctx, ControllerManagerInput{
 		HealthPort:          scm.healthPort,
 		MetricsPort:         scm.metricsPort,
-		PassThroughPort:     scm.passThroughPort,
+		PassthroughPort:     scm.passthroughPort,
 		EnabledControllers:  controllerNames,
-		EnabledPassThroughs: passThroughNames,
+		EnabledPassthroughs: passthroughNames,
 	})
 }
 
@@ -458,16 +458,16 @@ func (scm *SharedControllerManager) installControllerCRDs(ctx context.Context) e
 	return nil
 }
 
-func (scm *SharedControllerManager) runPassThroughServer(ctx context.Context) error {
-	hasPassThroughServers := false
+func (scm *SharedControllerManager) runPassthroughServer(ctx context.Context) error {
+	hasPassthroughServers := false
 	log := klog.FromContext(ctx)
 
 	mux := http.NewServeMux()
 	for _, registration := range scm.registrations {
-		if httpController, ok := registration.(base.PassThroughController); ok {
-			hasPassThroughServers = true
-			for _, endpoint := range httpController.GetPassThroughEndpoints() {
-				handler := httpController.GetPassThroughHandler(endpoint)
+		if httpController, ok := registration.(base.PassthroughController); ok {
+			hasPassthroughServers = true
+			for _, endpoint := range httpController.GetPassthroughEndpoints() {
+				handler := httpController.GetPassthroughHandler(endpoint)
 				fullPath := fmt.Sprintf("/%s/", endpoint)
 				log.V(2).Info("Registering pass through endpoint", "controller", registration.GetName(), "endpoint", fullPath)
 				mux.Handle(fullPath, handler)
@@ -475,13 +475,13 @@ func (scm *SharedControllerManager) runPassThroughServer(ctx context.Context) er
 		}
 	}
 
-	if !hasPassThroughServers {
+	if !hasPassthroughServers {
 		klog.V(2).InfoS("No pass through controllers registered, skipping pass through server startup")
 		return nil
 	}
 
 	server := http.Server{
-		Addr:     fmt.Sprintf("localhost:%d", scm.passThroughPort),
+		Addr:     fmt.Sprintf("localhost:%d", scm.passthroughPort),
 		Handler:  mux,
 		ErrorLog: slog.NewLogLogger(logr.ToSlogHandler(klog.FromContext(ctx)), slog.LevelError),
 	}

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -10,9 +10,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
+	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/go-logr/logr"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -28,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -42,15 +47,16 @@ const (
 
 // SharedControllerManager manages all embedded RDD controllers using a single controller-runtime manager.
 type SharedControllerManager struct {
-	name          string
-	manager       ctrl.Manager
-	registrations []base.Controller
-	kubeConfig    *rest.Config
-	metricsPort   int
-	healthPort    int
-	webhookPort   int
-	started       bool
-	discovery     *ControllerManagerDiscoveryGroup
+	name            string
+	manager         ctrl.Manager
+	registrations   []base.Controller
+	kubeConfig      *rest.Config
+	metricsPort     int
+	healthPort      int
+	webhookPort     int
+	passThroughPort int
+	started         bool
+	discovery       *ControllerManagerDiscoveryGroup
 }
 
 // NewSharedControllerManager creates a new shared controller manager.
@@ -68,15 +74,22 @@ func NewSharedControllerManager(ctx context.Context, name string, kubeConfig *re
 		return nil, fmt.Errorf("failed to get available webhook port: %w", err)
 	}
 
+	desiredPassThroughPort := 9090 + instance.Index()
+	passThroughPort, err := GetAvailablePort(ctx, desiredPassThroughPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get available pass through port: %w", err)
+	}
+
 	return &SharedControllerManager{
-		name:          name,
-		kubeConfig:    kubeConfig,
-		metricsPort:   metricsPort,
-		healthPort:    healthPort,
-		webhookPort:   webhookPort,
-		registrations: make([]base.Controller, 0),
-		started:       false,
-		discovery:     discovery,
+		name:            name,
+		kubeConfig:      kubeConfig,
+		metricsPort:     metricsPort,
+		healthPort:      healthPort,
+		webhookPort:     webhookPort,
+		passThroughPort: passThroughPort,
+		registrations:   make([]base.Controller, 0),
+		started:         false,
+		discovery:       discovery,
 	}, nil
 }
 
@@ -197,6 +210,11 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		}
 	}()
 
+	// Add pass through server
+	if err := mgr.Add(manager.RunnableFunc(scm.runPassThroughServer)); err != nil {
+		return fmt.Errorf("failed to add pass through server to manager: %w", err)
+	}
+
 	// Track webhook setup goroutines
 	var webhookWaitGroup sync.WaitGroup
 	webhookErrors := make(chan error, len(scm.registrations))
@@ -305,9 +323,13 @@ func (scm *SharedControllerManager) registerDiscovery(ctx context.Context) error
 	// Get controller names, filtering out builtin controllers.
 	// Builtin controllers are internal system controllers and should not be registered in discovery.
 	var controllerNames []string
+	var passThroughNames []string
 	for _, registration := range scm.registrations {
 		if registration.GetAPIGroup() != "builtin" {
 			controllerNames = append(controllerNames, registration.GetName())
+		}
+		if httpController, ok := registration.(base.PassThroughController); ok {
+			passThroughNames = append(passThroughNames, httpController.GetPassThroughEndpoints()...)
 		}
 	}
 
@@ -316,7 +338,13 @@ func (scm *SharedControllerManager) registerDiscovery(ctx context.Context) error
 		return nil
 	}
 
-	return scm.discovery.RegisterControllerManager(ctx, scm.healthPort, scm.metricsPort, controllerNames)
+	return scm.discovery.RegisterControllerManager(ctx, ControllerManagerInput{
+		HealthPort:          scm.healthPort,
+		MetricsPort:         scm.metricsPort,
+		PassThroughPort:     scm.passThroughPort,
+		EnabledControllers:  controllerNames,
+		EnabledPassThroughs: passThroughNames,
+	})
 }
 
 // installControllerCRDs installs all controller CRDs in parallel for better performance.
@@ -427,6 +455,54 @@ func (scm *SharedControllerManager) installControllerCRDs(ctx context.Context) e
 	}
 
 	klog.Infof("All %d CRDs are established", len(crdInfos))
+	return nil
+}
+
+func (scm *SharedControllerManager) runPassThroughServer(ctx context.Context) error {
+	hasPassThroughServers := false
+	log := klog.FromContext(ctx)
+
+	mux := http.NewServeMux()
+	for _, registration := range scm.registrations {
+		if httpController, ok := registration.(base.PassThroughController); ok {
+			hasPassThroughServers = true
+			for _, endpoint := range httpController.GetPassThroughEndpoints() {
+				handler := httpController.GetPassThroughHandler(endpoint)
+				fullPath := fmt.Sprintf("/%s/", endpoint)
+				log.V(2).Info("Registering pass through endpoint", "controller", registration.GetName(), "endpoint", fullPath)
+				mux.Handle(fullPath, handler)
+			}
+		}
+	}
+
+	if !hasPassThroughServers {
+		klog.V(2).InfoS("No pass through controllers registered, skipping pass through server startup")
+		return nil
+	}
+
+	server := http.Server{
+		Addr:     fmt.Sprintf("localhost:%d", scm.passThroughPort),
+		Handler:  mux,
+		ErrorLog: slog.NewLogLogger(logr.ToSlogHandler(klog.FromContext(ctx)), slog.LevelError),
+	}
+
+	shutdownComplete := make(chan struct{})
+	go func() {
+		defer close(shutdownComplete)
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Error(err, "failed to shutdown pass through server")
+		}
+	}()
+
+	log.V(2).Info("Starting pass through server", "addr", server.Addr)
+	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("pass through server failed: %w", err)
+	}
+	<-shutdownComplete
+
 	return nil
 }
 

--- a/pkg/service/controllers/passthrough.go
+++ b/pkg/service/controllers/passthrough.go
@@ -15,17 +15,30 @@ import (
 // NewPassthroughHandler creates a new HTTP handler that proxies requests to the
 // appropriate controller endpoint based on the discovery information.
 //
-// Note that this assume the target endpoints do not contain path segments; that
-// is, the endpoint URLs will be of the form "http://localhost:1234/" and not
-// "http://localhost:1234/path".
+// Note that this assumes the target endpoints do not contain path segments;
+// that is, the endpoint URLs will be of the form "http://localhost:1234/" and
+// not "http://localhost:1234/path".
 func NewPassthroughHandler(discovery *ControllerManagerDiscovery) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log := klog.FromContext(r.Context())
-		endpoint, _, _ := strings.Cut(strings.TrimPrefix(r.URL.Path, "/"), "/")
+		// The path is /<controller>/<endpoint>/...
+		parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/"), "/", 3)
+		if len(parts) < 2 {
+			log.V(5).Info("Invalid passthrough request path", "path", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		controller, endpoint := parts[0], parts[1]
 
-		target, err := discovery.LookupPassthroughEndpoint(r.Context(), endpoint)
+		target, err := discovery.LookupPassthroughEndpoint(r.Context(), controller, endpoint)
 		if err != nil {
-			log.V(5).Info("Pass through endpoint not found", "endpoint", endpoint)
+			log.V(5).Info("Failed to lookup passthrough endpoint",
+				"controller", controller, "endpoint", endpoint, "error", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		if target == "" {
+			log.V(5).Info("Passthrough endpoint not found", "controller", controller, "endpoint", endpoint)
 			http.NotFound(w, r)
 			return
 		}
@@ -33,12 +46,15 @@ func NewPassthroughHandler(discovery *ControllerManagerDiscovery) http.Handler {
 		targetURL, err := url.Parse(target)
 		if err != nil {
 			log.V(5).Info("Failed to parse pass through target URL",
-				"endpoint", endpoint, "target", target, "error", err)
-			http.Error(w, "Bad target URL", http.StatusInternalServerError)
+				"controller", controller, "endpoint", endpoint, "target", target, "error", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 
-		log.V(5).Info("Proxying pass through request", "endpoint", endpoint, "target", target)
+		log.V(5).Info("Proxying pass through request",
+			"controller", controller, "endpoint", endpoint, "target", target)
+		// NewSingleHostReverseProxy is cheap enough to make a new one per
+		// request; we can consider caching later if performance is an issue.
 		httputil.NewSingleHostReverseProxy(targetURL).ServeHTTP(w, r)
 	})
 }

--- a/pkg/service/controllers/passthrough.go
+++ b/pkg/service/controllers/passthrough.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
 package controllers
 
 import (
@@ -9,18 +12,18 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// NewPassThroughHandler creates a new HTTP handler that proxies requests to the
+// NewPassthroughHandler creates a new HTTP handler that proxies requests to the
 // appropriate controller endpoint based on the discovery information.
 //
 // Note that this assume the target endpoints do not contain path segments; that
 // is, the endpoint URLs will be of the form "http://localhost:1234/" and not
 // "http://localhost:1234/path".
-func NewPassThroughHandler(discovery *ControllerManagerDiscovery) http.Handler {
+func NewPassthroughHandler(discovery *ControllerManagerDiscovery) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log := klog.FromContext(r.Context())
 		endpoint, _, _ := strings.Cut(strings.TrimPrefix(r.URL.Path, "/"), "/")
 
-		target, err := discovery.LookupPassThroughEndpoint(r.Context(), endpoint)
+		target, err := discovery.LookupPassthroughEndpoint(r.Context(), endpoint)
 		if err != nil {
 			log.V(5).Info("Pass through endpoint not found", "endpoint", endpoint)
 			http.NotFound(w, r)

--- a/pkg/service/controllers/passthrough.go
+++ b/pkg/service/controllers/passthrough.go
@@ -1,0 +1,41 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// NewPassThroughHandler creates a new HTTP handler that proxies requests to the
+// appropriate controller endpoint based on the discovery information.
+//
+// Note that this assume the target endpoints do not contain path segments; that
+// is, the endpoint URLs will be of the form "http://localhost:1234/" and not
+// "http://localhost:1234/path".
+func NewPassThroughHandler(discovery *ControllerManagerDiscovery) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := klog.FromContext(r.Context())
+		endpoint, _, _ := strings.Cut(strings.TrimPrefix(r.URL.Path, "/"), "/")
+
+		target, err := discovery.LookupPassThroughEndpoint(r.Context(), endpoint)
+		if err != nil {
+			log.V(5).Info("Pass through endpoint not found", "endpoint", endpoint)
+			http.NotFound(w, r)
+			return
+		}
+
+		targetURL, err := url.Parse(target)
+		if err != nil {
+			log.V(5).Info("Failed to parse pass through target URL",
+				"endpoint", endpoint, "target", target, "error", err)
+			http.Error(w, "Bad target URL", http.StatusInternalServerError)
+			return
+		}
+
+		log.V(5).Info("Proxying pass through request", "endpoint", endpoint, "target", target)
+		httputil.NewSingleHostReverseProxy(targetURL).ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
This declares a new optional interface, `PassThroughController`, that can be supported by controllers.  If they do, they can implement HTTP handlers that will be exposed via the Kubernetes API server at `/passthrough/...` (completely independent of the rest of Kubernetes).  This can be used to implement endpoints that require websocket support, for example.

Note that this is still behind the normal Kubernetes authentication, though we do not currently do any access control.