### PR TITLE
`rdd service config`: add option to wait for changes

### DIFF
--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -59,6 +59,7 @@ func newServiceConfigCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  serviceConfigAction,
 	}
+	command.Flags().Bool("wait", false, "Wait until the kubeconfig changes before printing")
 	return command
 }
 
@@ -83,6 +84,13 @@ func serviceConfigAction(cmd *cobra.Command, _ []string) error {
 	if err := ensureServiceRunning(cmd.Context()); err != nil {
 		return err
 	}
+
+	if wait, err := cmd.Flags().GetBool("wait"); err == nil && wait {
+		if err := service.WatchKubeconfig(); err != nil {
+			return err
+		}
+	}
+
 	contents, err := service.GetKubeconfig()
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
@@ -137,7 +138,6 @@ require (
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/firefart/nonamedreturns v1.0.6 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.17 // indirect

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -90,6 +91,43 @@ func GetKubeconfig() ([]byte, error) {
 		return nil, fmt.Errorf("could not read kubeconfig from %s: %w (control plane may still be starting)", instance.KubeConfig(), err)
 	}
 	return data, nil
+}
+
+// WatchKubeconfig blocks until the kubeconfig file changes; it returns once a
+// change has been detected.
+func WatchKubeconfig() error {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	// fsnotify recommends watching the parent directory instead of the file;
+	// it is implied that on macOS, a rename-into-place (as in vim saving) would
+	// not trigger any events.
+	dir, name := filepath.Split(instance.KubeConfig())
+
+	if err := w.Add(dir); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case err, ok := <-w.Errors:
+			if !ok {
+				return nil // watcher was closed
+			}
+			return err
+		case event, ok := <-w.Events:
+			if !ok {
+				return nil // watcher was closed
+			}
+			if filepath.Base(event.Name) != name {
+				continue // a different file changed
+			}
+			return nil // The file changed
+		}
+	}
 }
 
 // GetKubeRestConfig generates and returns the kubeconfig as a *rest.Config.


### PR DESCRIPTION
This will be used by the front end to monitor file changes (by waiting for the process to exit).