### PR TITLE
Decouple restart request from execution via status.restartNeeded

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -163,6 +163,31 @@ assert_created() {
     assert_fatal "${not_found}"
 }
 
+@test "lima restart sets annotation and running=true" {
+    # Create a template ConfigMap and VM
+    rdd ctl create configmap "restart-template" --namespace "${LIMA_TEST_NS}" --from-literal="template=${TEMPLATE}"
+    run_e -0 rdd limavm create "restart-vm" "restart-template" --namespace "${LIMA_TEST_NS}"
+    assert_created "restart-vm" "${LIMA_TEST_NS}" "restart-template"
+
+    # Restart the VM (no controller running, so annotation stays)
+    run -0 rdd limavm restart "restart-vm"
+    assert_output --partial "restart requested"
+
+    # Verify annotation is set
+    run -0 rdd ctl get limavm "restart-vm" --namespace "${LIMA_TEST_NS}" \
+        --output "jsonpath={.metadata.annotations['lima\.rancherdesktop\.io/restartRequested']}"
+    assert [ -n "${output}" ]
+
+    # Verify spec.running is true
+    run -0 rdd ctl get limavm "restart-vm" --namespace "${LIMA_TEST_NS}" \
+        --output jsonpath='{.spec.running}'
+    assert_output "true"
+
+    # Delete the VM
+    run -0 rdd limavm delete "restart-vm"
+    rdd ctl wait --for=delete "limavm/restart-vm" --namespace "${LIMA_TEST_NS}" --timeout="30s"
+}
+
 @test "lima help text is displayed" {
     # lima is an alias of the limavm command
     run -0 rdd lima --help
@@ -170,6 +195,7 @@ assert_created() {
     assert_output --partial "Create a new LimaVM"
     assert_output --partial "Start a LimaVM"
     assert_output --partial "Stop a LimaVM"
+    assert_output --partial "Restart a LimaVM"
     assert_output --partial "Delete a LimaVM"
     assert_output --partial "Show LimaVM logs"
     assert_output --partial "Execute shell in Lima VM"

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -94,22 +94,15 @@ lima_instance_running() {
     assert_file_exists "${RDD_LIMA_HOME}/${name}/ha.pid"
 }
 
-get_instance_running_transition_time() {
+get_restart_count() {
     local name=$1
     rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
-        --output jsonpath='{.status.conditions[?(@.type=="Running")].lastTransitionTime}'
+        --output jsonpath='{.status.restartCount}'
 }
 
 get_hostagent_pid() {
     local name=$1
     cat "${RDD_LIMA_HOME}/${name}/ha.pid"
-}
-
-assert_recovery_completed() {
-    local before_time=$1
-    run -0 get_instance_running_transition_time "${VM_NAME}"
-    refute_output "${before_time}"
-    assert_instance_running_reason "${VM_NAME}" "Started"
 }
 
 assert_limavm_not_exists() {
@@ -261,15 +254,16 @@ EOF
 }
 
 @test "trigger reconcile and verify crash recovery" {
-    run -0 get_instance_running_transition_time "${VM_NAME}"
-    assert_output
-    before_time=${output}
+    run -0 get_restart_count "${VM_NAME}"
+    local before_count=${output}
 
     rdd ctl annotate limavm "${VM_NAME}" --namespace "${NAMESPACE}" --overwrite \
         reconcile-trigger="$(date +%s)"
 
     # The reconciler should detect the dead hostagent and restart the VM.
-    try --max 60 --delay 5 -- assert_recovery_completed "${before_time}"
+    # restartCount increments in the same status write that sets Running=True.
+    rdd ctl wait --for=jsonpath='{.status.restartCount}'="$((before_count + 1))" \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
 }
 
 @test "verify new hostagent after crash recovery" {
@@ -302,18 +296,16 @@ EOF
 }
 
 @test "trigger reconcile and verify recovery from broken state" {
-    # Capture the lastTransitionTime before triggering reconcile
-    run -0 get_instance_running_transition_time "${VM_NAME}"
-    assert_output
-    before_time=${output}
+    run -0 get_restart_count "${VM_NAME}"
+    local before_count=${output}
 
     # Annotate to trigger a reconcile while spec.running is still true
     rdd ctl annotate limavm "${VM_NAME}" --namespace "${NAMESPACE}" --overwrite \
         reconcile-trigger="$(date +%s)"
 
     # The reconciler should detect broken state, force stop, then restart.
-    # Verify the condition was actually updated by checking lastTransitionTime changed.
-    try --max 60 --delay 5 -- assert_recovery_completed "${before_time}"
+    rdd ctl wait --for=jsonpath='{.status.restartCount}'="$((before_count + 1))" \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
 }
 
 @test "verify hostagent is alive after recovery" {
@@ -329,6 +321,74 @@ EOF
     run -0 rdd ctl get events --namespace "${NAMESPACE}" \
         --field-selector involvedObject.kind=LimaVM,involvedObject.name="${VM_NAME}"
     assert_output --partial "BrokenStateRecovered"
+}
+
+# Restart tests
+# These tests verify the restart mechanism: annotation → status.restartNeeded → stop → start.
+
+@test "restart running VM via rdd limavm restart" {
+    run -0 get_restart_count "${VM_NAME}"
+    local before_count=${output}
+
+    rdd limavm restart "${VM_NAME}"
+
+    # Wait for restartCount to increment, confirming a full stop+start cycle.
+    rdd ctl wait --for=jsonpath='{.status.restartCount}'="$((before_count + 1))" \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
+}
+
+@test "verify restartNeeded cleared and annotation removed after restart" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --output jsonpath='{.status.restartNeeded}'
+    refute_output "true"
+
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --output "jsonpath={.metadata.annotations['lima\\.rancherdesktop\\.io/restartRequested']}"
+    assert_output ""
+}
+
+@test "stop VM for stopped-restart test" {
+    rdd ctl patch limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --type=merge --patch '{"spec":{"running":false}}'
+    rdd ctl wait --for=condition=Running=False \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
+}
+
+assert_restart_annotation_absent() {
+    local name=$1
+    run -0 rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
+        --output "jsonpath={.metadata.annotations['lima\.rancherdesktop\.io/restartRequested']}"
+    assert_output ""
+}
+
+@test "restart annotation on stopped VM with running=false clears restartNeeded" {
+    # Set annotation without changing spec.running (simulates annotation-only path)
+    rdd ctl annotate limavm "${VM_NAME}" --namespace "${NAMESPACE}" --overwrite \
+        "lima.rancherdesktop.io/restartRequested=$(date +%s)"
+
+    # Wait for the annotation to be removed (reconciler processed it)
+    try --max 30 --delay 1 -- assert_restart_annotation_absent "${VM_NAME}"
+
+    # restartNeeded should be cleared
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --output jsonpath='{.status.restartNeeded}'
+    refute_output "true"
+
+    # VM should stay stopped because spec.running=false
+    assert_instance_running_condition "${VM_NAME}" "False"
+    assert_instance_running_reason "${VM_NAME}" "Stopped"
+}
+
+@test "restart command on stopped VM starts it" {
+    rdd limavm restart "${VM_NAME}"
+
+    # The restart command sets spec.running=true, so the VM should start
+    rdd ctl wait --for=condition=Running=True \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
+
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --output jsonpath='{.status.restartNeeded}'
+    refute_output "true"
 }
 
 @test "cleanup LimaVM running test" {

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -44,6 +44,7 @@ func newLimaVMCommand() *cobra.Command {
 		newLimaVMCreateCommand(),
 		newLimaVMStartCommand(),
 		newLimaVMStopCommand(),
+		newLimaVMRestartCommand(),
 		newLimaVMDeleteCommand(),
 		newLimaVMLogsCommand(),
 		newLimaVMShellCommand(),
@@ -159,6 +160,44 @@ func newLimaVMStopCommand() *cobra.Command {
 		},
 	}
 	return command
+}
+
+func newLimaVMRestartCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "restart NAME",
+		Short: "Restart a LimaVM instance",
+		Long:  "Set the restartRequested annotation and spec.running=true to restart the instance.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return limaVMRestartAction(cmd.Context(), args[0])
+		},
+	}
+	return command
+}
+
+func limaVMRestartAction(ctx context.Context, name string) error {
+	c, err := getKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+	limaVM, err := findLimaVM(ctx, c, name)
+	if err != nil {
+		return err
+	}
+
+	patch := client.MergeFrom(limaVM.DeepCopy())
+	limaVM.Spec.Running = true
+	if limaVM.Annotations == nil {
+		limaVM.Annotations = make(map[string]string)
+	}
+	limaVM.Annotations[limav1alpha1.AnnotationRestartRequested] = time.Now().UTC().Format(time.RFC3339)
+
+	if err := c.Patch(ctx, limaVM, patch); err != nil {
+		return fmt.Errorf("failed to restart LimaVM: %w", err)
+	}
+
+	logrus.Infof("LimaVM %q restart requested in namespace %q", name, limaVM.Namespace)
+	return nil
 }
 
 func newLimaVMDeleteCommand() *cobra.Command {

--- a/docs/design/api_lima.md
+++ b/docs/design/api_lima.md
@@ -30,6 +30,7 @@ spec:
     DOCKER_ROOTFUL: "true"
 status:
   templateConfigMap: alpine-template
+  restartNeeded: false
   conditions:
   - type: Created
     status: "True"
@@ -41,7 +42,7 @@ status:
     message: Lima instance started successfully
 ```
 
-- **metadata.annotations**: Can be used to request "actions" from the reconciler, like resetting (deleting and recreating with the same settings), or restarting the instance. The `status.conditions` can be used to store the state machine information.
+- **metadata.annotations**: Request actions from the reconciler, such as resetting (deleting and recreating with the same settings) or restarting the instance. The `restartRequested` annotation (set to any value) tells the reconciler to restart the instance. The reconciler translates it to `status.restartNeeded` and removes the annotation. The `status.conditions` store the state machine information.
 
 - **spec.running**: Set to `true` when the instance should be running, set to `false` when it should be stopped.
 
@@ -58,6 +59,8 @@ status:
     If the template provisioning scripts are properly parameterized, then the instance settings can be modified by just updating `spec.params`, which is simpler than modifying the `template` inside the ConfigMap. If `spec.running` is `true` then changing `spec.params` will restart the instance.
 
 - **status.templateConfigMap**: Name of the ConfigMap containing the validated template. The reconciler creates this ConfigMap after copying and validating the template from `spec.templateRef`. This ConfigMap is owned by the LimaVM and deleted automatically when the LimaVM is deleted.
+
+- **status.restartNeeded**: Indicates a restart has been requested but not yet executed. The reconciler sets this field when it processes a `restartRequested` annotation or detects a template change on a running instance. When the instance is running, the reconciler stops it (clearing `restartNeeded` in the same write); the next reconcile starts it via normal logic. When the instance is already stopped, the reconciler clears the flag immediately. When the instance is starting, the reconciler waits for boot to finish before acting.
 
 - **status.conditions**: Standard Kubernetes conditions tracking the LimaVM state.
 

--- a/docs/design/cmd_lima.md
+++ b/docs/design/cmd_lima.md
@@ -38,7 +38,7 @@ Set `lima.rancherdesktop.io/resetRequested` annotation to the current timestamp.
 
 ### `rdd limavm restart NAME`
 
-Set `lima.rancherdesktop.io/restartRequested` annotation to the current timestamp. This tells the reconciler to stop the instance, if it is running. Then it will start the instance, even if it had been stopped initially.
+Set `lima.rancherdesktop.io/restartRequested` annotation and `spec.running=true` in a single patch. The annotation tells the reconciler to stop the instance if it is running; setting `spec.running=true` ensures the instance starts afterward, even if it had been stopped initially.
 
 ### `rdd limavm shell NAME CMD`
 

--- a/pkg/apis/lima/v1alpha1/applyconfiguration/lima/v1alpha1/limavmstatus.go
+++ b/pkg/apis/lima/v1alpha1/applyconfiguration/lima/v1alpha1/limavmstatus.go
@@ -26,6 +26,14 @@ type LimaVMStatusApplyConfiguration struct {
 	// An admission controller validates any updates to the ConfigMap.
 	// This field is informational - internal code should use GetTemplateConfigMapName() instead.
 	TemplateConfigMap *string `json:"templateConfigMap,omitempty"`
+	// restartNeeded indicates a restart has been requested but not yet executed.
+	// Set by the reconciler when it processes a restartRequested annotation or
+	// detects a template change on a running instance. Cleared when the restart
+	// completes or the instance is already stopped.
+	RestartNeeded *bool `json:"restartNeeded,omitempty"`
+	// restartCount tracks how many times the instance has reached the Running state.
+	// Incremented each time the controller sets Running=True/Started.
+	RestartCount *int32 `json:"restartCount,omitempty"`
 }
 
 // LimaVMStatusApplyConfiguration constructs a declarative configuration of the LimaVMStatus type for use with
@@ -52,5 +60,21 @@ func (b *LimaVMStatusApplyConfiguration) WithConditions(values ...*v1.ConditionA
 // If called multiple times, the TemplateConfigMap field is set to the value of the last call.
 func (b *LimaVMStatusApplyConfiguration) WithTemplateConfigMap(value string) *LimaVMStatusApplyConfiguration {
 	b.TemplateConfigMap = &value
+	return b
+}
+
+// WithRestartNeeded sets the RestartNeeded field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RestartNeeded field is set to the value of the last call.
+func (b *LimaVMStatusApplyConfiguration) WithRestartNeeded(value bool) *LimaVMStatusApplyConfiguration {
+	b.RestartNeeded = &value
+	return b
+}
+
+// WithRestartCount sets the RestartCount field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RestartCount field is set to the value of the last call.
+func (b *LimaVMStatusApplyConfiguration) WithRestartCount(value int32) *LimaVMStatusApplyConfiguration {
+	b.RestartCount = &value
 	return b
 }

--- a/pkg/apis/lima/v1alpha1/limavm_types.go
+++ b/pkg/apis/lima/v1alpha1/limavm_types.go
@@ -11,6 +11,10 @@ import (
 // TemplateConfigMapKey is the key used to store the template text in the templateConfigMap.
 const TemplateConfigMapKey = "template"
 
+// AnnotationRestartRequested triggers a restart when set on a LimaVM resource.
+// The reconciler translates it to status.restartNeeded and removes the annotation.
+const AnnotationRestartRequested = "lima.rancherdesktop.io/restartRequested"
+
 // TemplateReference specifies a reference to a ConfigMap containing a VM template.
 type TemplateReference struct {
 	// name is the name of the ConfigMap containing the VM template.
@@ -59,6 +63,18 @@ type LimaVMStatus struct {
 	// This field is informational - internal code should use GetTemplateConfigMapName() instead.
 	// +optional
 	TemplateConfigMap string `json:"templateConfigMap,omitempty"`
+
+	// restartNeeded indicates a restart has been requested but not yet executed.
+	// Set by the reconciler when it processes a restartRequested annotation or
+	// detects a template change on a running instance. Cleared when the restart
+	// completes or the instance is already stopped.
+	// +optional
+	RestartNeeded bool `json:"restartNeeded,omitempty"`
+
+	// restartCount tracks how many times the instance has reached the Running state.
+	// Incremented each time the controller sets Running=True/Started.
+	// +optional
+	RestartCount int32 `json:"restartCount,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -220,8 +220,11 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	// Instance already created - proceed to handle running state
+	// Instance already created - handle restart annotation, then running state.
 	if apimeta.IsStatusConditionTrue(limaVM.Status.Conditions, ConditionCreated) {
+		if _, hasAnnotation := limaVM.Annotations[v1alpha1.AnnotationRestartRequested]; hasAnnotation {
+			return r.handleRestartAnnotation(ctx, &limaVM)
+		}
 		return r.handleRunningState(ctx, &limaVM)
 	}
 

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
@@ -73,6 +74,37 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 	}
 
 	logger.Info("Deleted Lima instance, owned resources, and finalizer")
