### PR TITLE
Replace try-polling with rdd ctl wait in BATS tests

### DIFF
--- a/bats/tests/31-rdd-controllers/configmapreplicaset.bats
+++ b/bats/tests/31-rdd-controllers/configmapreplicaset.bats
@@ -34,11 +34,6 @@ spec:
 EOF
 }
 
-delete_configmapreplicaset() {
-    local name=$1
-    delete_resource "ConfigMapReplicaSet" "${name}"
-}
-
 wait_for_configmaps() {
     local name=$1
     local expected=$2
@@ -50,7 +45,7 @@ wait_for_configmaps() {
 }
 
 @test 'verify ConfigMapReplicaSet is created in Kubernetes' {
-    try --max 5 --delay 3 -- rdd ctl get ConfigMapReplicaSet basic
+    rdd ctl wait --for=create ConfigMapReplicaSet basic --timeout=15s
 }
 
 @test 'wait for controller to create 3 ConfigMaps' {
@@ -272,7 +267,7 @@ wait_for_configmaps() {
 }
 
 @test 'delete ConfigMapReplicaSet' {
-    delete_configmapreplicaset "basic"
+    delete_resource "ConfigMapReplicaSet" "basic"
 }
 
 @test 'verify parent resource deletion triggers finalizer cleanup' {
@@ -290,7 +285,7 @@ wait_for_configmaps() {
 }
 
 @test 'verify zero replicas ConfigMapReplicaSet is created' {
-    try --max 12 --delay 5 -- rdd ctl get ConfigMapReplicaSet zero
+    rdd ctl wait --for=create ConfigMapReplicaSet zero --timeout=60s
 }
 
 @test 'verify no ConfigMaps are created for zero replicas' {

--- a/bats/tests/31-rdd-controllers/notary-admission.bats
+++ b/bats/tests/31-rdd-controllers/notary-admission.bats
@@ -36,7 +36,7 @@ apply_notary() {
 
 @test "webhook configuration has correct structure" {
     # Wait for the webhook configuration to be created
-    try --max 20 --delay 3 -- rdd ctl get ValidatingWebhookConfiguration notary-validator
+    rdd ctl wait --for=create ValidatingWebhookConfiguration notary-validator --timeout=60s
 
     run -0 rdd ctl get ValidatingWebhookConfiguration notary-validator -o jsonpath='{.webhooks[0]}'
     local json=${output}

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -37,7 +37,8 @@ assert_process_exited() {
     echo "$!" >"${BATS_FILE_TMPDIR}/controller_pid"
 
     # Wait for external controller to register in discovery system
-    try --max 20 --delay 1 -- rdd ctl get configmap rdd-controller-manager --namespace rdd-system --allow-missing-template-keys=false --output jsonpath='{.data.rdd}'
+    rdd ctl wait --for=jsonpath='{.data.rdd}' \
+        configmap rdd-controller-manager --namespace rdd-system --timeout=20s
 
     # Verify the discovery ConfigMap contains notary controller
     run_e -0 rdd ctl get configmap rdd-controller-manager --namespace rdd-system --output jsonpath='{.data.rdd}'
@@ -47,7 +48,7 @@ assert_process_exited() {
 
 @test "webhook configuration is created" {
     # Wait for webhook configuration to be created by external controller
-    try --max 20 --delay 1 -- rdd ctl get ValidatingWebhookConfiguration notary-validator
+    rdd ctl wait --for=create ValidatingWebhookConfiguration notary-validator --timeout=20s
 
     # Verify webhook configuration structure
     run -0 rdd ctl get ValidatingWebhookConfiguration notary-validator -o jsonpath='{.webhooks[0].name}'
@@ -105,7 +106,7 @@ EOF
 
 @test "controller processes notary resources" {
     # Wait for the controller to process the valid notary and create ConfigMap
-    try --max 30 --delay 1 -- rdd ctl get configmap test-config
+    rdd ctl wait --for=create configmap test-config --timeout=30s
     # Verify ConfigMap was created with correct content
     run -0 rdd ctl get configmap test-config -o json
     run -0 jq -r '.data.change_000' <<<"${output}"
@@ -176,7 +177,8 @@ EOF
     echo "$!" >"${BATS_FILE_TMPDIR}/controller_pid"
 
     # Wait for external controller to register in discovery system
-    try --max 20 --delay 1 -- rdd ctl get configmap rdd-controller-manager --namespace rdd-system --allow-missing-template-keys=false --output jsonpath='{.data.rdd}'
+    rdd ctl wait --for=jsonpath='{.data.rdd}' \
+        configmap rdd-controller-manager --namespace rdd-system --timeout=20s
 
     # Verify the discovery ConfigMap contains notary controller
     run -0 --separate-stderr rdd ctl get configmap rdd-controller-manager --namespace rdd-system --output jsonpath='{.data.rdd}'

--- a/bats/tests/31-rdd-controllers/notary.bats
+++ b/bats/tests/31-rdd-controllers/notary.bats
@@ -27,11 +27,6 @@ spec:
 EOF
 }
 
-delete_notary() {
-    local name=$1
-    delete_resource "notary" "${name}"
-}
-
 update_notary_value() {
     local name=$1
     local value=$2
@@ -45,12 +40,12 @@ wait_for_notary_status() {
 }
 
 @test 'create Notary resource' {
-    delete_notary "basic"
+    delete_resource "notary" "basic"
     create_notary "basic" "initial-value" "basic-history"
 }
 
 @test 'verify Notary is created in Kubernetes' {
-    try --max 15 --delay 1 -- rdd ctl get notary basic
+    rdd ctl wait --for=create notary basic --timeout=15s
 }
 
 @test 'wait for controller to create ConfigMap' {
@@ -213,7 +208,7 @@ wait_for_notary_status() {
 }
 
 @test 'delete Notary resource' {
-    delete_notary "basic"
+    delete_resource "notary" "basic"
 }
 
 @test 'verify parent resource deletion triggers finalizer cleanup' {

--- a/bats/tests/32-app-controllers/demo.bats
+++ b/bats/tests/32-app-controllers/demo.bats
@@ -22,42 +22,12 @@ spec:
 EOF
 }
 
-get_demo_status() {
-    local field=$1
-    get_resource_status "demo" "demo" "${field}"
-}
-
-assert_demo_status() {
-    local field=${1:-processedCount}
-    local expected=${2:-0}
-
-    run -0 get_demo_status "${field}"
-    assert_output "${expected}"
-}
-
-assert_demo_condition() {
-    local condition_type=${1:-Ready}
-    local expected_status=${2:-True}
-
-    run rdd ctl get demo "demo" -o json
-    assert_success
-
-    run -0 jq -r ".status.conditions[] | select(.type == \"${condition_type}\") | .status" <<<"${output}"
-    assert_output "${expected_status}"
-}
-
-wait_for_demo_condition() {
-    local condition_type=${1:-Ready}
-    local expected_status=${2:-True}
-
-    try --max 12 --delay 5 -- assert_demo_condition "${condition_type}" "${expected_status}"
-}
-
 wait_for_demo_completion() {
     local expected=$1
 
-    try --max 20 --delay 2 -- assert_demo_status "processedCount" "${expected}"
-    wait_for_demo_condition "Completed" "True"
+    rdd ctl wait --for=jsonpath='{.status.processedCount}'="${expected}" \
+        demo/demo --timeout=40s
+    rdd ctl wait --for=condition=Completed demo/demo --timeout=60s
 }
 
 local_setup_file() {
@@ -70,7 +40,7 @@ local_setup_file() {
 }
 
 @test 'verify Demo is created in Kubernetes' {
-    try --max 30 --delay 2 -- rdd ctl get demo demo
+    rdd ctl wait --for=create demo demo --timeout=60s
 }
 
 @test 'verify Demo resource is cluster-scoped' {
@@ -83,11 +53,11 @@ local_setup_file() {
 }
 
 @test 'wait for Demo processing to start' {
-    wait_for_demo_condition "Ready" "True"
+    rdd ctl wait --for=condition=Ready demo/demo --timeout=60s
 
     # Processing condition might be True briefly or False if already completed
     # So just verify we have the Ready condition and some processing has occurred
-    run -0 get_demo_status "processedCount"
+    run -0 get_resource_status "demo" "demo" "processedCount"
     [[ "${output}" -ge 0 ]] # Should have some status
 }
 
@@ -102,7 +72,7 @@ local_setup_file() {
     assert_output "true"
 
     # Should have at least started processing (processedCount >= 1)
-    run -0 get_demo_status "processedCount"
+    run -0 get_resource_status "demo" "demo" "processedCount"
     [[ "${output}" -ge 1 ]]
 }
 
@@ -192,7 +162,7 @@ EOF
     create_demo "demo" "Zero count test" 0
 
     # Should immediately be marked as completed since no processing needed
-    wait_for_demo_condition "Completed" "True"
+    rdd ctl wait --for=condition=Completed demo/demo --timeout=60s
 
     # ProcessedCount might not be explicitly set to 0, or could be missing
     run -0 rdd ctl get demo demo -o json
@@ -206,7 +176,7 @@ EOF
     create_demo "demo" "Processing test" 20
 
     # Should start processing
-    wait_for_demo_condition "Ready" "True"
+    rdd ctl wait --for=condition=Ready demo/demo --timeout=60s
 
     # Should catch Processing=True at some point (or might already be completed)
     run -0 rdd ctl get demo demo -o json
@@ -221,7 +191,7 @@ EOF
     create_demo "demo" "Update test" 10
 
     # Wait for demo to be ready (which means processing has started and processedCount >= 1)
-    wait_for_demo_condition "Ready" "True"
+    rdd ctl wait --for=condition=Ready demo/demo --timeout=60s
 
     # Update the message and count
     rdd ctl patch demo demo --type='merge' -p='{"spec":{"message":"Updated message","count":15}}'
@@ -278,7 +248,7 @@ EOF
     create_demo "demo" "Finalizer test" 1
 
     # Wait for creation
-    try --max 12 --delay 5 -- rdd ctl get demo demo
+    rdd ctl wait --for=create demo demo --timeout=60s
 
     # Check that no finalizers are set (Demo controller doesn't use finalizers)
     run rdd ctl get demo demo -o jsonpath='{.metadata.finalizers}'

--- a/bats/tests/33-lima-controllers/limavm-admission.bats
+++ b/bats/tests/33-lima-controllers/limavm-admission.bats
@@ -20,7 +20,7 @@ local_setup_file() {
 
 @test "webhook configuration has correct structure" {
     # Wait for the mutating webhook configuration to be created
-    try --max 20 --delay 3 -- rdd ctl get MutatingWebhookConfiguration "limavm-defaulter"
+    rdd ctl wait --for=create MutatingWebhookConfiguration "limavm-defaulter" --timeout=60s
 
     run -0 rdd ctl get MutatingWebhookConfiguration limavm-defaulter -o jsonpath='{.webhooks[0]}'
     local json=${output}

--- a/bats/tests/33-lima-controllers/limavm-instance.bats
+++ b/bats/tests/33-lima-controllers/limavm-instance.bats
@@ -66,20 +66,6 @@ lima_instance_exists() {
     [[ -d "${RDD_LIMA_HOME}/${name}" ]]
 }
 
-assert_instance_created() {
-    local name=$1
-    run -0 rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
-        --output jsonpath='{.status.conditions[?(@.type=="Created")].status}'
-    assert_output "True"
-}
-
-assert_instance_create_failed() {
-    local name=$1
-    run -0 rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
-        --output jsonpath='{.status.conditions[?(@.type=="Created")].status}'
-    assert_output "False"
-}
-
 @test "create source template ConfigMap with Alpine ISO" {
     rdd ctl create configmap "alpine-source" --namespace "${NAMESPACE}" --from-literal="template=${ALPINE_TEMPLATE}"
 
@@ -100,7 +86,8 @@ assert_instance_create_failed() {
 }
 
 @test "wait for Created condition to be True" {
-    try --max 60 --delay 1 -- assert_instance_created "${VM_NAME}"
+    rdd ctl wait --for=condition=Created=True \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=60s
 }
 
 @test "verify Lima instance directory exists" {
@@ -155,7 +142,8 @@ assert_instance_create_failed() {
 }
 
 @test "wait for Created after leftover cleanup" {
-    try --max 60 --delay 1 -- assert_instance_created "${VM_NAME}"
+    rdd ctl wait --for=condition=Created=True \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=60s
 }
 
 @test "verify leftover was replaced with real instance" {
@@ -190,7 +178,8 @@ INVALID_TEMPLATE='images:
 }
 
 @test "wait for Created condition to be False" {
-    try --max 30 --delay 1 -- assert_instance_create_failed "invalid-vm"
+    rdd ctl wait --for=condition=Created=False \
+        "limavm/invalid-vm" --namespace "${NAMESPACE}" --timeout=30s
 }
 
 @test "verify Created condition has CreateFailed reason" {

--- a/bats/tests/34-containers-controllers/containers-mock.bats
+++ b/bats/tests/34-containers-controllers/containers-mock.bats
@@ -21,20 +21,19 @@ local_teardown_file() {
 }
 
 @test "containers are created" {
-    try --max 30 --delay 1 -- rdd ctl get namespace rdd-mocks -o name
+    rdd ctl wait --for=create namespace rdd-mocks --timeout=30s
 
     run -0 cat "${TEST_DATA_PATH}/containers.json"
     run -0 jq_output '.[].Id'
     containers=${output}
 
     while IFS= read -r container; do
-        try --max 30 --delay 1 -- rdd ctl get container "${container}" -o name
-        assert_line "container.containers.rancherdesktop.io/${container}"
+        rdd ctl wait --for=create container "${container}" --timeout=30s
     done <<<"${containers}"
 }
 
 @test "images are created" {
-    try --max 30 --delay 1 -- rdd ctl get namespace rdd-mocks -o name
+    rdd ctl wait --for=create namespace rdd-mocks --timeout=30s
 
     run -0 cat "${TEST_DATA_PATH}/images.json"
     run -0 jq_output '.[].RepoTags.[]'
@@ -47,14 +46,13 @@ local_teardown_file() {
 }
 
 @test "volumes are created" {
-    try --max 30 --delay 1 -- rdd ctl get namespace rdd-mocks -o name
+    rdd ctl wait --for=create namespace rdd-mocks --timeout=30s
 
     run -0 cat "${TEST_DATA_PATH}/volumes.json"
     run -0 jq_output '.[].Name'
     volumes=${output}
 
     while IFS= read -r volume; do
-        try --max 30 --delay 1 -- rdd ctl get volume "${volume}" -o name
-        assert_line "volume.containers.rancherdesktop.io/${volume}"
+        rdd ctl wait --for=create volume "${volume}" --timeout=30s
     done <<<"${volumes}"
 }


### PR DESCRIPTION
Replace manual `try`-loops with native `kubectl wait` semantics wherever possible: `--for=condition` for status conditions, `--for=jsonpath` for field values, `--for=create` for resource existence, and `--for=delete` for resource removal. Remove helper functions that existed only to support the polling pattern.

Remaining `try`-loops poll non-Kubernetes state (filesystem, processes, SSH readiness, log content) or need output validation from `rdd ctl get`.