### PR TITLE
Add `rdd lima shell` command

### DIFF
--- a/.github/actions/spelling/expect/golang.txt
+++ b/.github/actions/spelling/expect/golang.txt
@@ -30,6 +30,9 @@ RUnlock
 Warnf
 Warningf
 
+# Cobra
+NArgs
+
 # kubebuilder
 kubebuilder
 # kubebuilder marker

--- a/.github/actions/spelling/expect/rd.txt
+++ b/.github/actions/spelling/expect/rd.txt
@@ -27,3 +27,4 @@ limactl
 limavm
 pidfile
 syncer
+workdir

--- a/.github/actions/spelling/expect/tech.txt
+++ b/.github/actions/spelling/expect/tech.txt
@@ -25,6 +25,7 @@ printcolumn
 
 # Linux
 binfmt
+COLORTERM
 distros
 kvm
 # out of memory

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ GIT_DIRTY := $(shell git$(EXE) diff --quiet && echo 'clean' || echo 'dirty')
 GIT_VERSION := $(KUBE_VERSION)+rdd-$(shell git$(EXE) describe --tags --match='v*' --abbrev=14 "$(GIT_COMMIT)^{commit}" 2>/dev/null || echo v0.0.0-$(GIT_COMMIT))
 RDD_VERSION := $(shell git$(EXE) describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 RDD_VERSION_TRIMMED := $(RDD_VERSION:v%=%)
+LIMA_VERSION := $(shell go$(EXE) list -m -f '{{.Version}}' 'github.com/lima-vm/lima/v2')
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 PACKAGE := github.com/rancher-sandbox/rancher-desktop-daemon
 LDFLAGS := \
@@ -32,6 +33,7 @@ LDFLAGS := \
 	-X $(PACKAGE)/pkg/version.Version=$(RDD_VERSION) \
 	-X $(PACKAGE)/pkg/version.GitCommit=${GIT_COMMIT} \
 	-X $(PACKAGE)/pkg/version.BuildDate=${BUILD_DATE} \
+	-X github.com/lima-vm/lima/v2/pkg/version.Version=$(LIMA_VERSION) \
 	-s -w
 
 TAGS := sqlite_omit_load_extension

--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -158,6 +158,9 @@ assert_created() {
 
     run_e -1 rdd limavm delete "nonexistent"
     assert_fatal "${not_found}"
+
+    run_e -1 rdd limavm shell "nonexistent"
+    assert_fatal "${not_found}"
 }
 
 @test "lima help text is displayed" {
@@ -169,4 +172,5 @@ assert_created() {
     assert_output --partial "Stop a LimaVM"
     assert_output --partial "Delete a LimaVM"
     assert_output --partial "Show LimaVM logs"
+    assert_output --partial "Execute shell in Lima VM"
 }

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -116,6 +116,12 @@ assert_limavm_not_exists() {
     run ! rdd ctl get limavm "${name}" --namespace "${NAMESPACE}"
 }
 
+assert_shell_succeeds() {
+    local name=$1
+    shift
+    rdd lima shell "${name}" "$@"
+}
+
 @test "create source template ConfigMap for running tests" {
     rdd ctl create configmap "alpine-source" --namespace "${NAMESPACE}" --from-literal="template=${ALPINE_TEMPLATE}"
     run -0 rdd ctl get configmap "alpine-source" --namespace "${NAMESPACE}" --output jsonpath='{.data.template}'
@@ -172,6 +178,36 @@ assert_limavm_not_exists() {
     # The hostagent writes its first stdout event only after the VM's SSH port
     # becomes accessible, which can lag behind the InstanceRunning condition.
     try --max 60 --delay 5 -- assert_stdout_logs_contain "${VM_NAME}" "sshLocalPort"
+}
+
+@test "shell executes command in running VM" {
+    # SSH inside the guest may not be ready immediately after InstanceRunning=True
+    try --max 12 --delay 5 -- assert_shell_succeeds "${VM_NAME}" uname -s
+    assert_line "Linux"
+}
+
+@test "shell fails when VM is not running" {
+    # Create a stopped VM to test shell error
+    rdd ctl apply -f - <<EOF
+apiVersion: lima.rancherdesktop.io/v1alpha1
+kind: LimaVM
+metadata:
+  name: stopped-vm
+  namespace: ${NAMESPACE}
+spec:
+  templateRef:
+    name: alpine-source
+    namespace: ${NAMESPACE}
+  running: false
+EOF
+    # Wait for instance to be created
+    try --max 120 --delay 1 -- assert_instance_created_condition "stopped-vm" "True"
+
+    run -1 rdd lima shell "stopped-vm"
+    assert_output --partial "is not running"
+
+    # Cleanup
+    rdd ctl delete limavm "stopped-vm" --namespace "${NAMESPACE}" --grace-period=0
 }
 
 @test "stop the VM by setting running=false" {

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -43,6 +43,7 @@ func newLimaVMCommand() *cobra.Command {
 		newLimaVMStopCommand(),
 		newLimaVMDeleteCommand(),
 		newLimaVMLogsCommand(),
+		newLimaVMShellCommand(),
 	)
 	return command
 }

--- a/cmd/rdd/limavm_shell.go
+++ b/cmd/rdd/limavm_shell.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+// SPDX-FileCopyrightText: The Lima Authors
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"al.essio.dev/pkg/shellescape"
+	"github.com/coreos/go-semver/semver"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/sshutil"
+	"github.com/lima-vm/lima/v2/pkg/store"
+	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+)
+
+func newLimaVMShellCommand() *cobra.Command {
+	shellCmd := &cobra.Command{
+		Use:           "shell INSTANCE [COMMAND...]",
+		Short:         "Execute shell in Lima VM",
+		Long:          "Open an interactive shell or execute a command in a Lima VM instance.",
+		Args:          cobra.MinimumNArgs(1),
+		RunE:          limaVMShellAction,
+		SilenceErrors: true,
+	}
+
+	shellCmd.Flags().SetInterspersed(false)
+	shellCmd.Flags().String("shell", "", "Shell interpreter, e.g. /bin/bash")
+	shellCmd.Flags().String("workdir", "", "Working directory")
+
+	return shellCmd
+}
+
+func limaVMShellAction(cmd *cobra.Command, args []string) error {
+	logrus.SetLevel(logrus.InfoLevel)
+	ctx := cmd.Context()
+
+	// Validate the VM exists in the API server
+	c, err := getKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = findLimaVM(ctx, c, args[0])
+	if err != nil {
+		return err
+	}
+
+	// Set LIMA_HOME for the Lima library
+	if err := os.Setenv("LIMA_HOME", instance.LimaHome()); err != nil {
+		return fmt.Errorf("failed to set LIMA_HOME: %w", err)
+	}
+
+	// Get the Lima instance from the store
+	inst, err := store.Inspect(ctx, args[0])
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("instance %q does not exist on disk", args[0])
+		}
+		return err
+	}
+	if len(inst.Errors) > 0 {
+		return fmt.Errorf("instance %q has configuration errors: %w", args[0], errors.Join(inst.Errors...))
+	}
+	if inst.Config == nil {
+		return fmt.Errorf("instance %q has no configuration", args[0])
+	}
+	if inst.Status != limatype.StatusRunning {
+		return fmt.Errorf("instance %q is not running (status: %s), use 'rdd lima start %s' first", args[0], inst.Status, args[0])
+	}
+
+	// Build working directory change command
+	var changeDirCmd string
+	workDir, err := cmd.Flags().GetString("workdir")
+	if err != nil {
+		return err
+	}
+	if workDir != "" {
+		changeDirCmd = fmt.Sprintf("cd %s || exit 1", shellescape.Quote(workDir))
+	} else if len(inst.Config.Mounts) > 0 {
+		hostCurrentDir, err := os.Getwd()
+		if err == nil {
+			changeDirCmd = fmt.Sprintf("cd %s", shellescape.Quote(hostCurrentDir))
+		} else {
+			changeDirCmd = "false"
+			logrus.WithError(err).Warn("failed to get the current directory")
+		}
+		hostHomeDir, err := os.UserHomeDir()
+		if err == nil {
+			changeDirCmd = fmt.Sprintf("%s || cd %s", changeDirCmd, shellescape.Quote(hostHomeDir))
+		} else {
+			logrus.WithError(err).Warn("failed to get the home directory")
+		}
+	} else {
+		logrus.Debug("the host home does not seem mounted, so the guest shell will have a different cwd")
+	}
+
+	if changeDirCmd == "" {
+		changeDirCmd = "false"
+	}
+	logrus.Debugf("changeDirCmd=%q", changeDirCmd)
+
+	// Determine shell
+	shell, err := cmd.Flags().GetString("shell")
+	if err != nil {
+		return err
+	}
+	if shell == "" {
+		shell = `"$SHELL"`
+	} else {
+		shell = shellescape.Quote(shell)
+	}
+
+	// Build script
+	script := fmt.Sprintf("%s ; exec %s --login", changeDirCmd, shell)
+	if len(args) > 1 {
+		quotedArgs := make([]string, len(args[1:]))
+		for i, arg := range args[1:] {
+			quotedArgs[i] = shellescape.Quote(arg)
+		}
+		script += fmt.Sprintf(" -c %s", shellescape.Quote(strings.Join(quotedArgs, " ")))
+	}
+
+	// Build SSH command
+	sshExe, err := sshutil.NewSSHExe()
+	if err != nil {
+		return err
+	}
+
+	sshOpts, err := sshutil.SSHOpts(
+		ctx,
+		sshExe,
+		inst.Dir,
+		*inst.Config.User.Name,
+		*inst.Config.SSH.LoadDotSSHPubKeys,
+		*inst.Config.SSH.ForwardAgent,
+		*inst.Config.SSH.ForwardX11,
+		*inst.Config.SSH.ForwardX11Trusted)
+	if err != nil {
+		return err
+	}
+
+	if runtime.GOOS == "windows" {
+		sshOpts = sshutil.SSHOptsRemovingControlPath(sshOpts)
+	}
+
+	sshArgs := append([]string{}, sshExe.Args...)
+	sshArgs = append(sshArgs, sshutil.SSHArgsFromOpts(sshOpts)...)
+
+	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		sshArgs = append(sshArgs, "-t")
+	}
+
+	if _, present := os.LookupEnv("COLORTERM"); present {
+		sshArgs = append(sshArgs, "-o", "SendEnv=COLORTERM")
+	}
+
+	logLevel := "ERROR"
+	olderSSH := sshutil.DetectOpenSSHVersion(ctx, sshExe).LessThan(*semver.New("8.9.0"))
+	if olderSSH {
+		logLevel = "QUIET"
+	}
+
+	sshArgs = append(sshArgs, []string{
+		"-o", fmt.Sprintf("LogLevel=%s", logLevel),
+		"-p", strconv.Itoa(inst.SSHLocalPort),
+		inst.SSHAddress,
+		"--",
+		script,
+	}...)
+
+	sshCmd := exec.CommandContext(ctx, sshExe.Exe, sshArgs...)
+	sshCmd.Stdin = os.Stdin
+	sshCmd.Stdout = os.Stdout
+	sshCmd.Stderr = os.Stderr
+
+	logrus.Debugf("executing ssh: %+v", sshCmd.Args)
+
+	return sshCmd.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,15 @@ module github.com/rancher-sandbox/rancher-desktop-daemon
 go 1.25.0
 
 require (
+	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/coreos/go-semver v0.3.1
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/k3s-io/kine v1.14.2
 	github.com/lima-vm/lima/v2 v2.0.3
+	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/moby/api v1.53.0
 	github.com/muesli/reflow v0.3.0
 	github.com/nxadm/tail v1.4.11
@@ -110,7 +113,6 @@ require (
 	github.com/containerd/ltag v0.3.0 // indirect
 	github.com/containers/gvisor-tap-vsock v0.8.7 // indirect
 	github.com/coreos/go-oidc v2.3.0+incompatible // indirect
-	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.0 // indirect
@@ -249,7 +251,6 @@ require (
 	github.com/maratori/testpackage v1.1.2 // indirect
 	github.com/matoous/godox v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@
 4d63.com/gocheckcompilerdirectives v1.3.0/go.mod h1:ofsJ4zx2QAuIP/NO/NAh1ig6R1Fb18/GI7RVMwz7kAY=
 4d63.com/gochecknoglobals v0.2.2 h1:H1vdnwnMaZdQW/N+NrkT1SZMTBmcwHe9Vq8lJcYYTtU=
 4d63.com/gochecknoglobals v0.2.2/go.mod h1:lLxwTQjL5eIesRbvnzIP3jZtG140FnTdz+AlMa+ogt0=
+al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
+al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 codeberg.org/chavacava/garif v0.2.0 h1:F0tVjhYbuOCnvNcU3YSpO6b3Waw6Bimy4K0mM8y6MfY=
@@ -353,6 +355,8 @@ github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6 h1:EEHtgt9IwisQ2AZ4pI
 github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6/go.mod h1:I6V7YzU0XDpsHqbsyrghnFZLO1gwK6NPTNvmetQIk9U=
 github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/yamlfmt v0.20.0 h1:EfMuMFEZGnXPn2NY+KgJTH9sNs6P+am/Of6IwE2K6P8=


### PR DESCRIPTION
Reuse Lima's `sshutil` package to implement shell access to running VMs. The command validates the VM exists in the API server, sets `LIMA_HOME` for the correct RDD instance, then uses Lima's SSH utilities to connect.