### PR TITLE
Improve logging infrastructure

### DIFF
--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -13,7 +13,6 @@ pulumi
 Trivy
 
 # golangci-lint & its linter / formatter names
-golangci
 bodyclose
 copyloopvar
 depguard
@@ -26,6 +25,7 @@ gocritic
 godot
 gofmt
 gofumpt
+golangci
 govet
 ineffassign
 intrange
@@ -35,14 +35,14 @@ perfsprint
 usetesting
 
 # golangci-lint options
+errorf
+gotest
 localmodule
+mgechev
 nolint
 nolintlint
-gotest
-unlabel
-errorf
 strconcat
-mgechev
+unlabel
 
 # awk
 RLENGTH
@@ -50,6 +50,7 @@ RSTART
 
 # bash
 neq
+nullglob
 
 # bats
 batslib
@@ -68,10 +69,11 @@ DSQLITE
 endef
 ifeq
 ifneq
+MAKEFLAGS
 notdir
 patsubst
 VTAB
 
 # check-spelling
-hunspell
 dic
+hunspell

--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -49,7 +49,6 @@ RLENGTH
 RSTART
 
 # bash
-euo
 neq
 
 # bats

--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -49,6 +49,7 @@ RLENGTH
 RSTART
 
 # bash
+euo
 neq
 
 # bats

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -156,7 +156,7 @@ jobs:
         systemctl status systemd-binfmt.service || true
       continue-on-error: true
 
-    - run: make -C bats
+    - run: make -C bats --keep-going
       shell: run-in-wsl {0}
       env:
         RDD_TRACE: true

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -164,7 +164,7 @@ jobs:
     - name: Collect RDD logs
       if: always()
       shell: run-in-wsl {0}
-      run: scripts/collect-logs.sh
+      run: scripts/collect-bats-logs.sh rdd-logs
 
     - name: Upload RDD service logs
       if: always()

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -161,14 +161,10 @@ jobs:
       env:
         RDD_TRACE: true
 
-    - name: Collect RDD service logs
+    - name: Collect RDD logs
       if: always()
       shell: run-in-wsl {0}
-      run: |
-        mkdir -p rdd-logs
-        for instance in $(make --no-print-directory -C bats bats-instances); do
-          RDD_INSTANCE="$instance" bin/rdd svc log > "rdd-logs/${instance}.log" || true
-        done
+      run: scripts/collect-logs.sh
 
     - name: Upload RDD service logs
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ check-ltag:
 	go$(EXE) tool ltag -v -t .ltag -path . --excludes='lib check-spelling nxadmtail' --check
 .PHONY: ltag check-ltag
 
-BATS_TARGETS := $(shell $(MAKE) -C bats --print-data-base --question --no-builtin-variables | awk -F: '$$1 ~ /^bats-/ { print $$1 }')
+BATS_TARGETS := $(shell MAKEFLAGS= $(MAKE) -C bats --print-data-base --question --no-builtin-variables | awk -F: '$$1 ~ /^bats-/ { print $$1 }')
 $(BATS_TARGETS): bin/rdd$(EXE)
 	@$(MAKE) -C bats $@
 .PHONY: $(BATS_TARGETS)

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -67,23 +67,12 @@ bats-containers: check-bats build-rdd build-mock-controller
 	RDD_INSTANCE=bats-containers-controller $(BATS_CORE) tests/34-containers-controllers/
 .PHONY: bats-containers
 
-# Run all controller tests, continuing past failures.
-bats-controllers:
-	@rc=0; \
-	$(MAKE) bats-builtin || rc=1; \
-	$(MAKE) bats-rdd || rc=1; \
-	$(MAKE) bats-app || rc=1; \
-	$(MAKE) bats-lima || rc=1; \
-	$(MAKE) bats-containers || rc=1; \
-	exit $$rc
+# Run all controller tests.
+bats-controllers: bats-builtin bats-rdd bats-app bats-lima bats-containers
 .PHONY: bats-controllers
 
-# Run all BATS tests, continuing past failures so all suites produce logs.
-bats-all: bats-helpers bats-cli
-	@rc=0; \
-	$(MAKE) bats-service || rc=1; \
-	$(MAKE) bats-controllers || rc=1; \
-	exit $$rc
+# Run all BATS tests.
+bats-all: bats-helpers bats-cli bats-service bats-controllers
 .PHONY: bats-all
 
 # Run BATS tests with timeout to prevent hanging

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -29,7 +29,7 @@ export TMPDIR := $(shell wslpath -u $$(cmd.exe /c "echo %TEMP%"))
 endif
 
 # Run BATS tests for BATS helpers
-bats-helpers: check-bats
+bats-helpers: check-bats build-rdd
 	$(BATS_CORE) helpers/
 .PHONY: bats-helpers
 

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -67,12 +67,23 @@ bats-containers: check-bats build-rdd build-mock-controller
 	RDD_INSTANCE=bats-containers-controller $(BATS_CORE) tests/34-containers-controllers/
 .PHONY: bats-containers
 
-# Run all controller tests
-bats-controllers: bats-builtin bats-rdd bats-app bats-lima bats-containers
+# Run all controller tests, continuing past failures.
+bats-controllers:
+	@rc=0; \
+	$(MAKE) bats-builtin || rc=1; \
+	$(MAKE) bats-rdd || rc=1; \
+	$(MAKE) bats-app || rc=1; \
+	$(MAKE) bats-lima || rc=1; \
+	$(MAKE) bats-containers || rc=1; \
+	exit $$rc
 .PHONY: bats-controllers
 
-# Run all BATS tests
-bats-all: bats-helpers bats-cli bats-service bats-controllers
+# Run all BATS tests, continuing past failures so all suites produce logs.
+bats-all: bats-helpers bats-cli
+	@rc=0; \
+	$(MAKE) bats-service || rc=1; \
+	$(MAKE) bats-controllers || rc=1; \
+	exit $$rc
 .PHONY: bats-all
 
 # Run BATS tests with timeout to prevent hanging

--- a/bats/helpers/defaults.bash
+++ b/bats/helpers/defaults.bash
@@ -4,6 +4,8 @@ export RDD_INSTANCE
 
 : "${RDD_TRACE:=false}"
 : "${RDD_NAMESPACE:=default}"
