### PR TITLE
Add rdd limavm edit command

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-lifecycle.bats
+++ b/bats/tests/33-lima-controllers/limavm-lifecycle.bats
@@ -212,3 +212,83 @@ EOF
     run -0 rdd ctl get configmap test-vm-running-template --namespace "${NAMESPACE}" -o jsonpath='{.data.template}'
     assert_output "${TEMPLATE}"
 }
+
+@test "limavm edit command updates template ConfigMap" {
+    create_limavm "${VM_NAME}" "source-template"
+
+    # Wait for template ConfigMap to be created
+    rdd ctl wait --for=jsonpath='{.status.templateConfigMap}' \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout="30s"
+
+    # Since we can't interact with the editor in tests, we'll use a fake editor script that modifies the template file directly.
+    # Set EDITOR to a script that modifies the file
+    local editor_script="${BATS_TEST_TMPDIR}/fake-editor.sh"
+    cat >"${editor_script}" <<'SCRIPT'
+#!/bin/bash
+# Replace the template content
+echo 'images: [{"location":"https://bar"}]' > "$1"
+SCRIPT
+
+    chmod +x "${editor_script}"
+
+    # Run edit with fake editor
+    EDITOR="${editor_script}" run -0 rdd limavm edit "${VM_NAME}"
+    assert_output --partial "updated successfully"
+
+    # Verify ConfigMap was updated
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" \
+        -o jsonpath='{.data.template}'
+    assert_output "images: [{\"location\":\"https://bar\"}]"
+}
+
+@test "limavm edit aborts when all content is deleted" {
+    # Capture current template
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" \
+        -o jsonpath='{.data.template}'
+
+    local original_template="${output}"
+
+    # Deleting editor
+    local editor_script="${BATS_TEST_TMPDIR}/delete-editor.sh"
+    cat >"${editor_script}" <<'SCRIPT'
+#!/bin/bash
+# Delete all content
+echo "" > "$1"
+SCRIPT
+
+    chmod +x "${editor_script}"
+
+    # Run edit aborst
+    EDITOR="${editor_script}" run -1 rdd limavm edit "${VM_NAME}"
+    assert_output --partial "template data was cleared, aborting edit"
+
+    # Verify ConfigMap unchanged
+    run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" \
+        -o jsonpath='{.data.template}'
+    assert_output "${original_template}"
+}
+
+@test "limavm edit skips update when no changes made" {
+    # No-op editor
+    local editor_script="${BATS_TEST_TMPDIR}/noop-editor.sh"
+    cat >"${editor_script}" <<'SCRIPT'
+#!/bin/bash
+# Do nothing and exit happy :)
+exit 0
+SCRIPT
+
+    chmod +x "${editor_script}"
+
+    EDITOR="${editor_script}" run -0 rdd limavm edit "${VM_NAME}"
+    assert_output --partial "No changes made to template, skipping update"
+}
+
+@test "limavm edit fails gracefully for nonexistent VM" {
+    run -1 rdd limavm edit "nonexistent-vm"
+    assert_output --partial 'LimaVM \"nonexistent-vm\" not found in any namespace'
+}
+
+@test "limavm edit rejects invalid template" {
+    skip
+    # TODO: Implement test for invalid template edit once validation is wired in.
+}

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -6,9 +6,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -21,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	corev1scheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/kubectl/pkg/cmd/util/editor"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -44,8 +47,73 @@ func newLimaVMCommand() *cobra.Command {
 		newLimaVMDeleteCommand(),
 		newLimaVMLogsCommand(),
 		newLimaVMShellCommand(),
+		newLimaVMEditCommand(),
 	)
 	return command
+}
+
+func newLimaVMEditCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "edit NAME",
+		Short: "Edit the Lima template ConfigMap for a VM",
+		Long:  "Open the LimaVM resource manifest in the default editor for editing.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return limaVMEditAction(cmd.Context(), args[0])
+		},
+	}
+	return command
+}
+
+func limaVMEditAction(ctx context.Context, name string) error {
+	c, err := getKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+	limaVM, err := findLimaVM(ctx, c, name)
+	if err != nil {
+		return err
+	}
+
+	configMapName := limaVM.Status.TemplateConfigMap
+	if configMapName == "" {
+		return fmt.Errorf("LimaVM %q does not have a template ConfigMap", name)
+	}
+
+	configMap := &corev1.ConfigMap{}
+	configMapKey := types.NamespacedName{Name: configMapName, Namespace: limaVM.Namespace}
+	if err := c.Get(ctx, configMapKey, configMap); err != nil {
+		return fmt.Errorf("failed to get template ConfigMap %q: %w", configMapName, err)
+	}
+
+	templateData, exists := configMap.Data[limav1alpha1.TemplateConfigMapKey]
+	if !exists {
+		return fmt.Errorf("template ConfigMap %q does not contain key %q", configMapName, limav1alpha1.TemplateConfigMapKey)
+	}
+
+	edit := editor.NewDefaultEditor(editorEnvs())
+	updatedBytes, path, err := edit.LaunchTempFile(name+"-template-", ".yaml", strings.NewReader(templateData))
+	if err != nil {
+		return fmt.Errorf("failed to launch editor: %w", err)
+	}
+	defer os.Remove(path)
+
+	updatedContent := strings.TrimSpace(string(updatedBytes))
+	if updatedContent == "" {
+		return errors.New("template data was cleared, aborting edit")
+	}
+
+	if updatedContent == templateData {
+		logrus.Info("No changes made to template, skipping update")
+		return nil
+	}
+
+	configMap.Data[limav1alpha1.TemplateConfigMapKey] = updatedContent
+	if err := c.Update(ctx, configMap); err != nil {
+		return fmt.Errorf("failed to update template ConfigMap: %w", err)
+	}
+	logrus.Infof("Template ConfigMap %q updated successfully", configMapName)
+	return nil
 }
 
 func newLimaVMCreateCommand() *cobra.Command {
@@ -346,4 +414,13 @@ func newLimaVMLogsCommand() *cobra.Command {
 	command.Flags().BoolP("stdout", "o", false, "Print stdout instead of stderr")
 	command.Flags().BoolP("follow", "f", false, "Follow log output")
 	return command
+}
+
+// editorEnvs returns an ordered list of env vars to check for editor preferences.
+func editorEnvs() []string {
+	return []string{
+		"KUBE_EDITOR",
+		"EDITOR",
+		"VISUAL",
+	}
 }


### PR DESCRIPTION
The `rdd limavm edit` command extracts the template key from the ConfigMap data and opens it in the editor. It performs preliminary validation on the user input to ensure the file is neither empty nor unchanged.

This change fixes: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/73