### PR TITLE
apis: container: move namespace to .status

### DIFF
--- a/docs/design/api_containers.md
+++ b/docs/design/api_containers.md
@@ -53,12 +53,11 @@ kind: Container
 metadata:
   name: 8eb6f2cf72b6616aa743cf9187f350af84c9749dab65474db2530f26745d2ef3 # container ID
   namespace: default
-  labels:
-    name: magical_gates
-    namespace: k8s.io # Refers to a `ContainerNamespace` object
 spec:
   state: running # Desired state
 status:
+  name: magical_gates
+  namespace: k8s.io # Refers to a `ContainerNamespace` object
   path: /bin/sh
   args: [-c, 'sleep inf']
   # Image ID; corresponds to `Image` object's `.status.id` field.
@@ -108,10 +107,9 @@ kind: ContainerCreateRequest
 metadata:
   name: whatever-12345
   namespace: rancher-desktop
-  labels:
-    name: magical_gates # If unset, generate one randomly
-    namespace: k8s.io # Refers to a `ContainerNamespace` object
 spec:
+  name: magical_gates # If unset, generate one randomly
+  namespace: k8s.io # Refers to a `ContainerNamespace` object
   state: running # Default to `running`
   path: /bin/sh # defaults to image entry point / command
   args: [-c, 'sleep inf'] # defaults to image entry point / command
@@ -136,8 +134,8 @@ status:
     status: False
 ```
 
-If `.metadata.labels.namespace` / `.metadata.labels.name` duplicates an existing
-container, a `CreateFailed` status is set with some details.
+If `.spec.namespace` / `.spec.name` duplicates an existing container, a
+`CreateFailed` status is set with some details.
 
 An admission controller will ensure that we cannot have multiple
 `ContainerRequest` objects at the same time for the same containerd
@@ -147,12 +145,12 @@ An admission controller will ensure that we cannot have multiple
 Set `.spec.state` to match how Kubernetes resources normally work.
 
 #### Fetch container logs
-The `@kubernetes/client-node` package has some hand-written code to deal with
-logs; maybe we can make a copy of that (with a different endpoint) for this?
+An endpoint at `/passthrough/containers/logs` will speak WebSocket; messages are
+one way, text only, with each line being one message.
 
 #### Exec (shell) in container
-Same as logs; there's some special code in `@kubernetes/client-node` that we may
-be able to fork.
+An endpoint at `/passthrough/containers/exec` will speak WebSocket; messages are
+bidirectional, tentatively text only.
 
 #### Delete container
 Delete the `Container` object; a finalizer will be used to delete the container,
@@ -164,7 +162,7 @@ at which point the `Container` object will actually be deleted.
 as a new `Image` object; therefore, there may be multiple `Image` objects for
 the same image ID (one per tag).  If an image without any tags exists, that will
 be represented by an `Image` object without `.status.repoTag` and
-`.metadata.labels.namespace`.
+`.status.namespace`.
 
 ```yaml
 apiVersion: containers.rancherdesktop.io/v1alpha1
@@ -173,9 +171,8 @@ metadata:
   # Image ID, colon replaced with dot, with random suffix.
   name: 'sha256.999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b-12345'
   namespace: rancher-desktop # not the containerd namespace
-  labels:
-    namespace: moby # Refers to a `ContainerNamespace` object
 status:
+  namespace: moby # Refers to a `ContainerNamespace` object
   # Image ID, in the raw form.
   id: 'sha256:999adf320e40662dc96119a14f07459af9959a081d10ccab7c405257030ab96b'
   repoDigests:
@@ -201,9 +198,8 @@ kind: ImagePullRequest
 metadata:
   name: image-fetch-12345
   namespace: rancher-desktop
-  labels:
-    namespace: moby # Refers to a `ContainerNamespace` object
 spec:
+  namespace: moby # Refers to a `ContainerNamespace` object
   repoTag: 'registry.opensuse.org/opensuse/leap:latest'
 status:
   conditions:
@@ -281,10 +277,9 @@ kind: Volume
 metadata:
   name: volume-name-12345 # based on containerd name / namespace?
   namespace: default # Not related to containerd namespace
-  labels:
-    name: volume-name
-    namespace: k8s.io # Refers to a `ContainerNamespace` object
 status:
+  name: volume-name
+  namespace: k8s.io # Refers to a `ContainerNamespace` object
   createdAt: "2025-11-17T03:14:16Z"
   driver: local
   mountpoint: /var/lib/docker/volumes/volume-name/_data
@@ -303,10 +298,9 @@ kind: VolumeCreateRequest
 metadata:
   name: volume-create-12345
   namespace: default
-  labels:
-    name: volume-name
-    namespace: k8s.io # Refers to a `ContainerNamespace` object
 spec:
+  name: volume-name
+  namespace: k8s.io # Refers to a `ContainerNamespace` object
   driver: local
 status:
   conditions:

--- a/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/containerstatus.go
+++ b/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/containerstatus.go
@@ -13,6 +13,11 @@ import (
 //
 // ContainerStatus defines the observed state of the container.
 type ContainerStatusApplyConfiguration struct {
+	// Name of the container; this is distinct from the container ID.
+	Name *string `json:"name,omitempty"`
+	// Namespace is the container namespace; refers to a `ContainerNamespace`
+	// object in the same Kubernetes namespace.
+	Namespace *string `json:"namespace,omitempty"`
 	// Path to the executable (within the image) for the process.
 	Path *string `json:"path,omitempty"`
 	// Args is the arguments to the executable.
@@ -56,6 +61,22 @@ type ContainerStatusApplyConfiguration struct {
 // apply.
 func ContainerStatus() *ContainerStatusApplyConfiguration {
 	return &ContainerStatusApplyConfiguration{}
+}
+
+// WithName sets the Name field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Name field is set to the value of the last call.
+func (b *ContainerStatusApplyConfiguration) WithName(value string) *ContainerStatusApplyConfiguration {
+	b.Name = &value
+	return b
+}
+
+// WithNamespace sets the Namespace field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Namespace field is set to the value of the last call.
+func (b *ContainerStatusApplyConfiguration) WithNamespace(value string) *ContainerStatusApplyConfiguration {
+	b.Namespace = &value
+	return b
 }
 
 // WithPath sets the Path field in the declarative configuration to the given value

--- a/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/imagestatus.go
+++ b/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/imagestatus.go
@@ -12,6 +12,9 @@ import (
 //
 // ImageStatus defines the observed state of the image.
 type ImageStatusApplyConfiguration struct {
+	// Namespace is the container namespace; refers to a `ContainerNamespace`
+	// object in the same Kubernetes namespace.
+	Namespace *string `json:"namespace,omitempty"`
 	// ID is the image ID, as reported by the container runtime.
 	ID *string `json:"id,omitempty"`
 	// RepoTag is the tag of the image.  Images with multiple tags will have
@@ -39,6 +42,14 @@ type ImageStatusApplyConfiguration struct {
 // apply.
 func ImageStatus() *ImageStatusApplyConfiguration {
 	return &ImageStatusApplyConfiguration{}
+}
+
+// WithNamespace sets the Namespace field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Namespace field is set to the value of the last call.
+func (b *ImageStatusApplyConfiguration) WithNamespace(value string) *ImageStatusApplyConfiguration {
+	b.Namespace = &value
+	return b
 }
 
 // WithID sets the ID field in the declarative configuration to the given value

--- a/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/volumestatus.go
+++ b/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/volumestatus.go
@@ -11,6 +11,11 @@ import (
 //
 // VolumeStatus describes the configuration the volume was created with.
 type VolumeStatusApplyConfiguration struct {
+	// Name of the volume.
+	Name *string `json:"name,omitempty"`
+	// Namespace of the volume; refers to a `ContainerNamespace` object in the
+	// same Kubernetes namespace.
+	Namespace *string `json:"namespace,omitempty"`
 	// CreatedAt is the time the volume was created.
 	CreatedAt *v1.Time `json:"createdAt,omitempty"`
 	// Driver the volume uses.
@@ -29,6 +34,22 @@ type VolumeStatusApplyConfiguration struct {
 // apply.
 func VolumeStatus() *VolumeStatusApplyConfiguration {
 	return &VolumeStatusApplyConfiguration{}
+}
+
+// WithName sets the Name field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Name field is set to the value of the last call.
+func (b *VolumeStatusApplyConfiguration) WithName(value string) *VolumeStatusApplyConfiguration {
+	b.Name = &value
+	return b
+}
+
+// WithNamespace sets the Namespace field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Namespace field is set to the value of the last call.
+func (b *VolumeStatusApplyConfiguration) WithNamespace(value string) *VolumeStatusApplyConfiguration {
+	b.Namespace = &value
+	return b
 }
 
 // WithCreatedAt sets the CreatedAt field in the declarative configuration to the given value

--- a/pkg/apis/containers/v1alpha1/container_types.go
+++ b/pkg/apis/containers/v1alpha1/container_types.go
@@ -62,6 +62,15 @@ type ContainerSpec struct {
 
 // ContainerStatus defines the observed state of the container.
 type ContainerStatus struct {
+	// Name of the container; this is distinct from the container ID.
+	//
+	// +required
+	Name string `json:"name"`
+	// Namespace is the container namespace; refers to a `ContainerNamespace`
+	// object in the same Kubernetes namespace.
+	//
+	// +required
+	Namespace string `json:"namespace"`
 	// Path to the executable (within the image) for the process.
 	//
 	// +required
@@ -133,6 +142,7 @@ type ContainerStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=.status.namespace
 // +kubebuilder:printcolumn:name="Running",type=boolean,JSONPath=`.status.conditions[?(@.type=="Running")].status`
 
 // Container is the Schema for the containers API.
@@ -166,6 +176,17 @@ type ContainerList struct {
 
 // ContainerCreateRequestSpec defines the desired state for creating a container.
 type ContainerCreateRequestSpec struct {
+	// Name of the container to create; if not specified, a random name will be
+	// generated.
+	//
+	// +optional
+	Name string `json:"name"`
+	// Namespace is the container namespace; refers to a `ContainerNamespace`
+	// object in the same Kubernetes namespace.  If not specified, the container
+	// will be created in the default namespace.
+	//
+	// +optional
+	Namespace string `json:"namespace"`
 	// Path is the path to the executable (within the image) for the process.
 	// Defaults to the image's default command if not specified.
 	//
@@ -218,6 +239,7 @@ type ContainerCreateRequestStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=.spec.namespace
 // +kubebuilder:metadata:annotations=rdd.rancherdesktop.io/controller=container
 
 // ContainerCreateRequest defines a request to create a new container.

--- a/pkg/apis/containers/v1alpha1/image_types.go
+++ b/pkg/apis/containers/v1alpha1/image_types.go
@@ -10,6 +10,11 @@ import (
 
 // ImageStatus defines the observed state of the image.
 type ImageStatus struct {
+	// Namespace is the container namespace; refers to a `ContainerNamespace`
+	// object in the same Kubernetes namespace.
+	//
+	// +required
+	Namespace string `json:"namespace"`
 	// ID is the image ID, as reported by the container runtime.
 	//
 	// +required
@@ -57,6 +62,7 @@ type ImageStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=.status.namespace
 // +kubebuilder:selectablefield:JSONPath=.status.id
 // +kubebuilder:selectablefield:JSONPath=.status.repoTag
 // +kubebuilder:printcolumn:name="Tag",type=string,JSONPath=`.status.repoTag`
@@ -88,6 +94,12 @@ type ImageList struct {
 }
 
 type ImagePullRequestSpec struct {
+	// Namespace is the container namespace; refers to a `ContainerNamespace`
+	// object in the same Kubernetes namespace.  If not specified, the image
+	// will be pulled into the default namespace.
+	//
+	// +optional
+	Namespace string `json:"namespace"`
 	// RepoTag is the image to pull.
 	//
 	// +required
@@ -108,6 +120,7 @@ type ImagePullRequestStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=.spec.namespace
 // +kubebuilder:metadata:annotations=rdd.rancherdesktop.io/controller=image
 
 // ImagePullRequest defines a request to pull a new image.
@@ -143,7 +156,7 @@ type ImagePullRequestList struct {
 
 type ImagePushRequestSpec struct {
 	// ImageRef is the image to push.
-	// This must be the name of an Image object in the same namespace.
+	// This must be the name of an Image object in the same Kubernetes namespace.
 	//
 	// +required
 	ImageRef string `json:"imageRef"`

--- a/pkg/apis/containers/v1alpha1/volume_types.go
+++ b/pkg/apis/containers/v1alpha1/volume_types.go
@@ -10,6 +10,15 @@ import (
 
 // VolumeStatus describes the configuration the volume was created with.
 type VolumeStatus struct {
+	// Name of the volume.
+	//
+	// +required
+	Name string `json:"name"`
+	// Namespace of the volume; refers to a `ContainerNamespace` object in the
+	// same Kubernetes namespace.
+	//
+	// +required
+	Namespace string `json:"namespace"`
 	// CreatedAt is the time the volume was created.
 	//
 	// +required
@@ -39,6 +48,7 @@ type VolumeStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=.status.namespace
 // +kubebuilder:printcolumn:name="Driver",type=string,JSONPath=`.status.driver`
 
 // Volume is the Schema for the volumes API.
@@ -66,6 +76,17 @@ type VolumeList struct {
 }
 
 type VolumeCreateSpec struct {
+	// Name of the volume to create; if not specified, a random name will be
+	// generated.
+	//
+	// +optional
+	Name string `json:"name"`
+	// Namespace of the volume; refers to a `ContainerNamespace` object in the
+	// same Kubernetes namespace.  If not specified, the volume will be created
+	// in the default namespace.
+	//
+	// +optional
+	Namespace string `json:"namespace"`
 	// Driver the volume should use.
 	//
 	// +required

--- a/pkg/controllers/containers/container/crd.yaml
+++ b/pkg/controllers/containers/container/crd.yaml
@@ -63,6 +63,17 @@ spec:
                 description: Labels are the container labels.  They are merged with
                   the image labels.
                 type: object
+              name:
+                description: |-
+                  Name of the container to create; if not specified, a random name will be
+                  generated.
+                type: string
+              namespace:
+                description: |-
+                  Namespace is the container namespace; refers to a `ContainerNamespace`
+                  object in the same Kubernetes namespace.  If not specified, the container
+                  will be created in the default namespace.
+                type: string
               path:
                 description: |-
                   Path is the path to the executable (within the image) for the process.
@@ -203,6 +214,8 @@ spec:
         required:
         - spec
         type: object
+    selectableFields:
+    - jsonPath: .spec.namespace
     served: true
     storage: true
     subresources:
@@ -378,6 +391,15 @@ spec:
                   type: string
                 description: Labels are the container labels.
                 type: object
+              name:
+                description: Name of the container; this is distinct from the container
+                  ID.
+                type: string
+              namespace:
+                description: |-
+                  Namespace is the container namespace; refers to a `ContainerNamespace`
+                  object in the same Kubernetes namespace.
+                type: string
               path:
                 description: Path to the executable (within the image) for the process.
                 type: string
@@ -442,6 +464,8 @@ spec:
                 type: string
             required:
             - image
+            - name
+            - namespace
             - path
             - pid
             - status
@@ -449,6 +473,8 @@ spec:
         required:
         - spec
         type: object
+    selectableFields:
+    - jsonPath: .status.namespace
     served: true
     storage: true
     subresources:

--- a/pkg/controllers/containers/image/crd.yaml
+++ b/pkg/controllers/containers/image/crd.yaml
@@ -47,6 +47,12 @@ spec:
           spec:
             description: Spec defines the desired state of ImagePullRequest
             properties:
+              namespace:
+                description: |-
+                  Namespace is the container namespace; refers to a `ContainerNamespace`
+                  object in the same Kubernetes namespace.  If not specified, the image
+                  will be pulled into the default namespace.
+                type: string
               repoTag:
                 description: RepoTag is the image to pull.
                 type: string
@@ -125,6 +131,8 @@ spec:
         required:
         - spec
         type: object
+    selectableFields:
+    - jsonPath: .spec.namespace
     served: true
     storage: true
     subresources:
@@ -174,7 +182,7 @@ spec:
               imageRef:
                 description: |-
                   ImageRef is the image to push.
-                  This must be the name of an Image object in the same namespace.
+                  This must be the name of an Image object in the same Kubernetes namespace.
                 type: string
             required:
             - imageRef
@@ -384,6 +392,11 @@ spec:
                   type: string
                 description: Labels of the image.
                 type: object
+              namespace:
+                description: |-
+                  Namespace is the container namespace; refers to a `ContainerNamespace`
+                  object in the same Kubernetes namespace.
+                type: string
               os:
                 description: OS associated with the image.
                 type: string
@@ -405,11 +418,13 @@ spec:
             required:
             - architecture
             - id
+            - namespace
             - os
             - size
             type: object
         type: object
     selectableFields:
+    - jsonPath: .status.namespace
     - jsonPath: .status.id
     - jsonPath: .status.repoTag
     served: true

--- a/pkg/controllers/containers/volume/crd.yaml
+++ b/pkg/controllers/containers/volume/crd.yaml
@@ -50,6 +50,17 @@ spec:
               driver:
                 description: Driver the volume should use.
                 type: string
+              name:
+                description: |-
+                  Name of the volume to create; if not specified, a random name will be
+                  generated.
+                type: string
+              namespace:
+                description: |-
+                  Namespace of the volume; refers to a `ContainerNamespace` object in the
+                  same Kubernetes namespace.  If not specified, the volume will be created
+                  in the default namespace.
+                type: string
             required:
             - driver
             type: object
@@ -189,6 +200,14 @@ spec:
               mountpoint:
                 description: MountPoint is where on the host the volume is mounted.
                 type: string
+              name:
+                description: Name of the volume.
+                type: string
+              namespace:
+                description: |-
+                  Namespace of the volume; refers to a `ContainerNamespace` object in the
+                  same Kubernetes namespace.
+                type: string
               options:
                 additionalProperties:
                   type: string
@@ -201,9 +220,13 @@ spec:
             - createdAt
             - driver
             - mountpoint
+            - name
+            - namespace
             - scope
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .status.namespace
     served: true
     storage: true
     subresources:

--- a/pkg/controllers/mock/container_reconciler.go
+++ b/pkg/controllers/mock/container_reconciler.go
@@ -80,10 +80,6 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			state = containersv1alpha1.ContainerStatusRunning
 		}
 		applyConfig := containersv1alpha1apply.Container(inspect.ID, metav1.NamespaceDefault).
-			WithLabels(map[string]string{
-				"namespace": namespace,
-				"name":      name,
-			}).
 			WithOwnerReferences(ownerReference).
 			WithSpec(containersv1alpha1apply.ContainerSpec().WithState(state))
 
@@ -93,6 +89,8 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		applyStatus := containersv1alpha1apply.ContainerStatus().
+			WithName(name).
+			WithNamespace(namespace).
 			WithPath(inspect.Path).
 			WithArgs(inspect.Args...).
 			WithImage(inspect.Image).

--- a/pkg/controllers/mock/image_reconciler.go
+++ b/pkg/controllers/mock/image_reconciler.go
@@ -110,11 +110,11 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				statusApplyCopy := *statusApplyConfig
 				errs = append(errs, r.updateImage(ctx,
 					containersv1alpha1apply.Image(image.GetName(), image.GetNamespace()).
-						WithLabels(map[string]string{
-							"namespace": containerNamespace,
-						}).
 						WithOwnerReferences(ownerReference),
-					statusApplyCopy.WithRepoTag(tag))...,
+					statusApplyCopy.
+						WithRepoTag(tag).
+						WithNamespace(containerNamespace),
+				)...,
 				)
 			}
 		} else {

--- a/pkg/controllers/mock/volume_reconciler.go
+++ b/pkg/controllers/mock/volume_reconciler.go
@@ -76,9 +76,6 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			ctx,
 			containersv1alpha1apply.
 				Volume(sanitizeKubernetesObjectName(inspect.Name), metav1.NamespaceDefault).
-				WithLabels(map[string]string{
-					"namespace": containerNamespace,
-				}).
 				WithOwnerReferences(ownerReference),
 			client.ForceOwnership,
 			client.FieldOwner(controllerLongName))
@@ -87,6 +84,8 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 
 		statusApplyConfig := containersv1alpha1apply.VolumeStatus().
+			WithName(inspect.Name).
+			WithNamespace(containerNamespace).
 			WithDriver(inspect.Driver).
 			WithLabels(inspect.Labels).
 			WithOptions(inspect.Options).


### PR DESCRIPTION
Because `.metadata.labels` is a `map[string]...`, we can't use it as part of a field selector.  Move the `namespace` (and where appropriate, `name`) to be part of status instead.  This affects containers, images, and volumes.
