### PR TITLE
mock: namespaces: ensure we have all namespaces

### DIFF
--- a/bats/tests/34-containers-controllers/containers-mock.bats
+++ b/bats/tests/34-containers-controllers/containers-mock.bats
@@ -4,6 +4,7 @@ load '../../helpers/load'
 # and image controllers work as expected.
 
 TEST_DATA_PATH="${PATH_BATS_ROOT}/../pkg/controllers/mock/testdata"
+NAMESPACE="rancher-desktop"
 
 local_setup_file() {
     setup_rdd_control_plane "containers"
@@ -22,14 +23,13 @@ local_teardown_file() {
 
 @test "containers are created" {
     rdd ctl wait --for=create namespace rdd-mocks --timeout=30s
+    rdd ctl wait --for=create namespace "${NAMESPACE}" --timeout=30s
 
     run -0 cat "${TEST_DATA_PATH}/containers.json"
     run -0 jq_output '.[].Id'
     containers=${output}
 
-    while IFS= read -r container; do
-        rdd ctl wait --for=create container "${container}" --timeout=30s
-    done <<<"${containers}"
+    rdd ctl wait --for=create --namespace="${NAMESPACE}" container "${containers[@]}" --timeout=30s
 }
 
 @test "images are created" {
@@ -40,7 +40,7 @@ local_teardown_file() {
     images=${output}
 
     while IFS= read -r image; do
-        try --max 30 --delay 1 -- rdd ctl get image --field-selector "status.repoTag=${image}" --output jsonpath='{.items[*].status.repoTag}'
+        rdd ctl wait --for=create --namespace="${NAMESPACE}" image --field-selector "status.repoTag=${image}" --timeout=30s --output=jsonpath='{.items[*].status.repoTag}'
         assert_line "${image}"
     done <<<"${images}"
 }
@@ -52,7 +52,5 @@ local_teardown_file() {
     run -0 jq_output '.[].Name'
     volumes=${output}
 
-    while IFS= read -r volume; do
-        rdd ctl wait --for=create volume "${volume}" --timeout=30s
-    done <<<"${volumes}"
+    rdd ctl wait --for=create --namespace="${NAMESPACE}" volume "${volumes[@]}" --timeout=30s
 }

--- a/bats/tests/34-containers-controllers/containers-mock.bats
+++ b/bats/tests/34-containers-controllers/containers-mock.bats
@@ -27,7 +27,7 @@ local_teardown_file() {
 
     run -0 cat "${TEST_DATA_PATH}/containers.json"
     run -0 jq_output '.[].Id'
-    containers=${output}
+    mapfile -t containers <<<"${output}"
 
     rdd ctl wait --for=create --namespace="${NAMESPACE}" container "${containers[@]}" --timeout=30s
 }
@@ -40,8 +40,8 @@ local_teardown_file() {
     images=${output}
 
     while IFS= read -r image; do
-        rdd ctl wait --for=create --namespace="${NAMESPACE}" image --field-selector "status.repoTag=${image}" --timeout=30s --output=jsonpath='{.items[*].status.repoTag}'
-        assert_line "${image}"
+        rdd ctl wait --for=create --namespace="${NAMESPACE}" image \
+            --field-selector "status.repoTag=${image}" --timeout=30s
     done <<<"${images}"
 }
 
@@ -50,7 +50,7 @@ local_teardown_file() {
 
     run -0 cat "${TEST_DATA_PATH}/volumes.json"
     run -0 jq_output '.[].Name'
-    volumes=${output}
+    mapfile -t volumes <<<"${output}"
 
     rdd ctl wait --for=create --namespace="${NAMESPACE}" volume "${volumes[@]}" --timeout=30s
 }

--- a/pkg/apis/containers/v1alpha1/container_types.go
+++ b/pkg/apis/containers/v1alpha1/container_types.go
@@ -98,7 +98,7 @@ type ContainerStatus struct {
 	Status ContainerStatusValue `json:"status"`
 	// Pid is the process identifier for the main process in the container.
 	//
-	// +required
+	// +optional
 	Pid int32 `json:"pid"`
 	// ExitCode is the exit status of the main process in the container.
 	//

--- a/pkg/controllers/containers/container/crd.yaml
+++ b/pkg/controllers/containers/container/crd.yaml
@@ -467,7 +467,6 @@ spec:
             - name
             - namespace
             - path
-            - pid
             - status
             type: object
         required:

--- a/pkg/controllers/mock/container_namespace_reconciler.go
+++ b/pkg/controllers/mock/container_namespace_reconciler.go
@@ -14,7 +14,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
@@ -28,13 +27,13 @@ import (
 	containersv1alpha1apply "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1"
 )
 
-type namespaceReconciler struct {
+type containerNamespaceReconciler struct {
 	client.Client
 	Recorder events.EventRecorder
 	volumes  []mobyvolume.Volume
 }
 
-func (r *namespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *containerNamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
 	// Check for the CRD to be registered.
@@ -64,7 +63,7 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var errs []error
 	for namespace := range namespaces {
-		applyConfig := containersv1alpha1apply.ContainerNamespace(namespace, metav1.NamespaceDefault).
+		applyConfig := containersv1alpha1apply.ContainerNamespace(namespace, apiNamespace).
 			WithOwnerReferences(metav1apply.OwnerReference().
 				WithAPIVersion(gvk.GroupVersion().String()).
 				WithKind(gvk.Kind).
@@ -81,7 +80,7 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, errors.Join(errs...)
 }
 
-func (r *namespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *containerNamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	var volumes []mobyvolume.Volume
 	if err := json.Unmarshal(testVolumes, &volumes); err != nil {
 		return fmt.Errorf("failed to load static test volume data: %w", err)
@@ -90,7 +89,7 @@ func (r *namespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Namespace{}).
-		Named("mock-namespace-reconciler").
+		Named("mock-container-namespace-reconciler").
 		Watches(
 			&containersv1alpha1.ContainerNamespace{},
 			handler.EnqueueRequestForOwner(

--- a/pkg/controllers/mock/container_reconciler.go
+++ b/pkg/controllers/mock/container_reconciler.go
@@ -16,7 +16,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
@@ -79,7 +78,7 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if inspect.State.Running {
 			state = containersv1alpha1.ContainerStatusRunning
 		}
-		applyConfig := containersv1alpha1apply.Container(inspect.ID, metav1.NamespaceDefault).
+		applyConfig := containersv1alpha1apply.Container(inspect.ID, apiNamespace).
 			WithOwnerReferences(ownerReference).
 			WithSpec(containersv1alpha1apply.ContainerSpec().WithState(state))
 
@@ -109,7 +108,7 @@ func (r *containerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				WithBindings(bindings...))
 		}
 		applyStatus.WithPorts(applyPorts...)
-		applyConfig = containersv1alpha1apply.Container(inspect.ID, metav1.NamespaceDefault).
+		applyConfig = containersv1alpha1apply.Container(inspect.ID, apiNamespace).
 			WithStatus(applyStatus)
 
 		err = r.Client.SubResource("status").Apply(ctx, applyConfig, client.ForceOwnership, client.FieldOwner(controllerLongName))

--- a/pkg/controllers/mock/image_reconciler.go
+++ b/pkg/controllers/mock/image_reconciler.go
@@ -110,7 +110,7 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 					sha256.Sum256([]byte(tag)))
 				statusApplyCopy := *statusApplyConfig
 				errs = append(errs, r.updateImage(ctx,
-					containersv1alpha1apply.Image(name, metav1.NamespaceDefault).
+					containersv1alpha1apply.Image(name, apiNamespace).
 						WithOwnerReferences(ownerReference),
 					statusApplyCopy.
 						WithRepoTag(tag).
@@ -120,7 +120,7 @@ func (r *imageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		} else {
 			// No tags; create a single dangling image.
 			errs = append(errs, r.updateImage(ctx,
-				containersv1alpha1apply.Image(sanitizeKubernetesObjectName(inspect.ID), metav1.NamespaceDefault).
+				containersv1alpha1apply.Image(sanitizeKubernetesObjectName(inspect.ID), apiNamespace).
 					WithOwnerReferences(ownerReference),
 				statusApplyConfig)...,
 			)

--- a/pkg/controllers/mock/kube_namespace_reconciler.go
+++ b/pkg/controllers/mock/kube_namespace_reconciler.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package mock
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
+	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type kubeNamespaceReconciler struct {
+	client.Client
+	Recorder events.EventRecorder
+}
+
+// Reconcile implements [reconcile.TypedReconciler].
+func (r *kubeNamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	var rddNamespace corev1.Namespace
+	if err := r.Client.Get(ctx, req.NamespacedName, &rddNamespace); err != nil {
+		log.Error(err, "Failed to get namespace", "namespace", req.NamespacedName)
+		return ctrl.Result{}, err
+	}
+	gvk, err := r.Client.GroupVersionKindFor(&rddNamespace)
+	if err != nil {
+		log.Error(err, "Failed to get GVK for namespace", "namespace", &rddNamespace)
+		return ctrl.Result{}, err
+	}
+
+	ownerReference := metav1apply.OwnerReference().
+		WithAPIVersion(gvk.GroupVersion().String()).
+		WithKind(gvk.Kind).
+		WithName(rddNamespace.GetName()).
+		WithUID(rddNamespace.GetUID()).
+		WithBlockOwnerDeletion(true).
+		WithController(true)
+
+	err = r.Client.Apply(
+		ctx,
+		corev1apply.Namespace(apiNamespace).
+			WithOwnerReferences(ownerReference),
+		client.ForceOwnership,
+		client.FieldOwner(controllerLongName),
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *kubeNamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		Named("mock-kube-namespace-reconciler").
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestForOwner(
+				mgr.GetScheme(),
+				mgr.GetRESTMapper(),
+				&corev1.Namespace{},
+				handler.OnlyControllerOwner(),
+			)).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			if _, ok := object.(*corev1.Namespace); ok {
+				return object.GetName() == mockNamespaceName
+			}
+			return false
+		})).
+		Complete(r)
+}

--- a/pkg/controllers/mock/kube_namespace_reconciler.go
+++ b/pkg/controllers/mock/kube_namespace_reconciler.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -64,14 +63,6 @@ func (r *kubeNamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Namespace{}).
 		Named("mock-kube-namespace-reconciler").
-		Watches(
-			&corev1.Namespace{},
-			handler.EnqueueRequestForOwner(
-				mgr.GetScheme(),
-				mgr.GetRESTMapper(),
-				&corev1.Namespace{},
-				handler.OnlyControllerOwner(),
-			)).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			if _, ok := object.(*corev1.Namespace); ok {
 				return object.GetName() == mockNamespaceName

--- a/pkg/controllers/mock/mock_controller.go
+++ b/pkg/controllers/mock/mock_controller.go
@@ -22,6 +22,8 @@ import (
 const (
 	// The reconcilers will trigger on update of a namespace with this name.
 	mockNamespaceName = "rdd-mocks"
+	// The name of the Kubernetes namespace in which the resources will be created.
+	apiNamespace = "rancher-desktop"
 	// The mock controller creates all items in this (container) namespace.
 	containerNamespace = "buildkit"
 
@@ -64,8 +66,10 @@ func (c *controller) GetCRDData() string {
 }
 
 func (c *controller) setupReconciler(ctx context.Context, mgr ctrl.Manager) error {
-	mgr.GetLogger().Info("Setting up Mock NamespaceReconciler")
-	err := (&namespaceReconciler{
+	log := mgr.GetLogger()
+
+	log.Info("Setting up Mock KubeNamespaceReconciler")
+	err := (&kubeNamespaceReconciler{
 		Client:   mgr.GetClient(),
 		Recorder: mgr.GetEventRecorder(controllerLongName),
 	}).SetupWithManager(mgr)
@@ -73,7 +77,16 @@ func (c *controller) setupReconciler(ctx context.Context, mgr ctrl.Manager) erro
 		return err
 	}
 
-	mgr.GetLogger().Info("Setting up Mock ContainerReconciler")
+	log.Info("Setting up Mock ContainerNamespaceReconciler")
+	err = (&containerNamespaceReconciler{
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorder(controllerLongName),
+	}).SetupWithManager(mgr)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Setting up Mock ContainerReconciler")
 	err = (&containerReconciler{
 		Client:   mgr.GetClient(),
 		Recorder: mgr.GetEventRecorder(controllerLongName),
@@ -82,7 +95,7 @@ func (c *controller) setupReconciler(ctx context.Context, mgr ctrl.Manager) erro
 		return err
 	}
 
-	mgr.GetLogger().Info("Setting up Mock ImageReconciler")
+	log.Info("Setting up Mock ImageReconciler")
 	err = (&imageReconciler{
 		Client:   mgr.GetClient(),
 		Recorder: mgr.GetEventRecorder(controllerLongName),
@@ -91,7 +104,7 @@ func (c *controller) setupReconciler(ctx context.Context, mgr ctrl.Manager) erro
 		return err
 	}
 
-	mgr.GetLogger().Info("Setting up Mock VolumeReconciler")
+	log.Info("Setting up Mock VolumeReconciler")
 	err = (&volumeReconciler{
 		Client:   mgr.GetClient(),
 		Recorder: mgr.GetEventRecorder(controllerLongName),

--- a/pkg/controllers/mock/namespace_reconciler.go
+++ b/pkg/controllers/mock/namespace_reconciler.go
@@ -6,6 +6,11 @@ package mock
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	mobyvolume "github.com/moby/moby/api/types/volume"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -26,6 +31,7 @@ import (
 type namespaceReconciler struct {
 	client.Client
 	Recorder events.EventRecorder
+	volumes  []mobyvolume.Volume
 }
 
 func (r *namespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -50,20 +56,38 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	applyConfig := containersv1alpha1apply.ContainerNamespace(containerNamespace, metav1.NamespaceDefault).
-		WithOwnerReferences(metav1apply.OwnerReference().
-			WithAPIVersion(gvk.GroupVersion().String()).
-			WithKind(gvk.Kind).
-			WithName(rddNamespace.GetName()).
-			WithUID(rddNamespace.GetUID()).
-			WithBlockOwnerDeletion(true).
-			WithController(true))
-	err = r.Client.Apply(ctx, applyConfig, client.ForceOwnership, client.FieldOwner(controllerLongName))
+	namespaces := map[string]struct{}{containerNamespace: {}}
+	for _, volume := range r.volumes {
+		namespace, _ := getVolumeName(volume)
+		namespaces[namespace] = struct{}{}
+	}
 
-	return ctrl.Result{}, err
+	var errs []error
+	for namespace := range namespaces {
+		applyConfig := containersv1alpha1apply.ContainerNamespace(namespace, metav1.NamespaceDefault).
+			WithOwnerReferences(metav1apply.OwnerReference().
+				WithAPIVersion(gvk.GroupVersion().String()).
+				WithKind(gvk.Kind).
+				WithName(rddNamespace.GetName()).
+				WithUID(rddNamespace.GetUID()).
+				WithBlockOwnerDeletion(true).
+				WithController(true))
+		err = r.Client.Apply(ctx, applyConfig, client.ForceOwnership, client.FieldOwner(controllerLongName))
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return ctrl.Result{}, errors.Join(errs...)
 }
 
 func (r *namespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	var volumes []mobyvolume.Volume
+	if err := json.Unmarshal(testVolumes, &volumes); err != nil {
+		return fmt.Errorf("failed to load static test volume data: %w", err)
+	}
+	r.volumes = volumes
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Namespace{}).
 		Named("mock-namespace-reconciler").

--- a/pkg/controllers/mock/volume_reconciler.go
+++ b/pkg/controllers/mock/volume_reconciler.go
@@ -79,7 +79,7 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		err = r.Client.Apply(
 			ctx,
 			containersv1alpha1apply.
-				Volume(sanitizeKubernetesObjectName(inspect.Name), metav1.NamespaceDefault).
+				Volume(sanitizeKubernetesObjectName(inspect.Name), apiNamespace).
 				WithOwnerReferences(ownerReference),
 			client.ForceOwnership,
 			client.FieldOwner(controllerLongName))
@@ -104,7 +104,7 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		err = r.Client.Status().Apply(
 			ctx,
 			containersv1alpha1apply.
-				Volume(sanitizeKubernetesObjectName(inspect.Name), metav1.NamespaceDefault).
+				Volume(sanitizeKubernetesObjectName(inspect.Name), apiNamespace).
 				WithStatus(statusApplyConfig),
 			client.ForceOwnership,
 			client.FieldOwner(controllerLongName))

--- a/pkg/controllers/mock/volume_reconciler.go
+++ b/pkg/controllers/mock/volume_reconciler.go
@@ -39,6 +39,10 @@ type volumeReconciler struct {
 	inspects []mobyvolume.Volume
 }
 
+func getVolumeName(volume mobyvolume.Volume) (namespace, name string) {
+	return containerNamespace, volume.Name
+}
+
 // Reconcile implements [reconcile.TypedReconciler].
 func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var errs []error
@@ -83,9 +87,10 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			errs = append(errs, err)
 		}
 
+		namespace, name := getVolumeName(inspect)
 		statusApplyConfig := containersv1alpha1apply.VolumeStatus().
-			WithName(inspect.Name).
-			WithNamespace(containerNamespace).
+			WithName(name).
+			WithNamespace(namespace).
 			WithDriver(inspect.Driver).
 			WithLabels(inspect.Labels).
 			WithOptions(inspect.Options).


### PR DESCRIPTION
This updates the namespaces reconciler to ensure that we create namespaces for all the volumes in the test data. (We always create containers and images in the default namespace at the moment.)