+	return ctrl.Result{}, nil
+}
+
+// handleRestartAnnotation translates the restartRequested annotation into
+// status.restartNeeded. It takes two reconcile cycles:
+//  1. Set status.restartNeeded=true (if not already set).
+//  2. Remove the annotation (status is already persisted).
+//
+// This ordering ensures the status is durable before metadata changes.
+// If the annotation removal fails, the next reconcile sees both and retries.
+func (r *LimaVMReconciler) handleRestartAnnotation(ctx context.Context, limaVM *v1alpha1.LimaVM) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if !limaVM.Status.RestartNeeded {
+		logger.Info("Restart requested via annotation, setting status.restartNeeded")
+		limaVM.Status.RestartNeeded = true
+		if err := r.Status().Update(ctx, limaVM); err != nil {
+			logger.Error(err, "Failed to set status.restartNeeded")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// status.restartNeeded is already true; remove the annotation.
+	logger.Info("Removing restartRequested annotation")
+	patch := client.MergeFrom(limaVM.DeepCopy())
+	delete(limaVM.Annotations, v1alpha1.AnnotationRestartRequested)
+	if err := r.Patch(ctx, limaVM, patch); err != nil {
+		logger.Error(err, "Failed to remove restartRequested annotation")
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -140,6 +172,10 @@ func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alp
 		}
 	}
 
+	if limaVM.Status.RestartNeeded {
+		return r.handleRestartNeeded(ctx, limaVM, inst)
+	}
+
 	shouldRun := limaVM.Spec.Running
 	isRunning := inst.Status == limatype.StatusRunning
 
@@ -168,6 +204,7 @@ func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alp
 	// Update condition to reflect current state (including reason, so StartFailed/Starting gets updated)
 	if isRunning {
 		if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionTrue, ReasonStarted) {
+			limaVM.Status.RestartCount++
 			if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionTrue, ReasonStarted, "Lima instance is running"); err != nil {
 				logger.Error(err, "Failed to update running condition")
 				return ctrl.Result{}, err
@@ -183,6 +220,37 @@ func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alp
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// handleRestartNeeded acts on status.restartNeeded based on the instance state:
+//   - Running: stop the instance (clears restartNeeded in the same write).
+//     The next reconcile starts it via normal shouldRun && !isRunning logic.
+//   - Starting: requeue after 5s to wait for boot to finish.
+//   - Stopped: clear restartNeeded and fall through to normal logic.
+func (r *LimaVMReconciler) handleRestartNeeded(ctx context.Context, limaVM *v1alpha1.LimaVM, inst *limatype.Instance) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	switch inst.Status {
+	case limatype.StatusRunning:
+		logger.Info("Restart needed: stopping running instance")
+		limaVM.Status.RestartNeeded = false
+		return r.stopInstance(ctx, limaVM, inst)
+
+	case limatype.StatusStopped:
+		logger.Info("Restart needed but instance already stopped, clearing flag")
+		limaVM.Status.RestartNeeded = false
+		if err := r.Status().Update(ctx, limaVM); err != nil {
+			logger.Error(err, "Failed to clear restartNeeded")
+			return ctrl.Result{}, err
+		}
+		// Requeue so the next reconcile starts the VM if spec.running=true.
+		return ctrl.Result{}, nil
+
+	default:
+		// Instance is starting or in another transient state; wait.
+		logger.Info("Restart needed but instance is not yet running, waiting", "status", inst.Status)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
 }
 
 // startInstance starts the Lima VM hostagent in the background.
@@ -312,7 +380,9 @@ func (r *LimaVMReconciler) stopInstance(ctx context.Context, limaVM *v1alpha1.Li
 	logger := log.FromContext(ctx)
 	logger.Info("Stopping Lima instance", "instance", limaVM.Name)
 
-	if err := limainstance.StopGracefully(ctx, inst, false); err != nil {
+	stopCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if err := limainstance.StopGracefully(stopCtx, inst, false); err != nil {
 		logger.Error(err, "Failed to stop Lima instance gracefully")
 		// Try forceful stop
 		logger.Info("Attempting forceful stop")

--- a/pkg/controllers/lima/limavm/crd.yaml
+++ b/pkg/controllers/lima/limavm/crd.yaml
@@ -148,6 +148,19 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              restartCount:
+                description: |-
+                  restartCount tracks how many times the instance has reached the Running state.
+                  Incremented each time the controller sets Running=True/Started.
+                format: int32
+                type: integer
+              restartNeeded:
+                description: |-
+                  restartNeeded indicates a restart has been requested but not yet executed.
+                  Set by the reconciler when it processes a restartRequested annotation or
+                  detects a template change on a running instance. Cleared when the restart
+                  completes or the instance is already stopped.
+                type: boolean
               templateConfigMap:
                 description: |-
                   templateConfigMap is the name of the ConfigMap containing the validated template.


### PR DESCRIPTION
Add a restart mechanism that separates "request restart" from "execute restart." A new `status.restartNeeded` field tracks pending restarts. The reconciler sets this field (from the `restartRequested` annotation) and `handleRunningState` acts on it — stopping only when the VM is fully running, never during startup.

The reconciler translates the annotation to status in two cycles (status first, then annotation removal) for crash safety. `handleRestartNeeded` stops running instances, waits for starting ones, and clears the flag for stopped ones.

Also adds:
- `status.restartCount` to track `Running` state transitions
- 30-second timeout on `StopGracefully` before falling back to force stop
- `rdd limavm restart` command (sets annotation + `spec.running=true`)
- BATS tests for restart of running/stopped VMs and CLI annotation