### PR TITLE
Add `rdd lima logs` command

### DIFF
--- a/bats/tests/20-service/2-create.bats
+++ b/bats/tests/20-service/2-create.bats
@@ -51,6 +51,16 @@ EOT
     refute_line "\"rancher-desktop-${RDD_INSTANCE}\" control plane PID is: 0"
 }
 
+@test 'logs shows control plane stderr' {
+    run -0 rdd svc logs
+    assert_output --partial "apiserver"
+}
+
+@test 'logs --stdout shows control plane stdout' {
+    # stdout may be empty, just verify the command succeeds
+    rdd svc logs --stdout
+}
+
 @test 'stop instance' {
     run -0 rdd svc stop
     run -0 extract_msg

--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -168,4 +168,5 @@ assert_created() {
     assert_output --partial "Start a LimaVM"
     assert_output --partial "Stop a LimaVM"
     assert_output --partial "Delete a LimaVM"
+    assert_output --partial "Show LimaVM logs"
 }

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -156,6 +156,16 @@ assert_limavm_not_exists() {
     lima_instance_running "${VM_NAME}"
 }
 
+@test "logs shows hostagent stderr" {
+    run -0 rdd limavm logs "${VM_NAME}"
+    assert_output --partial "hostagent socket created"
+}
+
+@test "logs --stdout shows hostagent stdout" {
+    run -0 rdd limavm logs --stdout "${VM_NAME}"
+    assert_output --partial "sshLocalPort"
+}
+
 @test "stop the VM by setting running=false" {
     rdd ctl patch limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
         --type=merge --patch '{"spec":{"running":false}}'

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -81,6 +81,13 @@ assert_instance_running_reason() {
     assert_output "${expected}"
 }
 
+assert_stdout_logs_contain() {
+    local name=$1
+    local expected=$2
+    run -0 rdd limavm logs --stdout "${name}"
+    assert_output --partial "${expected}"
+}
+
 lima_instance_running() {
     local name=$1
     assert_file_exists "${LIMA_HOME}/${name}/ha.pid"
@@ -162,8 +169,9 @@ assert_limavm_not_exists() {
 }
 
 @test "logs --stdout shows hostagent stdout" {
-    run -0 rdd limavm logs --stdout "${VM_NAME}"
-    assert_output --partial "sshLocalPort"
+    # The hostagent writes its first stdout event only after the VM's SSH port
+    # becomes accessible, which can lag behind the InstanceRunning condition.
+    try --max 60 --delay 5 -- assert_stdout_logs_contain "${VM_NAME}" "sshLocalPort"
 }
 
 @test "stop the VM by setting running=false" {

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -24,7 +25,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/tail"
 )
 
 func newLimaVMCommand() *cobra.Command {
@@ -39,6 +42,7 @@ func newLimaVMCommand() *cobra.Command {
 		newLimaVMStartCommand(),
 		newLimaVMStopCommand(),
 		newLimaVMDeleteCommand(),
+		newLimaVMLogsCommand(),
 	)
 	return command
 }
@@ -316,4 +320,29 @@ func limaVMDeleteAction(ctx context.Context, name string, wait bool) error {
 
 	logrus.Infof("LimaVM %q deleted from namespace %q", name, limaVM.Namespace)
 	return nil
+}
+
+func newLimaVMLogsCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:     "log INSTANCE",
+		Aliases: []string{"logs"},
+		Short:   "Show LimaVM logs",
+		Long:    "Show hostagent logs for a LimaVM instance.",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.SetLevel(logrus.InfoLevel)
+
+			name := "ha.stderr.log"
+			if ok, _ := cmd.Flags().GetBool("stdout"); ok {
+				name = "ha.stdout.log"
+			}
+			logPath := filepath.Join(instance.LimaHome(), args[0], name)
+			follow, _ := cmd.Flags().GetBool("follow")
+
+			return tail.TailFile(cmd.Context(), cmd.OutOrStdout(), logPath, follow)
+		},
+	}
+	command.Flags().BoolP("stdout", "o", false, "Print stdout instead of stderr")
+	command.Flags().BoolP("follow", "f", false, "Follow log output")
+	return command
 }

--- a/docs/design/cmd_lima.md
+++ b/docs/design/cmd_lima.md
@@ -43,3 +43,10 @@ Set `lima.rancherdesktop.io/restartRequested` annotation to the current timestam
 ### `rdd limavm shell NAME CMD`
 
 Runs `CMD` inside a shell in the `NAME` instance, or opens an interactive shell if `CMD` is omitted.
+
+### `rdd limavm logs NAME`
+
+Show hostagent logs for the `NAME` instance.
+
+- `--stdout` (`-o`): Print stdout instead of stderr (default is stderr)
+- `--follow` (`-f`): Follow log output

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -106,6 +106,16 @@ Sends SIGTERM signal to control plane process (`rdd.pid`).
 
 Deletes the datastore, but create a new (empty) one with the same settings.
 
+### `rdd service status`
+
+Show control plane status: whether it has been created, whether it is running, and its PID.
+
+### `rdd service log`
+
+Show control plane logs.
+
+- `--stdout` (`-o`): Print stdout instead of stderr (default is stderr)
+- `--follow` (`-f`): Follow log output
 
 ## `rdd service config`
 


### PR DESCRIPTION
Show hostagent logs for a LimaVM instance, with `--stdout` and `--follow` flags matching the `rdd svc logs` command.

Also add docs and tests for `rdd svc log` and `rdd svc status` commands in `cmd_service.md`.