### PR TITLE
Distinguish starting Lima instance from broken state

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -203,6 +203,9 @@ assert_limavm_not_exists() {
     # shellcheck disable=SC2030 # Persisted via save_var, not subshell
     OLD_HA_PID=$(get_hostagent_pid "${VM_NAME}")
     assert [ -n "${OLD_HA_PID}" ]
+    # Verify the PID is a running process. On Windows the hostagent runs as a
+    # Win32 process but BATS runs inside WSL, so kill can't reach it.
+    kill -0 "${OLD_HA_PID}"
     save_var OLD_HA_PID
 
     kill -9 "${OLD_HA_PID}"

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -98,6 +98,11 @@ get_instance_running_transition_time() {
         --output jsonpath='{.status.conditions[?(@.type=="InstanceRunning")].lastTransitionTime}'
 }
 
+get_hostagent_pid() {
+    local name=$1
+    cat "${LIMA_HOME}/${name}/ha.pid"
+}
+
 assert_recovery_completed() {
     local before_time=$1
     run -0 get_instance_running_transition_time "${VM_NAME}"
@@ -179,27 +184,69 @@ assert_limavm_not_exists() {
     try --max 30 --delay 1 --until-fail -- lima_instance_running "${VM_NAME}"
 }
 
-# Broken state recovery tests
-# These tests verify that the controller can recover from a broken Lima instance
-# (e.g., when hostagent crashes but leaves stale PID file)
+# Crash recovery tests
+# These tests verify that the controller recovers when the hostagent crashes.
+# On VZ the VM dies with the hostagent (runs in-process) so Lima sees Stopped.
+# On QEMU the VM outlives the hostagent so Lima sees Broken, then force-stops
+# the orphaned QEMU process. Either way the controller restarts the full VM.
 
-@test "start VM again for broken state test" {
+@test "start VM for crash recovery test" {
     rdd ctl patch limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
         --type=merge --patch '{"spec":{"running":true}}'
     try --max 60 --delay 5 -- assert_instance_running_condition "${VM_NAME}" "True"
 }
 
-@test "simulate broken state by killing hostagent" {
-    # Kill hostagent, leaving a stale PID file behind
+@test "simulate crash by killing hostagent" {
     local pid_file="${LIMA_HOME}/${VM_NAME}/ha.pid"
     assert_file_exists "${pid_file}"
 
-    local pid
-    pid=$(cat "${pid_file}")
-    assert [ -n "${pid}" ]
+    # shellcheck disable=SC2030 # Persisted via save_var, not subshell
+    OLD_HA_PID=$(get_hostagent_pid "${VM_NAME}")
+    assert [ -n "${OLD_HA_PID}" ]
+    save_var OLD_HA_PID
 
-    kill -9 "${pid}" || true
+    kill -9 "${OLD_HA_PID}"
+}
+
+@test "trigger reconcile and verify crash recovery" {
+    run -0 get_instance_running_transition_time "${VM_NAME}"
+    assert_output
+    before_time=${output}
+
+    rdd ctl annotate limavm "${VM_NAME}" --namespace "${NAMESPACE}" --overwrite \
+        reconcile-trigger="$(date +%s)"
+
+    # The reconciler should detect the dead hostagent and restart the VM.
+    try --max 60 --delay 5 -- assert_recovery_completed "${before_time}"
+}
+
+@test "verify new hostagent after crash recovery" {
+    local pid_file="${LIMA_HOME}/${VM_NAME}/ha.pid"
     assert_file_exists "${pid_file}"
+    local new_pid
+    new_pid=$(get_hostagent_pid "${VM_NAME}")
+    assert [ -n "${new_pid}" ]
+    kill -0 "${new_pid}"
+
+    load_var OLD_HA_PID
+    # shellcheck disable=SC2031 # Loaded via load_var, not subshell
+    refute [ "${new_pid}" = "${OLD_HA_PID}" ]
+}
+
+# Broken state recovery tests
+# These tests verify that the controller can recover from a broken Lima instance.
+# We simulate breakage by replacing the hostagent socket with a regular file.
+# This makes Lima report StatusBroken (socket exists but is not a Unix socket)
+# without killing the VM process (which on VZ runs inside the hostagent).
+
+@test "simulate broken state by replacing hostagent socket" {
+    local sock_file="${LIMA_HOME}/${VM_NAME}/ha.sock"
+    assert_socket_exists "${sock_file}"
+
+    # Replace the Unix socket with a regular file so Lima can't connect
+    rm "${sock_file}"
+    touch "${sock_file}"
+    assert_file_exists "${sock_file}"
 }
 
 @test "trigger reconcile and verify recovery from broken state" {
@@ -209,7 +256,7 @@ assert_limavm_not_exists() {
     before_time=${output}
 
     # Annotate to trigger a reconcile while spec.running is still true
-    rdd ctl annotate limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+    rdd ctl annotate limavm "${VM_NAME}" --namespace "${NAMESPACE}" --overwrite \
         reconcile-trigger="$(date +%s)"
 
     # The reconciler should detect broken state, force stop, then restart.

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -104,6 +104,7 @@ func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alp
 					return ctrl.Result{}, err
 				}
 			}
+			// Poll until the hostagent finishes startup and the socket appears.
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -90,11 +90,24 @@ func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alp
 		return ctrl.Result{}, errors.New("instance not found")
 	}
 
-	// Handle broken state - attempt to recover via force stop
+	// Handle broken state. Lima reports "broken" when the hostagent PID file
+	// exists but the socket is not yet responding. During startup this is normal:
+	// the hostagent creates its PID file before the socket. If the hostagent
+	// process is alive and the socket doesn't exist yet, treat it as starting.
 	if inst.Status == limatype.StatusBroken {
-		logger.Info("Lima instance is in broken state, attempting force stop to recover", "errors", inst.Errors)
+		haSockPath := filepath.Join(inst.Dir, filenames.HostAgentSock)
+		if inst.HostAgentPID > 0 && !fileExists(haSockPath) {
+			logger.Info("Instance reports broken but hostagent is alive and socket not yet created, treating as starting", "pid", inst.HostAgentPID)
+			if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionInstanceRunning, metav1.ConditionFalse, ReasonStarting) {
+				if err := r.updateCondition(ctx, limaVM, ConditionInstanceRunning, metav1.ConditionFalse, ReasonStarting, "Lima instance is starting"); err != nil {
+					logger.Error(err, "Failed to update starting condition")
+					return ctrl.Result{}, err
+				}
+			}
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 
-		// Attempt force stop to clean up
+		logger.Info("Lima instance is broken, attempting force stop to recover", "errors", inst.Errors)
 		limainstance.StopForcibly(inst)
 
 		// Re-inspect to see if recovery succeeded
@@ -105,7 +118,6 @@ func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alp
 		}
 
 		if inst.Status == limatype.StatusBroken {
-			// Still broken after force stop - surface the error
 			errMsg := "Lima instance is in broken state"
 			if len(inst.Errors) > 0 {
 				errMsg = inst.Errors[0].Error()
@@ -332,4 +344,9 @@ func (r *LimaVMReconciler) stopInstance(ctx context.Context, limaVM *v1alpha1.Li
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }


### PR DESCRIPTION
Lima reports StatusBroken when the hostagent PID file exists but the socket is not yet responding. During startup this is normal: the hostagent creates its PID file before the socket. If the hostagent process is alive and the socket doesn't exist yet, treat the instance as starting rather than broken.

Also add a crash recovery test that kills the hostagent with SIGKILL and verifies the controller detects and restarts the VM. The existing broken-state test now simulates breakage by replacing the socket with a regular file instead of killing the hostagent, so it works on both VZ and QEMU backends.