### PR TITLE
mock controller: Add a mock logs endpoint

### DIFF
--- a/bats/helpers/commands.bash
+++ b/bats/helpers/commands.bash
@@ -23,6 +23,22 @@ ctrctl() {
 curl() {
     command "curl${EXE}" "$@"
 }
+
+# Check if curl supports WebSockets; some tests may require it.
+curl_has_websocket_support() {
+    if ! command -v "curl${EXE}" >/dev/null 2>&1; then
+        return 1
+    fi
+    local version
+    version=$(curl --version 2>/dev/null)
+    # `ws` may be the last protocol and precede a new line, so we only test for
+    # space to the left of it.
+    if [[ "${version}" =~ Protocols:.*\ wss? ]]; then
+        return 0
+    fi
+    return 1
+}
+
 rdd() {
     local arg
     local args=("$@")

--- a/bats/tests/32-app-controllers/passthrough.bats
+++ b/bats/tests/32-app-controllers/passthrough.bats
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
 load '../../helpers/load'
 
 local_setup_file() {
@@ -15,10 +19,7 @@ local_setup_file() {
     # We need to use curl for WebSocket support; however, some versions of curl
     # do not support ws:// URLs directly, so we check for that and skip the
     # test if not supported.
-    run -0 curl --version
-    # `ws` may be the last protocol and precede a new line, so we only test for
-    # space to the left of it.
-    if ! [[ "${output}" =~ Protocols:.*\ ws ]]; then
+    if ! curl_has_websocket_support; then
         skip "curl does not support WebSocket"
     fi
     run -0 rdd ctl config view --minify --flatten --output=jsonpath='{.clusters[].cluster.server}'

--- a/bats/tests/34-containers-controllers/containers-mock.bats
+++ b/bats/tests/34-containers-controllers/containers-mock.bats
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
 load '../../helpers/load'
 
 # Mock controller tests - using the mock controller, verify that the container
@@ -30,6 +34,46 @@ local_teardown_file() {
     mapfile -t containers <<<"${output}"
 
     rdd ctl wait --for=create --namespace="${NAMESPACE}" container "${containers[@]}" --timeout=30s
+}
+
+@test "container logs can be fetched" {
+    # Make sure everything we need exists
+    rdd ctl wait --for=create namespace/rdd-mocks --timeout=30s
+    rdd ctl wait --for=create --namespace rdd-system configmap/rdd-controller-manager --timeout=30s
+
+    # Check that the mock controller has a containers/logs passthrough.
+    run -0 rdd ctl get --namespace rdd-system configmap/rdd-controller-manager -o jsonpath='{.data.mock}'
+    run -0 jq_output '.enabledPassthroughs.mock[]'
+    assert_line logs
+
+    if ! curl_has_websocket_support; then
+        skip "curl does not support WebSocket"
+    fi
+
+    # Grab a random container and check its logs.
+    run -0 cat "${TEST_DATA_PATH}/containers.json"
+    container_data=${output}
+    run -0 jq_raw '.[0].Id' "${container_data}"
+    container=${output}
+    label=org.opencontainers.image.source
+    run -0 jq_raw ".[0].Config.Labels[\"${label}\"]" "${container_data}"
+    value=${output}
+
+    # Set up curl to fetch logs.
+    run -0 rdd ctl config view --minify --flatten --output=jsonpath='{.clusters[].cluster.server}'
+    local server_url=${output}
+    run -0 rdd ctl config view --minify --flatten --output=jsonpath='{.users[].user.token}'
+    local token=${output}
+    run -0 curl --silent --header "Authorization: Bearer ${token}" --insecure \
+        "${server_url/http/ws}/passthrough/mock/logs/${container}"
+    assert_line "Logs for container ${container}"
+    assert_line "Label: ${label}"$'\t'"${value}"
+
+    # Check that invalid containers are rejected.
+    run -22 curl --silent --header "Authorization: Bearer ${token}" --insecure \
+        "${server_url/http/ws}/passthrough/mock/logs/invalid-container-id"
+    run -22 curl --silent --header "Authorization: Bearer ${token}" --insecure \
+        "${server_url/http/ws}/passthrough/mock/logs/00000000"
 }
 
 @test "images are created" {

--- a/pkg/controllers/mock/logs_passthrough.go
+++ b/pkg/controllers/mock/logs_passthrough.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package mock
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
+)
+
+var containerIDValidator = regexp.MustCompile(`^[0-9a-fA-F]+$`)
+
+// handleLogs is the handler for the `/passthrough/mock/logs/{container}`
+// endpoint.  It exists for providing fake logs for testing and screenshots.
+func (c *controller) handleLogs(w http.ResponseWriter, r *http.Request) {
+	log := ctrl.LoggerFrom(r.Context())
+	containerID, _, _ := strings.Cut(strings.TrimLeft(r.URL.Path, "/"), "/")
+	log.Info("Handling logs request", "container", containerID)
+
+	if !containerIDValidator.MatchString(containerID) {
+		log.V(5).Info("Invalid container ID", "container", containerID)
+		http.Error(w, "Invalid container ID", http.StatusBadRequest)
+		return
+	}
+
+	var container v1alpha1.Container
+	err := c.mgr.GetClient().Get(r.Context(), types.NamespacedName{
+		Namespace: apiNamespace,
+		Name:      containerID,
+	}, &container)
+	if err != nil {
+		log.V(5).Info("Failed to get container", "error", err)
+		http.Error(w, "Failed to get container", http.StatusNotFound)
+		return
+	}
+
+	upgrader := websocket.Upgrader{}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.V(5).Info("Failed to upgrade to WebSocket", "error", err)
+		return
+	}
+	defer conn.Close()
+	defer func() {
+		message := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "Closing connection")
+		err := conn.WriteControl(websocket.CloseMessage, message, time.Now().Add(time.Second))
+		if err != nil {
+			log.V(5).Info("Failed to close WebSocket", "error", err)
+		}
+	}()
+
+	// Write a message per line to simulate the real logs better.
+	write := func(line string) error {
+		err := conn.WriteMessage(websocket.TextMessage, []byte(line))
+		if err != nil {
+			log.V(5).Info("Failed to write WebSocket message", "error", err)
+		}
+		return err
+	}
+
+	// We don't have any logs for the mock controller; just print out some
+	// stuff to show that we found the container.
+	if err := write(fmt.Sprintf("Logs for container %s\n", containerID)); err != nil {
+		return
+	}
+	keys := slices.Sorted(maps.Keys(container.Status.Labels))
+	for _, k := range keys {
+		err := write(fmt.Sprintf("Label: %s\t%s\n", k, container.Status.Labels[k]))
+		if err != nil {
+			return
+		}
+	}
+}

--- a/pkg/controllers/mock/mock_controller.go
+++ b/pkg/controllers/mock/mock_controller.go
@@ -8,6 +8,9 @@ package mock
 
 import (
 	"context"
+	"maps"
+	"net/http"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,20 +36,31 @@ const (
 )
 
 func init() {
-	base.RegisterController(&controller{})
+	base.RegisterController(newController())
 }
 
 // controller that creates mock data when started.
 // This creates a "rdd-mocks" namespace to own the created resources, and
 // reconcilers that create mocked resources based on the namespace.
 type controller struct {
+	mgr             ctrl.Manager
 	webhookPort     int
 	webhookManagers []base.WebhookManager
+	passthroughs    map[string]http.Handler
+}
+
+func newController() *controller {
+	c := &controller{}
+	c.passthroughs = map[string]http.Handler{
+		"logs": http.HandlerFunc(c.handleLogs),
+	}
+	return c
 }
 
 var (
-	_ base.Controller        = &controller{}
-	_ base.WebhookController = &controller{}
+	_ base.Controller            = &controller{}
+	_ base.WebhookController     = &controller{}
+	_ base.PassthroughController = &controller{}
 )
 
 func (c *controller) GetName() string {
@@ -63,6 +77,14 @@ func (c *controller) SetWebhookPort(port int) {
 
 func (c *controller) GetCRDData() string {
 	return ""
+}
+
+func (c *controller) GetPassthroughEndpoints() []string {
+	return slices.Collect(maps.Keys(c.passthroughs))
+}
+
+func (c *controller) GetPassthroughHandler(endpoint string) http.Handler {
+	return c.passthroughs[endpoint]
 }
 
 func (c *controller) setupReconciler(ctx context.Context, mgr ctrl.Manager) error {
@@ -148,6 +170,7 @@ func (c *controller) createNamespace(ctx context.Context, mgr ctrl.Manager) erro
 func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 	mgr.GetLogger().Info("Registering Mock Controller with Manager")
 	ctx := context.Background()
+	c.mgr = mgr
 
 	if err := containersv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err


### PR DESCRIPTION
For working on the UI, we need a mock logs endpoint.  Add it so we can use it for the front end later.

This needs to be looked at after #188 is merged.
