### PR TITLE
mock controller: use apply config

### DIFF
--- a/pkg/controllers/mock/container_reconciler.go
+++ b/pkg/controllers/mock/container_reconciler.go
@@ -16,9 +16,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	containersv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
+	containersv1alpha1apply "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1"
 )
 
 //go:embed testdata/containers.json
@@ -61,11 +62,15 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	ownerReference := metav1apply.OwnerReference().
+		WithAPIVersion(gvk.GroupVersion().String()).
+		WithKind(gvk.Kind).
+		WithName(rddNamespace.GetName()).
+		WithUID(rddNamespace.GetUID()).
+		WithBlockOwnerDeletion(true).
+		WithController(true)
+
 	for _, inspect := range r.inspects {
-		namespacedName := types.NamespacedName{
-			Namespace: metav1.NamespaceDefault,
-			Name:      inspect.ID,
-		}
 		namespace, name, _ := strings.Cut(inspect.Name, "/")
 		if namespace == "" {
 			namespace = containerNamespace
@@ -74,63 +79,44 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if inspect.State.Running {
 			state = containersv1alpha1.ContainerStatusRunning
 		}
-		targetContainer := containersv1alpha1.Container{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      inspect.ID,
-				Namespace: metav1.NamespaceDefault,
-				Labels: map[string]string{
-					"namespace": namespace,
-					"name":      name,
-				},
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(&rddNamespace, gvk),
-				},
-			},
-			Spec: containersv1alpha1.ContainerSpec{
-				State: state,
-			},
-			Status: containersv1alpha1.ContainerStatus{
-				Path:   inspect.Path,
-				Args:   inspect.Args,
-				Image:  inspect.Image,
-				Labels: inspect.Config.Labels,
-				Status: containersv1alpha1.ContainerStatusValue(inspect.State.Status),
-			},
+		applyConfig := containersv1alpha1apply.Container(inspect.ID, metav1.NamespaceDefault).
+			WithLabels(map[string]string{
+				"namespace": namespace,
+				"name":      name,
+			}).
+			WithOwnerReferences(ownerReference).
+			WithSpec(containersv1alpha1apply.ContainerSpec().WithState(state))
+
+		err := r.Client.Apply(ctx, applyConfig, client.ForceOwnership, client.FieldOwner(controllerLongName))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to apply container %s/%s: %w", namespace, name, err))
 		}
+
+		applyStatus := containersv1alpha1apply.ContainerStatus().
+			WithPath(inspect.Path).
+			WithArgs(inspect.Args...).
+			WithImage(inspect.Image).
+			WithLabels(inspect.Config.Labels).
+			WithStatus(containersv1alpha1.ContainerStatusValue(inspect.State.Status))
+		var applyPorts []*containersv1alpha1apply.ContainerPortApplyConfiguration
 		for portName, ports := range inspect.NetworkSettings.Ports {
-			containerPort := containersv1alpha1.ContainerPort{
-				Name: portName.String(),
-			}
+			var bindings []*containersv1alpha1apply.ContainerPortBindingApplyConfiguration
 			for _, port := range ports {
-				containerPort.Bindings = append(containerPort.Bindings, containersv1alpha1.ContainerPortBinding{
-					HostIP:   port.HostIP.String(),
-					HostPort: port.HostPort,
-				})
+				bindings = append(bindings, containersv1alpha1apply.ContainerPortBinding().
+					WithHostIP(port.HostIP.String()).
+					WithHostPort(port.HostPort))
 			}
-			targetContainer.Status.Ports = append(targetContainer.Status.Ports, containerPort)
+			applyPorts = append(applyPorts, containersv1alpha1apply.ContainerPort().
+				WithName(portName.String()).
+				WithBindings(bindings...))
 		}
-		var existingContainer containersv1alpha1.Container
-		canUpdateStatus := true
-		if err := r.Get(ctx, namespacedName, &existingContainer); apierrors.IsNotFound(err) {
-			if err := r.Create(ctx, &targetContainer); err != nil {
-				errs = append(errs, fmt.Errorf("failed to create static container %s: %w", namespacedName, err))
-				canUpdateStatus = false
-			}
-		} else if err != nil {
-			log.Error(err, "Failed to get static container", "name", namespacedName)
-			errs = append(errs, err)
-		} else {
-			targetContainer.ResourceVersion = existingContainer.ResourceVersion
-			targetContainer.Status.Conditions = existingContainer.Status.Conditions
-			if err := r.Update(ctx, &targetContainer); err != nil {
-				errs = append(errs, fmt.Errorf("failed to update static container %s: %w", namespacedName, err))
-				canUpdateStatus = false
-			}
-		}
-		if canUpdateStatus {
-			if err := r.Status().Update(ctx, &targetContainer); err != nil {
-				errs = append(errs, fmt.Errorf("failed to update status for static container %s: %w", namespacedName, err))
-			}
+		applyStatus.WithPorts(applyPorts...)
+		applyConfig = containersv1alpha1apply.Container(inspect.ID, metav1.NamespaceDefault).
+			WithStatus(applyStatus)
+
+		err = r.Client.SubResource("status").Apply(ctx, applyConfig, client.ForceOwnership, client.FieldOwner(controllerLongName))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to apply container status %s/%s: %w", namespace, name, err))
 		}
 	}
 

