### PR TITLE
Embed Lima guest agent in rdd binary

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -62,14 +62,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install --yes qemu-system-x86 qemu-utils
 
-        # Install Lima (provides guestagent needed by VM running tests)
-        # This should be removed once RDD bundles the guestagent binary.
-        LIMA_VERSION=2.0.3
-        curl --fail --location --output lima.tar.gz \
-          "https://github.com/lima-vm/lima/releases/download/v${LIMA_VERSION}/lima-${LIMA_VERSION}-Linux-x86_64.tar.gz"
-        sudo tar --extract --gzip --file=lima.tar.gz --directory=/usr/local
-        rm lima.tar.gz
-    
         # Set up run-in-wsl helper script (as a symlink to bash)
         mkdir -p bin
         ln -s $(which bash) bin/run-in-wsl
@@ -84,10 +76,6 @@ jobs:
       working-directory: ${{ runner.temp }}
       run: |
         brew install bash
-
-        # Install Lima (provides guestagent needed by VM running tests)
-        # This should be removed once RDD bundles the guestagent binary.
-        brew install lima
 
         # Set up run-in-wsl helper script (as a symlink to bash)
         mkdir -p bin
@@ -145,7 +133,7 @@ jobs:
       shell: run-in-wsl {0}
       run: >-
         zypper --non-interactive install
-        jq make netcat-openbsd
+        gzip jq make netcat-openbsd
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.github/actions/spelling/expect/golang-generated.txt
 /bin/*
+/pkg/guestagent/lima-guestagent.gz

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,8 @@ linters:
         exclude:
         # Lima driver files use blank imports to register drivers; e.g., drivers_vz.go imports vz driver.
         - "**/limavm/drivers_*.go"
+        # deps_linux.go uses a blank import to keep Linux-only transitive deps in go.sum.
+        - "**/guestagent/deps_linux.go"
       - name: context-as-argument
       - name: context-keys-type
       - name: deep-exit

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ LDFLAGS := \
 
 TAGS := sqlite_omit_load_extension
 
-GUESTAGENT_BINARY := pkg/guestagent/lima-guestagent.gz
+GUESTAGENT_BINARY := pkg/guestagent/lima-guestagent
+GUESTAGENT_GZ := $(GUESTAGENT_BINARY).gz
 
 default: build-rdd
 .PHONY: default
@@ -66,11 +67,13 @@ GOLANG_SOURCES := $(shell find . -name '*.go') go.mod go.sum
 $(GUESTAGENT_BINARY): go.mod go.sum
 	WSLENV=${WSLENV}:CGO_ENABLED:GOOS \
 	CGO_ENABLED=0 GOOS=linux \
-	go$(EXE) build -ldflags="-s -w" -o pkg/guestagent/lima-guestagent \
+	go$(EXE) build -ldflags="-s -w" -o $@ \
 		github.com/lima-vm/lima/v2/cmd/lima-guestagent
-	gzip --force pkg/guestagent/lima-guestagent
 
-bin/rdd$(EXE): $(GOLANG_SOURCES) $(GUESTAGENT_BINARY)
+$(GUESTAGENT_GZ): $(GUESTAGENT_BINARY)
+	gzip --to-stdout $< > $@
+
+bin/rdd$(EXE): $(GOLANG_SOURCES) $(GUESTAGENT_GZ)
 	WSLENV=${WSLENV}:CGO_CFLAGS:CGO_ENABLED \
 	CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" CGO_ENABLED=1 \
 	go$(EXE) build -tags="$(TAGS)" -gcflags="all=${GCFLAGS}" -ldflags="$(LDFLAGS)" -o $@ ./cmd/rdd
@@ -136,7 +139,7 @@ run: bin/rdd$(EXE)
 	$< service start
 .PHONY: run
 
-test: $(GOLANG_SOURCES) $(GUESTAGENT_BINARY)
+test: $(GOLANG_SOURCES) $(GUESTAGENT_GZ)
 	go$(EXE) test ./...
 .PHONY: test
 
@@ -144,7 +147,7 @@ lint-bats:
 	$(MAKE) -C bats lint
 .PHONY: lint-bats
 
