### PR TITLE
Replace hostagent polling with event-driven watcher

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -64,12 +64,13 @@ assert_created() {
     assert_running "false"
 
     # Start the VM (cross-namespace lookup: no --namespace flag needed)
-    run -0 rdd limavm start "test-vm"
+    # --wait=false because the template is non-functional (no real VM boots)
+    run -0 rdd limavm start --wait=false "test-vm"
     assert_output --partial 'started'
     assert_running "true"
 
     # Stop the VM
-    run -0 rdd limavm stop "test-vm"
+    run -0 rdd limavm stop --wait=false "test-vm"
     assert_output --partial 'stopped'
     assert_running "false"
 
@@ -78,6 +79,19 @@ assert_created() {
     assert_output --partial 'deleted'
     run -1 rdd ctl get limavm "test-vm" --namespace "${LIMA_TEST_NS}"
     assert_output --partial "not found"
+}
+
+@test "lima create --start sets running=true" {
+    rdd ctl create configmap "start-vm" --namespace "${LIMA_TEST_NS}" --from-literal="template=${TEMPLATE}"
+
+    # --wait=false because the template is non-functional (no real VM boots)
+    run_e -0 rdd limavm create "start-vm" "start-vm" --namespace "${LIMA_TEST_NS}" --start --wait=false
+    assert_created "start-vm" "${LIMA_TEST_NS}" "start-vm"
+
+    run -0 rdd ctl get limavm "start-vm" --namespace "${LIMA_TEST_NS}" -o jsonpath='{.spec.running}'
+    assert_output "true"
+
+    run -0 rdd limavm delete --wait "start-vm"
 }
 
 @test "lima create with file template" {
@@ -163,6 +177,37 @@ assert_created() {
     assert_fatal "${not_found}"
 }
 
+@test "lima restart sets running=true" {
+    # Create a template ConfigMap and VM
+    rdd ctl create configmap "restart-vm" --namespace "${LIMA_TEST_NS}" --from-literal="template=${TEMPLATE}"
+    run_e -0 rdd limavm create "restart-vm" "restart-vm" --namespace "${LIMA_TEST_NS}"
+    assert_created "restart-vm" "${LIMA_TEST_NS}" "restart-vm"
+
+    # --wait=false because the template is non-functional (no real VM boots)
+    run -0 rdd limavm restart --wait=false "restart-vm"
+    assert_output --partial "restart requested"
+
+    # Verify spec.running is true
+    run -0 rdd ctl get limavm "restart-vm" --namespace "${LIMA_TEST_NS}" \
+        --output jsonpath='{.spec.running}'
+    assert_output "true"
+
+    # Delete the VM
+    run -0 rdd limavm delete "restart-vm"
+    rdd ctl wait --for=delete "limavm/restart-vm" --namespace "${LIMA_TEST_NS}" --timeout="30s"
+}
+
+@test "lima start --timeout fails when VM cannot reach desired state" {
+    rdd ctl create configmap "timeout-vm" --namespace "${LIMA_TEST_NS}" \
+        --from-literal="template=${TEMPLATE}"
+    run_e -0 rdd limavm create "timeout-vm" "timeout-vm" --namespace "${LIMA_TEST_NS}"
+    assert_created "timeout-vm" "${LIMA_TEST_NS}" "timeout-vm"
+
+    # Non-functional template cannot boot, so --wait --timeout should fail
+    run -1 rdd limavm start --wait --timeout=3s "timeout-vm"
+    assert_output --partial 'context deadline exceeded'
+}
+
 @test "lima help text is displayed" {
     # lima is an alias of the limavm command
     run -0 rdd lima --help
@@ -170,6 +215,7 @@ assert_created() {
     assert_output --partial "Create a new LimaVM"
     assert_output --partial "Start a LimaVM"
     assert_output --partial "Stop a LimaVM"
+    assert_output --partial "Restart a LimaVM"
     assert_output --partial "Delete a LimaVM"
     assert_output --partial "Show LimaVM logs"
     assert_output --partial "Execute shell in Lima VM"

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -10,8 +10,9 @@ NAMESPACE="running-test-ns"
 VM_NAME="alpine-running"
 TEMPLATE_NAME="${VM_NAME}-template"
 
-# Use a minimal Alpine template for faster boot
-ALPINE_TEMPLATE='
+# Use a minimal Alpine template for faster boot.
+# Set RDD_VM_TYPE=qemu to reproduce QEMU-specific behavior on macOS.
+ALPINE_TEMPLATE="
 images:
 - location: https://github.com/lima-vm/alpine-lima/releases/download/v0.2.47/alpine-lima-std-3.23.0-x86_64.iso
   arch: x86_64
@@ -19,9 +20,10 @@ images:
 - location: https://github.com/lima-vm/alpine-lima/releases/download/v0.2.47/alpine-lima-std-3.23.0-aarch64.iso
   arch: aarch64
   digest: sha512:44659e71c1e277361bc10ecc813fba799d0371c2bc291db811e05e43429fd31aaa7ebe185331d02dccadccddfe9d54184376cdceeb1c444b58e3e9a4e690ce33
+${RDD_VM_TYPE:+vmType: ${RDD_VM_TYPE}}
 containerd:
   system: false
-  user: false'
+  user: false"
 
 local_setup_file() {
     setup_rdd_control_plane "lima"
@@ -94,22 +96,15 @@ lima_instance_running() {
     assert_file_exists "${RDD_LIMA_HOME}/${name}/ha.pid"
 }
 
-get_instance_running_transition_time() {
+get_restart_count() {
     local name=$1
     rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
-        --output jsonpath='{.status.conditions[?(@.type=="Running")].lastTransitionTime}'
+        --output jsonpath='{.status.restartCount}'
 }
 
 get_hostagent_pid() {
     local name=$1
     cat "${RDD_LIMA_HOME}/${name}/ha.pid"
-}
-
-assert_recovery_completed() {
-    local before_time=$1
-    run -0 get_instance_running_transition_time "${VM_NAME}"
-    refute_output "${before_time}"
-    assert_instance_running_reason "${VM_NAME}" "Started"
 }
 
 assert_limavm_not_exists() {
@@ -257,19 +252,28 @@ EOF
     kill -0 "${OLD_HA_PID}"
     save_var OLD_HA_PID
 
+    # Save restart count before the kill. The watcher detects the crash
+    # instantly, so recovery may complete before the next test starts.
+    # shellcheck disable=SC2030 # Persisted via save_var, not subshell
+    BEFORE_KILL_COUNT=$(get_restart_count "${VM_NAME}")
+    save_var BEFORE_KILL_COUNT
+
     kill -9 "${OLD_HA_PID}"
 }
 
 @test "trigger reconcile and verify crash recovery" {
-    run -0 get_instance_running_transition_time "${VM_NAME}"
-    assert_output
-    before_time=${output}
+    load_var BEFORE_KILL_COUNT
 
+    # Annotate the resource to exercise concurrent modification during recovery.
+    # The watcher already triggers a reconcile, but users may also modify the
+    # object while the controller is restarting the hostagent.
     rdd ctl annotate limavm "${VM_NAME}" --namespace "${NAMESPACE}" --overwrite \
         reconcile-trigger="$(date +%s)"
 
-    # The reconciler should detect the dead hostagent and restart the VM.
-    try --max 60 --delay 5 -- assert_recovery_completed "${before_time}"
+    # restartCount increments in the same status write that sets Running=True.
+    # shellcheck disable=SC2031 # Loaded via load_var, not subshell
+    rdd ctl wait --for=jsonpath='{.status.restartCount}'="$((BEFORE_KILL_COUNT + 1))" \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
 }
 
 @test "verify new hostagent after crash recovery" {
@@ -280,55 +284,162 @@ EOF
     assert [ -n "${new_pid}" ]
     kill -0 "${new_pid}"
 
+    # Windows recycles PIDs quickly, so this assertion is only reliable on Unix.
     load_var OLD_HA_PID
     # shellcheck disable=SC2031 # Loaded via load_var, not subshell
-    refute [ "${new_pid}" = "${OLD_HA_PID}" ]
+    if is_unix; then
+        refute [ "${new_pid}" = "${OLD_HA_PID}" ]
+    fi
 }
 
-# Broken state recovery tests
-# These tests verify that the controller can recover from a broken Lima instance.
-# We simulate breakage by replacing the hostagent socket with a regular file.
-# This makes Lima report StatusBroken (socket exists but is not a Unix socket)
-# without killing the VM process (which on VZ runs inside the hostagent).
+# Orphaned hostagent recovery tests
+# When the service crashes (SIGKILL), the hostagent survives (own process group).
+# On restart, the controller detects the orphaned hostagent via store.Inspect(),
+# kills it, and starts a fresh one with a watcher.
 
-@test "simulate broken state by replacing hostagent socket" {
-    local sock_file="${RDD_LIMA_HOME}/${VM_NAME}/ha.sock"
-    assert_socket_exists "${sock_file}"
+@test "save hostagent PID before service crash" {
+    # shellcheck disable=SC2030 # Persisted via save_var, not subshell
+    ORPHAN_HA_PID=$(get_hostagent_pid "${VM_NAME}")
+    assert [ -n "${ORPHAN_HA_PID}" ]
+    kill -0 "${ORPHAN_HA_PID}"
+    save_var ORPHAN_HA_PID
 
-    # Replace the Unix socket with a regular file so Lima can't connect
-    rm "${sock_file}"
-    touch "${sock_file}"
-    assert_file_exists "${sock_file}"
+    # Save restart count to detect when recovery completes after restart.
+    # shellcheck disable=SC2030 # Persisted via save_var, not subshell
+    BEFORE_CRASH_COUNT=$(get_restart_count "${VM_NAME}")
+    save_var BEFORE_CRASH_COUNT
 }
 
-@test "trigger reconcile and verify recovery from broken state" {
-    # Capture the lastTransitionTime before triggering reconcile
-    run -0 get_instance_running_transition_time "${VM_NAME}"
-    assert_output
-    before_time=${output}
+@test "simulate service crash with SIGKILL" {
+    local svc_pid
+    svc_pid=$(cat "${RDD_PID_FILE}")
+    assert [ -n "${svc_pid}" ]
 
-    # Annotate to trigger a reconcile while spec.running is still true
+    kill -9 "${svc_pid}"
+
+    # Wait for the service process to be fully reaped
+    try --max 10 --delay 1 --until-fail -- kill -0 "${svc_pid}"
+}
+
+@test "verify hostagent survived service crash" {
+    load_var ORPHAN_HA_PID
+    # shellcheck disable=SC2031 # Loaded via load_var, not subshell
+    kill -0 "${ORPHAN_HA_PID}"
+}
+
+@test "restart service and verify orphaned hostagent recovery" {
+    rdd svc start
+
+    load_var ORPHAN_HA_PID
+    load_var BEFORE_CRASH_COUNT
+
+    # Wait for the controller to detect and kill the orphaned hostagent.
+    # shellcheck disable=SC2031 # Loaded via load_var, not subshell
+    try --max 30 --delay 1 --until-fail -- kill -0 "${ORPHAN_HA_PID}"
+
+    # restartCount increments when the new hostagent reaches Running.
+    # shellcheck disable=SC2031 # Loaded via load_var, not subshell
+    rdd ctl wait --for=jsonpath='{.status.restartCount}'="$((BEFORE_CRASH_COUNT + 1))" \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
+
+    local new_pid
+    new_pid=$(get_hostagent_pid "${VM_NAME}")
+    assert [ -n "${new_pid}" ]
+    kill -0 "${new_pid}"
+
+    # Windows recycles PIDs quickly, so this assertion is only reliable on Unix.
+    # shellcheck disable=SC2031 # Loaded via load_var, not subshell
+    if is_unix; then
+        refute [ "${new_pid}" = "${ORPHAN_HA_PID}" ]
+    fi
+}
+
+# Graceful shutdown test
+# Verifies that stopping the service terminates all running hostagents.
+# The controller's shutdown runnable calls shutdownAllHostagents() on exit.
+
+@test "graceful service stop terminates hostagent" {
+    local ha_pid
+    ha_pid=$(get_hostagent_pid "${VM_NAME}")
+    assert [ -n "${ha_pid}" ]
+    kill -0 "${ha_pid}"
+
+    rdd svc stop
+
+    try --max 15 --delay 1 --until-fail -- kill -0 "${ha_pid}"
+}
+
+@test "restart service after graceful shutdown" {
+    rdd svc start
+
+    # VM should start fresh (no orphan — graceful shutdown killed it).
+    try --max 60 --delay 5 -- assert_instance_running_condition "${VM_NAME}" "True"
+    assert_instance_running_reason "${VM_NAME}" "Started"
+}
+
+# Restart tests
+# These tests verify the restart mechanism: annotation → status.restartNeeded → stop → start.
+
+@test "restart running VM via rdd limavm restart" {
+    run -0 get_restart_count "${VM_NAME}"
+    local before_count=${output}
+
+    # restart blocks until restartCount increments (Running=True/Started).
+    rdd limavm restart "${VM_NAME}"
+
+    run -0 get_restart_count "${VM_NAME}"
+    assert_output "$((before_count + 1))"
+}
+
+@test "verify restartNeeded cleared and annotation removed after restart" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --output jsonpath='{.status.restartNeeded}'
+    refute_output # restartNeeded has omitempty; false means absent
+
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --output "jsonpath={.metadata.annotations['lima\.rancherdesktop\.io/restartRequested']}"
+    refute_output
+}
+
+@test "stop VM for stopped-restart test" {
+    rdd ctl patch limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --type=merge --patch '{"spec":{"running":false}}'
+    rdd ctl wait --for=condition=Running=False \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
+}
+
+assert_restart_annotation_absent() {
+    local name=$1
+    run -0 rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
+        --output "jsonpath={.metadata.annotations['lima\.rancherdesktop\.io/restartRequested']}"
+    refute_output
+}
+
+@test "restart annotation on stopped VM with running=false clears restartNeeded" {
+    # Set annotation without changing spec.running (simulates annotation-only path)
     rdd ctl annotate limavm "${VM_NAME}" --namespace "${NAMESPACE}" --overwrite \
-        reconcile-trigger="$(date +%s)"
+        "lima.rancherdesktop.io/restartRequested=$(date +%s)"
 
-    # The reconciler should detect broken state, force stop, then restart.
-    # Verify the condition was actually updated by checking lastTransitionTime changed.
-    try --max 60 --delay 5 -- assert_recovery_completed "${before_time}"
+    # Wait for the annotation to be removed (reconciler processed it)
+    try --max 30 --delay 1 -- assert_restart_annotation_absent "${VM_NAME}"
+
+    # restartNeeded should be cleared
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --output jsonpath='{.status.restartNeeded}'
+    refute_output # restartNeeded has omitempty; false means absent
+
+    # VM should stay stopped because spec.running=false
+    assert_instance_running_condition "${VM_NAME}" "False"
+    assert_instance_running_reason "${VM_NAME}" "Stopped"
 }
 
-@test "verify hostagent is alive after recovery" {
-    local pid_file="${RDD_LIMA_HOME}/${VM_NAME}/ha.pid"
-    assert_file_exists "${pid_file}"
-    local pid
-    pid=$(cat "${pid_file}")
-    assert [ -n "${pid}" ]
-    kill -0 "${pid}"
-}
+@test "restart command on stopped VM starts it" {
+    # restart blocks until the VM is running again.
+    rdd limavm restart "${VM_NAME}"
 
-@test "verify BrokenStateRecovered event was emitted" {
-    run -0 rdd ctl get events --namespace "${NAMESPACE}" \
-        --field-selector involvedObject.kind=LimaVM,involvedObject.name="${VM_NAME}"
-    assert_output --partial "BrokenStateRecovered"
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
+        --output jsonpath='{.status.restartNeeded}'
+    refute_output # restartNeeded has omitempty; false means absent
 }
 
 @test "cleanup LimaVM running test" {

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -18,11 +18,14 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
 	corev1scheme "k8s.io/client-go/kubernetes/scheme"
+	toolswatch "k8s.io/client-go/tools/watch"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -44,6 +47,7 @@ func newLimaVMCommand() *cobra.Command {
 		newLimaVMCreateCommand(),
 		newLimaVMStartCommand(),
 		newLimaVMStopCommand(),
+		newLimaVMRestartCommand(),
 		newLimaVMDeleteCommand(),
 		newLimaVMLogsCommand(),
 		newLimaVMShellCommand(),
@@ -119,6 +123,9 @@ func limaVMEditAction(ctx context.Context, name string) error {
 func newLimaVMCreateCommand() *cobra.Command {
 	var namespace string
 	var dryRun bool
+	var start bool
+	var wait bool
+	var timeout time.Duration
 	command := &cobra.Command{
 		Use:   "create NAME TEMPLATE",
 		Short: "Create a new LimaVM resource",
@@ -129,54 +136,124 @@ TEMPLATE can be one of:
 - A file path (if it's not a valid ConfigMap name) - creates a ConfigMap with the VM name`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return limaVMCreateAction(cmd.Context(), args[0], args[1], namespace, dryRun)
+			return limaVMCreateAction(cmd.Context(), args[0], args[1], namespace, dryRun, start, wait, timeout)
 		},
 	}
 	command.Flags().StringVarP(&namespace, "namespace", "n", metav1.NamespaceDefault, "Namespace for the LimaVM resource")
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "If set, do not commit any changes to the cluster")
+	command.Flags().BoolVar(&start, "start", false, "Start the VM after creation")
+	command.Flags().BoolVar(&wait, "wait", true, "Wait for the operation to complete (only applies with --start)")
+	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
 	return command
 }
 
 func newLimaVMStartCommand() *cobra.Command {
+	var wait bool
+	var timeout time.Duration
 	command := &cobra.Command{
 		Use:   "start NAME",
 		Short: "Start a LimaVM by setting running=true",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return limaVMSetRunningAction(cmd.Context(), args[0], true)
+			return limaVMSetRunningAction(cmd.Context(), args[0], true, wait, timeout)
 		},
 	}
+	command.Flags().BoolVar(&wait, "wait", true, "Wait for the operation to complete")
+	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
 	return command
 }
 
 func newLimaVMStopCommand() *cobra.Command {
+	var wait bool
+	var timeout time.Duration
 	command := &cobra.Command{
 		Use:   "stop NAME",
 		Short: "Stop a LimaVM by setting running=false",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return limaVMSetRunningAction(cmd.Context(), args[0], false)
+			return limaVMSetRunningAction(cmd.Context(), args[0], false, wait, timeout)
 		},
 	}
+	command.Flags().BoolVar(&wait, "wait", true, "Wait for the operation to complete")
+	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
 	return command
+}
+
+func newLimaVMRestartCommand() *cobra.Command {
+	var wait bool
+	var timeout time.Duration
+	command := &cobra.Command{
+		Use:   "restart NAME",
+		Short: "Restart a LimaVM instance",
+		Long:  "Set the restartRequested annotation and spec.running=true to restart the instance.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return limaVMRestartAction(cmd.Context(), args[0], wait, timeout)
+		},
+	}
+	command.Flags().BoolVar(&wait, "wait", true, "Wait for the operation to complete")
+	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
+	return command
+}
+
+func limaVMRestartAction(ctx context.Context, name string, wait bool, timeout time.Duration) error {
+	c, err := getKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+	limaVM, err := findLimaVM(ctx, c, name)
+	if err != nil {
+		return err
+	}
+
+	beforeCount := limaVM.Status.RestartCount
+
+	patch := client.MergeFrom(limaVM.DeepCopy())
+	limaVM.Spec.Running = true
+	if limaVM.Annotations == nil {
+		limaVM.Annotations = make(map[string]string)
+	}
+	limaVM.Annotations[limav1alpha1.AnnotationRestartRequested] = time.Now().UTC().Format(time.RFC3339)
+
+	if err := c.Patch(ctx, limaVM, patch); err != nil {
+		return fmt.Errorf("failed to restart LimaVM: %w", err)
+	}
+
+	logrus.Infof("LimaVM %q restart requested in namespace %q", name, limaVM.Namespace)
+
+	if wait {
+		waitCtx, cancel := toolswatch.ContextWithOptionalTimeout(ctx, timeout)
+		defer cancel()
+		key := client.ObjectKeyFromObject(limaVM)
+		if err := watchUntil(waitCtx, c, key, func(vm *limav1alpha1.LimaVM) bool {
+			return vm.Status.RestartCount > beforeCount
+		}); err != nil {
+			return fmt.Errorf("failed waiting for restart to complete: %w", err)
+		}
+		logrus.Infof("LimaVM %q restarted in namespace %q", name, limaVM.Namespace)
+	}
+	return nil
 }
 
 func newLimaVMDeleteCommand() *cobra.Command {
 	var wait bool
+	var timeout time.Duration
 	command := &cobra.Command{
 		Use:   "delete NAME",
 		Short: "Delete a LimaVM resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return limaVMDeleteAction(cmd.Context(), args[0], wait)
+			return limaVMDeleteAction(cmd.Context(), args[0], wait, timeout)
 		},
 	}
 	command.Flags().BoolVar(&wait, "wait", false, "Wait for the VM to be deleted before returning")
+	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
 	return command
 }
 
 // getKubeClient returns a controller-runtime client configured for the RDD control plane.
-func getKubeClient(ctx context.Context) (client.Client, error) {
+// The returned client supports Watch for event-driven waiting on resource changes.
+func getKubeClient(ctx context.Context) (client.WithWatch, error) {
 	if err := ensureServiceRunning(ctx); err != nil {
 		return nil, err
 	}
@@ -191,7 +268,7 @@ func getKubeClient(ctx context.Context) (client.Client, error) {
 	if err := limav1alpha1.AddToScheme(runtimeScheme); err != nil {
 		return nil, fmt.Errorf("failed to add LimaVM types to scheme: %w", err)
 	}
-	c, err := client.New(config, client.Options{Scheme: runtimeScheme})
+	c, err := client.NewWithWatch(config, client.Options{Scheme: runtimeScheme})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
@@ -263,7 +340,7 @@ func takeOwnership(ctx context.Context, c client.Client, limaVM *limav1alpha1.Li
 	return nil
 }
 
-func limaVMCreateAction(ctx context.Context, name, template, namespace string, dryRun bool) error {
+func limaVMCreateAction(ctx context.Context, name, template, namespace string, dryRun, start, wait bool, timeout time.Duration) error {
 	c, err := getKubeClient(ctx)
 	if err != nil {
 		return err
@@ -292,7 +369,6 @@ func limaVMCreateAction(ctx context.Context, name, template, namespace string, d
 	}()
 
 	// Create the LimaVM resource with the template reference
-	running := false
 	limaVM := &limav1alpha1.LimaVM{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -302,7 +378,7 @@ func limaVMCreateAction(ctx context.Context, name, template, namespace string, d
 			TemplateRef: limav1alpha1.TemplateReference{
 				Name: configMapName,
 			},
-			Running: running,
+			Running: start,
 		},
 	}
 
@@ -324,10 +400,22 @@ func limaVMCreateAction(ctx context.Context, name, template, namespace string, d
 			createdConfigMap = nil
 		}
 	}
+
+	if start && wait && !dryRun {
+		waitCtx, cancel := toolswatch.ContextWithOptionalTimeout(ctx, timeout)
+		defer cancel()
+		key := client.ObjectKeyFromObject(limaVM)
+		if err := watchUntil(waitCtx, c, key, func(vm *limav1alpha1.LimaVM) bool {
+			return apimeta.IsStatusConditionPresentAndEqual(vm.Status.Conditions, "Running", metav1.ConditionTrue)
+		}); err != nil {
+			return fmt.Errorf("failed waiting for LimaVM to start: %w", err)
+		}
+		logrus.Infof("LimaVM %q started in namespace %q", name, namespace)
+	}
 	return nil
 }
 
-func limaVMSetRunningAction(ctx context.Context, name string, running bool) error {
+func limaVMSetRunningAction(ctx context.Context, name string, running, wait bool, timeout time.Duration) error {
 	c, err := getKubeClient(ctx)
 	if err != nil {
 		return err
@@ -346,14 +434,103 @@ func limaVMSetRunningAction(ctx context.Context, name string, running bool) erro
 	}
 
 	action := "stopped"
+	desiredStatus := metav1.ConditionFalse
 	if running {
 		action = "started"
+		desiredStatus = metav1.ConditionTrue
 	}
 	logrus.Infof("LimaVM %q %s in namespace %q", name, action, limaVM.Namespace)
+
+	if wait {
+		waitCtx, cancel := toolswatch.ContextWithOptionalTimeout(ctx, timeout)
+		defer cancel()
+		key := client.ObjectKeyFromObject(limaVM)
+		if err := watchUntil(waitCtx, c, key, func(vm *limav1alpha1.LimaVM) bool {
+			return apimeta.IsStatusConditionPresentAndEqual(vm.Status.Conditions, "Running", desiredStatus)
+		}); err != nil {
+			return fmt.Errorf("failed waiting for LimaVM to be %s: %w", action, err)
+		}
+	}
 	return nil
 }
 
-func limaVMDeleteAction(ctx context.Context, name string, wait bool) error {
+// watchUntil watches a LimaVM until the check function returns true.
+// It reads the current state first, then watches from that resource version
+// to avoid missing events between reads.
+func watchUntil(ctx context.Context, c client.WithWatch, key client.ObjectKey, check func(*limav1alpha1.LimaVM) bool) error {
+	var vm limav1alpha1.LimaVM
+	if err := c.Get(ctx, key, &vm); err != nil {
+		return err
+	}
+	if check(&vm) {
+		return nil
+	}
+
+	vmList := &limav1alpha1.LimaVMList{}
+	watcher, err := c.Watch(ctx, vmList,
+		client.InNamespace(key.Namespace),
+		client.MatchingFields{"metadata.name": key.Name},
+		&client.ListOptions{Raw: &metav1.ListOptions{ResourceVersion: vm.ResourceVersion}},
+	)
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
+	for ev := range watcher.ResultChan() {
+		switch ev.Type {
+		case k8swatch.Error:
+			return apierrors.FromObject(ev.Object)
+		case k8swatch.Deleted:
+			return fmt.Errorf("LimaVM %q was deleted while waiting", key.Name)
+		}
+		updated, ok := ev.Object.(*limav1alpha1.LimaVM)
+		if ok && check(updated) {
+			return nil
+		}
+	}
+	return ctx.Err()
+}
+
+// watchUntilDeleted watches a LimaVM until it is deleted.
+func watchUntilDeleted(ctx context.Context, c client.WithWatch, limaVM *limav1alpha1.LimaVM) error {
+	key := client.ObjectKeyFromObject(limaVM)
+
+	var vm limav1alpha1.LimaVM
+	err := c.Get(ctx, key, &vm)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if vm.UID != limaVM.UID {
+		return nil
+	}
+
+	vmList := &limav1alpha1.LimaVMList{}
+	watcher, err := c.Watch(ctx, vmList,
+		client.InNamespace(key.Namespace),
+		client.MatchingFields{"metadata.name": key.Name},
+		&client.ListOptions{Raw: &metav1.ListOptions{ResourceVersion: vm.ResourceVersion}},
+	)
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
+	for ev := range watcher.ResultChan() {
+		switch ev.Type {
+		case k8swatch.Deleted:
+			return nil
+		case k8swatch.Error:
+			return apierrors.FromObject(ev.Object)
+		}
+	}
+	return ctx.Err()
+}
+
+func limaVMDeleteAction(ctx context.Context, name string, wait bool, timeout time.Duration) error {
 	c, err := getKubeClient(ctx)
 	if err != nil {
 		return err
@@ -369,20 +546,9 @@ func limaVMDeleteAction(ctx context.Context, name string, wait bool) error {
 	}
 
 	if wait {
-		// Wait for the LimaVM to be deleted
-		for {
-			var vm limav1alpha1.LimaVM
-			time.Sleep(time.Second)
-			err := c.Get(ctx, client.ObjectKeyFromObject(limaVM), &vm)
-			if apierrors.IsNotFound(err) {
-				break
-			}
-			if err == nil {
-				if vm.UID != limaVM.UID {
-					break
-				}
-				continue
-			}
+		waitCtx, cancel := toolswatch.ContextWithOptionalTimeout(ctx, timeout)
+		defer cancel()
+		if err := watchUntilDeleted(waitCtx, c, limaVM); err != nil {
 			return fmt.Errorf("failed to wait for LimaVM deletion: %w", err)
 		}
 	}

--- a/docs/design/api_lima.md
+++ b/docs/design/api_lima.md
@@ -30,6 +30,8 @@ spec:
     DOCKER_ROOTFUL: "true"
 status:
   templateConfigMap: alpine-template
+  restartNeeded: false
+  restartCount: 3
   conditions:
   - type: Created
     status: "True"
@@ -41,7 +43,12 @@ status:
     message: Lima instance started successfully
 ```
 
-- **metadata.annotations**: Can be used to request "actions" from the reconciler, like resetting (deleting and recreating with the same settings), or restarting the instance. The `status.conditions` can be used to store the state machine information.
+- **metadata.annotations**: Request actions from the reconciler. All annotations use the `lima.rancherdesktop.io/` prefix.
+
+    | Annotation | Description |
+    |------------|-------------|
+    | `restartRequested` | Triggers a restart. The reconciler translates the annotation to `status.restartNeeded` and removes it. Set to any value (e.g., a timestamp). |
+    | `resetRequested` | Triggers a reset: delete the instance and recreate it with the same template and params. Set to any value. |
 
 - **spec.running**: Set to `true` when the instance should be running, set to `false` when it should be stopped.
 
@@ -59,6 +66,10 @@ status:
 
 - **status.templateConfigMap**: Name of the ConfigMap containing the validated template. The reconciler creates this ConfigMap after copying and validating the template from `spec.templateRef`. This ConfigMap is owned by the LimaVM and deleted automatically when the LimaVM is deleted.
 
+- **status.restartNeeded**: Indicates a restart has been requested but not yet executed. The reconciler sets this field when it processes a `restartRequested` annotation or detects a template change on a running instance. The reconciler clears the flag when stopping the instance (before the restart begins), not after the restart completes. When the instance is already stopped, the reconciler clears the flag immediately. When the instance is starting, the reconciler waits for boot to finish before stopping.
+
+- **status.restartCount**: Tracks how many times the instance has reached the Running state. The reconciler increments this counter each time it sets `Running=True/Started`. Because the next value is predictable, callers can use `kubectl wait --for=jsonpath` to block until a restart completes — something `lastTransitionTime` cannot support since `kubectl wait` matches exact values, not comparisons.
+
 - **status.conditions**: Standard Kubernetes conditions tracking the LimaVM state.
 
     | Type      | Status    | Reason         | Description                                                  |
@@ -66,12 +77,25 @@ status:
     | `Created` | `Unknown` | `Pending`      | Reconciler has seen the resource; creation not yet attempted |
     | `Created` | `True`    | `Created`      | Lima instance exists on disk and is ready                    |
     | `Created` | `False`   | `CreateFailed` | Instance creation or preparation failed                      |
+    | `Running` | `False`   | `Starting`     | Hostagent launched, VM booting                               |
     | `Running` | `True`    | `Started`      | Lima instance is running                                     |
     | `Running` | `False`   | `Stopped`      | Lima instance is stopped                                     |
     | `Running` | `False`   | `StartFailed`  | Lima instance failed to start                                |
     | `Running` | `False`   | `StopFailed`   | Lima instance failed to stop cleanly                         |
 
-Deleting a `LimaVM` object triggers the finalizer to stop the running instance, delete the Lima instance from disk, and remove the template ConfigMap.
+    ```mermaid
+    stateDiagram-v2
+      [*] --> Created=Unknown/Pending: Resource created
+      Created=Unknown/Pending --> Created=True/Created: Lima instance created
+      Created=Unknown/Pending --> Created=False/CreateFailed: Creation failed
+      Created=True/Created --> Running=False/Starting: Hostagent launched
+      Running=False/Starting --> Running=True/Started: VM running
+      Running=False/Starting --> Running=False/StartFailed: Start failed
+      Running=True/Started --> Running=False/Stopped: VM stopped
+      Running=True/Started --> Running=False/StopFailed: Stop failed
+    ```
+
+Deleting a `LimaVM` object triggers the finalizer to force-stop the running instance, delete the Lima instance from disk, and remove the template ConfigMap. Users who want a graceful shutdown should stop the instance before deleting it.
 
 #### Future: Grace Period Support
 
@@ -90,7 +114,7 @@ The `rdd limavm` commands would support:
 - `rdd limavm stop foo --grace-period=30` - wait up to 30 seconds before forcing
 - `rdd limavm delete foo --grace-period=30` - wait up to 30 seconds before forcing deletion
 
-Currently, the reconciler attempts graceful shutdown first, then falls back to forced shutdown if graceful shutdown fails or times out (~6 minutes, controlled by Lima).
+Currently, the reconciler force-stops the instance on deletion. Graceful shutdown on delete could be added via the grace period mechanism described above.
 
 ### LimaVM Component Interactions
 
@@ -118,10 +142,10 @@ sequenceDiagram
     R->>R: Set Created=True
 
     User->>R: Set spec.running=true
-    R->>Lima: Launch hostagent
     R->>R: Set Running=False (Starting)
-    R->>Lima: Poll status
-    R->>R: Set Running=True
+    R->>Lima: Launch hostagent + watcher
+    Lima-->>R: Watcher: hostagent running
+    R->>R: Set Running=True (Started)
 
     User->>R: Set spec.running=false
     R->>Lima: Stop
@@ -145,7 +169,149 @@ The mutating webhook creates the ConfigMap during admission, but cannot set an o
 
 A `.preparing` sentinel file marks preparation in progress. If a reconcile fails after creating the instance but before updating the status, the next reconcile detects the sentinel and cleans up the incomplete instance.
 
-If Lima reports the instance as "Broken" (e.g., hostagent crashed leaving stale PID files, or process mismatch between hostagent and VM driver), the reconciler attempts automatic recovery via force stop. If recovery succeeds, the instance returns to the Stopped state. If recovery fails, the `Running` condition is set to `False` with reason `Broken` and a message describing the error.
+A watcher goroutine monitors each hostagent process. If the hostagent crashes, the watcher detects the exit and triggers a reconcile, which restarts the instance. If the control plane itself crashes, the reconciler detects orphaned hostagents (running without a watcher) on restart, sends SIGTERM to allow a graceful shutdown, falls back to SIGKILL after 30 seconds, and starts fresh. See [Running State Lifecycle](#running-state-lifecycle) for details.
+
+### Running State Lifecycle
+
+The reconciler manages the hostagent process for each `LimaVM`. A watcher goroutine monitors the hostagent and triggers reconciles on state changes. The reconciler reads the watcher's in-memory phase and writes Kubernetes conditions — the watcher never writes conditions directly.
+
+#### Normal Start
+
+The user sets `spec.running=true`. The reconciler launches a hostagent and starts a watcher goroutine that tails the hostagent's event stream.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant R as Reconciler
+    participant W as Watcher
+    participant HA as Hostagent
+
+    U->>R: Set spec.running=true
+    R->>R: Set Running=False/Starting
+    R->>HA: Start hostagent process
+    R->>W: Start watcher goroutine
+    HA-->>W: Event: SSH port ready
+    HA-->>W: Event: Running=true
+    W->>R: Enqueue reconcile (phase=Running)
+    R->>R: Increment restartCount + Set Running=True/Started
+```
+
+#### Normal Stop
+
+The user sets `spec.running=false`. The reconciler stops the hostagent gracefully (SIGINT with 30-second timeout) and cleans up the watcher.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant R as Reconciler
+    participant W as Watcher
+    participant HA as Hostagent
+
+    U->>R: Set spec.running=false
+    R->>HA: StopGracefully (SIGINT)
+    HA-->>W: Event: Exiting
+    HA->>HA: Exit
+    R->>W: Stop watcher
+    R->>R: Set Running=False/Stopped
+```
+
+#### Crash Recovery
+
+The hostagent crashes (killed or exits unexpectedly). The watcher detects the process exit via `haCmd.Wait()` and triggers a reconcile. The reconciler restarts the instance.
+
+```mermaid
+sequenceDiagram
+    participant R as Reconciler
+    participant W as Watcher
+    participant HA as Hostagent
+
+    HA->>HA: Crash (SIGKILL, panic, etc.)
+    W->>W: haCmd.Wait() returns
+    W->>W: Set phase=Stopped
+    W->>R: Enqueue reconcile
+    R->>R: Set Running=False/Starting
+    R->>HA: Start new hostagent
+    R->>W: Start new watcher
+    HA-->>W: Event: Running=true
+    W->>R: Enqueue reconcile (phase=Running)
+    R->>R: Increment restartCount + Set Running=True/Started
+```
+
+#### Orphan Recovery (Control Plane Restart)
+
+The control plane crashes. Hostagents survive (own process group). On restart, the reconciler has no watcher state. It detects orphaned hostagents via `store.Inspect()`, sends SIGTERM to allow a graceful shutdown (falling back to SIGKILL after 30 seconds), and starts fresh with a watcher.
+
+```mermaid
+sequenceDiagram
+    participant R as Reconciler
+    participant W as Watcher
+    participant HA as Hostagent
+    participant S as store.Inspect
+
+    Note over R: Control plane restarts (no watcher state)
+    R->>S: Inspect instance
+    S-->>R: Status=Running (orphaned hostagent)
+    R->>HA: Kill orphaned hostagent (SIGTERM→SIGKILL)
+    R->>R: Requeue
+    R->>S: Inspect instance
+    S-->>R: Status=Stopped
+    R->>R: Set Running=False/Starting
+    R->>HA: Start new hostagent
+    R->>W: Start new watcher
+    HA-->>W: Event: Running=true
+    W->>R: Enqueue reconcile (phase=Running)
+    R->>R: Increment restartCount + Set Running=True/Started
+```
+
+#### Restart
+
+The user (or CLI) sets the `restartRequested` annotation. The reconciler translates it to `status.restartNeeded` in two cycles (status first, then annotation removal), stops the instance, and lets the normal start logic bring it back up.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant R as Reconciler
+    participant W as Watcher
+    participant HA as Hostagent
+
+    U->>R: Set restartRequested annotation
+    R->>R: Set status.restartNeeded=true
+    R->>R: Remove annotation
+    R->>HA: StopGracefully (SIGINT)
+    R->>W: Stop watcher
+    R->>R: Clear restartNeeded + Set Running=False/Stopped
+    Note over R: Next reconcile: shouldRun && !isRunning
+    R->>R: Set Running=False/Starting
+    R->>HA: Start new hostagent
+    R->>W: Start new watcher
+    HA-->>W: Event: Running=true
+    W->>R: Enqueue reconcile (phase=Running)
+    R->>R: Increment restartCount + Set Running=True/Started
+```
+
+#### Graceful Shutdown
+
+The control plane shuts down. Hostagents run in their own process groups so they survive the control plane's exit. This allows the shutdown runnable to send SIGINT and wait for each hostagent to flush data and exit cleanly. If a hostagent were killed with the service, it could lose unsaved state. The shutdown runnable sends SIGINT first; hostagents that do not exit within 30 seconds receive SIGKILL.
+
+```mermaid
+sequenceDiagram
+    participant M as Manager
+    participant SR as Shutdown Runnable
+    participant W as Watcher
+    participant HA as Hostagent
+
+    M->>M: Context cancelled
+    M->>SR: Run shutdown
+    loop Each running hostagent
+        SR->>HA: SIGINT
+        alt Exits within 30s
+            HA->>HA: Graceful exit
+        else Still alive after 30s
+            SR->>HA: SIGKILL
+        end
+    end
+    SR->>W: Cancel all watchers
+```
 
 ## LimaDisk
 

--- a/docs/design/cmd_lima.md
+++ b/docs/design/cmd_lima.md
@@ -12,17 +12,30 @@ Create a new `LimaVM` instance `NAME` in `NAMESPACE` (or `default`) using `TEMPL
 
 `TEMPLATE` will be treated as a local filename or template URL if it contains a `/` or a `:`.  In that case the `create` command will create a ConfigMap in `NAMESPACE` called `NAME`. It will store the "fully embedded" template from the file or URL inside that ConfigMap and use it as the `spec.templateRef`. If a ConfigMap of this name already exists, then the `create` command will fail. If `LimaVM` creation succeeds then ownership of this ConfigMap is transferred to the `LimaVM` resource, and it will be deleted when the `LimaVM` instance is deleted. But when the command fails, then any ConfigMap created from a file or URL is deleted immediately.
 
+- `--start` (default `false`): Set `spec.running=true` to start the VM immediately after creation.
+- `--wait` (default `true`): When used with `--start`, wait until the Running condition becomes True before returning.
+- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely. Accepts Go duration strings (e.g., `30s`, `5m`).
+
 ### `rdd limavm start NAME`
 
 Set `spec.running` of the specified instance to `true`. There is no `--namespace` option because `LimaVM` names are globally unique (within the control plane).
+
+- `--wait` (default `true`): Wait until the Running condition becomes True before returning.
+- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely. Accepts Go duration strings (e.g., `30s`, `5m`).
 
 ### `rdd limavm stop NAME`
 
 Set `spec.running` of the specified instance to `false`.
 
+- `--wait` (default `true`): Wait until the Running condition becomes False before returning.
+- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely.
+
 ### `rdd limavm delete NAME`
 
-This will stop and delete the instance. The `LimaVM` resource will be deleted, which in turn will delete all owned resources. Currently, this is the `status.templateConfigMap`, and potentially the `spec.templateRef.name` template if it was created by `rdd limavm create`.
+Stop and delete the instance. The `LimaVM` resource deletion triggers cleanup of all owned resources: the `status.templateConfigMap`, and the `spec.templateRef.name` template if `rdd limavm create` created it.
+
+- `--wait` (default `false`): Wait until the resource is fully deleted before returning.
+- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely.
 
 ### `rdd limavm params NAME1=VALUE1 NAME2=VALUE2`
 
@@ -38,7 +51,10 @@ Set `lima.rancherdesktop.io/resetRequested` annotation to the current timestamp.
 
 ### `rdd limavm restart NAME`
 
-Set `lima.rancherdesktop.io/restartRequested` annotation to the current timestamp. This tells the reconciler to stop the instance, if it is running. Then it will start the instance, even if it had been stopped initially.
+Set `lima.rancherdesktop.io/restartRequested` annotation and `spec.running=true` in a single patch. The annotation tells the reconciler to stop the instance if it is running; setting `spec.running=true` ensures the instance starts afterward, even if it had been stopped initially.
+
+- `--wait` (default `true`): Wait until `status.restartCount` increments (the instance has fully restarted) before returning.
+- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely.
 
 ### `rdd limavm shell NAME CMD`
 

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -21,6 +21,7 @@ These variables configure the BATS test framework. They have no effect on `rdd` 
 | --- | --- | --- |
 | `RDD_TRACE` | Enables verbose trace output in BATS tests. | `false` |
 | `RDD_NAMESPACE` | Default Kubernetes namespace for BATS controller tests. | `default` |
+| `RDD_VM_TYPE` | Lima VM type for tests that boot a VM (`qemu` or `vz`). Useful for reproducing QEMU-specific failures on macOS. | Lima's default (`vz` on macOS, `qemu` on Linux) |
 
 ## Path Variables
 

--- a/pkg/apis/lima/v1alpha1/applyconfiguration/lima/v1alpha1/limavmstatus.go
+++ b/pkg/apis/lima/v1alpha1/applyconfiguration/lima/v1alpha1/limavmstatus.go
@@ -26,6 +26,14 @@ type LimaVMStatusApplyConfiguration struct {
 	// An admission controller validates any updates to the ConfigMap.
 	// This field is informational - internal code should use GetTemplateConfigMapName() instead.
 	TemplateConfigMap *string `json:"templateConfigMap,omitempty"`
+	// restartNeeded indicates a restart has been requested but not yet executed.
+	// Set by the reconciler when it processes a restartRequested annotation or
+	// detects a template change on a running instance. Cleared when the restart
+	// completes or the instance is already stopped.
+	RestartNeeded *bool `json:"restartNeeded,omitempty"`
+	// restartCount tracks how many times the instance has reached the Running state.
+	// Incremented each time the controller sets Running=True/Started.
+	RestartCount *int32 `json:"restartCount,omitempty"`
 }
 
 // LimaVMStatusApplyConfiguration constructs a declarative configuration of the LimaVMStatus type for use with
@@ -52,5 +60,21 @@ func (b *LimaVMStatusApplyConfiguration) WithConditions(values ...*v1.ConditionA
 // If called multiple times, the TemplateConfigMap field is set to the value of the last call.
 func (b *LimaVMStatusApplyConfiguration) WithTemplateConfigMap(value string) *LimaVMStatusApplyConfiguration {
 	b.TemplateConfigMap = &value
+	return b
+}
+
+// WithRestartNeeded sets the RestartNeeded field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RestartNeeded field is set to the value of the last call.
+func (b *LimaVMStatusApplyConfiguration) WithRestartNeeded(value bool) *LimaVMStatusApplyConfiguration {
+	b.RestartNeeded = &value
+	return b
+}
+
+// WithRestartCount sets the RestartCount field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RestartCount field is set to the value of the last call.
+func (b *LimaVMStatusApplyConfiguration) WithRestartCount(value int32) *LimaVMStatusApplyConfiguration {
+	b.RestartCount = &value
 	return b
 }

--- a/pkg/apis/lima/v1alpha1/limavm_types.go
+++ b/pkg/apis/lima/v1alpha1/limavm_types.go
@@ -11,6 +11,10 @@ import (
 // TemplateConfigMapKey is the key used to store the template text in the templateConfigMap.
 const TemplateConfigMapKey = "template"
 
+// AnnotationRestartRequested triggers a restart when set on a LimaVM resource.
+// The reconciler translates it to status.restartNeeded and removes the annotation.
+var AnnotationRestartRequested = SchemeGroupVersion.Group + "/restartRequested"
+
 // TemplateReference specifies a reference to a ConfigMap containing a VM template.
 type TemplateReference struct {
 	// name is the name of the ConfigMap containing the VM template.
@@ -59,6 +63,18 @@ type LimaVMStatus struct {
 	// This field is informational - internal code should use GetTemplateConfigMapName() instead.
 	// +optional
 	TemplateConfigMap string `json:"templateConfigMap,omitempty"`
+
+	// restartNeeded indicates a restart has been requested but not yet executed.
+	// Set by the reconciler when it processes a restartRequested annotation or
+	// detects a template change on a running instance. Cleared when the instance
+	// stops (before the restart starts) or immediately if already stopped.
+	// +optional
+	RestartNeeded bool `json:"restartNeeded,omitempty"`
+
+	// restartCount tracks how many times the instance has reached the Running state.
+	// Incremented each time the controller sets Running=True/Started.
+	// +optional
+	RestartCount int32 `json:"restartCount,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
+++ b/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	hostagentevents "github.com/lima-vm/lima/v2/pkg/hostagent/events"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
+)
+
+// instancePhase represents the hostagent lifecycle as observed by the watcher.
+type instancePhase string
+
+const (
+	phaseUnknown  instancePhase = ""
+	phaseStarting instancePhase = "Starting"
+	phaseRunning  instancePhase = "Running"
+	phaseStopped  instancePhase = "Stopped"
+)
+
+// instanceState tracks the watcher goroutine and its observed phase for one VM.
+type instanceState struct {
+	mu         sync.RWMutex
+	phase      instancePhase
+	cancel     context.CancelFunc // cancels the watcher goroutine
+	done       chan struct{}      // closed when the watcher goroutine exits
+	procExited chan struct{}      // closed when haCmd.Wait() returns (process dead)
+	cmd        *exec.Cmd          // hostagent process, for graceful shutdown
+}
+
+// startWatcher launches a goroutine that tails the hostagent event stream and
+// tracks lifecycle phase transitions. It also reaps the hostagent process via
+// haCmd.Wait(), preventing zombies and detecting unclean exits.
+//
+// The watcher writes phase changes to in-memory state only; the reconciler
+// reads this state and writes K8s conditions.
+func (r *LimaVMReconciler) startWatcher(ctx context.Context, name, namespace string, haCmd *exec.Cmd, instDir string, begin time.Time) {
+	watchCtx, watchCancel := context.WithCancel(ctx)
+
+	state := &instanceState{
+		phase:      phaseStarting,
+		cancel:     watchCancel,
+		done:       make(chan struct{}),
+		procExited: make(chan struct{}),
+		cmd:        haCmd,
+	}
+
+	r.instanceStatesMu.Lock()
+	r.instanceStates[name] = state
+	r.instanceStatesMu.Unlock()
+
+	go r.runWatcher(watchCtx, name, namespace, instDir, begin, state)
+}
+
+// runWatcher is the watcher goroutine. It races haCmd.Wait() against
+// events.Watch() so that process exit is detected even without an Exiting event
+// (e.g. SIGKILL).
+func (r *LimaVMReconciler) runWatcher(ctx context.Context, name, namespace, instDir string, begin time.Time, state *instanceState) {
+	logger := log.FromContext(ctx).WithValues("instance", name, "component", "watcher")
+	defer close(state.done)
+
+	// Reap the hostagent process in a sub-goroutine. haCmd.Wait() blocks until
+	// the process exits and cannot be cancelled via context. This is safe because
+	// every code path that cancels the watcher also kills the hostagent process
+	// (stopInstance, shutdownAllHostagents, StopForcibly on delete), so this
+	// goroutine always returns promptly after cancellation.
+	// When the process exits, cancel the Watch context so events.Watch returns.
+	waitCtx, waitCancel := context.WithCancel(ctx)
+	defer waitCancel()
+	go func() {
+		err := state.cmd.Wait()
+		close(state.procExited)
+		if err != nil {
+			logger.Info("Hostagent process exited with error", "error", err)
+		} else {
+			logger.Info("Hostagent process exited cleanly")
+		}
+		waitCancel()
+	}()
+
+	haStdoutPath := filepath.Join(instDir, filenames.HostAgentStdoutLog)
+	haStderrPath := filepath.Join(instDir, filenames.HostAgentStderrLog)
+
+	onEvent := func(ev hostagentevents.Event) bool {
+		state.mu.Lock()
+		defer state.mu.Unlock()
+
+		// Note: ev.Status.Degraded is intentionally not handled here.
+		// Lima's hostagent does not currently emit Degraded events, so there
+		// is nothing to act on. If Lima adds Degraded support in the future,
+		// we should map it to a condition (e.g. Running=True with a degraded reason).
+
+		if ev.Status.Exiting {
+			logger.Info("Hostagent exiting")
+			state.phase = phaseStopped
+			r.enqueueReconcile(name, namespace)
+			return true // stop watching
+		}
+		if ev.Status.Running {
+			if state.phase != phaseRunning {
+				logger.Info("Hostagent running")
+				state.phase = phaseRunning
+				r.enqueueReconcile(name, namespace)
+			}
+			return false
+		}
+		if ev.Status.SSHLocalPort > 0 && state.phase != phaseRunning {
+			if state.phase != phaseStarting {
+				logger.Info("Hostagent starting", "sshLocalPort", ev.Status.SSHLocalPort)
+				state.phase = phaseStarting
+				r.enqueueReconcile(name, namespace)
+			}
+		}
+		return false
+	}
+
+	if err := hostagentevents.Watch(waitCtx, haStdoutPath, haStderrPath, begin, onEvent); err != nil {
+		// Context cancellation is expected (process exit or controller shutdown).
+		if waitCtx.Err() == nil {
+			logger.Error(err, "Event watcher failed")
+		}
+	}
+
+	// Ensure phase is Stopped after Watch returns, regardless of reason.
+	state.mu.Lock()
+	if state.phase != phaseStopped {
+		state.phase = phaseStopped
+		state.mu.Unlock()
+		r.enqueueReconcile(name, namespace)
+	} else {
+		state.mu.Unlock()
+	}
+
+	logger.Info("Watcher stopped")
+}
+
+// stopWatcher cancels the watcher goroutine and waits for it to finish.
+func (r *LimaVMReconciler) stopWatcher(name string) {
+	r.instanceStatesMu.RLock()
+	state, ok := r.instanceStates[name]
+	r.instanceStatesMu.RUnlock()
+	if !ok {
+		return
+	}
+
+	state.cancel()
+	<-state.done
+
+	r.instanceStatesMu.Lock()
+	delete(r.instanceStates, name)
+	r.instanceStatesMu.Unlock()
+}
+
+// getInstancePhase returns the current observed phase for a VM instance.
+// Returns phaseUnknown if no watcher exists.
+func (r *LimaVMReconciler) getInstancePhase(name string) instancePhase {
+	r.instanceStatesMu.RLock()
+	state, ok := r.instanceStates[name]
+	r.instanceStatesMu.RUnlock()
+	if !ok {
+		return phaseUnknown
+	}
+
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	return state.phase
+}
+
+// waitForProcessExit waits for the hostagent process to exit. Returns true if
+// the process exited, false if the context was cancelled first.
+// Returns true immediately if no watcher exists for the instance.
+func (r *LimaVMReconciler) waitForProcessExit(ctx context.Context, name string) bool {
+	r.instanceStatesMu.RLock()
+	state, ok := r.instanceStates[name]
+	r.instanceStatesMu.RUnlock()
+	if !ok {
+		return true
+	}
+	select {
+	case <-state.procExited:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// signalHostagent sends a signal to the hostagent process. Returns false if no
+// watcher exists or the process handle is unavailable.
+func (r *LimaVMReconciler) signalHostagent(name string, sig os.Signal) bool {
+	r.instanceStatesMu.RLock()
+	state, ok := r.instanceStates[name]
+	r.instanceStatesMu.RUnlock()
+	if !ok || state.cmd == nil || state.cmd.Process == nil {
+		return false
+	}
+	return state.cmd.Process.Signal(sig) == nil
+}
+
+// enqueueReconcile sends a GenericEvent to trigger a reconcile for the named VM.
+func (r *LimaVMReconciler) enqueueReconcile(name, namespace string) {
+	vm := &v1alpha1.LimaVM{}
+	vm.Name = name
+	vm.Namespace = namespace
+
+	select {
+	case r.reconcileChan <- event.TypedGenericEvent[*v1alpha1.LimaVM]{Object: vm}:
+	default:
+		// Channel full; a reconcile is already pending.
+	}
+}

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -7,8 +7,12 @@ package controllers
 import (
 	"context"
 	"errors"
+	"maps"
 	"os"
 	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
 
 	limainstance "github.com/lima-vm/lima/v2/pkg/instance"
 	"github.com/lima-vm/lima/v2/pkg/store"
@@ -22,7 +26,11 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
@@ -63,12 +71,13 @@ const (
 	// ReasonStopFailed is used when the Lima instance failed to stop.
 	ReasonStopFailed = "StopFailed"
 
-	// ReasonBroken is used when the Lima instance is in an inconsistent state.
-	ReasonBroken = "Broken"
-
 	// preparingSentinel is a marker file created during instance preparation.
 	// Its presence indicates that preparation is in progress or failed.
 	preparingSentinel = ".preparing"
+
+	// gracefulShutdownTimeout is the time to wait for a hostagent to exit
+	// after sending SIGINT before falling back to SIGKILL.
+	gracefulShutdownTimeout = 30 * time.Second
 )
 
 // sentinelPath returns the path to the preparing sentinel file for an instance.
@@ -102,6 +111,10 @@ type LimaVMReconciler struct {
 	Scheme   *runtime.Scheme
 	Manager  ctrl.Manager
 	Recorder events.EventRecorder
+
+	instanceStatesMu sync.RWMutex
+	instanceStates   map[string]*instanceState
+	reconcileChan    chan event.TypedGenericEvent[*v1alpha1.LimaVM]
 }
 
 // +kubebuilder:rbac:groups=lima.rancherdesktop.io,resources=limavms,verbs=get;list;watch;create;update;patch;delete
@@ -171,7 +184,7 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 		}
 		// Requeue to continue with fresh state after cleanup.
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
 	// Delete any leftover instance from a failed deletion before setting up owner references.
@@ -220,8 +233,11 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	// Instance already created - proceed to handle running state
+	// Instance already created - handle restart annotation, then running state.
 	if apimeta.IsStatusConditionTrue(limaVM.Status.Conditions, ConditionCreated) {
+		if _, hasAnnotation := limaVM.Annotations[v1alpha1.AnnotationRestartRequested]; hasAnnotation {
+			return r.handleRestartAnnotation(ctx, &limaVM)
+		}
 		return r.handleRunningState(ctx, &limaVM)
 	}
 
@@ -316,16 +332,79 @@ func (r *LimaVMReconciler) setCondition(limaVM *v1alpha1.LimaVM, conditionType s
 	}
 }
 
-// updateCondition sets a condition and updates the status in one call.
+// updateCondition sets a condition and patches the status subresource.
 func (r *LimaVMReconciler) updateCondition(ctx context.Context, limaVM *v1alpha1.LimaVM, conditionType string, status metav1.ConditionStatus, reason, message string) error {
+	// Patch (not Update) avoids resource version conflicts when the object is
+	// modified externally during long-running operations like waitForPIDFile or
+	// graceful shutdown.
+	patch := client.MergeFrom(limaVM.DeepCopy())
 	r.setCondition(limaVM, conditionType, status, reason, message)
-	return r.Status().Update(ctx, limaVM)
+	return r.Status().Patch(ctx, limaVM, patch)
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *LimaVMReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.instanceStates = make(map[string]*instanceState)
+	r.reconcileChan = make(chan event.TypedGenericEvent[*v1alpha1.LimaVM], 1)
+
+	if err := mgr.Add(manager.RunnableFunc(r.waitForShutdown)); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.LimaVM{}).
 		Owns(&corev1.ConfigMap{}).
+		WatchesRawSource(source.Channel(
+			r.reconcileChan,
+			&handler.TypedEnqueueRequestForObject[*v1alpha1.LimaVM]{},
+		)).
 		Complete(r)
+}
+
+// waitForShutdown blocks until the manager context is cancelled, then
+// terminates all running hostagents.
+func (r *LimaVMReconciler) waitForShutdown(ctx context.Context) error {
+	<-ctx.Done()
+	r.shutdownAllHostagents()
+	return nil
+}
+
+// shutdownAllHostagents terminates all running hostagents during graceful shutdown.
+// It sends SIGINT to each hostagent for graceful shutdown, waits for them to exit,
+// and falls back to SIGKILL after a timeout.
+func (r *LimaVMReconciler) shutdownAllHostagents() {
+	r.instanceStatesMu.RLock()
+	states := maps.Clone(r.instanceStates)
+	r.instanceStatesMu.RUnlock()
+
+	if len(states) == 0 {
+		return
+	}
+
+	// Send SIGINT to all hostagents in parallel for graceful shutdown.
+	for _, state := range states {
+		if state.cmd != nil && state.cmd.Process != nil {
+			_ = state.cmd.Process.Signal(syscall.SIGINT)
+		}
+	}
+
+	// Wait for each hostagent process to exit. The watcher goroutine may finish
+	// before the process (events.Watch returns on context cancel), so we wait on
+	// procExited (closed by haCmd.Wait) rather than done (closed by the watcher).
+	// TODO: Wait on all hostagents in parallel instead of sequentially; with the
+	// current loop, the total wait is N × gracefulShutdownTimeout in the worst case.
+	for name, state := range states {
+		select {
+		case <-state.procExited:
+		case <-time.After(gracefulShutdownTimeout):
+			if state.cmd != nil && state.cmd.Process != nil {
+				_ = state.cmd.Process.Kill()
+			}
+			<-state.procExited
+		}
+		state.cancel()
+		r.instanceStatesMu.Lock()
+		delete(r.instanceStates, name)
+		r.instanceStatesMu.Unlock()
+	}
 }

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -18,9 +18,9 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/store"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
@@ -32,6 +32,8 @@ import (
 func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.LimaVM) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	r.stopWatcher(limaVM.Name)
+
 	// Stop and delete the Lima instance.
 	// Inspect may fail if the instance doesn't exist, which is fine during
 	// deletion - we just proceed to remove the finalizer.
@@ -40,13 +42,12 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 		logger.Error(err, "Failed to inspect Lima instance for deletion")
 	}
 	if existingInst != nil {
-		// Stop the instance if running
+		// Force-stop the instance if running. No graceful shutdown needed
+		// since the instance is being deleted; users who want a graceful
+		// shutdown can stop the instance before deleting.
 		if existingInst.Status == limatype.StatusRunning {
-			logger.Info("Stopping Lima instance before deletion", "instance", limaVM.Name)
-			if err := limainstance.StopGracefully(ctx, existingInst, false); err != nil {
-				logger.Error(err, "Failed to stop Lima instance gracefully, forcing stop")
-				limainstance.StopForcibly(existingInst)
-			}
+			logger.Info("Force-stopping Lima instance before deletion", "instance", limaVM.Name)
+			limainstance.StopForcibly(existingInst)
 		}
 		logger.Info("Deleting Lima instance", "instance", limaVM.Name)
 		if err := limainstance.Delete(ctx, existingInst, true); err != nil {
@@ -76,119 +77,239 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 	return ctrl.Result{}, nil
 }
 
-// handleRunningState manages VM start/stop based on spec.running.
-func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alpha1.LimaVM) (ctrl.Result, error) {
+// handleRestartAnnotation translates the restartRequested annotation into
+// status.restartNeeded. It takes two reconcile cycles:
+//  1. Set status.restartNeeded=true (if not already set).
+//  2. Remove the annotation (status is already persisted).
+//
+// This ordering ensures the status is durable before metadata changes.
+// If the annotation removal fails, the next reconcile sees both and retries.
+func (r *LimaVMReconciler) handleRestartAnnotation(ctx context.Context, limaVM *v1alpha1.LimaVM) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// Get current instance status
+	if !limaVM.Status.RestartNeeded {
+		logger.Info("Restart requested via annotation, setting status.restartNeeded")
+		patch := client.MergeFrom(limaVM.DeepCopy())
+		limaVM.Status.RestartNeeded = true
+		if err := r.Status().Patch(ctx, limaVM, patch); err != nil {
+			logger.Error(err, "Failed to set status.restartNeeded")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// status.restartNeeded is already true; remove the annotation.
+	logger.Info("Removing restartRequested annotation")
+	patch := client.MergeFrom(limaVM.DeepCopy())
+	delete(limaVM.Annotations, v1alpha1.AnnotationRestartRequested)
+	if err := r.Patch(ctx, limaVM, patch); err != nil {
+		logger.Error(err, "Failed to remove restartRequested annotation")
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// handleRunningState manages VM start/stop based on spec.running and the
+// watcher's observed phase. When a watcher is active, its phase is the source
+// of truth. When no watcher exists (controller restart), store.Inspect detects
+// orphaned hostagents.
+func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alpha1.LimaVM) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	shouldRun := limaVM.Spec.Running
+	phase := r.getInstancePhase(limaVM.Name)
+
+	logger.Info("Checking running state", "shouldRun", shouldRun, "phase", phase)
+
+	if limaVM.Status.RestartNeeded {
+		return r.handleRestartNeeded(ctx, limaVM, phase)
+	}
+
+	if phase != phaseUnknown {
+		return r.handleWatchedState(ctx, limaVM, shouldRun, phase)
+	}
+	return r.handleUnwatchedState(ctx, limaVM, shouldRun)
+}
+
+// handleWatchedState handles a VM that has an active watcher reporting its phase.
+func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alpha1.LimaVM, shouldRun bool, phase instancePhase) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	switch {
+	case phase == phaseStarting && shouldRun:
+		// Watcher triggers the next reconcile when phase changes.
+		if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionFalse, ReasonStarting) {
+			if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStarting, "Lima instance is starting"); err != nil {
+				logger.Error(err, "Failed to update starting condition")
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+
+	case phase == phaseRunning && shouldRun:
+		if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionTrue, ReasonStarted) {
+			patch := client.MergeFrom(limaVM.DeepCopy())
+			limaVM.Status.RestartCount++
+			r.setCondition(limaVM, ConditionRunning, metav1.ConditionTrue, ReasonStarted, "Lima instance is running")
+			if err := r.Status().Patch(ctx, limaVM, patch); err != nil {
+				logger.Error(err, "Failed to update running condition")
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+
+	case phase == phaseStopped && shouldRun:
+		// Hostagent exited while it should be running (crash or failed start).
+		// Clean up the dead watcher and start fresh.
+		r.stopWatcher(limaVM.Name)
+		inst, err := store.Inspect(ctx, limaVM.Name)
+		if err != nil {
+			logger.Error(err, "Failed to inspect Lima instance")
+			return ctrl.Result{}, err
+		}
+		if inst == nil {
+			return ctrl.Result{}, errors.New("instance not found")
+		}
+		// The VM driver (e.g., QEMU) may outlive the hostagent. Force-stop
+		// the instance so the next hostagent can start with a clean slate.
+		if inst.Status == limatype.StatusRunning || inst.Status == limatype.StatusBroken {
+			logger.Info("Force-stopping orphaned VM driver", "status", inst.Status)
+			limainstance.StopForcibly(inst)
+		}
+		return r.startInstance(ctx, limaVM, inst)
+
+	case phase == phaseRunning && !shouldRun:
+		inst, err := store.Inspect(ctx, limaVM.Name)
+		if err != nil {
+			logger.Error(err, "Failed to inspect Lima instance")
+			return ctrl.Result{}, err
+		}
+		if inst == nil {
+			return ctrl.Result{}, errors.New("instance not found")
+		}
+		// TODO: Non-blocking stop: send SIGINT and return immediately;
+		// the watcher detects the Exiting event and triggers a reconcile.
+		return r.stopInstance(ctx, limaVM, inst)
+
+	case phase == phaseStarting && !shouldRun:
+		// Hostagent is alive and starting, but user wants it stopped.
+		inst, err := store.Inspect(ctx, limaVM.Name)
+		if err != nil {
+			logger.Error(err, "Failed to inspect Lima instance")
+			return ctrl.Result{}, err
+		}
+		if inst == nil {
+			return ctrl.Result{}, errors.New("instance not found")
+		}
+		return r.stopInstance(ctx, limaVM, inst)
+
+	default:
+		// phase == phaseStopped && !shouldRun
+		r.stopWatcher(limaVM.Name)
+		if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionFalse, ReasonStopped) {
+			if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStopped, "Lima instance is stopped"); err != nil {
+				logger.Error(err, "Failed to update stopped condition")
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+}
+
+// handleUnwatchedState handles a VM with no active watcher. This occurs after
+// controller restart. If a hostagent is still running, it is orphaned and must
+// be killed so the next reconcile can start fresh with a watcher.
+func (r *LimaVMReconciler) handleUnwatchedState(ctx context.Context, limaVM *v1alpha1.LimaVM, shouldRun bool) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
 	inst, err := store.Inspect(ctx, limaVM.Name)
 	if err != nil {
 		logger.Error(err, "Failed to inspect Lima instance")
 		return ctrl.Result{}, err
 	}
 	if inst == nil {
-		// Instance doesn't exist - shouldn't happen if Created is True
-		logger.Error(nil, "Lima instance not found despite Created condition")
 		return ctrl.Result{}, errors.New("instance not found")
 	}
 
-	// Handle broken state. Lima reports "broken" when the hostagent PID file
-	// exists but the socket is not yet responding. During startup this is normal:
-	// the hostagent creates its PID file before the socket. If the hostagent
-	// process is alive and the socket doesn't exist yet, treat it as starting.
-	if inst.Status == limatype.StatusBroken {
-		haSockPath := filepath.Join(inst.Dir, filenames.HostAgentSock)
-		if inst.HostAgentPID > 0 && !fileExists(haSockPath) {
-			logger.Info("Instance reports broken but hostagent is alive and socket not yet created, treating as starting", "pid", inst.HostAgentPID)
-			if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionFalse, ReasonStarting) {
-				if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStarting, "Lima instance is starting"); err != nil {
-					logger.Error(err, "Failed to update starting condition")
-					return ctrl.Result{}, err
-				}
-			}
-			// Poll until the hostagent finishes startup and the socket appears.
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-
-		logger.Info("Lima instance is broken, attempting force stop to recover", "errors", inst.Errors)
-		limainstance.StopForcibly(inst)
-
-		// Re-inspect to see if recovery succeeded
-		inst, err = store.Inspect(ctx, limaVM.Name)
-		if err != nil {
-			logger.Error(err, "Failed to inspect Lima instance after force stop")
+	switch inst.Status {
+	case limatype.StatusRunning, limatype.StatusBroken:
+		// Orphaned hostagent from before controller restart. Kill it so the
+		// next reconcile can start with a watcher.
+		logger.Info("Found orphaned hostagent, killing it", "status", inst.Status)
+		if err := r.killOrphanedHostagent(ctx, inst); err != nil {
+			logger.Error(err, "Failed to kill orphaned hostagent")
 			return ctrl.Result{}, err
 		}
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 
-		if inst.Status == limatype.StatusBroken {
-			errMsg := "Lima instance is in broken state"
-			if len(inst.Errors) > 0 {
-				errMsg = inst.Errors[0].Error()
-			}
-			logger.Error(nil, "Failed to recover broken Lima instance", "errors", inst.Errors)
-			if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonBroken, errMsg); err != nil {
-				logger.Error(err, "Failed to update broken condition")
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, errors.New(errMsg)
+	default:
+		// Stopped — proceed normally.
+		if shouldRun {
+			return r.startInstance(ctx, limaVM, inst)
 		}
-
-		logger.Info("Recovered broken Lima instance via force stop", "newStatus", inst.Status)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(limaVM, nil, corev1.EventTypeWarning, "BrokenStateRecovered", "Recovery",
-				"Recovered from broken state via force stop")
-		}
-	}
-
-	shouldRun := limaVM.Spec.Running
-	isRunning := inst.Status == limatype.StatusRunning
-
-	logger.Info("Checking running state", "shouldRun", shouldRun, "isRunning", isRunning, "status", inst.Status)
-
-	if shouldRun && !isRunning {
-		// Check if hostagent is already starting (PID file exists)
-		haPIDPath := filepath.Join(inst.Dir, filenames.HostAgentPID)
-		if _, err := os.Stat(haPIDPath); err == nil {
-			// PID file exists, hostagent is starting
-			logger.Info("Lima instance is starting, waiting for it to be running")
-			if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionFalse, ReasonStarting) {
-				if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStarting, "Lima instance is starting"); err != nil {
-					logger.Error(err, "Failed to update starting condition")
-					return ctrl.Result{}, err
-				}
-			}
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-		return r.startInstance(ctx, limaVM, inst)
-	}
-	if !shouldRun && isRunning {
-		return r.stopInstance(ctx, limaVM, inst)
-	}
-
-	// Update condition to reflect current state (including reason, so StartFailed/Starting gets updated)
-	if isRunning {
-		if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionTrue, ReasonStarted) {
-			if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionTrue, ReasonStarted, "Lima instance is running"); err != nil {
-				logger.Error(err, "Failed to update running condition")
-				return ctrl.Result{}, err
-			}
-		}
-	} else {
 		if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionFalse, ReasonStopped) {
 			if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStopped, "Lima instance is stopped"); err != nil {
-				logger.Error(err, "Failed to update running condition")
+				logger.Error(err, "Failed to update stopped condition")
 				return ctrl.Result{}, err
 			}
 		}
+		return ctrl.Result{}, nil
 	}
-
-	return ctrl.Result{}, nil
 }
 
-// startInstance starts the Lima VM hostagent in the background.
-// It returns immediately after launching the hostagent, without waiting for
-// the VM to be fully running. The reconciler will be requeued to check the
-// running state later.
+// handleRestartNeeded acts on status.restartNeeded based on the watcher phase:
+//   - Running: stop the instance and clear restartNeeded atomically.
+//     The next reconcile starts it via normal shouldRun && !isRunning logic.
+//   - Starting: return and let the watcher trigger the next reconcile.
+//   - Stopped/Unknown: clear restartNeeded and fall through to normal logic.
+func (r *LimaVMReconciler) handleRestartNeeded(ctx context.Context, limaVM *v1alpha1.LimaVM, phase instancePhase) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	switch phase {
+	case phaseRunning:
+		logger.Info("Restart needed: stopping running instance")
+
+		r.signalHostagent(limaVM.Name, os.Interrupt)
+		stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
+		defer cancel()
+		if !r.waitForProcessExit(stopCtx, limaVM.Name) {
+			logger.Info("Hostagent did not exit gracefully, forcing stop")
+			inst, err := store.Inspect(ctx, limaVM.Name)
+			if err != nil {
+				logger.Error(err, "Failed to inspect Lima instance for forceful stop")
+			} else if inst != nil {
+				limainstance.StopForcibly(inst)
+			}
+			r.waitForProcessExit(ctx, limaVM.Name)
+		}
+
+		r.stopWatcher(limaVM.Name)
+
+		// Clear restartNeeded and set Stopped condition in one write.
+		// This is inlined (rather than calling stopInstance) so both changes
+		// land in a single patch — stopInstance's updateCondition would take
+		// its own DeepCopy and miss the RestartNeeded change.
+		patch := client.MergeFrom(limaVM.DeepCopy())
+		limaVM.Status.RestartNeeded = false
+		r.setCondition(limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStopped, "Stopped for restart")
+		return ctrl.Result{}, r.Status().Patch(ctx, limaVM, patch)
+
+	case phaseStarting:
+		// Watcher triggers next reconcile when phase changes.
+		logger.Info("Restart needed but instance is starting, waiting for boot to complete")
+		return ctrl.Result{}, nil
+
+	default:
+		// phaseStopped or phaseUnknown: clear flag and let normal logic handle it.
+		logger.Info("Restart needed but instance not running, clearing flag", "phase", phase)
+		patch := client.MergeFrom(limaVM.DeepCopy())
+		limaVM.Status.RestartNeeded = false
+		return ctrl.Result{}, r.Status().Patch(ctx, limaVM, patch)
+	}
+}
+
+// startInstance launches the hostagent and starts a watcher goroutine to track
+// its lifecycle. The watcher triggers reconciles as the hostagent progresses
+// through Starting → Running → Stopped, so no polling is needed.
 //
 // This duplicates much of Lima's own start logic because Lima's API blocks
 // until the VM is fully running. We need to return immediately so the
@@ -196,6 +317,14 @@ func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alp
 func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.LimaVM, inst *limatype.Instance) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Starting Lima instance", "instance", limaVM.Name)
+
+	// Record the Starting condition before any slow operations (waitForPIDFile
+	// can block up to 5 seconds). This ensures the True→False status transition
+	// is visible even if the object is modified externally during startup.
+	if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStarting, "Lima instance is starting"); err != nil {
+		logger.Error(err, "Failed to update starting condition")
+		return ctrl.Result{}, err
+	}
 
 	// Get the path to our own executable (rdd) to use as the hostagent launcher
 	rddPath, err := os.Executable()
@@ -223,7 +352,7 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	args = append(args, inst.Name)
 
 	// Create rotated log files. The active names (ha.stdout.log, ha.stderr.log)
-	// match what Lima expects for StopGracefully.
+	// match what Lima expects (e.g. StopForcibly, store.Inspect).
 	keepLogs := os.Getenv("RDD_KEEP_LOGS") != ""
 	title := os.Getenv("RDD_LOG_TITLE")
 	var header string
@@ -253,7 +382,10 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 		return ctrl.Result{}, err
 	}
 	defer haStderrW.Close()
-	// Start hostagent in background
+
+	begin := time.Now()
+
+	// Start hostagent in background.
 	haCmd := exec.CommandContext(ctx, rddPath, args...)
 	process.SetGroup(haCmd)
 	haCmd.Stdout = haStdoutW
@@ -267,14 +399,6 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 		return ctrl.Result{}, err
 	}
 
-	// Reap the hostagent process when it exits. Without this, the hostagent
-	// becomes a zombie, and Lima's kill(pid, 0) check thinks it is still alive.
-	go func() {
-		if err := haCmd.Wait(); err != nil {
-			logger.Error(err, "Hostagent process exited with error")
-		}
-	}()
-
 	// Wait for PID file to be created (indicates hostagent has started)
 	if err := r.waitForPIDFile(haPIDPath, haStderrPath); err != nil {
 		logger.Error(err, "Hostagent did not start")
@@ -284,13 +408,12 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 		return ctrl.Result{}, err
 	}
 
-	logger.Info("Hostagent started, waiting for instance to be running", "instance", limaVM.Name)
-	if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStarting, "Lima instance is starting"); err != nil {
-		logger.Error(err, "Failed to update status after hostagent start")
-		return ctrl.Result{}, err
-	}
+	// Start watcher goroutine to track hostagent lifecycle and reap the process.
+	// The watcher enqueues reconciles as phase transitions occur.
+	r.startWatcher(ctx, limaVM.Name, limaVM.Namespace, haCmd, inst.Dir, begin)
 
-	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	logger.Info("Hostagent started, watcher active", "instance", limaVM.Name)
+	return ctrl.Result{}, nil
 }
 
 // waitForPIDFile waits for the hostagent PID file to be created.
@@ -307,17 +430,23 @@ func (r *LimaVMReconciler) waitForPIDFile(haPIDPath, haStderrPath string) error 
 	}
 }
 
-// stopInstance stops the Lima VM.
+// stopInstance stops the Lima VM and cleans up its watcher.
+// TODO: Non-blocking stop: send SIGINT and return immediately;
+// the watcher detects the Exiting event and triggers a reconcile.
 func (r *LimaVMReconciler) stopInstance(ctx context.Context, limaVM *v1alpha1.LimaVM, inst *limatype.Instance) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Stopping Lima instance", "instance", limaVM.Name)
 
-	if err := limainstance.StopGracefully(ctx, inst, false); err != nil {
-		logger.Error(err, "Failed to stop Lima instance gracefully")
-		// Try forceful stop
-		logger.Info("Attempting forceful stop")
+	r.signalHostagent(limaVM.Name, os.Interrupt)
+	stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
+	defer cancel()
+	if !r.waitForProcessExit(stopCtx, limaVM.Name) {
+		logger.Info("Hostagent did not exit gracefully, forcing stop")
 		limainstance.StopForcibly(inst)
+		r.waitForProcessExit(ctx, limaVM.Name)
 	}
+
+	r.stopWatcher(limaVM.Name)
 
 	// Verify the instance stopped
 	inst, err := store.Inspect(ctx, limaVM.Name)
@@ -347,7 +476,14 @@ func (r *LimaVMReconciler) stopInstance(ctx context.Context, limaVM *v1alpha1.Li
 	return ctrl.Result{}, nil
 }
 
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
+// killOrphanedHostagent terminates an orphaned hostagent (one running without a
+// watcher, typically after a controller restart). Sends SIGTERM first and falls
+// back to SIGKILL after the graceful shutdown timeout.
+func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *limatype.Instance) error {
+	stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
+	defer cancel()
+	if err := limainstance.StopGracefully(stopCtx, inst, false); err != nil {
+		limainstance.StopForcibly(inst)
+	}
+	return nil
 }

--- a/pkg/controllers/lima/limavm/crd.yaml
+++ b/pkg/controllers/lima/limavm/crd.yaml
@@ -148,6 +148,19 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              restartCount:
+                description: |-
+                  restartCount tracks how many times the instance has reached the Running state.
+                  Incremented each time the controller sets Running=True/Started.
+                format: int32
+                type: integer
+              restartNeeded:
+                description: |-
+                  restartNeeded indicates a restart has been requested but not yet executed.
+                  Set by the reconciler when it processes a restartRequested annotation or
+                  detects a template change on a running instance. Cleared when the restart
+                  completes or the instance is already stopped.
+                type: boolean
               templateConfigMap:
                 description: |-
                   templateConfigMap is the name of the ConfigMap containing the validated template.

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -355,8 +356,9 @@ func StopWithWait(wait bool) error {
 	}
 
 	if wait {
-		// Wait for the process to actually terminate
-		timeout := time.After(10 * time.Second)
+		// Wait for the process to actually terminate. The service needs up to
+		// 30s for graceful hostagent shutdown plus overhead, so allow 60s total.
+		timeout := time.After(60 * time.Second)
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 
@@ -670,9 +672,14 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 		}
 	}
 
