### PR TITLE
Detect template ConfigMap changes and restart running instances

### DIFF
--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -10,6 +10,7 @@ mkfifo
 mktemp
 moby
 netcat
+printenv
 pulumi
 Trivy
 

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -391,6 +391,108 @@ assert_restart_annotation_absent() {
     refute_output "true"
 }
 
+# Template change detection tests
+# These tests verify that the controller detects template ConfigMap changes,
+# updates the on-disk lima.yaml, and restarts the instance if it was running.
+# We use Lima's env: field because it writes to /etc/environment on every boot,
+# so we can verify the new template took effect inside the guest.
+
+TEMPLATE_CM="${VM_NAME}-template"
+
+# Append an env variable to the original template.
+# Keep images identical so Lima doesn't re-download them.
+MODIFIED_TEMPLATE="${ALPINE_TEMPLATE}
+env:
+  TEMPLATE_CHANGE_MARKER: applied"
+
+assert_instance_template_contains() {
+    local name=$1
+    local expected=$2
+    run -0 cat "${RDD_LIMA_HOME}/${name}/lima.yaml"
+    assert_output --partial "${expected}"
+}
+
+assert_guest_env_var() {
+    local name=$1
+    local var=$2
+    local expected=$3
+    run -0 ssh -F "${RDD_LIMA_HOME}/${name}/ssh.config" lima-"${name}" printenv "${var}"
+    assert_output "${expected}"
+}
+
+@test "verify on-disk template does not contain TEMPLATE_CHANGE_MARKER" {
+    run -0 cat "${RDD_LIMA_HOME}/${VM_NAME}/lima.yaml"
+    refute_output --partial "TEMPLATE_CHANGE_MARKER"
+}
+
+@test "patch template ConfigMap to trigger restart of running instance" {
+    rdd ctl patch configmap "${TEMPLATE_CM}" --namespace "${NAMESPACE}" --type='merge' \
+        --patch "$(jq -n --arg t "${MODIFIED_TEMPLATE}" '{"data":{"template":$t}}')"
+
+    # Capture the patched ConfigMap's resourceVersion so we can wait for
+    # the controller to observe it.
+    run -0 rdd ctl get configmap "${TEMPLATE_CM}" --namespace "${NAMESPACE}" \
+        --output jsonpath='{.metadata.resourceVersion}'
+    # shellcheck disable=SC2030
+    PATCHED_TEMPLATE_RV="${output}"
+    save_var PATCHED_TEMPLATE_RV
+}
+
+@test "wait for instance restart after template change" {
+    load_var PATCHED_TEMPLATE_RV
+    # The controller writes observedTemplateResourceVersion and Running=False
+    # in the same status update, so once this returns the VM is stopped.
+    # shellcheck disable=SC2031
+    rdd ctl wait --for=jsonpath='{.status.observedTemplateResourceVersion}'="${PATCHED_TEMPLATE_RV}" \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=120s
+    # Wait for the VM to finish restarting.
+    rdd ctl wait --for=condition=Running=True \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
+}
+
+@test "verify on-disk template contains env variable after restart" {
+    assert_instance_template_contains "${VM_NAME}" "TEMPLATE_CHANGE_MARKER"
+}
+
+@test "verify guest applied template change" {
+    # SSH may not be ready immediately after Running=True
+    try --max 12 --delay 5 -- assert_guest_env_var "${VM_NAME}" "TEMPLATE_CHANGE_MARKER" "applied"
+}
+
+@test "stop VM for stopped-template-change test" {
+    rdd ctl patch limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --type=merge --patch '{"spec":{"running":false}}'
+    rdd ctl wait --for=condition=Running=False \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
+}
+
+# Build a second modified template with a different env value.
+MODIFIED_TEMPLATE_2="${ALPINE_TEMPLATE}
+env:
+  TEMPLATE_CHANGE_MARKER: updated-while-stopped"
+
+@test "patch template ConfigMap while instance is stopped" {
+    rdd ctl patch configmap "${TEMPLATE_CM}" --namespace "${NAMESPACE}" --type='merge' \
+        --patch "$(jq -n --arg t "${MODIFIED_TEMPLATE_2}" '{"data":{"template":$t}}')"
+
+    # Capture the patched ConfigMap's resourceVersion.
+    run -0 rdd ctl get configmap "${TEMPLATE_CM}" --namespace "${NAMESPACE}" \
+        --output jsonpath='{.metadata.resourceVersion}'
+    # shellcheck disable=SC2030
+    PATCHED_TEMPLATE_RV_2="${output}"
+    save_var PATCHED_TEMPLATE_RV_2
+}
+
+@test "verify on-disk template updated without starting the instance" {
+    load_var PATCHED_TEMPLATE_RV_2
+    # shellcheck disable=SC2031
+    rdd ctl wait --for=jsonpath='{.status.observedTemplateResourceVersion}'="${PATCHED_TEMPLATE_RV_2}" \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=30s
+    assert_instance_template_contains "${VM_NAME}" "updated-while-stopped"
+    assert_instance_running_condition "${VM_NAME}" "False"
+    assert_instance_running_reason "${VM_NAME}" "Stopped"
+}
+
 @test "cleanup LimaVM running test" {
     rdd ctl delete limavm "${VM_NAME}" --namespace "${NAMESPACE}"
     try --max 60 --delay 1 -- assert_limavm_not_exists "${VM_NAME}"

--- a/pkg/apis/lima/v1alpha1/applyconfiguration/lima/v1alpha1/limavmstatus.go
+++ b/pkg/apis/lima/v1alpha1/applyconfiguration/lima/v1alpha1/limavmstatus.go
@@ -26,6 +26,11 @@ type LimaVMStatusApplyConfiguration struct {
 	// An admission controller validates any updates to the ConfigMap.
 	// This field is informational - internal code should use GetTemplateConfigMapName() instead.
 	TemplateConfigMap *string `json:"templateConfigMap,omitempty"`
+	// observedTemplateResourceVersion tracks the resourceVersion of the template
+	// ConfigMap last written to the instance's lima.yaml on disk.
+	// When this differs from the ConfigMap's current resourceVersion, the
+	// reconciler checks for template changes.
+	ObservedTemplateResourceVersion *string `json:"observedTemplateResourceVersion,omitempty"`
 	// restartNeeded indicates a restart has been requested but not yet executed.
 	// Set by the reconciler when it processes a restartRequested annotation or
 	// detects a template change on a running instance. Cleared when the restart
@@ -60,6 +65,14 @@ func (b *LimaVMStatusApplyConfiguration) WithConditions(values ...*v1.ConditionA
 // If called multiple times, the TemplateConfigMap field is set to the value of the last call.
 func (b *LimaVMStatusApplyConfiguration) WithTemplateConfigMap(value string) *LimaVMStatusApplyConfiguration {
 	b.TemplateConfigMap = &value
+	return b
+}
+
+// WithObservedTemplateResourceVersion sets the ObservedTemplateResourceVersion field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedTemplateResourceVersion field is set to the value of the last call.
+func (b *LimaVMStatusApplyConfiguration) WithObservedTemplateResourceVersion(value string) *LimaVMStatusApplyConfiguration {
+	b.ObservedTemplateResourceVersion = &value
 	return b
 }
 

--- a/pkg/apis/lima/v1alpha1/limavm_types.go
+++ b/pkg/apis/lima/v1alpha1/limavm_types.go
@@ -64,6 +64,13 @@ type LimaVMStatus struct {
 	// +optional
 	TemplateConfigMap string `json:"templateConfigMap,omitempty"`
 
+	// observedTemplateResourceVersion tracks the resourceVersion of the template
+	// ConfigMap last written to the instance's lima.yaml on disk.
+	// When this differs from the ConfigMap's current resourceVersion, the
+	// reconciler checks for template changes.
+	// +optional
+	ObservedTemplateResourceVersion string `json:"observedTemplateResourceVersion,omitempty"`
+
 	// restartNeeded indicates a restart has been requested but not yet executed.
 	// Set by the reconciler when it processes a restartRequested annotation or
 	// detects a template change on a running instance. Cleared when the restart

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -9,8 +9,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"time"
 
 	limainstance "github.com/lima-vm/lima/v2/pkg/instance"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/store"
 
 	corev1 "k8s.io/api/core/v1"
@@ -96,6 +99,21 @@ func removeSentinel(instanceName string) error {
 	return err
 }
 
+// instanceTemplatePath returns the path to the lima.yaml for an instance.
+func instanceTemplatePath(instanceName string) string {
+	return filepath.Join(instance.LimaHome(), instanceName, filenames.LimaYAML)
+}
+
+// readInstanceTemplate reads the lima.yaml from the instance directory.
+func readInstanceTemplate(instanceName string) ([]byte, error) {
+	return os.ReadFile(instanceTemplatePath(instanceName))
+}
+
+// writeInstanceTemplate writes the lima.yaml to the instance directory.
+func writeInstanceTemplate(instanceName string, data []byte) error {
+	return os.WriteFile(instanceTemplatePath(instanceName), data, 0o644)
+}
+
 // LimaVMReconciler reconciles a LimaVM object.
 type LimaVMReconciler struct {
 	client.Client
@@ -171,7 +189,7 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 		}
 		// Requeue to continue with fresh state after cleanup.
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
 	// Delete any leftover instance from a failed deletion before setting up owner references.
@@ -220,10 +238,16 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	// Instance already created - handle restart annotation, then running state.
+	// Instance already created - handle restart annotation, template changes, then running state.
 	if apimeta.IsStatusConditionTrue(limaVM.Status.Conditions, ConditionCreated) {
 		if _, hasAnnotation := limaVM.Annotations[v1alpha1.AnnotationRestartRequested]; hasAnnotation {
 			return r.handleRestartAnnotation(ctx, &limaVM)
+		}
+		if templateConfigMap.ResourceVersion != limaVM.Status.ObservedTemplateResourceVersion {
+			result, err := r.handleTemplateUpdate(ctx, &limaVM, templateConfigMap)
+			if err != nil || !result.IsZero() {
+				return result, err
+			}
 		}
 		return r.handleRunningState(ctx, &limaVM)
 	}
@@ -233,6 +257,7 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	existingInst, err := store.Inspect(ctx, limaVM.Name)
 	if err == nil && existingInst != nil {
 		logger.Info("Lima instance already exists", "instance", limaVM.Name)
+		limaVM.Status.ObservedTemplateResourceVersion = templateConfigMap.ResourceVersion
 		r.setCondition(&limaVM, ConditionCreated, metav1.ConditionTrue, ReasonCreated, "Lima instance exists")
 		if statusErr := r.Status().Update(ctx, &limaVM); statusErr != nil {
 			logger.Error(statusErr, "Failed to update status for existing instance")
@@ -290,6 +315,7 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	logger.Info("Created Lima instance", "instance", limaVM.Name)
+	limaVM.Status.ObservedTemplateResourceVersion = templateConfigMap.ResourceVersion
 	r.setCondition(&limaVM, ConditionCreated, metav1.ConditionTrue, ReasonCreated, "Lima instance created successfully")
 	if err := r.Status().Update(ctx, &limaVM); err != nil {
 		logger.Error(err, "Failed to update status after instance creation")
@@ -304,6 +330,61 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Return and let the next reconcile handle running state (one mutation per reconcile)
 	return ctrl.Result{}, nil
+}
+
+// handleTemplateUpdate detects and applies changes to the template ConfigMap.
+// If the on-disk lima.yaml differs from the ConfigMap, it writes the new template
+// and stops the instance (if running) so the caller can restart it.
+//
+// Returns a non-zero result only when a running instance was stopped (the
+// caller should let the next reconcile restart it). All other paths return
+// an empty result so the caller falls through to handleRunningState.
+func (r *LimaVMReconciler) handleTemplateUpdate(ctx context.Context, limaVM *v1alpha1.LimaVM, templateConfigMap *corev1.ConfigMap) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	diskTemplate, err := readInstanceTemplate(limaVM.Name)
+	if err != nil {
+		logger.Error(err, "Failed to read on-disk template")
+		return ctrl.Result{}, err
+	}
+
+	newTemplate := templateConfigMap.Data[v1alpha1.TemplateConfigMapKey]
+
+	// Update observed version regardless of whether the template data changed.
+	// A ConfigMap update that doesn't change the template key (e.g. label change)
+	// still bumps resourceVersion; recording it avoids repeated comparisons.
+	limaVM.Status.ObservedTemplateResourceVersion = templateConfigMap.ResourceVersion
+
+	if string(diskTemplate) == newTemplate {
+		logger.Info("Template ConfigMap changed but on-disk template is identical")
+		return ctrl.Result{}, r.Status().Update(ctx, limaVM)
+	}
+
+	logger.Info("Template changed, updating on-disk lima.yaml")
+	if err := writeInstanceTemplate(limaVM.Name, []byte(newTemplate)); err != nil {
+		logger.Error(err, "Failed to write updated template to disk")
+		return ctrl.Result{}, err
+	}
+
+	inst, err := store.Inspect(ctx, limaVM.Name)
+	if err != nil {
+		logger.Error(err, "Failed to inspect Lima instance")
+		return ctrl.Result{}, err
+	}
+
+	if inst != nil && inst.Status == limatype.StatusRunning {
+		logger.Info("Stopping instance to apply template change")
+		// stopInstance updates status (sets Running condition and persists
+		// the ObservedTemplateResourceVersion we set above).
+		if _, err := r.stopInstance(ctx, limaVM, inst); err != nil {
+			return ctrl.Result{}, err
+		}
+		// Requeue so the next reconcile calls handleRunningState to restart.
+		return ctrl.Result{RequeueAfter: time.Second}, nil
+	}
+
+	// Instance is not running; persist the new observed version.
+	return ctrl.Result{}, r.Status().Update(ctx, limaVM)
 }
 
 // setCondition updates or adds a condition in the LimaVM status.

--- a/pkg/controllers/lima/limavm/crd.yaml
+++ b/pkg/controllers/lima/limavm/crd.yaml
@@ -148,6 +148,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedTemplateResourceVersion:
+                description: |-
+                  observedTemplateResourceVersion tracks the resourceVersion of the template
+                  ConfigMap last written to the instance's lima.yaml on disk.
+                  When this differs from the ConfigMap's current resourceVersion, the
+                  reconciler checks for template changes.
+                type: string
               restartCount:
                 description: |-
                   restartCount tracks how many times the instance has reached the Running state.


### PR DESCRIPTION
#### Summary

- Add `observedTemplateResourceVersion` to LimaVM `status` to track the last template ConfigMap version written to disk
- When the template ConfigMap changes, compare its data with the on-disk `lima.yaml`; if they differ, write the new template and stop a running instance so the existing state machine restarts it
- A stopped instance gets its `lima.yaml` updated without starting

#### Design

The `Owns(&corev1.ConfigMap{})` watch already triggers reconciliation when the managed template ConfigMap changes. This PR adds the logic to act on it:

1. The reconciler compares `templateConfigMap.ResourceVersion` against `status.observedTemplateResourceVersion`
2. On mismatch, it reads the on-disk `lima.yaml` and compares with the ConfigMap data
3. If the template data differs, it writes the new file and calls `stopInstance()` for a running VM
4. The next reconcile sees `spec.running=true` + stopped instance and starts it normally
5. If only the `resourceVersion` changed (e.g. a label update), it records the new version without restarting

Closes #149