-lint-rdd: $(GUESTAGENT_BINARY)
+lint-rdd: $(GUESTAGENT_GZ)
 	go$(EXE) tool golangci-lint run
 .PHONY: lint-rdd
 
@@ -178,5 +181,5 @@ check: test lint spelling check-ltag
 
 clean:
 	-rm -r bin
-	-rm $(GUESTAGENT_BINARY)
+	-rm $(GUESTAGENT_BINARY) $(GUESTAGENT_GZ)
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ LDFLAGS := \
 
 TAGS := sqlite_omit_load_extension
 
+GUESTAGENT_BINARY := pkg/guestagent/lima-guestagent.gz
+
 default: build-rdd
 .PHONY: default
 
@@ -60,7 +62,15 @@ endif
 
 GOLANG_SOURCES := $(shell find . -name '*.go') go.mod go.sum
 
-bin/rdd$(EXE): $(GOLANG_SOURCES)
+# Build the Lima guest agent from our Go dependency and compress it for embedding.
+$(GUESTAGENT_BINARY): go.mod go.sum
+	WSLENV=${WSLENV}:CGO_ENABLED:GOOS \
+	CGO_ENABLED=0 GOOS=linux \
+	go$(EXE) build -ldflags="-s -w" -o pkg/guestagent/lima-guestagent \
+		github.com/lima-vm/lima/v2/cmd/lima-guestagent
+	gzip --force pkg/guestagent/lima-guestagent
+
+bin/rdd$(EXE): $(GOLANG_SOURCES) $(GUESTAGENT_BINARY)
 	WSLENV=${WSLENV}:CGO_CFLAGS:CGO_ENABLED \
 	CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" CGO_ENABLED=1 \
 	go$(EXE) build -tags="$(TAGS)" -gcflags="all=${GCFLAGS}" -ldflags="$(LDFLAGS)" -o $@ ./cmd/rdd
@@ -126,7 +136,7 @@ run: bin/rdd$(EXE)
 	$< service start
 .PHONY: run
 
-test: $(GOLANG_SOURCES)
+test: $(GOLANG_SOURCES) $(GUESTAGENT_BINARY)
 	go$(EXE) test ./...
 .PHONY: test
 
@@ -134,7 +144,7 @@ lint-bats:
 	$(MAKE) -C bats lint
 .PHONY: lint-bats
 
-lint-rdd:
+lint-rdd: $(GUESTAGENT_BINARY)
 	go$(EXE) tool golangci-lint run
 .PHONY: lint-rdd
 
@@ -168,4 +178,5 @@ check: test lint spelling check-ltag
 
 clean:
 	-rm -r bin
+	-rm $(GUESTAGENT_BINARY)
 .PHONY: clean

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -5,7 +5,6 @@
 load '../../helpers/load'
 
 # LimaVM running tests verify that Lima instances can be started and stopped.
-# These tests require a guestagent binary at /usr/local/share/lima/lima-guestagent.Linux-${ARCH}.gz
 
 NAMESPACE="running-test-ns"
 VM_NAME="alpine-running"