-	// Start shared controller manager if any controllers are enabled
+	// Start shared controller manager if any controllers are enabled.
+	// The WaitGroup ensures the controller manager completes shutdown
+	// (including terminating hostagent processes) before Run returns.
+	var mgrWg sync.WaitGroup
 	if len(enabledControllers) > 0 {
+		mgrWg.Add(1)
 		go func() {
+			defer mgrWg.Done()
 			klog.InfoS("Starting shared controller manager", "controllers", len(enabledControllers))
 
 			// Get available ports for metrics and health endpoints with instance offset
@@ -729,6 +736,21 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 	}
 
 	<-ctx.Done()
+
+	// Wait for the controller manager to finish shutdown, but don't block
+	// forever — a misbehaving controller should not prevent the service
+	// from exiting. The graceful shutdown timeout for hostagents is 30s;
+	// allow 45s total before giving up.
+	mgrDone := make(chan struct{})
+	go func() {
+		mgrWg.Wait()
+		close(mgrDone)
+	}()
+	select {
+	case <-mgrDone:
+	case <-time.After(45 * time.Second):
+		klog.Warning("Controller manager did not shut down within 45s, exiting anyway")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Replace the 5-second `store.Inspect()` polling loop with a push-based watcher that tails Lima hostagent event streams. The watcher goroutine tracks lifecycle phases (`Starting`, `Running`, `Stopped`) and triggers reconciles via `source.Channel` as transitions occur.

Add restart support: a `restartRequested` annotation triggers a two-phase annotation-to-status translation (set `status.restartNeeded`, then remove annotation). The reconciler stops the instance when `restartNeeded` is set on a running VM and lets normal start logic bring it back. A monotonic `restartCount` replaces `lastTransitionTime` for detecting recovery completion: its next value is predictable, so callers can use `kubectl wait --for=jsonpath` to block until a restart finishes.

Add `--wait` (default `true`) and `--timeout` flags to the `start`, `stop`, `restart`, and `delete` CLI commands. When `--wait` is true, the command blocks until the desired state is reached. A `--timeout` of `0` (the default) waits indefinitely; a positive duration caps the wait.

`hostagent_watcher.go` (new): Watcher goroutine races `haCmd.Wait()` against `events.Watch()`. Process exit triggers `phase=Stopped` even without an `Exiting` event (e.g., SIGKILL). A `procExited` channel signals when the process is dead, distinct from the watcher goroutine finishing.

`limavm_controller.go`: Add `instanceStates` map and `reconcileChan`. Register a shutdown runnable that sends SIGINT to all hostagents, waits up to 10 seconds, then falls back to SIGKILL. Use `Status().Patch()` instead of `Status().Update()` for condition writes to avoid resource version conflicts during slow operations. Check `restartRequested` annotation before dispatching to `handleRunningState`.

`limavm_lifecycle.go`: Split `handleRunningState` into `handleWatchedState` (watcher active, phase-based dispatch) and `handleUnwatchedState` (no watcher, `store.Inspect` fallback for orphaned hostagents after controller restart). Remove the broken-state heuristic and polling `RequeueAfter`. Use `exec.Command` instead of `exec.CommandContext` since the hostagent lifecycle is managed explicitly through `shutdownAllHostagents` and `stopInstance`. Record the `Starting` condition before `waitForPIDFile` so the status transition is visible even if the object changes during startup. Force-stop orphaned VM drivers (e.g., QEMU) when the hostagent exits but the driver survives in its own process group. Add `handleRestartAnnotation` (two-phase annotation-to-status translation) and `handleRestartNeeded` (stop-then-start adapted to watcher phases). Increment `restartCount` atomically with the `Running=True/Started` condition in `handleWatchedState`.

`cmd/rdd/limavm.go`: Add `restart` command that sets the `restartRequested` annotation and `spec.running=true` in a single patch. Add `--wait` and `--timeout` flags to `start`, `stop`, `restart`, and `delete`. Add `waitForRunningCondition` and `waitForRestartCount` poll helpers.

`service.go`: Wait for the controller manager goroutine to finish before `Run` returns. Without this, the service process exits before `shutdownAllHostagents` completes, and hostagents survive shutdown.

`api_lima.md`: Add `restartNeeded` and `restartCount` to status documentation. Add lifecycle sequence diagrams for normal start/stop, crash recovery, orphan recovery, restart, and graceful shutdown.

`cmd_lima.md`: Document `--wait` and `--timeout` flags on `start`, `stop`, `restart`, and `delete` commands.

Tests: Add BATS tests for orphaned hostagent recovery (SIGKILL service, verify hostagent survives, restart, verify controller kills orphan and starts fresh), graceful shutdown (verify service stop terminates hostagents), restart (running VM restart, stopped VM restart, annotation on stopped VM), and `--timeout` failure (non-functional template cannot boot within deadline). Remove broken-state recovery tests. Replace `lastTransitionTime`-based recovery detection with `restartCount`. Add `RDD_VM_TYPE` support to reproduce QEMU-specific behavior on macOS.

Closes #149 
Closes #150
Closes #196