+: "${RDD_KEEP_LOGS:=1}"
+export RDD_KEEP_LOGS
 
 using_windows_exe() {
     true # TODO: WSL testing, later.

--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -83,12 +83,19 @@ setup_file() {
 teardown_file() {
     # Stop the control plane but don't delete it, to preserve logs for debugging.
     # The next test run's setup will clean up and create a fresh instance.
-    rdd svc stop 2>/dev/null || true
+    rdd svc stop || true
 
     call_local_function
 }
 
 setup() {
+    # Write test markers to RDD log files for easier debugging.
+    # The append may fail if the service is not running; that's fine.
+    local log
+    for log in "${PATH_LOGS}"/rdd.stderr.log "${PATH_LOGS}"/rdd.stdout.log; do
+        echo "=== BATS: ${BATS_TEST_DESCRIPTION} ===" >>"${log}" 2>/dev/null || true
+    done
+
     call_local_function
 }
 

--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -92,7 +92,7 @@ setup() {
     # Write test markers to RDD log files for easier debugging.
     # The append may fail if the service is not running; that's fine.
     local log
-    for log in "${PATH_LOGS}"/rdd.stderr.log "${PATH_LOGS}"/rdd.stdout.log; do
+    for log in "${RDD_LOG_DIR}"/rdd.stderr.log "${RDD_LOG_DIR}"/rdd.stdout.log; do
         echo "=== BATS: ${BATS_TEST_DESCRIPTION} ===" >>"${log}" 2>/dev/null || true
     done
 

--- a/bats/helpers/paths.bash
+++ b/bats/helpers/paths.bash
@@ -18,7 +18,7 @@ win_to_wsl_exports() {
 # Get instance paths from rdd (single source of truth).
 # shellcheck disable=SC1090
 if is_windows; then
-    source <("${PATH_REPO_ROOT}/bin/rdd.exe" svc paths --shell | win_to_wsl_exports)
+    source <("${PATH_REPO_ROOT}/bin/rdd.exe" svc paths --output=shell | win_to_wsl_exports)
 else
-    source <("${PATH_REPO_ROOT}/bin/rdd" svc paths --shell)
+    source <("${PATH_REPO_ROOT}/bin/rdd" svc paths --output=shell)
 fi

--- a/bats/helpers/paths.bash
+++ b/bats/helpers/paths.bash
@@ -6,44 +6,25 @@ inside_repo_clone() {
     [[ -d "${PATH_REPO_ROOT}/pkg/rancher-desktop-daemon" ]]
 }
 
-if is_macos; then
-    PATH_APP_HOME="${HOME}/Library/Application Support/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CONFIG="${HOME}/Library/Preferences/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CACHE="${HOME}/Library/Caches/rancher-desktop-${RDD_INSTANCE}"
-    PATH_LOGS="${PATH_APP_HOME}"
-fi
-
-if is_linux; then
-    PATH_APP_HOME="${HOME}/.local/share/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CONFIG="${HOME}/.config/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CACHE="${HOME}/.cache/rancher-desktop-${RDD_INSTANCE}"
-    PATH_LOGS="${PATH_APP_HOME}"
-fi
-
-# Get the WSL (Unix) path for a Windows shell folder id; for a list of valid ids,
-# see https://learn.microsoft.com/en-us/dotnet/api/system.environment.specialfolder
-wslpath_from_win32_folder_id() {
-    local folder_id=$1
-    local windows_path
-    windows_path=$(powershell.exe -Command "[System.Environment]::GetFolderPath(${folder_id})")
-    local unix_path
-    unix_path=$(wslpath -u "${windows_path}")
-    tr -d "\r" <<<"${unix_path}"
+# Convert 'export KEY="C:\win\path"' to 'export KEY="/mnt/c/wsl/path"'.
+win_to_wsl_exports() {
+    tr -d "\r" | while IFS= read -r line; do
+        if [[ "${line}" =~ ^(export\ [A-Z_]+=)\"(.+)\"$ ]]; then
+            printf '%s"%s"\n' "${BASH_REMATCH[1]}" "$(wslpath -u "${BASH_REMATCH[2]}")"
+        fi
+    done
 }
 
+# Get instance paths from rdd (single source of truth).
+# shellcheck disable=SC1090
 if is_windows; then
-    LOCALAPPDATA="$(wslpath_from_win32_folder_id 28)"
-    PROGRAMFILES="$(wslpath_from_win32_folder_id 38)"
-
-    PATH_APP_HOME="${LOCALAPPDATA}/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CONFIG="${LOCALAPPDATA}/rancher-desktop-${RDD_INSTANCE}"
-    PATH_CACHE="${PATH_APP_HOME}/cache"
-    PATH_LOGS="${PATH_APP_HOME}"
-    PATH_DISTRO="${PATH_APP_HOME}/distro"
-    PATH_DISTRO_DATA="${PATH_APP_HOME}/distro-data"
+    source <("${PATH_REPO_ROOT}/bin/rdd.exe" svc paths --shell | win_to_wsl_exports)
+else
+    source <("${PATH_REPO_ROOT}/bin/rdd" svc paths --shell)
 fi
 
-# PATH_RD is the "short directory" (e.g., ~/.rd2) as documented in docs/design/cmd_service.md.
-# LIMA_HOME uses PATH_RD instead of PATH_APP_HOME because of socket name length constraints.
-PATH_RD="${HOME}/.rd${RDD_INSTANCE}"
-LIMA_HOME="${PATH_RD}/lima"
+PATH_APP_HOME="${RDD_DIR}"
+PATH_ARGS_FILE="${RDD_ARGS_FILE}"
+PATH_LOGS="${RDD_LOG_DIR}"
+PATH_RD="${RDD_SHORT_DIR}"
+LIMA_HOME="${RDD_LIMA_HOME}"

--- a/bats/helpers/paths.bash
+++ b/bats/helpers/paths.bash
@@ -22,9 +22,3 @@ if is_windows; then
 else
     source <("${PATH_REPO_ROOT}/bin/rdd" svc paths --shell)
 fi
-
-PATH_APP_HOME="${RDD_DIR}"
-PATH_ARGS_FILE="${RDD_ARGS_FILE}"
-PATH_LOGS="${RDD_LOG_DIR}"
-PATH_RD="${RDD_SHORT_DIR}"
-LIMA_HOME="${RDD_LIMA_HOME}"

--- a/bats/tests/10-cli/4-log-level.bats
+++ b/bats/tests/10-cli/4-log-level.bats
@@ -2,7 +2,7 @@ load '../../helpers/load'
 
 assert_klog_level() {
     local level=$1
-    run -0 jq --compact-output . "${PATH_APP_HOME}/args.json"
+    run -0 jq --compact-output . "${PATH_ARGS_FILE}"
     assert_line --partial "\"-v\",\"${level}\""
 }
 

--- a/bats/tests/10-cli/4-log-level.bats
+++ b/bats/tests/10-cli/4-log-level.bats
@@ -2,7 +2,7 @@ load '../../helpers/load'
 
 assert_klog_level() {
     local level=$1
-    run -0 jq --compact-output . "${PATH_ARGS_FILE}"
+    run -0 jq --compact-output . "${RDD_ARGS_FILE}"
     assert_line --partial "\"-v\",\"${level}\""
 }
 
@@ -44,16 +44,16 @@ assert_klog_level() {
 }
 
 # Test log level persistence in service configuration
-@test 'debug log level creates service with -v 1' {
+@test 'debug log level creates service with -v 2' {
     rdd svc delete
     run -0 rdd --log-level=debug svc create --controllers=""
-    assert_klog_level 1
+    assert_klog_level 2
 }
 
-@test 'trace log level creates service with -v 2' {
+@test 'trace log level creates service with -v 4' {
     rdd svc delete
     run -0 rdd --log-level=trace svc create --controllers=""
-    assert_klog_level 2
+    assert_klog_level 4
 }
 
 @test 'error log level creates service with -v 0' {
@@ -63,13 +63,13 @@ assert_klog_level() {
 }
 
 # Test default log levels based on developer mode
-@test 'default log level in developer mode creates -v 1' {
+@test 'default log level in developer mode creates -v 2' {
     run -0 rdd svc delete
     # Developer mode should default to debug level
     # shellcheck disable=SC2030,SC2031 # This only applies to the subshell
     export RDD_DEVELOPER_MODE=1
     run -0 rdd svc create --controllers=""
-    assert_klog_level 1
+    assert_klog_level 2
 }
 
 @test 'default log level in non-developer mode creates -v 0' {

--- a/bats/tests/10-cli/5-paths.bats
+++ b/bats/tests/10-cli/5-paths.bats
@@ -1,0 +1,41 @@
+load '../../helpers/load'
+
+ALL_KEYS="dir log_dir short_dir lima_home tls_dir kubeconfig pid_file args_file"
+
+@test 'rdd svc paths prints all keys in table format' {
+    run -0 rdd svc paths
+    for key in ${ALL_KEYS}; do
+        assert_line --regexp "^${key} "
+    done
+}
+
+@test 'rdd svc paths --json produces valid JSON with all keys' {
+    run -0 rdd svc paths --json
+    local json="${output}"
+    for key in ${ALL_KEYS}; do
+        jq --exit-status --arg k "${key}" 'has($k)' <<<"${json}"
+    done
+}
+
+@test 'rdd svc paths --shell produces shell export statements' {
+    run -0 rdd svc paths --shell
+    for key in ${ALL_KEYS}; do
+        upper_key=$(echo "${key}" | tr '[:lower:]' '[:upper:]')
+        assert_line --regexp "^export RDD_${upper_key}="
+    done
+}
+
+@test 'rdd svc paths <key> prints only the value' {
+    run -0 rdd svc paths log_dir
+    # Output should be a single line with no key prefix
+    assert_output --regexp '^(/|[A-Z]:)'
+    refute_output --regexp '^log_dir'
+    [[ "${#lines[@]}" -eq 1 ]]
+}
+
+@test 'rdd svc paths with invalid key fails and lists valid keys' {
+    run -1 rdd svc paths no_such_key
+    assert_output --partial 'unknown key'
+    assert_output --partial 'no_such_key'
+    assert_output --partial 'valid keys'
+}

--- a/bats/tests/10-cli/5-paths.bats
+++ b/bats/tests/10-cli/5-paths.bats
@@ -9,16 +9,16 @@ ALL_KEYS="dir log_dir short_dir lima_home tls_dir kubeconfig pid_file args_file"
     done
 }
 
-@test 'rdd svc paths --json produces valid JSON with all keys' {
-    run -0 rdd svc paths --json
+@test 'rdd svc paths --output=json produces valid JSON with all keys' {
+    run -0 rdd svc paths --output=json
     local json="${output}"
     for key in ${ALL_KEYS}; do
         jq --exit-status --arg k "${key}" 'has($k)' <<<"${json}"
     done
 }
 
-@test 'rdd svc paths --shell produces shell export statements' {
-    run -0 rdd svc paths --shell
+@test 'rdd svc paths --output=shell produces shell export statements' {
+    run -0 rdd svc paths --output=shell
     for key in ${ALL_KEYS}; do
         upper_key=$(echo "${key}" | tr '[:lower:]' '[:upper:]')
         assert_line --regexp "^export RDD_${upper_key}="
@@ -30,7 +30,7 @@ ALL_KEYS="dir log_dir short_dir lima_home tls_dir kubeconfig pid_file args_file"
     # Output should be a single line with no key prefix
     assert_output --regexp '^(/|[A-Z]:)'
     refute_output --regexp '^log_dir'
-    [[ "${#lines[@]}" -eq 1 ]]
+    assert_equal "${#lines[@]}" 1
 }
 
 @test 'rdd svc paths with invalid key fails and lists valid keys' {

--- a/bats/tests/10-cli/5-paths.bats
+++ b/bats/tests/10-cli/5-paths.bats
@@ -1,6 +1,6 @@
 load '../../helpers/load'
 
-ALL_KEYS="dir log_dir short_dir lima_home tls_dir kubeconfig pid_file args_file"
+ALL_KEYS="args_file config dir lima_home log_dir pid_file short_dir tls_dir"
 
 @test 'rdd svc paths prints all keys in table format' {
     run -0 rdd svc paths

--- a/bats/tests/20-service/2-create.bats
+++ b/bats/tests/20-service/2-create.bats
@@ -4,7 +4,7 @@ load '../../helpers/load'
 
 @test 'Make sure instance does not exist' {
     rdd svc delete || :
-    assert_dir_not_exist "${PATH_APP_HOME}"
+    assert_dir_not_exist "${RDD_DIR}"
 }
 
 @test 'Delete instance succeeds even when the instance does not exist' {
@@ -23,7 +23,7 @@ load '../../helpers/load'
     run -0 rdd svc create
     run -0 extract_msg
     assert_output "successfully created \"rancher-desktop-${RDD_INSTANCE}\" control plane"
-    assert_dir_exist "${PATH_APP_HOME}"
+    assert_dir_exist "${RDD_DIR}"
 }
 
 @test 'verify instance does exist but has not been started' {
@@ -65,7 +65,7 @@ EOT
     run -0 rdd svc stop
     run -0 extract_msg
     assert_output "successfully stopped \"rancher-desktop-${RDD_INSTANCE}\" control plane"
-    assert_dir_exist "${PATH_APP_HOME}"
+    assert_dir_exist "${RDD_DIR}"
 }
 
 @test 'verify instance has been stopped' {
@@ -80,7 +80,7 @@ EOT
     run -0 rdd svc delete
     run -0 extract_msg
     assert_output "successfully deleted \"rancher-desktop-${RDD_INSTANCE}\" control plane"
-    assert_dir_not_exist "${PATH_APP_HOME}"
+    assert_dir_not_exist "${RDD_DIR}"
 }
 
 @test 'verify instance has been deleted' {

--- a/bats/tests/20-service/4-start-parameters.bats
+++ b/bats/tests/20-service/4-start-parameters.bats
@@ -61,7 +61,7 @@ assert_no_controllers() {
     run -0 rdd svc create --controllers="rdd"
 
     # Verify parameters were saved
-    ARGS_JSON="${PATH_APP_HOME}/args.json"
+    ARGS_JSON="${PATH_ARGS_FILE}"
     assert_file_exist "${ARGS_JSON}"
     assert_file_contains "${ARGS_JSON}" '"--controllers"'
     assert_file_contains "${ARGS_JSON}" '"rdd"'

--- a/bats/tests/20-service/4-start-parameters.bats
+++ b/bats/tests/20-service/4-start-parameters.bats
@@ -61,7 +61,7 @@ assert_no_controllers() {
     run -0 rdd svc create --controllers="rdd"
 
     # Verify parameters were saved
-    ARGS_JSON="${PATH_ARGS_FILE}"
+    ARGS_JSON="${RDD_ARGS_FILE}"
     assert_file_exist "${ARGS_JSON}"
     assert_file_contains "${ARGS_JSON}" '"--controllers"'
     assert_file_contains "${ARGS_JSON}" '"rdd"'

--- a/bats/tests/20-service/5-port-fallback.bats
+++ b/bats/tests/20-service/5-port-fallback.bats
@@ -52,7 +52,7 @@ is_port_available() {
         skip "Port ${expected_port} is not available for testing"
     fi
 
-    ARGS_JSON="${PATH_APP_HOME}/args.json"
+    ARGS_JSON="${PATH_ARGS_FILE}"
     assert_file_exist "${ARGS_JSON}"
     assert_file_contains "${ARGS_JSON}" '"--secure-port"'
     assert_file_contains "${ARGS_JSON}" "\"${expected_port}\""
@@ -177,7 +177,7 @@ is_port_available() {
     rdd svc create --secure-port 7777 --controllers="rdd"
 
     # Verify the port is saved in args.json
-    ARGS_JSON="${PATH_APP_HOME}/args.json"
+    ARGS_JSON="${PATH_ARGS_FILE}"
     assert_file_exist "${ARGS_JSON}"
     assert_file_contains "${ARGS_JSON}" '"--secure-port"'
     assert_file_contains "${ARGS_JSON}" '"7777"'

--- a/bats/tests/20-service/5-port-fallback.bats
+++ b/bats/tests/20-service/5-port-fallback.bats
@@ -52,7 +52,7 @@ is_port_available() {
         skip "Port ${expected_port} is not available for testing"
     fi
 
-    ARGS_JSON="${PATH_ARGS_FILE}"
+    ARGS_JSON="${RDD_ARGS_FILE}"
     assert_file_exist "${ARGS_JSON}"
     assert_file_contains "${ARGS_JSON}" '"--secure-port"'
     assert_file_contains "${ARGS_JSON}" "\"${expected_port}\""
@@ -177,7 +177,7 @@ is_port_available() {
     rdd svc create --secure-port 7777 --controllers="rdd"
 
     # Verify the port is saved in args.json
-    ARGS_JSON="${PATH_ARGS_FILE}"
+    ARGS_JSON="${RDD_ARGS_FILE}"
     assert_file_exist "${ARGS_JSON}"
     assert_file_contains "${ARGS_JSON}" '"--secure-port"'
     assert_file_contains "${ARGS_JSON}" '"7777"'

--- a/bats/tests/33-lima-controllers/limavm-instance.bats
+++ b/bats/tests/33-lima-controllers/limavm-instance.bats
@@ -33,8 +33,8 @@ local_setup_file() {
 local_teardown_file() {
     # Clean up any remaining Lima instances
     for vm in "${VM_NAME}" "invalid-vm"; do
-        if [[ -d "${LIMA_HOME}/${vm}" ]]; then
-            rm -rf "${LIMA_HOME:?}/${vm}"
+        if [[ -d "${RDD_LIMA_HOME}/${vm}" ]]; then
+            rm -rf "${RDD_LIMA_HOME:?}/${vm}"
         fi
     done
 }
@@ -63,7 +63,7 @@ EOF
 
 lima_instance_exists() {
     local name=$1
-    [[ -d "${LIMA_HOME}/${name}" ]]
+    [[ -d "${RDD_LIMA_HOME}/${name}" ]]
 }
 
 assert_instance_created() {
@@ -108,7 +108,7 @@ assert_instance_create_failed() {
 }
 
 @test "verify Lima instance has lima.yaml file" {
-    assert_file_exists "${LIMA_HOME}/${VM_NAME}/lima.yaml"
+    assert_file_exists "${RDD_LIMA_HOME}/${VM_NAME}/lima.yaml"
 }
 
 @test "verify Created condition has correct reason" {
@@ -142,10 +142,10 @@ assert_instance_create_failed() {
 @test "create fake leftover Lima instance" {
     # Create a fake instance directory to simulate a leftover from a failed deletion.
     # The reconciler should clean this up before creating the real instance.
-    echo -n | create_file "${LIMA_HOME}/${VM_NAME}/lima.yaml"
-    echo -n | create_file "${LIMA_HOME}/${VM_NAME}/.fake-leftover"
-    echo "0.0.0" | create_file "${LIMA_HOME}/${VM_NAME}/lima-version"
-    assert_file_exists "${LIMA_HOME}/${VM_NAME}/.fake-leftover"
+    echo -n | create_file "${RDD_LIMA_HOME}/${VM_NAME}/lima.yaml"
+    echo -n | create_file "${RDD_LIMA_HOME}/${VM_NAME}/.fake-leftover"
+    echo "0.0.0" | create_file "${RDD_LIMA_HOME}/${VM_NAME}/lima-version"
+    assert_file_exists "${RDD_LIMA_HOME}/${VM_NAME}/.fake-leftover"
 }
 
 @test "create LimaVM with leftover instance present" {
@@ -160,9 +160,9 @@ assert_instance_create_failed() {
 
 @test "verify leftover was replaced with real instance" {
     # The fake leftover had a .fake-leftover sentinel file
-    assert_file_not_exists "${LIMA_HOME}/${VM_NAME}/.fake-leftover"
+    assert_file_not_exists "${RDD_LIMA_HOME}/${VM_NAME}/.fake-leftover"
     # Real instance should have images from template
-    run -0 cat "${LIMA_HOME}/${VM_NAME}/lima.yaml"
+    run -0 cat "${RDD_LIMA_HOME}/${VM_NAME}/lima.yaml"
     assert_output --partial "alpine-lima"
 }
 

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -29,8 +29,8 @@ local_setup_file() {
 
 local_teardown_file() {
     # Clean up any remaining Lima instances
-    if [[ -d "${LIMA_HOME}/${VM_NAME}" ]]; then
-        rm -rf "${LIMA_HOME:?}/${VM_NAME}"
+    if [[ -d "${RDD_LIMA_HOME}/${VM_NAME}" ]]; then
+        rm -rf "${RDD_LIMA_HOME:?}/${VM_NAME}"
     fi
 }
 
@@ -90,7 +90,7 @@ assert_stdout_logs_contain() {
 
 lima_instance_running() {
     local name=$1
-    assert_file_exists "${LIMA_HOME}/${name}/ha.pid"
+    assert_file_exists "${RDD_LIMA_HOME}/${name}/ha.pid"
 }
 
 get_instance_running_transition_time() {
@@ -101,7 +101,7 @@ get_instance_running_transition_time() {
 
 get_hostagent_pid() {
     local name=$1
-    cat "${LIMA_HOME}/${name}/ha.pid"
+    cat "${RDD_LIMA_HOME}/${name}/ha.pid"
 }
 
 assert_recovery_completed() {
@@ -245,7 +245,7 @@ EOF
 }
 
 @test "simulate crash by killing hostagent" {
-    local pid_file="${LIMA_HOME}/${VM_NAME}/ha.pid"
+    local pid_file="${RDD_LIMA_HOME}/${VM_NAME}/ha.pid"
     assert_file_exists "${pid_file}"
 
     # shellcheck disable=SC2030 # Persisted via save_var, not subshell
@@ -272,7 +272,7 @@ EOF
 }
 
 @test "verify new hostagent after crash recovery" {
-    local pid_file="${LIMA_HOME}/${VM_NAME}/ha.pid"
+    local pid_file="${RDD_LIMA_HOME}/${VM_NAME}/ha.pid"
     assert_file_exists "${pid_file}"
     local new_pid
     new_pid=$(get_hostagent_pid "${VM_NAME}")
@@ -291,7 +291,7 @@ EOF
 # without killing the VM process (which on VZ runs inside the hostagent).
 
 @test "simulate broken state by replacing hostagent socket" {
-    local sock_file="${LIMA_HOME}/${VM_NAME}/ha.sock"
+    local sock_file="${RDD_LIMA_HOME}/${VM_NAME}/ha.sock"
     assert_socket_exists "${sock_file}"
 
     # Replace the Unix socket with a regular file so Lima can't connect
@@ -316,7 +316,7 @@ EOF
 }
 
 @test "verify hostagent is alive after recovery" {
-    local pid_file="${LIMA_HOME}/${VM_NAME}/ha.pid"
+    local pid_file="${RDD_LIMA_HOME}/${VM_NAME}/ha.pid"
     assert_file_exists "${pid_file}"
     local pid
     pid=$(cat "${pid_file}")

--- a/bats/tests/34-containers-controllers/containers-mock.bats
+++ b/bats/tests/34-containers-controllers/containers-mock.bats
@@ -7,8 +7,8 @@ TEST_DATA_PATH="${PATH_BATS_ROOT}/../pkg/controllers/mock/testdata"
 
 local_setup_file() {
     setup_rdd_control_plane "containers"
-    echo "${PATH_LOGS}/mock-controller.log" >&3
-    "mock-controller${EXE}" &>"${PATH_LOGS}/mock-controller.log" &
+    echo "${RDD_LOG_DIR}/mock-controller.log" >&3
+    "mock-controller${EXE}" &>"${RDD_LOG_DIR}/mock-controller.log" &
     echo "$!" >"${BATS_FILE_TMPDIR}/controller_pid"
 }
 

--- a/cmd/rdd/kubectl.go
+++ b/cmd/rdd/kubectl.go
@@ -45,7 +45,7 @@ func ctlAction(cmd *cobra.Command, args []string) error {
 	if err := service.WaitWithTimeout(cmd.Context()); err != nil {
 		return err
 	}
-	if err := os.Setenv("KUBECONFIG", instance.KubeConfig()); err != nil {
+	if err := os.Setenv("KUBECONFIG", instance.Config()); err != nil {
 		return fmt.Errorf("failed to set KUBECONFIG: %w", err)
 	}
 	return kubectlAction(cmd, args)

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -48,6 +48,7 @@ func newServiceCommand(ctx context.Context) *cobra.Command {
 		newServiceDeleteCommand(),
 		newServiceStatusCommand(),
 		newServiceLogCommand(),
+		newServicePathsCommand(),
 	)
 	return command
 }
@@ -274,7 +275,7 @@ func newServiceLogCommand() *cobra.Command {
 			if ok, _ := cmd.Flags().GetBool("stdout"); ok {
 				name = "rdd.stdout.log"
 			}
-			logPath := filepath.Join(instance.Dir(), name)
+			logPath := filepath.Join(instance.LogDir(), name)
 			follow, _ := cmd.Flags().GetBool("follow")
 
 			return tail.TailFile(cmd.Context(), cmd.OutOrStdout(), logPath, follow)

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -23,9 +23,9 @@ import (
 func logrusLevelToKlog() string {
 	switch logrus.GetLevel() {
 	case logrus.DebugLevel:
-		return "1"
-	case logrus.TraceLevel:
 		return "2"
+	case logrus.TraceLevel:
+		return "4"
 	default:
 		return "0"
 	}

--- a/cmd/rdd/service_paths.go
+++ b/cmd/rdd/service_paths.go
@@ -6,11 +6,11 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
@@ -37,16 +37,16 @@ func newServicePathsCommand() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  servicePathsAction,
 	}
-	command.Flags().Bool("json", false, "Output as JSON")
-	command.Flags().Bool("shell", false, "Output as shell export statements")
+	command.Flags().StringP("output", "o", "table", "Output format: table, json, or shell")
 	return command
 }
 
 func servicePathsAction(cmd *cobra.Command, args []string) error {
-	asJSON, _ := cmd.Flags().GetBool("json")
-	asShell, _ := cmd.Flags().GetBool("shell")
-	if asJSON && asShell {
-		return errors.New("--json and --shell are mutually exclusive")
+	format, _ := cmd.Flags().GetString("output")
+	switch format {
+	case "table", "json", "shell":
+	default:
+		return fmt.Errorf("unknown output format %q; valid formats: table, json, shell", format)
 	}
 
 	paths := instancePaths()
@@ -58,7 +58,7 @@ func servicePathsAction(cmd *cobra.Command, args []string) error {
 		if _, ok := paths[key]; !ok {
 			return fmt.Errorf("unknown key %q; valid keys: %s", key, strings.Join(keys, ", "))
 		}
-		if !asJSON && !asShell {
+		if format == "table" {
 			_, err := fmt.Fprintln(cmd.OutOrStdout(), paths[key])
 			return err
 		}
@@ -66,14 +66,14 @@ func servicePathsAction(cmd *cobra.Command, args []string) error {
 	}
 
 	w := cmd.OutOrStdout()
-	switch {
-	case asJSON:
+	switch format {
+	case "json":
 		m := make(map[string]string, len(keys))
 		for _, key := range keys {
 			m[key] = paths[key]
 		}
 		return json.NewEncoder(w).Encode(m)
-	case asShell:
+	case "shell":
 		for _, key := range keys {
 			if _, err := fmt.Fprintf(w, "export RDD_%s=%q\n", strings.ToUpper(key), paths[key]); err != nil {
 				return err
@@ -81,17 +81,10 @@ func servicePathsAction(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	default:
-		maxKey := 0
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 		for _, key := range keys {
-			if len(key) > maxKey {
-				maxKey = len(key)
-			}
+			fmt.Fprintf(tw, "%s\t%s\n", key, paths[key])
 		}
-		for _, key := range keys {
-			if _, err := fmt.Fprintf(w, "%-*s  %s\n", maxKey, key, paths[key]); err != nil {
-				return err
-			}
-		}
-		return nil
+		return tw.Flush()
 	}
 }

--- a/cmd/rdd/service_paths.go
+++ b/cmd/rdd/service_paths.go
@@ -19,14 +19,14 @@ import (
 
 func instancePaths() map[string]string {
 	return map[string]string{
-		"dir":        instance.Dir(),
-		"log_dir":    instance.LogDir(),
-		"short_dir":  instance.ShortDir(),
-		"lima_home":  instance.LimaHome(),
-		"tls_dir":    instance.TLSDir(),
-		"kubeconfig": instance.KubeConfig(),
-		"pid_file":   instance.PIDFile(),
-		"args_file":  instance.ArgsFile(),
+		"dir":       instance.Dir(),
+		"log_dir":   instance.LogDir(),
+		"short_dir": instance.ShortDir(),
+		"lima_home": instance.LimaHome(),
+		"tls_dir":   instance.TLSDir(),
+		"config":    instance.Config(),
+		"pid_file":  instance.PIDFile(),
+		"args_file": instance.ArgsFile(),
 	}
 }
 

--- a/cmd/rdd/service_paths.go
+++ b/cmd/rdd/service_paths.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+)
+
+func instancePaths() map[string]string {
+	return map[string]string{
+		"dir":        instance.Dir(),
+		"log_dir":    instance.LogDir(),
+		"short_dir":  instance.ShortDir(),
+		"lima_home":  instance.LimaHome(),
+		"tls_dir":    instance.TLSDir(),
+		"kubeconfig": instance.KubeConfig(),
+		"pid_file":   instance.PIDFile(),
+		"args_file":  instance.ArgsFile(),
+	}
+}
+
+func newServicePathsCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "paths [key]",
+		Short: "Print instance paths",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  servicePathsAction,
+	}
+	command.Flags().Bool("json", false, "Output as JSON")
+	command.Flags().Bool("shell", false, "Output as shell export statements")
+	return command
+}
+
+func servicePathsAction(cmd *cobra.Command, args []string) error {
+	asJSON, _ := cmd.Flags().GetBool("json")
+	asShell, _ := cmd.Flags().GetBool("shell")
+	if asJSON && asShell {
+		return errors.New("--json and --shell are mutually exclusive")
+	}
+
+	paths := instancePaths()
+	keys := slices.Sorted(maps.Keys(paths))
+
+	// Filter to a single key if specified.
+	if len(args) == 1 {
+		key := args[0]
+		if _, ok := paths[key]; !ok {
+			return fmt.Errorf("unknown key %q; valid keys: %s", key, strings.Join(keys, ", "))
+		}
+		if !asJSON && !asShell {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), paths[key])
+			return err
+		}
+		keys = []string{key}
+	}
+
+	w := cmd.OutOrStdout()
+	switch {
+	case asJSON:
+		m := make(map[string]string, len(keys))
+		for _, key := range keys {
+			m[key] = paths[key]
+		}
+		return json.NewEncoder(w).Encode(m)
+	case asShell:
+		for _, key := range keys {
+			if _, err := fmt.Fprintf(w, "export RDD_%s=%q\n", strings.ToUpper(key), paths[key]); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		maxKey := 0
+		for _, key := range keys {
+			if len(key) > maxKey {
+				maxKey = len(key)
+			}
+		}
+		for _, key := range keys {
+			if _, err := fmt.Fprintf(w, "%-*s  %s\n", maxKey, key, paths[key]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/cmd/rdd/service_paths.go
+++ b/cmd/rdd/service_paths.go
@@ -30,6 +30,14 @@ func instancePaths() map[string]string {
 	}
 }
 
+const (
+	outputTable = "table"
+	outputJSON  = "json"
+	outputShell = "shell"
+)
+
+var validOutputFormats = fmt.Sprintf("%s, %s, or %s", outputTable, outputJSON, outputShell)
+
 func newServicePathsCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "paths [key]",
@@ -37,16 +45,16 @@ func newServicePathsCommand() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  servicePathsAction,
 	}
-	command.Flags().StringP("output", "o", "table", "Output format: table, json, or shell")
+	command.Flags().StringP("output", "o", outputTable, "Output format: "+validOutputFormats)
 	return command
 }
 
 func servicePathsAction(cmd *cobra.Command, args []string) error {
 	format, _ := cmd.Flags().GetString("output")
 	switch format {
-	case "table", "json", "shell":
+	case outputTable, outputJSON, outputShell:
 	default:
-		return fmt.Errorf("unknown output format %q; valid formats: table, json, shell", format)
+		return fmt.Errorf("unknown output format %q; valid formats: %s", format, validOutputFormats)
 	}
 
 	paths := instancePaths()
@@ -58,7 +66,7 @@ func servicePathsAction(cmd *cobra.Command, args []string) error {
 		if _, ok := paths[key]; !ok {
 			return fmt.Errorf("unknown key %q; valid keys: %s", key, strings.Join(keys, ", "))
 		}
-		if format == "table" {
+		if format == outputTable {
 			_, err := fmt.Fprintln(cmd.OutOrStdout(), paths[key])
 			return err
 		}
@@ -67,13 +75,13 @@ func servicePathsAction(cmd *cobra.Command, args []string) error {
 
 	w := cmd.OutOrStdout()
 	switch format {
-	case "json":
+	case outputJSON:
 		m := make(map[string]string, len(keys))
 		for _, key := range keys {
 			m[key] = paths[key]
 		}
 		return json.NewEncoder(w).Encode(m)
-	case "shell":
+	case outputShell:
 		for _, key := range keys {
 			if _, err := fmt.Fprintf(w, "export RDD_%s=%q\n", strings.ToUpper(key), paths[key]); err != nil {
 				return err

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -128,7 +128,7 @@ Prints instance directory and file paths. Accepts an optional key argument to pr
 | `short_dir` | Short directory (e.g. `~/.rd2`) |
 | `lima_home` | Lima home directory (`$short_dir/lima`) |
 | `tls_dir` | TLS certificate directory |
-| `kubeconfig` | Kubeconfig file path |
+| `config` | RDD control plane config file path |
 | `pid_file` | PID file path |
 | `args_file` | Saved arguments file path |
 

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -117,6 +117,42 @@ Show control plane logs.
 - `--stdout` (`-o`): Print stdout instead of stderr (default is stderr)
 - `--follow` (`-f`): Follow log output
 
+## `rdd service paths`
+
+Prints instance directory and file paths. Accepts an optional key argument to print a single path.
+
+| Key | Description |
+| --- | --- |
+| `dir` | Service directory (`$APPDATA/rancher-desktop-$INSTANCE`) |
+| `log_dir` | Log directory |
+| `short_dir` | Short directory (e.g. `~/.rd2`) |
+| `lima_home` | Lima home directory (`$short_dir/lima`) |
+| `tls_dir` | TLS certificate directory |
+| `kubeconfig` | Kubeconfig file path |
+| `pid_file` | PID file path |
+| `args_file` | Saved arguments file path |
+
+Output formats:
+
+*   Default: aligned key-value table for human readability.
+
+*   `--json`: JSON object with all keys.
+
+*   `--shell`: `export` statements with `RDD_` prefix suitable for `source`, e.g. `export RDD_LOG_DIR="/path/to/logs"`.
+
+Examples:
+
+```shell
+# Print all paths
+rdd svc paths
+
+# Get just the log directory
+rdd svc paths log_dir
+
+# Source paths into the current shell
+source <(rdd svc paths --shell)
+```
+
 ## `rdd service config`
 
 Prints a kube config with context and service account[^sa] setup to give access to the RDD control plane.

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -132,13 +132,13 @@ Prints instance directory and file paths. Accepts an optional key argument to pr
 | `pid_file` | PID file path |
 | `args_file` | Saved arguments file path |
 
-Output formats:
+Output formats (`--output`, `-o`):
 
-*   Default: aligned key-value table for human readability.
+*   `table` (default): aligned key-value table for human readability.
 
-*   `--json`: JSON object with all keys.
+*   `json`: JSON object with all keys.
 
-*   `--shell`: `export` statements with `RDD_` prefix suitable for `source`, e.g. `export RDD_LOG_DIR="/path/to/logs"`.
+*   `shell`: `export` statements with `RDD_` prefix suitable for `source`, e.g. `export RDD_LOG_DIR="/path/to/logs"`.
 
 Examples:
 
@@ -150,7 +150,7 @@ rdd svc paths
 rdd svc paths log_dir
 
 # Source paths into the current shell
-source <(rdd svc paths --shell)
+source <(rdd svc paths --output=shell)
 ```
 
 ## `rdd service config`

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -140,17 +140,25 @@ Output formats (`--output`, `-o`):
 
 *   `shell`: `export` statements with `RDD_` prefix suitable for `source`, e.g. `export RDD_LOG_DIR="/path/to/logs"`.
 
+With a key argument and table output, only the value is printed (no key prefix), so the result can be used directly in scripts.
+
 Examples:
 
-```shell
-# Print all paths
-rdd svc paths
+```console
+$ rdd svc paths
+args_file  /path/to/rancher-desktop-default/rdd.args
+config     /path/to/rancher-desktop-default/config.json
+dir        /path/to/rancher-desktop-default
+lima_home  /path/to/.rd2/lima
+log_dir    /path/to/rancher-desktop-default/log
+pid_file   /path/to/rancher-desktop-default/rdd.pid
+short_dir  /path/to/.rd2
+tls_dir    /path/to/rancher-desktop-default/tls
 
-# Get just the log directory
-rdd svc paths log_dir
+$ rdd svc paths log_dir
+/path/to/rancher-desktop-default/log
 
-# Source paths into the current shell
-source <(rdd svc paths --output=shell)
+$ source <(rdd svc paths --output=shell)
 ```
 
 ## `rdd service config`

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -24,19 +24,19 @@ These variables configure the BATS test framework. They have no effect on `rdd` 
 
 ## Path Variables
 
-`rdd svc paths --shell` exports these variables. They reflect the paths RDD uses for the current instance; setting them has no effect on RDD's behavior.
+`rdd svc paths --output=shell` exports these variables. They reflect the paths RDD uses for the current instance; setting them has no effect on RDD's behavior.
 
 ```shell
-source <(rdd svc paths --shell)
+source <(rdd svc paths --output=shell)
 ```
 
 | Variable | Description | Example (macOS, instance `2`) |
 | --- | --- | --- |
 | `RDD_ARGS_FILE` | Saved startup arguments | `~/Library/Application Support/rancher-desktop-2/args.json` |
 | `RDD_DIR` | Service instance directory | `~/Library/Application Support/rancher-desktop-2` |
-| `RDD_KUBECONFIG` | Kubeconfig file | `~/.rd2/kube.config` |
+| `RDD_KUBECONFIG` | Kubeconfig file | `~/Library/Application Support/rancher-desktop-2/kubeconfig.yaml` |
 | `RDD_LIMA_HOME` | Lima home directory | `~/.rd2/lima` |
-| `RDD_LOG_DIR` | Log directory (survives instance deletion) | `~/Library/Logs/rancher-desktop-2` |
+| `RDD_LOG_DIR` | Log directory | `~/Library/Logs/rancher-desktop-2` |
 | `RDD_PID_FILE` | Service PID file | `~/Library/Application Support/rancher-desktop-2/rdd.pid` |
 | `RDD_SHORT_DIR` | Short directory path | `~/.rd2` |
 | `RDD_TLS_DIR` | TLS certificate directory | `~/Library/Application Support/rancher-desktop-2/tls` |

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -34,7 +34,7 @@ source <(rdd svc paths --output=shell)
 | --- | --- | --- |
 | `RDD_ARGS_FILE` | Saved startup arguments | `~/Library/Application Support/rancher-desktop-2/args.json` |
 | `RDD_DIR` | Service instance directory | `~/Library/Application Support/rancher-desktop-2` |
-| `RDD_KUBECONFIG` | Kubeconfig file | `~/Library/Application Support/rancher-desktop-2/kubeconfig.yaml` |
+| `RDD_CONFIG` | RDD control plane config file | `~/Library/Application Support/rancher-desktop-2/config.yaml` |
 | `RDD_LIMA_HOME` | Lima home directory | `~/.rd2/lima` |
 | `RDD_LOG_DIR` | Log directory | `~/Library/Logs/rancher-desktop-2` |
 | `RDD_PID_FILE` | Service PID file | `~/Library/Application Support/rancher-desktop-2/rdd.pid` |

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -1,0 +1,50 @@
+# Environment Variables
+
+RDD uses environment variables prefixed with `RDD_` for configuration and path discovery.
+
+## Configuration Variables
+
+These variables control RDD behavior. Set them before running `rdd` commands.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `RDD_INSTANCE` | Instance identifier. Determines which control plane and directories to use. Also settable via `rdd --instance`. | `2` |
+| `RDD_DEVELOPER_MODE` | Enables developer mode: exposes hidden CLI flags, detects source tree for local builds. | unset |
+| `RDD_KEEP_LOGS` | When set to any non-empty value, preserves numbered log files instead of pruning old ones. Also prevents log directory removal on `rdd svc delete`. | unset |
+| `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
+
+### BATS Test Variables
+
+These variables configure the BATS test framework. They have no effect on `rdd` itself.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `RDD_TRACE` | Enables verbose trace output in BATS tests. | `false` |
+| `RDD_NAMESPACE` | Default Kubernetes namespace for BATS controller tests. | `default` |
+
+## Path Variables
+
+`rdd svc paths --shell` exports these variables. They reflect the paths RDD uses for the current instance; setting them has no effect on RDD's behavior.
+
+```shell
+source <(rdd svc paths --shell)
+```
+
+| Variable | Description | Example (macOS, instance `2`) |
+| --- | --- | --- |
+| `RDD_ARGS_FILE` | Saved startup arguments | `~/Library/Application Support/rancher-desktop-2/args.json` |
+| `RDD_DIR` | Service instance directory | `~/Library/Application Support/rancher-desktop-2` |
+| `RDD_KUBECONFIG` | Kubeconfig file | `~/.rd2/kube.config` |
+| `RDD_LIMA_HOME` | Lima home directory | `~/.rd2/lima` |
+| `RDD_LOG_DIR` | Log directory (survives instance deletion) | `~/Library/Logs/rancher-desktop-2` |
+| `RDD_PID_FILE` | Service PID file | `~/Library/Application Support/rancher-desktop-2/rdd.pid` |
+| `RDD_SHORT_DIR` | Short directory path | `~/.rd2` |
+| `RDD_TLS_DIR` | TLS certificate directory | `~/Library/Application Support/rancher-desktop-2/tls` |
+
+The short directory (`RDD_SHORT_DIR`) exists because Lima uses Unix domain sockets with a 104-byte path limit. Placing `LIMA_HOME` under `~/.rd2/lima` instead of the full application support path keeps socket paths short enough.
+
+Path variables are listed alphabetically. To retrieve a single path, pass the key name (lowercase, without the `RDD_` prefix):
+
+```shell
+rdd svc paths log_dir
+```

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -222,8 +222,8 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	}
 	args = append(args, inst.Name)
 
-	// Create numbered log files with symlinks. The symlink names (ha.stdout.log,
-	// ha.stderr.log) match what Lima expects, so StopGracefully follows them.
+	// Create rotated log files. The active names (ha.stdout.log, ha.stderr.log)
+	// match what Lima expects for StopGracefully.
 	keepLogs := os.Getenv("RDD_KEEP_LOGS") != ""
 	title := os.Getenv("RDD_LOG_TITLE")
 	var header string

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -6,6 +6,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/logfile"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
 )
 
@@ -208,7 +210,6 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	// Build hostagent command arguments
 	haPIDPath := filepath.Join(inst.Dir, filenames.HostAgentPID)
 	haSockPath := filepath.Join(inst.Dir, filenames.HostAgentSock)
-	haStdoutPath := filepath.Join(inst.Dir, filenames.HostAgentStdoutLog)
 	haStderrPath := filepath.Join(inst.Dir, filenames.HostAgentStderrLog)
 
 	args := []string{
@@ -221,8 +222,20 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	}
 	args = append(args, inst.Name)
 
-	// Create log files for hostagent output (os.Create truncates existing files)
-	haStdoutW, err := os.Create(haStdoutPath)
+	// Create numbered log files with symlinks. The symlink names (ha.stdout.log,
+	// ha.stderr.log) match what Lima expects, so StopGracefully follows them.
+	keepLogs := os.Getenv("RDD_KEEP_LOGS") != ""
+	title := os.Getenv("RDD_LOG_TITLE")
+	var header string
+	if title != "" {
+		// JSONL format: Lima's event watcher parses it as a zero-value Event
+		// and skips it; PropagateJSON logs it as a raw info line.
+		b, _ := json.Marshal(struct {
+			Title string `json:"title"`
+		}{title})
+		header = string(b) + "\n"
+	}
+	haStdoutW, err := logfile.Create(inst.Dir, "ha.stdout", keepLogs, header)
 	if err != nil {
 		logger.Error(err, "Failed to create stdout log file")
 		if updateErr := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStartFailed, err.Error()); updateErr != nil {
@@ -231,7 +244,7 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 		return ctrl.Result{}, err
 	}
 	defer haStdoutW.Close()
-	haStderrW, err := os.Create(haStderrPath)
+	haStderrW, err := logfile.Create(inst.Dir, "ha.stderr", keepLogs, header)
 	if err != nil {
 		logger.Error(err, "Failed to create stderr log file")
 		if updateErr := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStartFailed, err.Error()); updateErr != nil {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -82,8 +82,8 @@ var ArgsFile = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "args.json")
 })
 
-var KubeConfig = sync.OnceValue(func() string {
-	return filepath.Join(Dir(), "kubeconfig.yaml")
+var Config = sync.OnceValue(func() string {
+	return filepath.Join(Dir(), "config.yaml")
 })
 
 var PIDFile = sync.OnceValue(func() string {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -58,6 +58,26 @@ var Dir = sync.OnceValue(func() string {
 	}
 })
 
+// LogDir returns the OS-specific log directory for this instance.
+// Logs are stored separately from instance data so they can be preserved
+// independently (e.g., when deleting an instance but keeping logs for debugging).
+var LogDir = sync.OnceValue(func() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(fmt.Errorf("could not get home directory: %w", err))
+	}
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join(home, "AppData", "Local", Name()+"-logs")
+	case "linux":
+		return filepath.Join(home, ".local", "state", Name())
+	case "darwin":
+		return filepath.Join(home, "Library", "Logs", Name())
+	default:
+		panic(fmt.Sprintf("platform %s not supported", runtime.GOOS))
+	}
+})
+
 var ArgsFile = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "args.json")
 })

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -85,9 +85,9 @@ func GetKubeconfig() ([]byte, error) {
 	if !Running() {
 		return nil, fmt.Errorf("control plane %q is not running", instance.Name())
 	}
-	data, err := os.ReadFile(instance.KubeConfig())
+	data, err := os.ReadFile(instance.Config())
 	if err != nil {
-		return nil, fmt.Errorf("could not read kubeconfig from %s: %w (control plane may still be starting)", instance.KubeConfig(), err)
+		return nil, fmt.Errorf("could not read config from %s: %w (control plane may still be starting)", instance.Config(), err)
 	}
 	return data, nil
 }
@@ -108,8 +108,8 @@ func storeKubeConfigToDisk(adminToken, userToken, serverURL, tlsServerName strin
 	if err != nil {
 		return fmt.Errorf("failed to marshal kubeconfig: %w", err)
 	}
-	if err := os.WriteFile(instance.KubeConfig(), data, 0o600); err != nil {
-		return fmt.Errorf("failed to write kubeconfig to %s: %w", instance.KubeConfig(), err)
+	if err := os.WriteFile(instance.Config(), data, 0o600); err != nil {
+		return fmt.Errorf("failed to write config to %s: %w", instance.Config(), err)
 	}
 	return nil
 }
@@ -366,14 +366,14 @@ func StopWithWait(wait bool) error {
 				return fmt.Errorf("timed out waiting for %q control plane with pid %d to stop", instance.Name(), pid)
 			case <-ticker.C:
 				if !Running() {
-					_ = os.Remove(instance.KubeConfig()) // Ignore error as file might not exist
+					_ = os.Remove(instance.Config()) // Ignore error as file might not exist
 					return nil
 				}
 			}
 		}
 	}
 
-	_ = os.Remove(instance.KubeConfig()) // Ignore error as file might not exist
+	_ = os.Remove(instance.Config()) // Ignore error as file might not exist
 	return nil
 }
 

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -67,6 +66,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/datastore"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/readiness"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/logfile"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
 )
 
@@ -213,20 +213,17 @@ func Start(ctx context.Context, args []string) error {
 		return fmt.Errorf("%q control plane is already running", instance.Name())
 	}
 
-	// TODO The log files should eventually move to the log directory
-	stdoutPath := filepath.Join(instance.Dir(), "rdd.stdout.log")
-	stderrPath := filepath.Join(instance.Dir(), "rdd.stderr.log")
-	if err := os.RemoveAll(stdoutPath); err != nil {
-		return err
+	keepLogs := os.Getenv("RDD_KEEP_LOGS") != ""
+	title := os.Getenv("RDD_LOG_TITLE")
+	var header string
+	if title != "" {
+		header = "=== " + title + " ===\n"
 	}
-	if err := os.RemoveAll(stderrPath); err != nil {
-		return err
-	}
-	stdout, err := os.Create(stdoutPath)
+	stdout, err := logfile.Create(instance.LogDir(), "rdd.stdout", keepLogs, header)
 	if err != nil {
 		return err
 	}
-	stderr, err := os.Create(stderrPath)
+	stderr, err := logfile.Create(instance.LogDir(), "rdd.stderr", keepLogs, header)
 	if err != nil {
 		return err
 	}
@@ -413,6 +410,9 @@ func Delete() error {
 		return fmt.Errorf("%q control plane does not exist", instance.Name())
 	}
 	_ = Stop()
+	if os.Getenv("RDD_KEEP_LOGS") == "" {
+		_ = os.RemoveAll(instance.LogDir())
+	}
 	return os.RemoveAll(instance.Dir())
 }
 

--- a/pkg/util/logfile/logfile.go
+++ b/pkg/util/logfile/logfile.go
@@ -2,11 +2,10 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package logfile creates sequentially numbered log files with symlinks.
+// Package logfile creates log files with automatic rotation.
 //
-// Each call to Create opens the next numbered file ({name}.{N}.log) and
-// updates a symlink ({name}.log) pointing to it. Callers that open the
-// symlink (e.g., tail -f, Lima's StopGracefully) follow it transparently.
+// Each call to Create renames any existing {name}.log to {name}.{N}.log
+// and opens a fresh {name}.log. The active log always has a stable name.
 package logfile
 
 import (
@@ -24,11 +23,11 @@ type numberedFile struct {
 	name string
 }
 
-// Create opens the next numbered log file in dir and updates the symlink.
+// Create opens a new log file named {name}.log in dir, renaming any
+// existing {name}.log to {name}.{N}.log first.
 //
-// File naming: {name}.{N}.log, with symlink {name}.log -> {name}.{N}.log.
-// When keepAll is false, numbered files beyond the retention count are removed.
-// If header is non-empty, it is written as the first line of the new file.
+// When keepAll is false, old numbered files beyond the retention count
+// are removed. If header is non-empty, it is written as the first line.
 func Create(dir, name string, keepAll bool, header string) (*os.File, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("create log directory %s: %w", dir, err)
@@ -60,8 +59,16 @@ func Create(dir, name string, keepAll bool, header string) (*os.File, error) {
 	}
 
 	nextN := maxN + 1
-	fileName := fmt.Sprintf("%s.%d.log", name, nextN)
-	filePath := filepath.Join(dir, fileName)
+	filePath := filepath.Join(dir, name+".log")
+
+	// Rename the current log to a numbered backup.
+	if _, err := os.Lstat(filePath); err == nil {
+		numberedName := fmt.Sprintf("%s.%d.log", name, nextN)
+		if err := os.Rename(filePath, filepath.Join(dir, numberedName)); err != nil {
+			return nil, fmt.Errorf("rename %s to %s: %w", filePath, numberedName, err)
+		}
+		numberedFiles = append(numberedFiles, numberedFile{n: nextN, name: numberedName})
+	}
 
 	f, err := os.Create(filePath)
 	if err != nil {
@@ -71,16 +78,9 @@ func Create(dir, name string, keepAll bool, header string) (*os.File, error) {
 	if header != "" {
 		if _, err := f.WriteString(header); err != nil {
 			f.Close()
+			os.Remove(filePath)
 			return nil, fmt.Errorf("write header to %s: %w", filePath, err)
 		}
-	}
-
-	// Update symlink: remove old one first (Symlink fails if target exists).
-	symlinkPath := filepath.Join(dir, name+".log")
-	_ = os.Remove(symlinkPath)
-	if err := os.Symlink(fileName, symlinkPath); err != nil {
-		// Non-fatal: the file is still usable, just without the symlink.
-		fmt.Fprintf(os.Stderr, "logfile: failed to create symlink %s -> %s: %v\n", symlinkPath, fileName, err)
 	}
 
 	if !keepAll {

--- a/pkg/util/logfile/logfile.go
+++ b/pkg/util/logfile/logfile.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package logfile creates sequentially numbered log files with symlinks.
+//
+// Each call to Create opens the next numbered file ({name}.{N}.log) and
+// updates a symlink ({name}.log) pointing to it. Callers that open the
+// symlink (e.g., tail -f, Lima's StopGracefully) follow it transparently.
+package logfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+)
+
+const retentionCount = 5
+
+type numberedFile struct {
+	n    int
+	name string
+}
+
+// Create opens the next numbered log file in dir and updates the symlink.
+//
+// File naming: {name}.{N}.log, with symlink {name}.log -> {name}.{N}.log.
+// When keepAll is false, numbered files beyond the retention count are removed.
+// If header is non-empty, it is written as the first line of the new file.
+func Create(dir, name string, keepAll bool, header string) (*os.File, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create log directory %s: %w", dir, err)
+	}
+
+	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `\.(\d+)\.log$`)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read log directory %s: %w", dir, err)
+	}
+
+	// Find the highest existing sequence number.
+	maxN := 0
+	var numberedFiles []numberedFile
+	for _, entry := range entries {
+		matches := pattern.FindStringSubmatch(entry.Name())
+		if matches == nil {
+			continue
+		}
+		n, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+		numberedFiles = append(numberedFiles, numberedFile{n: n, name: entry.Name()})
+		if n > maxN {
+			maxN = n
+		}
+	}
+
+	nextN := maxN + 1
+	fileName := fmt.Sprintf("%s.%d.log", name, nextN)
+	filePath := filepath.Join(dir, fileName)
+
+	f, err := os.Create(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("create log file %s: %w", filePath, err)
+	}
+
+	if header != "" {
+		if _, err := f.WriteString(header); err != nil {
+			f.Close()
+			return nil, fmt.Errorf("write header to %s: %w", filePath, err)
+		}
+	}
+
+	// Update symlink: remove old one first (Symlink fails if target exists).
+	symlinkPath := filepath.Join(dir, name+".log")
+	_ = os.Remove(symlinkPath)
+	if err := os.Symlink(fileName, symlinkPath); err != nil {
+		// Non-fatal: the file is still usable, just without the symlink.
+		fmt.Fprintf(os.Stderr, "logfile: failed to create symlink %s -> %s: %v\n", symlinkPath, fileName, err)
+	}
+
+	if !keepAll {
+		pruneOldFiles(dir, numberedFiles, nextN)
+	}
+
+	return f, nil
+}
+
+// pruneOldFiles removes numbered log files beyond the retention count,
+// keeping the most recent files (those with the highest sequence numbers).
+func pruneOldFiles(dir string, files []numberedFile, currentN int) {
+	// Keep files with sequence numbers > currentN - retentionCount.
+	cutoff := currentN - retentionCount
+	for _, nf := range files {
+		if nf.n <= cutoff {
+			_ = os.Remove(filepath.Join(dir, nf.name))
+		}
+	}
+}

--- a/pkg/util/logfile/logfile_test.go
+++ b/pkg/util/logfile/logfile_test.go
@@ -5,10 +5,9 @@
 package logfile
 
 import (
-	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -21,14 +20,11 @@ func TestCreateFirstFile(t *testing.T) {
 	assert.NilError(t, err)
 	f.Close()
 
-	// Should create test.1.log
+	// Should create test.log directly (no numbered file on first call)
+	_, err = os.Stat(filepath.Join(dir, "test.log"))
+	assert.NilError(t, err, "expected test.log to exist")
 	_, err = os.Stat(filepath.Join(dir, "test.1.log"))
-	assert.NilError(t, err, "expected test.1.log to exist")
-
-	// Should create symlink test.log -> test.1.log
-	target, err := os.Readlink(filepath.Join(dir, "test.log"))
-	assert.NilError(t, err)
-	assert.Equal(t, target, "test.1.log")
+	assert.Assert(t, os.IsNotExist(err), "expected no test.1.log on first call")
 }
 
 func TestSequentialNumbering(t *testing.T) {
@@ -40,60 +36,71 @@ func TestSequentialNumbering(t *testing.T) {
 		f.Close()
 	}
 
-	// All three files should exist
-	for i := 1; i <= 3; i++ {
-		name := filepath.Join(dir, "app."+itoa(i)+".log")
+	// Active file should exist
+	_, err := os.Stat(filepath.Join(dir, "app.log"))
+	assert.NilError(t, err, "expected app.log to exist")
+
+	// Two numbered backups should exist (from calls 2 and 3)
+	for i := 1; i <= 2; i++ {
+		name := filepath.Join(dir, fmt.Sprintf("app.%d.log", i))
 		_, err := os.Stat(name)
 		assert.NilError(t, err, "expected %s to exist", name)
 	}
 
-	// Symlink should point to the latest
-	target, err := os.Readlink(filepath.Join(dir, "app.log"))
-	assert.NilError(t, err)
-	assert.Equal(t, target, "app.3.log")
+	// No app.3.log (the third call created app.log, not a numbered file)
+	_, err = os.Stat(filepath.Join(dir, "app.3.log"))
+	assert.Assert(t, os.IsNotExist(err), "expected no app.3.log")
 }
 
 func TestPruning(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create 7 files with pruning enabled
-	for i := range 7 {
+	// Create enough files to trigger pruning.
+	// Call 1 creates prune.log (no rename). Subsequent calls rename to numbered files.
+	count := retentionCount + 2
+	for i := 1; i <= count; i++ {
 		f, err := Create(dir, "prune", false, "")
-		assert.NilError(t, err, "Create #%d", i+1)
+		assert.NilError(t, err, "Create #%d", i)
 		f.Close()
 	}
 
-	// Files 1 and 2 should be pruned (7 - 5 = 2)
-	for _, n := range []int{1, 2} {
-		name := filepath.Join(dir, "prune."+itoa(n)+".log")
-		_, err := os.Stat(name)
-		assert.Assert(t, os.IsNotExist(err), "expected %s to be pruned", name)
-	}
+	// File 1 should be pruned
+	name := filepath.Join(dir, "prune.1.log")
+	_, err := os.Stat(name)
+	assert.Assert(t, os.IsNotExist(err), "expected %s to be pruned", name)
 
-	// Files 3-7 should still exist
-	for _, n := range []int{3, 4, 5, 6, 7} {
-		name := filepath.Join(dir, "prune."+itoa(n)+".log")
+	// Remaining numbered files should still exist
+	for n := 2; n <= count-1; n++ {
+		name := filepath.Join(dir, fmt.Sprintf("prune.%d.log", n))
 		_, err := os.Stat(name)
 		assert.NilError(t, err, "expected %s to exist", name)
 	}
+
+	// Active file should exist
+	_, err = os.Stat(filepath.Join(dir, "prune.log"))
+	assert.NilError(t, err, "expected prune.log to exist")
 }
 
 func TestKeepAll(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create 7 files with keepAll=true
-	for i := range 7 {
+	for i := 1; i <= 7; i++ {
 		f, err := Create(dir, "keep", true, "")
-		assert.NilError(t, err, "Create #%d", i+1)
+		assert.NilError(t, err, "Create #%d", i)
 		f.Close()
 	}
 
-	// All files should exist
-	for n := 1; n <= 7; n++ {
-		name := filepath.Join(dir, "keep."+itoa(n)+".log")
+	// All numbered backups (1-6) should exist
+	for n := 1; n <= 6; n++ {
+		name := filepath.Join(dir, fmt.Sprintf("keep.%d.log", n))
 		_, err := os.Stat(name)
 		assert.NilError(t, err, "expected %s to exist", name)
 	}
+
+	// Active file should exist
+	_, err := os.Stat(filepath.Join(dir, "keep.log"))
+	assert.NilError(t, err, "expected keep.log to exist")
 }
 
 func TestHeader(t *testing.T) {
@@ -104,7 +111,7 @@ func TestHeader(t *testing.T) {
 	assert.NilError(t, err)
 	f.Close()
 
-	data, err := os.ReadFile(filepath.Join(dir, "header.1.log"))
+	data, err := os.ReadFile(filepath.Join(dir, "header.log"))
 	assert.NilError(t, err)
 	assert.Equal(t, string(data), header)
 }
@@ -114,22 +121,30 @@ func TestGapsInNumbering(t *testing.T) {
 
 	// Manually create files with gaps: 1, 3, 5
 	for _, n := range []int{1, 3, 5} {
-		f, err := os.Create(filepath.Join(dir, "gap."+itoa(n)+".log"))
+		f, err := os.Create(filepath.Join(dir, fmt.Sprintf("gap.%d.log", n)))
 		assert.NilError(t, err, "create gap file")
 		f.Close()
 	}
 
-	// Next file should be 6 (max=5, next=6)
+	// No gap.log exists, so nothing to rename. Active file is gap.log.
 	f, err := Create(dir, "gap", false, "")
 	assert.NilError(t, err)
 	f.Close()
 
-	_, err = os.Stat(filepath.Join(dir, "gap.6.log"))
-	assert.NilError(t, err, "expected gap.6.log to exist")
+	_, err = os.Stat(filepath.Join(dir, "gap.log"))
+	assert.NilError(t, err, "expected gap.log to exist")
 
-	target, err := os.Readlink(filepath.Join(dir, "gap.log"))
-	assert.NilError(t, err)
-	assert.Equal(t, target, "gap.6.log")
+	// No gap.6.log since there was nothing to rename
+	_, err = os.Stat(filepath.Join(dir, "gap.6.log"))
+	assert.Assert(t, os.IsNotExist(err), "expected no gap.6.log")
+
+	// Pre-existing files 1, 3, 5 should be pruned based on nextN=6
+	_, err = os.Stat(filepath.Join(dir, "gap.1.log"))
+	assert.Assert(t, os.IsNotExist(err), "expected gap.1.log to be pruned")
+	for _, n := range []int{3, 5} {
+		_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("gap.%d.log", n)))
+		assert.NilError(t, err, "expected gap.%d.log to exist", n)
+	}
 }
 
 func TestCreatesDirectory(t *testing.T) {
@@ -139,25 +154,31 @@ func TestCreatesDirectory(t *testing.T) {
 	assert.NilError(t, err)
 	f.Close()
 
-	_, err = os.Stat(filepath.Join(dir, "test.1.log"))
-	assert.NilError(t, err, "expected test.1.log in nested dir")
+	_, err = os.Stat(filepath.Join(dir, "test.log"))
+	assert.NilError(t, err, "expected test.log in nested dir")
 }
 
-func TestSymlinkFollowsTransparently(t *testing.T) {
+func TestRenamePreservesContent(t *testing.T) {
 	dir := t.TempDir()
 
-	f, err := Create(dir, "follow", false, "")
+	f, err := Create(dir, "app", false, "")
 	assert.NilError(t, err)
-	_, _ = f.WriteString("content1\n")
+	_, _ = f.WriteString("first log\n")
 	f.Close()
 
-	// Reading via symlink should give the same content as the numbered file
-	symlinkData, err := os.ReadFile(filepath.Join(dir, "follow.log"))
+	// Second call renames the first to app.1.log
+	f, err = Create(dir, "app", false, "")
 	assert.NilError(t, err)
-	fileData, err := os.ReadFile(filepath.Join(dir, "follow.1.log"))
+	_, _ = f.WriteString("second log\n")
+	f.Close()
+
+	data, err := os.ReadFile(filepath.Join(dir, "app.1.log"))
 	assert.NilError(t, err)
-	assert.Assert(t, bytes.Equal(symlinkData, fileData),
-		"symlink content = %q, numbered file content = %q", symlinkData, fileData)
+	assert.Equal(t, string(data), "first log\n")
+
+	data, err = os.ReadFile(filepath.Join(dir, "app.log"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "second log\n")
 }
 
 func TestMultipleNamesInSameDir(t *testing.T) {
@@ -172,13 +193,9 @@ func TestMultipleNamesInSameDir(t *testing.T) {
 	assert.NilError(t, err)
 	f2.Close()
 
-	// Both should have their own .1.log files
-	_, err = os.Stat(filepath.Join(dir, "stdout.1.log"))
-	assert.NilError(t, err, "expected stdout.1.log")
-	_, err = os.Stat(filepath.Join(dir, "stderr.1.log"))
-	assert.NilError(t, err, "expected stderr.1.log")
-}
-
-func itoa(n int) string {
-	return strconv.Itoa(n)
+	// Both should have their own .log files
+	_, err = os.Stat(filepath.Join(dir, "stdout.log"))
+	assert.NilError(t, err, "expected stdout.log")
+	_, err = os.Stat(filepath.Join(dir, "stderr.log"))
+	assert.NilError(t, err, "expected stderr.log")
 }

--- a/pkg/util/logfile/logfile_test.go
+++ b/pkg/util/logfile/logfile_test.go
@@ -5,7 +5,9 @@
 package logfile
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +26,7 @@ func TestCreateFirstFile(t *testing.T) {
 	_, err = os.Stat(filepath.Join(dir, "test.log"))
 	assert.NilError(t, err, "expected test.log to exist")
 	_, err = os.Stat(filepath.Join(dir, "test.1.log"))
-	assert.Assert(t, os.IsNotExist(err), "expected no test.1.log on first call")
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected no test.1.log on first call")
 }
 
 func TestSequentialNumbering(t *testing.T) {
@@ -49,7 +51,7 @@ func TestSequentialNumbering(t *testing.T) {
 
 	// No app.3.log (the third call created app.log, not a numbered file)
 	_, err = os.Stat(filepath.Join(dir, "app.3.log"))
-	assert.Assert(t, os.IsNotExist(err), "expected no app.3.log")
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected no app.3.log")
 }
 
 func TestPruning(t *testing.T) {
@@ -67,7 +69,7 @@ func TestPruning(t *testing.T) {
 	// File 1 should be pruned
 	name := filepath.Join(dir, "prune.1.log")
 	_, err := os.Stat(name)
-	assert.Assert(t, os.IsNotExist(err), "expected %s to be pruned", name)
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected %s to be pruned", name)
 
 	// Remaining numbered files should still exist
 	for n := 2; n <= count-1; n++ {
@@ -84,15 +86,16 @@ func TestPruning(t *testing.T) {
 func TestKeepAll(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create 7 files with keepAll=true
-	for i := 1; i <= 7; i++ {
+	// Create enough files to exceed the retention count with keepAll=true.
+	count := retentionCount + 2
+	for i := 1; i <= count; i++ {
 		f, err := Create(dir, "keep", true, "")
 		assert.NilError(t, err, "Create #%d", i)
 		f.Close()
 	}
 
-	// All numbered backups (1-6) should exist
-	for n := 1; n <= 6; n++ {
+	// All numbered backups should exist
+	for n := 1; n <= count-1; n++ {
 		name := filepath.Join(dir, fmt.Sprintf("keep.%d.log", n))
 		_, err := os.Stat(name)
 		assert.NilError(t, err, "expected %s to exist", name)
@@ -136,11 +139,11 @@ func TestGapsInNumbering(t *testing.T) {
 
 	// No gap.6.log since there was nothing to rename
 	_, err = os.Stat(filepath.Join(dir, "gap.6.log"))
-	assert.Assert(t, os.IsNotExist(err), "expected no gap.6.log")
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected no gap.6.log")
 
 	// Pre-existing files 1, 3, 5 should be pruned based on nextN=6
 	_, err = os.Stat(filepath.Join(dir, "gap.1.log"))
-	assert.Assert(t, os.IsNotExist(err), "expected gap.1.log to be pruned")
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected gap.1.log to be pruned")
 	for _, n := range []int{3, 5} {
 		_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("gap.%d.log", n)))
 		assert.NilError(t, err, "expected gap.%d.log to exist", n)

--- a/pkg/util/logfile/logfile_test.go
+++ b/pkg/util/logfile/logfile_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package logfile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCreateFirstFile(t *testing.T) {
+	dir := t.TempDir()
+
+	f, err := Create(dir, "test", false, "")
+	assert.NilError(t, err)
+	f.Close()
+
+	// Should create test.1.log
+	_, err = os.Stat(filepath.Join(dir, "test.1.log"))
+	assert.NilError(t, err, "expected test.1.log to exist")
+
+	// Should create symlink test.log -> test.1.log
+	target, err := os.Readlink(filepath.Join(dir, "test.log"))
+	assert.NilError(t, err)
+	assert.Equal(t, target, "test.1.log")
+}
+
+func TestSequentialNumbering(t *testing.T) {
+	dir := t.TempDir()
+
+	for i := 1; i <= 3; i++ {
+		f, err := Create(dir, "app", true, "")
+		assert.NilError(t, err, "Create #%d", i)
+		f.Close()
+	}
+
+	// All three files should exist
+	for i := 1; i <= 3; i++ {
+		name := filepath.Join(dir, "app."+itoa(i)+".log")
+		_, err := os.Stat(name)
+		assert.NilError(t, err, "expected %s to exist", name)
+	}
+
+	// Symlink should point to the latest
+	target, err := os.Readlink(filepath.Join(dir, "app.log"))
+	assert.NilError(t, err)
+	assert.Equal(t, target, "app.3.log")
+}
+
+func TestPruning(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create 7 files with pruning enabled
+	for i := range 7 {
+		f, err := Create(dir, "prune", false, "")
+		assert.NilError(t, err, "Create #%d", i+1)
+		f.Close()
+	}
+
+	// Files 1 and 2 should be pruned (7 - 5 = 2)
+	for _, n := range []int{1, 2} {
+		name := filepath.Join(dir, "prune."+itoa(n)+".log")
+		_, err := os.Stat(name)
+		assert.Assert(t, os.IsNotExist(err), "expected %s to be pruned", name)
+	}
+
+	// Files 3-7 should still exist
+	for _, n := range []int{3, 4, 5, 6, 7} {
+		name := filepath.Join(dir, "prune."+itoa(n)+".log")
+		_, err := os.Stat(name)
+		assert.NilError(t, err, "expected %s to exist", name)
+	}
+}
+
+func TestKeepAll(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create 7 files with keepAll=true
+	for i := range 7 {
+		f, err := Create(dir, "keep", true, "")
+		assert.NilError(t, err, "Create #%d", i+1)
+		f.Close()
+	}
+
+	// All files should exist
+	for n := 1; n <= 7; n++ {
+		name := filepath.Join(dir, "keep."+itoa(n)+".log")
+		_, err := os.Stat(name)
+		assert.NilError(t, err, "expected %s to exist", name)
+	}
+}
+
+func TestHeader(t *testing.T) {
+	dir := t.TempDir()
+
+	header := "=== test header ===\n"
+	f, err := Create(dir, "header", false, header)
+	assert.NilError(t, err)
+	f.Close()
+
+	data, err := os.ReadFile(filepath.Join(dir, "header.1.log"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), header)
+}
+
+func TestGapsInNumbering(t *testing.T) {
+	dir := t.TempDir()
+
+	// Manually create files with gaps: 1, 3, 5
+	for _, n := range []int{1, 3, 5} {
+		f, err := os.Create(filepath.Join(dir, "gap."+itoa(n)+".log"))
+		assert.NilError(t, err, "create gap file")
+		f.Close()
+	}
+
+	// Next file should be 6 (max=5, next=6)
+	f, err := Create(dir, "gap", false, "")
+	assert.NilError(t, err)
+	f.Close()
+
+	_, err = os.Stat(filepath.Join(dir, "gap.6.log"))
+	assert.NilError(t, err, "expected gap.6.log to exist")
+
+	target, err := os.Readlink(filepath.Join(dir, "gap.log"))
+	assert.NilError(t, err)
+	assert.Equal(t, target, "gap.6.log")
+}
+
+func TestCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+
+	f, err := Create(dir, "test", false, "")
+	assert.NilError(t, err)
+	f.Close()
+
+	_, err = os.Stat(filepath.Join(dir, "test.1.log"))
+	assert.NilError(t, err, "expected test.1.log in nested dir")
+}
+
+func TestSymlinkFollowsTransparently(t *testing.T) {
+	dir := t.TempDir()
+
+	f, err := Create(dir, "follow", false, "")
+	assert.NilError(t, err)
+	_, _ = f.WriteString("content1\n")
+	f.Close()
+
+	// Reading via symlink should give the same content as the numbered file
+	symlinkData, err := os.ReadFile(filepath.Join(dir, "follow.log"))
+	assert.NilError(t, err)
+	fileData, err := os.ReadFile(filepath.Join(dir, "follow.1.log"))
+	assert.NilError(t, err)
+	assert.Assert(t, bytes.Equal(symlinkData, fileData),
+		"symlink content = %q, numbered file content = %q", symlinkData, fileData)
+}
+
+func TestMultipleNamesInSameDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create files with different names; they should not interfere
+	f1, err := Create(dir, "stdout", false, "")
+	assert.NilError(t, err)
+	f1.Close()
+
+	f2, err := Create(dir, "stderr", false, "")
+	assert.NilError(t, err)
+	f2.Close()
+
+	// Both should have their own .1.log files
+	_, err = os.Stat(filepath.Join(dir, "stdout.1.log"))
+	assert.NilError(t, err, "expected stdout.1.log")
+	_, err = os.Stat(filepath.Join(dir, "stderr.1.log"))
+	assert.NilError(t, err, "expected stderr.1.log")
+}
+
+func itoa(n int) string {
+	return strconv.Itoa(n)
+}

--- a/scripts/collect-bats-logs.sh
+++ b/scripts/collect-bats-logs.sh
@@ -4,8 +4,8 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-# Collect RDD service and Lima hostagent logs into a single directory.
-# Usage: scripts/collect-logs.sh [output-dir]
+# Collect RDD service and Lima hostagent BATS logs into a single directory.
+# Usage: scripts/collect-bats-logs.sh [output-dir]
 #
 # Iterates over all BATS instances, resolves their log and Lima home
 # directories via "rdd svc paths", and copies log files into output-dir.
@@ -14,7 +14,8 @@
 #   output-dir/{instance}/           — service logs (rdd.stdout, rdd.stderr)
 #   output-dir/{instance}/lima-{vm}/ — hostagent logs (ha.stdout, ha.stderr)
 
-set -euo pipefail
+set -o errexit -o nounset -o pipefail
+shopt -s nullglob
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
@@ -60,7 +61,6 @@ for instance in $(make --no-print-directory -C "${REPO_ROOT}/bats" bats-instance
     # Lima hostagent logs (ha.stdout, ha.stderr per VM)
     if lima_home=$(resolve_path lima_home); then
         for vm_dir in "$lima_home"/*/; do
-            [ -d "$vm_dir" ] || continue
             vm_name=$(basename "$vm_dir")
             collect_logs "$vm_dir" "$dest/lima-${vm_name}"
         done

--- a/scripts/collect-logs.sh
+++ b/scripts/collect-logs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# Collect RDD service and Lima hostagent logs into a single directory.
+# Usage: scripts/collect-logs.sh [output-dir]
+#
+# Iterates over all BATS instances, resolves their log and Lima home
+# directories via "rdd svc paths", and copies log files into output-dir.
+#
+# Output layout:
+#   output-dir/{instance}/           — service logs (rdd.stdout, rdd.stderr)
+#   output-dir/{instance}/lima-{vm}/ — hostagent logs (ha.stdout, ha.stderr)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+output_dir=${1:-rdd-logs}
+
+# Use .exe extension on Windows (WSL runs Windows binaries via interop).
+rdd="${REPO_ROOT}/bin/rdd"
+if command -v wslpath >/dev/null 2>&1; then
+    rdd="${REPO_ROOT}/bin/rdd.exe"
+fi
+
+# Pass RDD_INSTANCE to Windows binaries via WSL interop.
+export WSLENV="${WSLENV:+${WSLENV}:}RDD_INSTANCE"
+
+# Resolve a path from rdd, converting Windows paths to WSL paths if needed.
+resolve_path() {
+    local p
+    p=$("$rdd" svc paths "$1" | tr -d '\r') || return 1
+    if command -v wslpath >/dev/null 2>&1; then
+        p=$(wslpath -ua "$p")
+    fi
+    echo "$p"
+}
+
+# Copy log files (not symlinks) from a directory into the output.
+collect_logs() {
+    local src=$1 dest=$2
+    [ -d "$src" ] || return 0
+    mkdir -p "$dest"
+    find "$src" -maxdepth 1 -type f -name '*.log' -exec cp {} "$dest/" \;
+}
+
+for instance in $(make --no-print-directory -C "${REPO_ROOT}/bats" bats-instances); do
+    export RDD_INSTANCE="$instance"
+    dest="${output_dir}/${instance}"
+
+    # Service logs (rdd.stdout, rdd.stderr)
+    if log_dir=$(resolve_path log_dir); then
+        collect_logs "$log_dir" "$dest"
+    fi
+
+    # Lima hostagent logs (ha.stdout, ha.stderr per VM)
+    if lima_home=$(resolve_path lima_home); then
+        for vm_dir in "$lima_home"/*/; do
+            [ -d "$vm_dir" ] || continue
+            vm_name=$(basename "$vm_dir")
+            collect_logs "$vm_dir" "$dest/lima-${vm_name}"
+        done
+    fi
+done
+
+echo "Logs collected in ${output_dir}/"


### PR DESCRIPTION
Improve CI log collection by giving each RDD instance a dedicated log directory and numbered log files that survive instance deletion.

- Add `instance.LogDir()` for OS-specific log directories separate from instance data, so logs persist when an instance is deleted
- Add `rdd svc paths` command that prints all instance paths in table, JSON, or shell-export format; BATS helpers now source paths from this command instead of duplicating per-platform logic
- Add `pkg/util/logfile` package: each restart creates the next sequentially numbered file (`{name}.{N}.log`) and updates a symlink (`{name}.log`); old files beyond the retention count are pruned
- Use numbered log files for the RDD service and hostagent
- Collect the entire log directory per instance in CI artifacts instead of a single log file
- Run all BATS test suites even when one fails, so CI always produces complete logs