@@ -37,11 +36,6 @@ local_teardown_file() {
 
 local_setup() {
     skip_on_windows
-    # The guestagent binary is installed by Lima (brew install lima). This is a
-    # workaround until we bundle our own guestagent.
-    if [[ ! -f "/usr/local/share/lima/lima-guestagent.Linux-${ARCH}.gz" ]]; then
-        skip "Running tests require lima-guestagent.Linux-${ARCH}.gz (install Lima: brew install lima)"
-    fi
 }
 
 create_limavm_running() {

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cheggaaa/pb/v3 v3.1.7 // indirect
+	github.com/cilium/ebpf v0.20.0 // indirect
 	github.com/ckaznocha/intrange v0.3.1 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/log v0.1.0 // indirect
@@ -252,6 +253,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
+	github.com/mdlayher/netlink v1.8.0 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/mgechev/revive v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cheggaaa/pb/v3 v3.1.7 h1:2FsIW307kt7A/rz/ZI2lvPO+v3wKazzE4K/0LtTWsOI=
 github.com/cheggaaa/pb/v3 v3.1.7/go.mod h1:/Ji89zfVPeC/u5j8ukD0MBPHt2bzTYp74lQ7KlgFWTQ=
+github.com/cilium/ebpf v0.20.0 h1:atwWj9d3NffHyPZzVlx3hmw1on5CLe9eljR8VuHTwhM=
+github.com/cilium/ebpf v0.20.0/go.mod h1:pzLjFymM+uZPLk/IXZUL63xdx5VXEo+enTzxkZXdycw=
 github.com/ckaznocha/intrange v0.3.1 h1:j1onQyXvHUsPWujDH6WIjhyH26gkRt/txNlV7LspvJs=
 github.com/ckaznocha/intrange v0.3.1/go.mod h1:QVepyz1AkUoFQkpEqksSYpNpUo3c5W7nWh/s6SHIJJk=
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
@@ -258,8 +260,8 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
-github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
-github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
@@ -425,6 +427,9 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
 github.com/josharian/native v1.1.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
+github.com/jsimonetti/rtnetlink v1.3.5 h1:hVlNQNRlLDGZz31gBPicsG7Q53rnlsz1l1Ix/9XlpVA=
+github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCXxpaIEIlM=
+github.com/jsimonetti/rtnetlink/v2 v2.0.1/go.mod h1:7MoNYNbb3UaDHtF8udiJo/RH6VsTKP1pqKLUTVCvToE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/julz/importas v0.2.0 h1:y+MJN/UdL63QbFJHws9BVC5RpA2iq0kpjrFajTGivjQ=
@@ -514,6 +519,8 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mdlayher/netlink v1.8.0 h1:e7XNIYJKD7hUct3Px04RuIGJbBxy1/c4nX7D5YyvvlM=
+github.com/mdlayher/netlink v1.8.0/go.mod h1:UhgKXUlDQhzb09DrCl2GuRNEglHmhYoWAHid9HK3594=
 github.com/mdlayher/packet v1.1.2 h1:3Up1NG6LZrsgDVn6X4L9Ge/iyRyxFEFD9o6Pr3Q1nQY=
 github.com/mdlayher/packet v1.1.2/go.mod h1:GEu1+n9sG5VtiRE4SydOmX5GTwyyYlteZiFU+x0kew4=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	goruntime "runtime"
 
 	limainstance "github.com/lima-vm/lima/v2/pkg/instance"
 	"github.com/lima-vm/lima/v2/pkg/store"
@@ -71,18 +70,6 @@ const (
 	// Its presence indicates that preparation is in progress or failed.
 	preparingSentinel = ".preparing"
 )
-
-// guestAgentPath returns the path to the Lima guest agent binary for the current architecture.
-// TODO This is just a temporary hack until the guestagent binary can be embedded into rdd.
-func guestAgentPath() string {
-	arch := goruntime.GOARCH
-	if arch == "amd64" {
-		arch = "x86_64"
-	} else if arch == "arm64" {
-		arch = "aarch64"
-	}
-	return "/usr/local/share/lima/lima-guestagent.Linux-" + arch + ".gz"
-}
 
 // sentinelPath returns the path to the preparing sentinel file for an instance.
 func sentinelPath(instanceName string) string {

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -192,16 +192,6 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 		return ctrl.Result{}, err
 	}
 
-	// Instance was already prepared as part of creation, but still need to update cidata.iso
-	prepared, err := limainstance.Prepare(ctx, inst, guestAgentPath())
-	if err != nil {
-		logger.Error(err, "Failed to prepare Lima instance")
-		if updateErr := r.updateCondition(ctx, limaVM, ConditionInstanceRunning, metav1.ConditionFalse, ReasonStartFailed, err.Error()); updateErr != nil {
-			logger.Error(updateErr, "Failed to update status after prepare failure")
-		}
-		return ctrl.Result{}, err
-	}
-
 	// Build hostagent command arguments
 	haPIDPath := filepath.Join(inst.Dir, filenames.HostAgentPID)
 	haSockPath := filepath.Join(inst.Dir, filenames.HostAgentSock)
@@ -215,9 +205,6 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	}
 	if logger.V(1).Enabled() {
 		args = append(args, "--debug")
-	}
-	if prepared.GuestAgent != "" {
-		args = append(args, "--guestagent", prepared.GuestAgent)
 	}
 	args = append(args, inst.Name)
 

--- a/pkg/guestagent/deps_linux.go
+++ b/pkg/guestagent/deps_linux.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package guestagent
+
+// Blank import ensures go mod tidy retains the guest agent's
+// Linux-only transitive dependencies in go.sum.
+// Without this, go mod tidy on macOS would strip them, breaking the
+// Makefile's cross-compilation build of lima-guestagent.
+import _ "github.com/lima-vm/lima/v2/pkg/guestagent"

--- a/pkg/guestagent/guestagent.go
+++ b/pkg/guestagent/guestagent.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package guestagent provides the embedded Lima guest agent binary.
+package guestagent
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+)
+
+//go:embed lima-guestagent.gz
+var guestAgentGZ []byte
+
+// WriteTempFile writes the embedded guest agent to a temporary file
+// and returns the path and a cleanup function. The caller must call
+// cleanup when the file is no longer needed.
+//
+// The file has a .gz suffix so Lima's hostagent decompresses it
+// before copying it into the guest.
+func WriteTempFile() (path string, cleanup func(), err error) {
+	f, err := os.CreateTemp("", "lima-guestagent-*.gz")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating guest agent temp file: %w", err)
+	}
+	if _, err := f.Write(guestAgentGZ); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", nil, fmt.Errorf("writing guest agent temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", nil, fmt.Errorf("closing guest agent temp file: %w", err)
+	}
+	return f.Name(), func() { os.Remove(f.Name()) }, nil
+}

