### PR TITLE
CI: BATS: Run in parallel

### DIFF
--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -1,8 +1,11 @@
 # Words from tools.
 buildkit
 buildvcs
+coreutils
 cpanm
 cpanminus
+gnubin
+libexec
 ltag
 maxdepth
 mindepth
@@ -10,6 +13,7 @@ mkfifo
 mktemp
 moby
 netcat
+nproc
 pulumi
 Trivy
 

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -75,12 +75,15 @@ jobs:
       if: runner.os == 'macOS'
       working-directory: ${{ runner.temp }}
       run: |
-        brew install bash
+        brew install bash coreutils make
 
         # Set up run-in-wsl helper script (as a symlink to bash)
         mkdir -p bin
         ln -s $(brew --prefix bash)/bin/bash bin/run-in-wsl
         readlink -f bin >> "$GITHUB_PATH"
+
+        # Use GNU make
+        echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
 
     - name: "Windows: install prerequisites"
       if: runner.os == 'Windows'
@@ -156,7 +159,7 @@ jobs:
         systemctl status systemd-binfmt.service || true
       continue-on-error: true
 
-    - run: make -C bats --keep-going
+    - run: make -C bats --keep-going --jobs=$(nproc) --output-sync=target
       shell: run-in-wsl {0}
       env:
         RDD_TRACE: true


### PR DESCRIPTION
Since we use an instance per BATS suite, we can run them in parallel to make CI (hopefully) a bit faster.  We already have `--keep-going` to avoid stopping on the first failure; with `--jobs --output-sync=target` we can do that in parallel but still print logs from each suite as a group.

I'm not sure this actually _is_ faster, but the previous commit (56e68e9dc33b02fb1161a7b542bbeeb2e4c18305) seemed to take extra long (~30m), so this is at least faster than that? A different comparison build (4dee57c1fe06444edd85d807c652aca53e2d8e4e) took ~13m macOS, ~12m Linux, ~16m Windows (BATS step only). So this is still much faster, slightly faster, and slightly faster.