--- a/pkg/controllers/mock/image_reconciler.go
+++ b/pkg/controllers/mock/image_reconciler.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	containersv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
+	containersv1alpha1apply "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 )
 
@@ -72,49 +74,56 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
+	ownerReference := metav1apply.OwnerReference().
+		WithAPIVersion(gvk.GroupVersion().String()).
+		WithKind(gvk.Kind).
+		WithName(rddNamespace.GetName()).
+		WithUID(rddNamespace.GetUID()).
+		WithBlockOwnerDeletion(true).
+		WithController(true)
+
 	for _, inspect := range r.inspects {
-		imageName := inspect.ID
-		if len(inspect.RepoTags) > 0 {
-			imageName = inspect.RepoTags[0]
-		}
-		templateImage := containersv1alpha1.Image{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: metav1.NamespaceDefault,
-				Labels:    map[string]string{},
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(&rddNamespace, gvk),
-				},
-			},
-			Status: containersv1alpha1.ImageStatus{
-				ID:           inspect.ID,
-				RepoDigests:  inspect.RepoDigests,
-				Architecture: inspect.Architecture,
-				OS:           inspect.Os,
-				Size:         inspect.Size,
-				Labels:       inspect.Config.Labels,
-			},
-		}
+		statusApplyConfig := containersv1alpha1apply.ImageStatus().
+			WithID(inspect.ID).
+			WithRepoDigests(inspect.RepoDigests...).
+			WithArchitecture(inspect.Architecture).
+			WithOS(inspect.Os).
+			WithSize(inspect.Size).
+			WithLabels(inspect.Config.Labels)
 		if t, err := time.Parse(time.RFC3339Nano, inspect.Created); err == nil {
-			templateImage.Status.CreatedAt = metav1.NewTime(t)
+			statusApplyConfig.WithCreatedAt(metav1.NewTime(t))
 		} else if inspect.Created != "" {
+			imageName := inspect.ID
+			if len(inspect.RepoTags) > 0 {
+				imageName = inspect.RepoTags[0]
+			}
 			log.Error(err, "Failed to parse image created time", "image", imageName, "created", inspect.Created)
 		}
+
 		if len(inspect.RepoTags) > 0 {
-			templateImage.ObjectMeta.GenerateName = sanitizeKubernetesObjectName(inspect.ID) + "-"
 			for _, tag := range inspect.RepoTags {
-				targetImage := templateImage.DeepCopy()
-				targetImage.Labels["namespace"] = containerNamespace
-				targetImage.Status.RepoTag = tag
-				if err := r.upsertImage(ctx, targetImage); err != nil {
-					errs = append(errs, err)
+				image, err := r.findOrCreateImage(ctx, inspect.ID, tag)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("failed to find or create image %s: %w", tag, err))
+					continue
 				}
+				statusApplyCopy := *statusApplyConfig
+				errs = append(errs, r.updateImage(ctx,
+					containersv1alpha1apply.Image(image.GetName(), image.GetNamespace()).
+						WithLabels(map[string]string{
+							"namespace": containerNamespace,
+						}).
+						WithOwnerReferences(ownerReference),
+					statusApplyCopy.WithRepoTag(tag))...,
+				)
 			}
 		} else {
 			// No tags; create a single dangling image.
-			templateImage.ObjectMeta.Name = sanitizeKubernetesObjectName(inspect.ID)
-			if err := r.upsertImage(ctx, &templateImage); err != nil {
-				errs = append(errs, err)
-			}
+			errs = append(errs, r.updateImage(ctx,
+				containersv1alpha1apply.Image(sanitizeKubernetesObjectName(inspect.ID), metav1.NamespaceDefault).
+					WithOwnerReferences(ownerReference),
+				statusApplyConfig)...,
+			)
 		}
 	}
 
@@ -126,38 +135,67 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	return ctrl.Result{}, nil
 }
 
