### PR TITLE
Update existing CRDs on startup instead of skipping them

### DIFF
--- a/bats/tests/31-rdd-controllers/crd-upgrade.bats
+++ b/bats/tests/31-rdd-controllers/crd-upgrade.bats
@@ -54,8 +54,7 @@ assert_crd_has_change_count() {
 
 @test "restart control plane without controllers" {
     rdd svc delete
-    rdd svc create --controllers=""
-    rdd svc start
+    rdd svc start --controllers=""
     run -0 rdd ctl get namespaces --output name
     assert_line namespace/default
 }

--- a/bats/tests/31-rdd-controllers/crd-upgrade.bats
+++ b/bats/tests/31-rdd-controllers/crd-upgrade.bats
@@ -1,0 +1,95 @@
+load '../../helpers/load'
+
+# Verify that the controller updates existing CRDs on startup.
+# Applies a notary CRD with a missing field, starts the controller,
+# and confirms the schema is updated.
+
+# Note: This test requires bin/rdd-controller to be built.
+# Run 'make build-rdd-controller' before running this test.
+
+local_setup_file() {
+    rdd svc delete
+    rdd svc start
+}
+
+local_teardown_file() {
+    if [[ -f "${BATS_FILE_TMPDIR}/controller_pid" ]]; then
+        kill "$(cat "${BATS_FILE_TMPDIR}/controller_pid")" 2>/dev/null || true
+    fi
+    rdd svc delete
+}
+
+assert_process_exited() {
+    local pid=$1
+    ! kill -0 "${pid}" 2>/dev/null
+}
+
+assert_crd_has_change_count() {
+    local expected=$1
+    run_e -0 rdd ctl get crd notaries.rdd.rancherdesktop.io --output json
+    run -0 jq_output '.spec.versions[0].schema.openAPIV3Schema.properties.status.properties | has("changeCount")'
+    assert_output "${expected}"
+}
+
+@test "controllers install CRDs" {
+    rdd ctl wait crd notaries.rdd.rancherdesktop.io --for create --timeout=20s
+    rdd ctl wait crd notaries.rdd.rancherdesktop.io --for condition=Established --timeout=10s
+}
+
+@test "extract CRD and remove changeCount field" {
+    # Strip server-managed metadata so the CRD can be re-applied to a fresh
+    # control plane, and remove changeCount to simulate an old schema.
+    run_e -0 rdd ctl get crd notaries.rdd.rancherdesktop.io --output json
+    run -0 jq_output 'del(
+        .metadata.resourceVersion,
+        .metadata.uid,
+        .metadata.creationTimestamp,
+        .metadata.generation,
+        .metadata.managedFields,
+        .status,
+        .spec.versions[0].schema.openAPIV3Schema.properties.status.properties.changeCount
+    )'
+    save_var output
+}
+
+@test "restart control plane without controllers" {
+    rdd svc delete
+    rdd svc create --controllers=""
+    rdd svc start
+    run -0 rdd ctl get namespaces --output name
+    assert_line namespace/default
+}
+
+@test "apply old CRD without changeCount field" {
+    load_var output
+    echo "${output}" | rdd ctl apply --filename -
+    rdd ctl wait crd notaries.rdd.rancherdesktop.io --for condition=Established --timeout=10s
+}
+
+@test "old CRD schema lacks changeCount" {
+    assert_crd_has_change_count false
+}
+
+@test "external controller updates CRD on startup" {
+    "rdd-controller${EXE}" &>"${RDD_LOG_DIR}/rdd-controller.log" &
+    echo "$!" >"${BATS_FILE_TMPDIR}/controller_pid"
+
+    # Wait for the controller to start and update the CRD schema
+    try --max 30 --delay 1 -- assert_crd_has_change_count true
+}
+
+@test "controller shuts down with control plane" {
+    controller_pid=$(cat "${BATS_FILE_TMPDIR}/controller_pid")
+    kill -0 "${controller_pid}"
+
+    trace "# Stopping control plane at $(date +%T)"
+    rdd svc stop
+    trace "# Control plane stopped at $(date +%T), waiting for controller exit"
+
+    if ! try --max 30 --delay 1 -- assert_process_exited "${controller_pid}"; then
+        trace "# Controller did not exit in time. Log contents:"
+        trace "$(cat "${RDD_LOG_DIR}/rdd-controller.log" || true)"
+        return 1
+    fi
+    trace "# Controller exited at $(date +%T)"
+}

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -12,6 +12,13 @@ local_setup_file() {
     rdd svc start
 }
 
