### PR TITLE
Replace CustomDefaulter/CustomValidator

### DIFF
--- a/pkg/controllers/base/controller.go
+++ b/pkg/controllers/base/controller.go
@@ -49,7 +49,7 @@ type WebhookController interface {
 
 	// GetWebhookManagers returns all WebhookManagers for parallel setup.
 	// Returns nil or empty slice if the controller doesn't use webhooks.
-	GetWebhookManagers() []*WebhookManager
+	GetWebhookManagers() []WebhookManager
 }
 
 // Registry holds all registered controllers.

--- a/pkg/controllers/base/webhook.go
+++ b/pkg/controllers/base/webhook.go
@@ -15,6 +15,7 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -68,7 +69,7 @@ const (
 )
 
 // WebhookConfig contains configuration for creating a webhook configuration.
-type WebhookConfig struct {
+type WebhookConfig[T runtime.Object] struct {
 	// Name is the name of the webhook configuration resource
 	Name string
 
@@ -95,15 +96,29 @@ type WebhookConfig struct {
 	SideEffects *admissionregistrationv1.SideEffectClass
 
 	// Validator is the custom validator for validating admission webhooks
-	Validator admission.CustomValidator //nolint:staticcheck // CustomValidator is a type alias for Validator[runtime.Object]
+	Validator admission.Validator[T]
 
 	// Defaulter is the custom defaulter for mutating admission webhooks
-	Defaulter admission.CustomDefaulter //nolint:staticcheck // CustomDefaulter is a type alias for Defaulter[runtime.Object]
+	Defaulter admission.Defaulter[T]
 }
 
 // WebhookManager handles the creation and management of webhook configurations.
-type WebhookManager struct {
-	config      WebhookConfig
+type WebhookManager interface {
+	// GetConfigName returns the name of the webhook configuration resource.
+	GetConfigName() string
+
+	// GetWebhookType returns the type of webhook (Validating or Mutating).
+	GetWebhookType() WebhookType
+
+	// Setup creates the webhook configuration with retry logic.
+	// This blocks until the webhook is successfully registered or max attempts are exceeded.
+	// This should be called after the webhook server is registered with the manager.
+	Setup() error
+}
+
+// webhookManagerImpl is the implementation of WebhookManager for a specific resource type.
+type webhookManagerImpl[T runtime.Object] struct {
+	config      WebhookConfig[T]
 	webhookType WebhookType // Validating or Mutating - set by SetupWebhookForResource
 	mgr         ctrl.Manager
 
@@ -114,12 +129,12 @@ type WebhookManager struct {
 }
 
 // GetConfigName returns the name of the webhook configuration resource.
-func (wm *WebhookManager) GetConfigName() string {
+func (wm *webhookManagerImpl[T]) GetConfigName() string {
 	return wm.config.Name
 }
 
 // GetWebhookType returns the type of webhook (Validating or Mutating).
-func (wm *WebhookManager) GetWebhookType() WebhookType {
+func (wm *webhookManagerImpl[T]) GetWebhookType() WebhookType {
 	return wm.webhookType
 }
 
@@ -128,7 +143,7 @@ func (wm *WebhookManager) GetWebhookType() WebhookType {
 //
 // The config must specify either a validator, a defaulter, or both. The function will create the
 // appropriate webhook manager(s) based on which are provided.
-func SetupWebhookForResource(mgr ctrl.Manager, obj client.Object, config WebhookConfig) ([]*WebhookManager, error) {
+func SetupWebhookForResource[T runtime.Object](mgr ctrl.Manager, obj T, config WebhookConfig[T]) ([]WebhookManager, error) {
 	if config.Validator == nil && config.Defaulter == nil {
 		return nil, errors.New("config must specify at least one of either Validator or Defaulter (or both)")
 	}
@@ -145,14 +160,14 @@ func SetupWebhookForResource(mgr ctrl.Manager, obj client.Object, config Webhook
 	gvk := gvks[0]
 
 	// Build webhook registration with controller-runtime
-	builder := ctrl.NewWebhookManagedBy(mgr, obj).WithCustomValidator(config.Validator).WithCustomDefaulter(config.Defaulter) //nolint:staticcheck // CustomValidator/CustomDefaulter are type aliases
+	builder := ctrl.NewWebhookManagedBy(mgr, obj).WithValidator(config.Validator).WithDefaulter(config.Defaulter)
 	if err := builder.Complete(); err != nil {
 		return nil, err
 	}
 
-	var managers []*WebhookManager
+	var managers []WebhookManager
 	if config.Validator != nil {
-		managers = append(managers, &WebhookManager{
+		managers = append(managers, &webhookManagerImpl[T]{
 			config:      config,
 			webhookType: ValidatingWebhook,
 			mgr:         mgr,
@@ -160,7 +175,7 @@ func SetupWebhookForResource(mgr ctrl.Manager, obj client.Object, config Webhook
 		})
 	}
 	if config.Defaulter != nil {
-		managers = append(managers, &WebhookManager{
+		managers = append(managers, &webhookManagerImpl[T]{
 			config:      config,
 			webhookType: MutatingWebhook,
 			mgr:         mgr,
@@ -173,7 +188,7 @@ func SetupWebhookForResource(mgr ctrl.Manager, obj client.Object, config Webhook
 // Setup creates the webhook configuration with retry logic.
 // This blocks until the webhook is successfully registered or max attempts are exceeded.
 // This should be called after the webhook server is registered with the manager.
-func (wm *WebhookManager) Setup() error {
+func (wm *webhookManagerImpl[T]) Setup() error {
 	klog.Info("Starting webhook configuration creation...")
 
 	const maxAttempts = 20
@@ -217,7 +232,7 @@ func (wm *WebhookManager) Setup() error {
 }
 
 // createWebhookConfiguration creates the webhook configuration (Validating or Mutating).
-func (wm *WebhookManager) createWebhookConfiguration() error {
+func (wm *webhookManagerImpl[T]) createWebhookConfiguration() error {
 	klog.Infof("Creating %s webhook configuration...", wm.webhookType)
 	ctx := context.Background()
 
@@ -284,7 +299,7 @@ func (wm *WebhookManager) createWebhookConfiguration() error {
 	}
 }
 
-func (wm *WebhookManager) createValidatingWebhook(ctx context.Context, c client.Client, webhookURL string, clientConfig admissionregistrationv1.WebhookClientConfig, rules []admissionregistrationv1.RuleWithOperations, failurePolicy admissionregistrationv1.FailurePolicyType, sideEffects admissionregistrationv1.SideEffectClass) error {
+func (wm *webhookManagerImpl[T]) createValidatingWebhook(ctx context.Context, c client.Client, webhookURL string, clientConfig admissionregistrationv1.WebhookClientConfig, rules []admissionregistrationv1.RuleWithOperations, failurePolicy admissionregistrationv1.FailurePolicyType, sideEffects admissionregistrationv1.SideEffectClass) error {
 	webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "admissionregistration.k8s.io/v1",
@@ -316,7 +331,7 @@ func (wm *WebhookManager) createValidatingWebhook(ctx context.Context, c client.
 	return nil
 }
 
-func (wm *WebhookManager) createMutatingWebhook(ctx context.Context, c client.Client, webhookURL string, clientConfig admissionregistrationv1.WebhookClientConfig, rules []admissionregistrationv1.RuleWithOperations, failurePolicy admissionregistrationv1.FailurePolicyType, sideEffects admissionregistrationv1.SideEffectClass) error {
+func (wm *webhookManagerImpl[T]) createMutatingWebhook(ctx context.Context, c client.Client, webhookURL string, clientConfig admissionregistrationv1.WebhookClientConfig, rules []admissionregistrationv1.RuleWithOperations, failurePolicy admissionregistrationv1.FailurePolicyType, sideEffects admissionregistrationv1.SideEffectClass) error {
 	webhook := &admissionregistrationv1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "admissionregistration.k8s.io/v1",

--- a/pkg/controllers/containers/container/container_controller.go
+++ b/pkg/controllers/containers/container/container_controller.go
@@ -30,7 +30,7 @@ var controllerCRD string
 // controller implements the base.Controller interface for container.
 type controller struct {
 	webhookPort     int
-	webhookManagers []*base.WebhookManager
+	webhookManagers []base.WebhookManager
 }
 
 // Verify that controller implements base.Controller and base.WebhookController interfaces.
@@ -59,7 +59,7 @@ func (c *controller) GetWebhookServiceName() string {
 }
 
 // GetWebhookManagers implements base.WebhookController.
-func (c *controller) GetWebhookManagers() []*base.WebhookManager {
+func (c *controller) GetWebhookManagers() []base.WebhookManager {
 	return c.webhookManagers
 }
 
@@ -81,7 +81,7 @@ func (c *controller) setupReconciler(mgr ctrl.Manager) error {
 // set up the container controller with a webhook which prevents all modification.
 func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 	mgr.GetLogger().Info("Setting up container webhook")
-	mutatingConfig := base.WebhookConfig{
+	mutatingConfig := base.WebhookConfig[*v1alpha1.Container]{
 		Name:        "container-mutating",
 		WebhookName: "container-mutating.containers.rancherdesktop.io",
 		WebhookPort: c.webhookPort,

--- a/pkg/controllers/containers/container/container_webhooks.go
+++ b/pkg/controllers/containers/container/container_webhooks.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlwebhookadmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -21,28 +20,19 @@ type ContainerImmutableValidator struct {
 	Client client.Client
 }
 
-// ValidateCreate implements ctrlwebhookadmission.CustomValidator.
-func (c *ContainerImmutableValidator) ValidateCreate(_ context.Context, _ runtime.Object) (warnings ctrlwebhookadmission.Warnings, err error) {
+// ValidateCreate implements [ctrlwebhookadmission.Validator].
+func (c *ContainerImmutableValidator) ValidateCreate(context.Context, *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
 	return nil, errors.New("webhook does not implement create")
 }
 
-// ValidateDelete implements ctrlwebhookadmission.CustomValidator.
-func (c *ContainerImmutableValidator) ValidateDelete(_ context.Context, _ runtime.Object) (warnings ctrlwebhookadmission.Warnings, err error) {
+// ValidateDelete implements [ctrlwebhookadmission.Validator].
+func (c *ContainerImmutableValidator) ValidateDelete(context.Context, *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
 	return nil, errors.New("webhook does not implement delete")
 }
 
-// ValidateUpdate implements ctrlwebhookadmission.CustomValidator.
-func (c *ContainerImmutableValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (warnings ctrlwebhookadmission.Warnings, err error) {
+// ValidateUpdate implements [ctrlwebhookadmission.Validator].
+func (c *ContainerImmutableValidator) ValidateUpdate(_ context.Context, oldContainer, newContainer *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
 	// Return an error if the old object does not match the new object.
-	oldContainer, ok := oldObj.(*v1alpha1.Container)
-	if !ok {
-		return nil, fmt.Errorf("old object should be a Container, but got %T", oldObj)
-	}
-	newContainer, ok := newObj.(*v1alpha1.Container)
-	if !ok {
-		return nil, fmt.Errorf("new object should be a Container, but got a %T", newObj)
-	}
-
 	if !equality.Semantic.DeepEqual(oldContainer.Spec, newContainer.Spec) {
 		return nil, fmt.Errorf("container objects must not be modified: old: %v, new: %v", oldContainer, newContainer)
 	}

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -13,7 +13,6 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -55,8 +54,8 @@ var limaCRD string
 
 // controller implements the base.Controller interface for limavm.
 type controller struct {
-	webhookPort     int                    // The actual webhook port allocated by SharedControllerManager
-	webhookManagers []*base.WebhookManager // WebhookManagers for parallel setup
+	webhookPort     int                   // The actual webhook port allocated by SharedControllerManager
+	webhookManagers []base.WebhookManager // WebhookManagers for parallel setup
 }
 
 // Verify that controller implements base.Controller and base.WebhookController interfaces.
@@ -86,7 +85,7 @@ func (c *controller) GetWebhookServiceName() string {
 }
 
 // GetWebhookManagers returns all WebhookManagers for parallel setup.
-func (c *controller) GetWebhookManagers() []*base.WebhookManager {
+func (c *controller) GetWebhookManagers() []base.WebhookManager {
 	return c.webhookManagers
 }
 
@@ -109,7 +108,7 @@ func (c *controller) setupReconciler(mgr ctrl.Manager) error {
 func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 	// Set up LimaVM mutating webhook (validates uniqueness and creates template ConfigMap during admission)
 	sideEffectsNoneOnDryRun := admissionregistrationv1.SideEffectClassNoneOnDryRun
-	mutatingConfig := base.WebhookConfig{
+	mutatingConfig := base.WebhookConfig[*v1alpha1.LimaVM]{
 		Name:        limaVMDefaulterConfigName,
 		WebhookName: limaVMDefaulterWebhookName,
 		WebhookPort: c.webhookPort,
@@ -127,7 +126,7 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 	c.webhookManagers = append(c.webhookManagers, managers...)
 
 	// Set up ConfigMap webhook for template ConfigMaps
-	configMapWebhookConfig := base.WebhookConfig{
+	configMapWebhookConfig := base.WebhookConfig[*corev1.ConfigMap]{
 		Name:        configMapValidatorConfigName,
 		WebhookName: configMapValidatorWebhookName,
 		WebhookPort: c.webhookPort,
@@ -178,16 +177,10 @@ type defaulter struct {
 	Client client.Client
 }
 
-//nolint:staticcheck // CustomDefaulter is a type alias for Defaulter[runtime.Object]
-var _ ctrlwebhookadmission.CustomDefaulter = &defaulter{}
+var _ ctrlwebhookadmission.Defaulter[*v1alpha1.LimaVM] = &defaulter{}
 
 // Default is called during CREATE operations to add finalizer and create the template ConfigMap.
-func (d *defaulter) Default(ctx context.Context, obj runtime.Object) error {
-	limavm, ok := obj.(*v1alpha1.LimaVM)
-	if !ok {
-		return fmt.Errorf("expected a LimaVM object but got %T", obj)
-	}
-
+func (d *defaulter) Default(ctx context.Context, limavm *v1alpha1.LimaVM) error {
 	controllerutil.AddFinalizer(limavm, base.FinalizerName)
 
 	// Validate name uniqueness BEFORE creating ConfigMap
@@ -262,22 +255,17 @@ type ConfigMapValidator struct {
 	Client client.Client
 }
 
-//nolint:staticcheck // CustomValidator is a type alias for Validator[runtime.Object]
-var _ ctrlwebhookadmission.CustomValidator = &ConfigMapValidator{}
+var _ ctrlwebhookadmission.Validator[*corev1.ConfigMap] = &ConfigMapValidator{}
 
-func (v *ConfigMapValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (ctrlwebhookadmission.Warnings, error) {
-	return v.validateTemplateConfigMap(ctx, obj)
+func (v *ConfigMapValidator) ValidateCreate(ctx context.Context, configMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
+	return v.validateTemplateConfigMap(ctx, configMap)
 }
 
-func (v *ConfigMapValidator) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) (ctrlwebhookadmission.Warnings, error) {
-	return v.validateTemplateConfigMap(ctx, newObj)
+func (v *ConfigMapValidator) ValidateUpdate(ctx context.Context, _, newConfigMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
+	return v.validateTemplateConfigMap(ctx, newConfigMap)
 }
 
-func (v *ConfigMapValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (ctrlwebhookadmission.Warnings, error) {
-	configMap, ok := obj.(*corev1.ConfigMap)
-	if !ok {
-		return nil, fmt.Errorf("expected a ConfigMap object but got %T", obj)
-	}
+func (v *ConfigMapValidator) ValidateDelete(ctx context.Context, configMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
 	if base.IsDryRun(ctx) {
 		klog.V(1).Infof("[DryRun] Webhook validating ConfigMap deletion %s/%s\n", configMap.Namespace, configMap.Name)
 	}
@@ -288,11 +276,7 @@ func (v *ConfigMapValidator) ValidateDelete(ctx context.Context, obj runtime.Obj
 }
 
 // validateTemplateConfigMap validates the template data in a ConfigMap.
-func (v *ConfigMapValidator) validateTemplateConfigMap(ctx context.Context, obj runtime.Object) (ctrlwebhookadmission.Warnings, error) {
-	configMap, ok := obj.(*corev1.ConfigMap)
-	if !ok {
-		return nil, fmt.Errorf("expected a ConfigMap object but got %T", obj)
-	}
+func (v *ConfigMapValidator) validateTemplateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
 	if base.IsDryRun(ctx) {
 		klog.V(1).Infof("[DryRun] Webhook validating template ConfigMap %s/%s\n", configMap.Namespace, configMap.Name)
 	}

--- a/pkg/controllers/mock/mock_controller.go
+++ b/pkg/controllers/mock/mock_controller.go
@@ -36,7 +36,7 @@ func init() {
 // reconcilers that create mocked resources based on the namespace.
 type controller struct {
 	webhookPort     int
-	webhookManagers []*base.WebhookManager
+	webhookManagers []base.WebhookManager
 }
 
 var (

--- a/pkg/controllers/mock/mock_webhook.go
+++ b/pkg/controllers/mock/mock_webhook.go
@@ -11,7 +11,6 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlwebhookadmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -23,7 +22,7 @@ func (c *controller) setupWebhookWithManager(mgr ctrl.Manager) error {
 	mgr.GetLogger().Info("Setting up Mock Namespace webhook")
 
 	// set up the container controller with a webhook which prevents all modification.
-	mutatingConfig := base.WebhookConfig{
+	mutatingConfig := base.WebhookConfig[*corev1.Namespace]{
 		Name:        "mock-namespace-no-delete",
 		WebhookName: "mock-namespace-no-delete.mock.rancherdesktop.io",
 		WebhookPort: c.webhookPort,
@@ -47,23 +46,19 @@ func (c *controller) GetWebhookServiceName() string {
 	return controllerName + "-webhook"
 }
 
-func (c *controller) GetWebhookManagers() []*base.WebhookManager {
+func (c *controller) GetWebhookManagers() []base.WebhookManager {
 	return c.webhookManagers
 }
 
 type staticNamespaceNoDeleteValidator struct{}
 
-// ValidateCreate implements ctrlwebhookadmission.CustomValidator.
-func (c *staticNamespaceNoDeleteValidator) ValidateCreate(_ context.Context, _ runtime.Object) (warnings ctrlwebhookadmission.Warnings, err error) {
+// ValidateCreate implements [ctrlwebhookadmission.Validator].
+func (c *staticNamespaceNoDeleteValidator) ValidateCreate(context.Context, *corev1.Namespace) (warnings ctrlwebhookadmission.Warnings, err error) {
 	return nil, nil
 }
 
-// ValidateDelete implements ctrlwebhookadmission.CustomValidator.
-func (c *staticNamespaceNoDeleteValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings ctrlwebhookadmission.Warnings, err error) {
-	ns, ok := obj.(*corev1.Namespace)
-	if !ok {
-		return nil, errors.New("object is not a Namespace")
-	}
+// ValidateDelete implements [ctrlwebhookadmission.Validator].
+func (c *staticNamespaceNoDeleteValidator) ValidateDelete(ctx context.Context, ns *corev1.Namespace) (warnings ctrlwebhookadmission.Warnings, err error) {
 	if ns.Name == mockNamespaceName {
 		klog.FromContext(ctx).V(4).Info("Rejecting delete of namespace")
 		return nil, apierrors.NewForbidden(
@@ -75,7 +70,7 @@ func (c *staticNamespaceNoDeleteValidator) ValidateDelete(ctx context.Context, o
 	return nil, nil
 }
 
-// ValidateUpdate implements ctrlwebhookadmission.CustomValidator.
-func (c *staticNamespaceNoDeleteValidator) ValidateUpdate(_ context.Context, _, _ runtime.Object) (warnings ctrlwebhookadmission.Warnings, err error) {
+// ValidateUpdate implements [ctrlwebhookadmission.Validator].
+func (c *staticNamespaceNoDeleteValidator) ValidateUpdate(_ context.Context, _, _ *corev1.Namespace) (warnings ctrlwebhookadmission.Warnings, err error) {
 	return nil, nil
 }

--- a/pkg/controllers/rdd/notary/controller.go
+++ b/pkg/controllers/rdd/notary/controller.go
@@ -7,9 +7,7 @@ package notary
 import (
 	"context"
 	_ "embed"
-	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlwebhookadmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -42,8 +40,8 @@ var notaryCRD string
 
 // controller implements the base.Controller interface for notary.
 type controller struct {
-	webhookPort     int                    // The actual webhook port allocated by SharedControllerManager
-	webhookManagers []*base.WebhookManager // WebhookManagers for parallel setup
+	webhookPort     int                   // The actual webhook port allocated by SharedControllerManager
+	webhookManagers []base.WebhookManager // WebhookManagers for parallel setup
 }
 
 // Verify that controller implements base.Controller and base.WebhookController interfaces.
@@ -73,7 +71,7 @@ func (c *controller) GetWebhookServiceName() string {
 }
 
 // GetWebhookManagers returns all WebhookManagers for parallel setup.
-func (c *controller) GetWebhookManagers() []*base.WebhookManager {
+func (c *controller) GetWebhookManagers() []base.WebhookManager {
 	return c.webhookManagers
 }
 
@@ -94,7 +92,7 @@ func (c *controller) setupReconciler(mgr ctrl.Manager) error {
 
 // setupWebhookWithRuntimeConfig sets up webhook with shared certificate configuration.
 func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
-	webhookConfig := base.WebhookConfig{
+	webhookConfig := base.WebhookConfig[*v1alpha1.Notary]{
 		Name:        validatorConfigName,
 		WebhookName: webhookName,
 		WebhookPort: c.webhookPort,
@@ -125,26 +123,17 @@ func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 // validator validates Notary resources via webhook (for external controllers).
 type validator struct{}
 
-//nolint:staticcheck // CustomValidator is a type alias for Validator[runtime.Object]
-var _ ctrlwebhookadmission.CustomValidator = &validator{}
+var _ ctrlwebhookadmission.Validator[*v1alpha1.Notary] = &validator{}
 
-func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (ctrlwebhookadmission.Warnings, error) {
-	notary, ok := obj.(*v1alpha1.Notary)
-	if !ok {
-		return nil, fmt.Errorf("expected a Notary object but got %T", obj)
-	}
+func (v *validator) ValidateCreate(ctx context.Context, notary *v1alpha1.Notary) (ctrlwebhookadmission.Warnings, error) {
 	return v.validateNotary(ctx, notary)
 }
 
-func (v *validator) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) (ctrlwebhookadmission.Warnings, error) {
-	notary, ok := newObj.(*v1alpha1.Notary)
-	if !ok {
-		return nil, fmt.Errorf("expected a Notary object but got %T", newObj)
-	}
-	return v.validateNotary(ctx, notary)
+func (v *validator) ValidateUpdate(ctx context.Context, _, newNotary *v1alpha1.Notary) (ctrlwebhookadmission.Warnings, error) {
+	return v.validateNotary(ctx, newNotary)
 }
 
-func (v *validator) ValidateDelete(context.Context, runtime.Object) (ctrlwebhookadmission.Warnings, error) {
+func (v *validator) ValidateDelete(context.Context, *v1alpha1.Notary) (ctrlwebhookadmission.Warnings, error) {
 	// Allow all deletions
 	return nil, nil
 }


### PR DESCRIPTION
The admission webhook types have been deprecated, and replaced with generic versions that specify the type of the object.  To make this work in our code, `WebhookManager` has been turned into an interface so that we can have typed versions for the implementation.

The main fallout for the controllers is that `GetWebhookManagers` no longer return a slice of pointers to struct, but a slice of interfaces instead.

Fixes #125