### PR TITLE
docs/cmd_service: update specs

### DIFF
--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -113,7 +113,9 @@ Prints a kube config with context and service account[^sa] setup to give access 
 
 [^sa]: A locked deployment profile will result in a service account with limited functionality to prevent bypassing the profile restrictions.
 
-Runs `rdd service start` to ensure the `apiserver` is ready to accept requests.
+This command will implicitly start the service, and will block until startup is complete.
+
+The returned config will be static for the lifetime of the service, but may change the next time the service starts.
 
 ## `rdd ctl`
 


### PR DESCRIPTION
From discussion with Jan, the kubeconfig will not change until reset (or, at some point in the future, when we need to update the `notAfter` date).

Replaces #167