--- a/pkg/hostagent/command.go
+++ b/pkg/hostagent/command.go
@@ -23,6 +23,8 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/store"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/guestagent"
 )
 
 // NewCommand creates a new hostagent cobra command.
@@ -37,7 +39,6 @@ func NewCommand() *cobra.Command {
 	hostagentCommand.Flags().StringP("pidfile", "p", "", "Write PID to file")
 	hostagentCommand.Flags().String("socket", "", "Path of hostagent socket")
 	hostagentCommand.Flags().Bool("run-gui", false, "Run GUI synchronously within hostagent")
-	hostagentCommand.Flags().String("guestagent", "", "Local file path of lima-guestagent")
 	hostagentCommand.Flags().String("nerdctl-archive", "", "Local file path of nerdctl archive")
 	hostagentCommand.Flags().Bool("progress", false, "Show provision script progress")
 	hostagentCommand.Flags().Bool("debug", false, "Enable debug logging")
@@ -93,14 +94,15 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	stderr := &syncWriter{w: cmd.ErrOrStderr()}
 
 	initHostagentLogrus(stderr)
-	var opts []hostagent.Opt
-	guestagentBinary, err := cmd.Flags().GetString("guestagent")
+	// Extract the embedded guest agent binary for VM provisioning.
+	gaPath, gaCleanup, err := guestagent.WriteTempFile()
 	if err != nil {
-		return err
+		return fmt.Errorf("extracting embedded guest agent: %w", err)
 	}
-	if guestagentBinary != "" {
-		opts = append(opts, hostagent.WithGuestAgentBinary(guestagentBinary))
-	}
+	defer gaCleanup()
+
+	var opts []hostagent.Opt
+	opts = append(opts, hostagent.WithGuestAgentBinary(gaPath))
 	nerdctlArchive, err := cmd.Flags().GetString("nerdctl-archive")
 	if err != nil {
 		return err


### PR DESCRIPTION
Build the guest agent from our existing Lima Go dependency and embed the compressed binary via go:embed. This eliminates the requirement to have Lima installed, both for developers and in CI.

The Makefile cross-compiles the guest agent for Linux (matching the host GOARCH), compresses it with gzip, and places it where go:embed picks it up. At runtime, the hostagent extracts it for provisioning.

A blank import in deps_linux.go ensures go mod tidy retains the guest agent's Linux-only transitive dependencies in go.sum.