-// upsertImage creates or updates the given Image resource.  The passed in image
-// will be updated with the results.
-func (r *imageReconciler) upsertImage(ctx context.Context, image *containersv1alpha1.Image) error {
-	imageName := image.Status.RepoTag
-	if imageName == "" {
-		imageName = image.Status.ID
-	}
-
+// findOrCreateImage looks for an existing Image with the given ID and repoTag,
+// and creates one if it doesn't exist.  This is needed because apply cannot be
+// used with `GenerateName` (because it is unclear when a new object needs to be
+// created).
+func (r *imageReconciler) findOrCreateImage(ctx context.Context, id, repoTag string) (*containersv1alpha1.Image, error) {
 	var existingImages containersv1alpha1.ImageList
-	originalImage := image.DeepCopy()
 	err := r.List(ctx, &existingImages,
 		client.MatchingFieldsSelector{Selector: fields.AndSelectors(
-			fields.OneTermEqualSelector(".status.id", image.Status.ID),
-			fields.OneTermEqualSelector(".status.repoTag", image.Status.RepoTag),
+			fields.OneTermEqualSelector(".status.id", id),
+			fields.OneTermEqualSelector(".status.repoTag", repoTag),
 		)})
 	if apierrors.IsNotFound(err) || (err == nil && len(existingImages.Items) == 0) {
-		if err := r.Create(ctx, image); err != nil {
-			return fmt.Errorf("failed to create static image %s: %w", imageName, err)
+		// No existing image found; create a new one.
+		image := containersv1alpha1.Image{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    metav1.NamespaceDefault,
+				GenerateName: sanitizeKubernetesObjectName(id) + "-",
+			},
 		}
-	} else if err != nil {
-		return fmt.Errorf("failed to find existing static images for %s: %w", imageName, err)
-	} else if len(existingImages.Items) == 1 {
-		existingImages.Items[0].DeepCopyInto(image)
+		if err := r.Create(ctx, &image); err != nil {
+			return nil, fmt.Errorf("failed to create image %s: %w", repoTag, err)
+		}
+		return &image, nil
 	}
-	// We either found an existing image, or we created a new one; in the former
-	// case, we need to update the status.  In the latter case, the status field
-	// isn't updated in the initial create, so we need to set it.
-	originalImage.Status.DeepCopyInto(&image.Status)
-	if err := r.Status().Update(ctx, image); err != nil {
-		return fmt.Errorf("failed to update static image %s status: %w", imageName, err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list images: %w", err)
 	}
-	return nil
+	for _, image := range existingImages.Items {
+		// Return the first matching image.
+		return &image, nil
+	}
+	// This should be unreachable, but handle it just in case.
+	return nil, fmt.Errorf("unexpectedly found no images with id %s and repoTag %s", id, repoTag)
+}
+
+// updateImage applies the given configuration to the Image and its status.
+func (r *imageReconciler) updateImage(
+	ctx context.Context,
+	image *containersv1alpha1apply.ImageApplyConfiguration,
+	status *containersv1alpha1apply.ImageStatusApplyConfiguration,
+) []error {
+	var errs []error
+	err := r.Client.Apply(
+		ctx,
+		image,
+		client.ForceOwnership,
+		client.FieldOwner(controllerLongName))
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to apply image %s: %w", *image.GetName(), err))
+	}
+	// Update the status subresource separately, per Kubernetes API requirements.
+	err = r.Client.SubResource("status").Apply(
+		ctx,
+		containersv1alpha1apply.Image(*image.GetName(), *image.GetNamespace()).
+			WithStatus(status),
+		client.ForceOwnership,
+		client.FieldOwner(controllerLongName))
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to apply image status %s: %w", *image.GetName(), err))
+	}
+	return errs
 }
 
 func (r *imageReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {

--- a/pkg/controllers/mock/testdata/images.json
+++ b/pkg/controllers/mock/testdata/images.json
@@ -55,7 +55,8 @@
     {
         "Id": "sha256:702bb92714f2547d0eec39b68e0d527a99513638a95e71be175bc210d8668756",
         "RepoTags": [
-            "registry.opensuse.org/opensuse/leap:latest"
+            "registry.opensuse.org/opensuse/leap:latest",
+            "registry.opensuse.org/opensuse/leap:15.6"
         ],
         "RepoDigests": [
             "registry.opensuse.org/opensuse/leap@sha256:702bb92714f2547d0eec39b68e0d527a99513638a95e71be175bc210d8668756"

--- a/pkg/controllers/mock/volume_reconciler.go
+++ b/pkg/controllers/mock/volume_reconciler.go
@@ -16,9 +16,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	containersv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
+	containersv1alpha1apply "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1"
 )
 
 //go:embed testdata/volumes.json
@@ -62,61 +63,49 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
+	ownerReference := metav1apply.OwnerReference().
+		WithAPIVersion(gvk.GroupVersion().String()).
+		WithKind(gvk.Kind).
+		WithName(rddNamespace.GetName()).
+		WithUID(rddNamespace.GetUID()).
+		WithBlockOwnerDeletion(true).
+		WithController(true)
+
 	for _, inspect := range r.inspects {
-		namespacedName := types.NamespacedName{
-			Namespace: metav1.NamespaceDefault,
-			Name:      inspect.Name,
-		}
-		targetVolume := containersv1alpha1.Volume{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespacedName.Namespace,
-				Name:      namespacedName.Name,
-				Labels: map[string]string{
+		err = r.Client.Apply(
+			ctx,
+			containersv1alpha1apply.
+				Volume(sanitizeKubernetesObjectName(inspect.Name), metav1.NamespaceDefault).
+				WithLabels(map[string]string{
 					"namespace": containerNamespace,
-				},
-				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(&rddNamespace, gvk),
-				},
-			},
-			Status: containersv1alpha1.VolumeStatus{
-				Driver:     inspect.Driver,
-				Labels:     inspect.Labels,
-				Options:    inspect.Options,
-				MountPoint: inspect.Mountpoint,
-				Scope:      inspect.Scope,
-			},
-		}
-		if t, err := time.Parse(time.RFC3339Nano, inspect.CreatedAt); err == nil {
-			targetVolume.Status.CreatedAt = metav1.NewTime(t)
-		} else if inspect.CreatedAt != "" {
-			log.Error(err, "Failed to parse volume created time", "volume", namespacedName, "created", inspect.CreatedAt)
-		}
-		var existingVolume containersv1alpha1.Volume
-		if err := r.Get(ctx, namespacedName, &existingVolume); apierrors.IsNotFound(err) {
-			// No existing volume found; create it.  Note that the status subresource
-			// is ignored on initial create, so we need to copy it into another object
-			// and update it separately.
-			targetVolume.DeepCopyInto(&existingVolume)
-			if err := r.Create(ctx, &existingVolume); err != nil {
-				errs = append(errs, fmt.Errorf("failed to create static volume %s: %w", namespacedName, err))
-			} else {
-				existingVolume.Status = targetVolume.Status
-				if err := r.Status().Update(ctx, &existingVolume); err != nil {
-					errs = append(errs, fmt.Errorf("failed to update status for static volume %s: %w", namespacedName, err))
-				}
-			}
-		} else if err != nil {
-			log.Error(err, "Failed to get static volume", "name", namespacedName)
+				}).
+				WithOwnerReferences(ownerReference),
+			client.ForceOwnership,
+			client.FieldOwner(controllerLongName))
+		if err != nil {
 			errs = append(errs, err)
-		} else {
-			targetVolume.ResourceVersion = existingVolume.ResourceVersion
-			if err := r.Update(ctx, &targetVolume); err != nil {
-				errs = append(errs, fmt.Errorf("failed to update static volume %s: %w", namespacedName, err))
-			} else {
-				if err := r.Status().Update(ctx, &targetVolume); err != nil {
-					errs = append(errs, fmt.Errorf("failed to update status for static volume %s: %w", namespacedName, err))
-				}
-			}
+		}
+
+		statusApplyConfig := containersv1alpha1apply.VolumeStatus().
+			WithDriver(inspect.Driver).
+			WithLabels(inspect.Labels).
+			WithOptions(inspect.Options).
+			WithMountPoint(inspect.Mountpoint).
+			WithScope(inspect.Scope)
+		if t, err := time.Parse(time.RFC3339Nano, inspect.CreatedAt); err == nil {
+			statusApplyConfig = statusApplyConfig.WithCreatedAt(metav1.NewTime(t))
+		} else if inspect.CreatedAt != "" {
+			log.Error(err, "Failed to parse volume created time", "volume", inspect.Name, "created", inspect.CreatedAt)
+		}
+		err = r.Client.Status().Apply(
+			ctx,
+			containersv1alpha1apply.
+				Volume(sanitizeKubernetesObjectName(inspect.Name), metav1.NamespaceDefault).
+				WithStatus(statusApplyConfig),
+			client.ForceOwnership,
+			client.FieldOwner(controllerLongName))
+		if err != nil {
+			errs = append(errs, err)
 		}
 	}
 


### PR DESCRIPTION
#175 generated apply configurations.  This uses them in the existing mock reconcilers.

The image reconciler is a bit annoying: we can't use apply configurations with `GenerateName` (because it can't figure out whether it needs to create a new object, or update one of the existing objects), so we need to keep some of the old logic to be able to create the image if it doesn't exist, then update it.  Since the relevant field selectors select upon the status (which is a sub-resource), we can't do that atomically anyway.