+local_teardown_file() {
+    if [[ -f "${BATS_FILE_TMPDIR}/controller_pid" ]]; then
+        kill "$(cat "${BATS_FILE_TMPDIR}/controller_pid")" 2>/dev/null || true
+    fi
+    rdd svc delete
+}
+
 assert_process_exited() {
     local pid=$1
     # Return 0 (success) if process has exited, 1 (failure) if still running

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -258,27 +258,17 @@ func checkReadiness(ctx context.Context) error {
 		return err
 	}
 
-	if len(runtimeControllers) == 0 {
-		// If we found no controllers, check to see if we just need to wait longer
-		// for the controller manager to register.
-		klog.V(2).Info("No controller manager found - checking if this is truly no-controllers mode")
-
-		// Check the original command args to see if --controllers="" was specified
-		serveArgs := ServeArgs()
-		argIndex := slices.Index(serveArgs, "--controllers")
-		isNoControllersMode := argIndex >= 0 && argIndex+1 < len(serveArgs) && serveArgs[argIndex+1] == ""
-
-		if isNoControllersMode {
-			// Check if API server is ready for basic operations
-			if err := readiness.WaitForReady(ctx, config, false); err == nil {
-				klog.V(2).Info("API server ready and no controllers expected - no controllers mode")
-				return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
-			}
-			klog.V(2).Info("API server not ready yet, continuing to wait...")
-		} else {
-			klog.V(2).Info("Controllers expected but discovery configmap not found yet - waiting for external controllers to register...")
-		}
+	if runtimeControllers == nil {
+		// Discovery ConfigMap doesn't exist yet; the serve subprocess hasn't
+		// finished initializing. Keep polling.
+		klog.V(2).Info("Discovery configmap not found yet - waiting for control plane initialization")
 		return errors.New("waiting for controller manager registration")
+	}
+
+	if len(runtimeControllers) == 0 {
+		// ConfigMap exists but no controllers are registered.
+		klog.V(2).Info("No controllers registered - checking API server readiness")
+		return readiness.WaitForReadyWithCRDs(ctx, config, []base.Controller{}, false)
 	}
 
 	klog.V(2).Infof("Waiting for %d runtime controllers to be ready", len(runtimeControllers))

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -269,7 +269,7 @@ func (d *ControllerManagerDiscovery) GetEnabledControllers(ctx context.Context) 
 		return nil, fmt.Errorf("failed to discover controller manager: %w", err)
 	}
 
-	var enabledControllers []string
+	enabledControllers := make([]string, 0) // non-nil: distinguishes "0 controllers" from "ConfigMap not found"
 	for _, serializedInfo := range configMap.Data {
 		var info ControllerManagerInfo
 		if err := json.Unmarshal([]byte(serializedInfo), &info); err != nil {

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -20,6 +20,7 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -353,7 +354,7 @@ func (scm *SharedControllerManager) installControllerCRDs(ctx context.Context) e
 
 	crdClient := apiextensionsClient.ApiextensionsV1().CustomResourceDefinitions()
 
-	// Step 1: Create all CRDs that don't already exist
+	// Step 1: Create or update all CRDs
 	type crdInfo struct {
 		controller base.Controller
 		crd        apiextensionsv1.CustomResourceDefinition
@@ -385,10 +386,18 @@ func (scm *SharedControllerManager) installControllerCRDs(ctx context.Context) e
 				continue // Comment block before the first document has no data.
 			}
 
-			// Check if CRD already exists
-			_, err = crdClient.Get(ctx, crd.Name, metav1.GetOptions{})
+			// Update existing CRDs so new schema fields take effect on upgrade.
+			existing, err := crdClient.Get(ctx, crd.Name, metav1.GetOptions{})
 			if err == nil {
-				klog.Infof("%s CRD already exists", controllerName)
+				if !apiequality.Semantic.DeepEqual(existing.Spec, crd.Spec) {
+					existing.Spec = crd.Spec
+					if _, err := crdClient.Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+						return fmt.Errorf("failed to update CRD for controller %s: %w", controllerName, err)
+					}
+					klog.Infof("Updated %s CRD %s", controllerName, crd.Name)
+				} else {
+					klog.V(2).Infof("%s CRD %s is up to date", controllerName, crd.Name)
+				}
 				crdInfos = append(crdInfos, crdInfo{controller: controller, crd: crd, needsWait: false})
 				continue
 			}


### PR DESCRIPTION
`installControllerCRDs` skipped CRDs that already existed, so new schema fields (e.g. `status.observedTemplateResourceVersion`) were never added after an upgrade. Controllers writing to these fields got silent "unknown field" warnings and lost the data.

Replace the skip with an update: fetch the existing CRD, overwrite its spec with the embedded version, and persist it. This ensures the schema stays current across binary upgrades.

Also includes a fix for readiness check hanging when `--controllers=""` is a session override.