### PR TITLE
Serialize CRD deletion per API group to prevent cleanup timeout

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -163,6 +163,7 @@ jobs:
       shell: run-in-wsl {0}
       env:
         RDD_TRACE: true
+        RDD_LOG_LEVEL: trace
 
     - name: Collect RDD logs
       if: always()

--- a/bats/tests/10-cli/4-log-level.bats
+++ b/bats/tests/10-cli/4-log-level.bats
@@ -65,8 +65,11 @@ assert_klog_level() {
 # Test default log levels based on developer mode
 @test 'default log level in developer mode creates -v 2' {
     run -0 rdd svc delete
-    # Developer mode should default to debug level
-    # shellcheck disable=SC2030,SC2031 # This only applies to the subshell
+    # Developer mode should default to debug level.
+    # Use empty string (not unset) because unset does not cross the WSL boundary on Windows.
+    # shellcheck disable=SC2030,SC2031 # Subshell-local modifications are intentional
+    export RDD_LOG_LEVEL=""
+    # shellcheck disable=SC2030,SC2031
     export RDD_DEVELOPER_MODE=1
     run -0 rdd svc create --controllers=""
     assert_klog_level 2
@@ -74,10 +77,30 @@ assert_klog_level() {
 
 @test 'default log level in non-developer mode creates -v 0' {
     run -0 rdd svc delete
-    # Non-developer mode should default to warning level
-    # shellcheck disable=SC2030,SC2031 # This only applies to the subshell
+    # Non-developer mode should default to warning level.
+    # Use empty string (not unset) because unset does not cross the WSL boundary on Windows.
+    # shellcheck disable=SC2030,SC2031 # Subshell-local modifications are intentional
+    export RDD_LOG_LEVEL=""
+    # shellcheck disable=SC2030,SC2031
     export RDD_DEVELOPER_MODE=0
     run -0 rdd svc create --controllers=""
+    assert_klog_level 0
+}
+
+# Test RDD_LOG_LEVEL environment variable
+@test 'RDD_LOG_LEVEL sets log level' {
+    run -0 rdd svc delete
+    # shellcheck disable=SC2030,SC2031 # This only applies to the subshell
+    export RDD_LOG_LEVEL=trace
+    run -0 rdd svc create --controllers=""
+    assert_klog_level 4
+}
+
+@test '--log-level flag overrides RDD_LOG_LEVEL' {
+    run -0 rdd svc delete
+    # shellcheck disable=SC2030,SC2031 # This only applies to the subshell
+    export RDD_LOG_LEVEL=trace
+    run -0 rdd --log-level=error svc create --controllers=""
     assert_klog_level 0
 }
 

--- a/cmd/rdd/main.go
+++ b/cmd/rdd/main.go
@@ -68,11 +68,14 @@ func parseInstanceFlag() {
 	}
 }
 
-// setLogLevel sets the log level from command flags.
+// setLogLevel sets the log level from command flags or RDD_LOG_LEVEL.
 func setLogLevel(cmd *cobra.Command, _ []string) error {
 	logLevel, err := cmd.Root().Flags().GetString("log-level")
 	if err != nil {
 		return err
+	}
+	if logLevel == "" {
+		logLevel = os.Getenv("RDD_LOG_LEVEL")
 	}
 	if logLevel == "" {
 		// Default log level: warn for regular mode, debug for developer mode

--- a/cmd/rdd/main.go
+++ b/cmd/rdd/main.go
@@ -75,7 +75,7 @@ func setLogLevel(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if logLevel == "" {
-		logLevel = os.Getenv("RDD_LOG_LEVEL")
+		logLevel = strings.TrimSpace(os.Getenv("RDD_LOG_LEVEL"))
 	}
 	if logLevel == "" {
 		// Default log level: warn for regular mode, debug for developer mode

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -11,6 +11,7 @@ These variables control RDD behavior. Set them before running `rdd` commands.
 | `RDD_INSTANCE` | Instance identifier. Determines which control plane and directories to use. Also settable via `rdd --instance`. | `2` |
 | `RDD_DEVELOPER_MODE` | Enables developer mode: exposes hidden CLI flags, detects source tree for local builds. | unset |
 | `RDD_KEEP_LOGS` | When set to any non-empty value, preserves numbered log files instead of pruning old ones. Also prevents log directory removal on `rdd svc delete`. | unset |
+| `RDD_LOG_LEVEL` | Sets the log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`). Overridden by `--log-level` flag. When unset, defaults to `debug` in developer mode, `warn` otherwise. | unset |
 | `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
 
 ### BATS Test Variables

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -546,6 +547,14 @@ func (scm *SharedControllerManager) cleanupUnusedResources(ctx context.Context) 
 
 // cleanupUnusedCRDs removes CRDs for controllers that are not currently running
 // and waits for the deletions to complete.
+//
+// CRDs in the same API group are deleted sequentially because each deletion
+// triggers an API group handler rebuild that tears down watch caches for all
+// sibling CRDs. Deleting them all at once creates a thundering herd: the CRD
+// finalizer hits "storage is (re)initializing" 429s, retries conflict, and
+// drops work items. Serializing within a group lets each CRD finalize cleanly
+// before the next deletion. Different API groups are independent, so they are
+// processed in parallel.
 func (scm *SharedControllerManager) cleanupUnusedCRDs(ctx context.Context, controllersToCleanup []base.Controller) error {
 	if len(controllersToCleanup) == 0 {
 		return nil
@@ -562,7 +571,8 @@ func (scm *SharedControllerManager) cleanupUnusedCRDs(ctx context.Context, contr
 
 	crdClient := apiextensionsClient.ApiextensionsV1().CustomResourceDefinitions()
 
-	var deletedCRDs []*apiextensionsv1.CustomResourceDefinition
+	// Collect CRDs to delete, grouped by API group.
+	crdsByGroup := make(map[string][]*apiextensionsv1.CustomResourceDefinition)
 
 	for _, controller := range controllersToCleanup {
 		crdData := controller.GetCRDData()
@@ -596,47 +606,94 @@ func (scm *SharedControllerManager) cleanupUnusedCRDs(ctx context.Context, contr
 				continue
 			}
 
-			klog.InfoS("Deleting unused CRD", "crd", crd.Name, "controller", controller.GetName())
-			if err := crdClient.Delete(ctx, crd.Name, metav1.DeleteOptions{}); err != nil {
-				if apierrors.IsNotFound(err) {
-					continue
-				}
-				return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
-			}
-			deletedCRDs = append(deletedCRDs, existingCRD)
+			group := existingCRD.Spec.Group
+			crdsByGroup[group] = append(crdsByGroup[group], existingCRD)
 		}
 	}
 
-	if len(deletedCRDs) == 0 {
+	total := 0
+	for _, crds := range crdsByGroup {
+		total += len(crds)
+	}
+	if total == 0 {
 		return nil
 	}
 
-	// Wait for all deleted CRDs to be fully removed. On each iteration,
-	// re-warm the watch cache for CRDs that still exist. CRD deletions and
-	// finalizations trigger API group handler rebuilds that tear down watch
-	// caches for sibling CRDs. Without re-warming, the CRD finalizer hits
-	// 429s ("storage is (re)initializing") and enters exponential backoff
-	// that can exceed the cleanup timeout.
-	klog.InfoS("Waiting for CRD deletions to complete", "count", len(deletedCRDs))
-	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-		allGone := true
-		for _, crd := range deletedCRDs {
-			_, err := crdClient.Get(ctx, crd.Name, metav1.GetOptions{})
+	klog.InfoS("Deleting unused CRDs", "count", total, "groups", len(crdsByGroup))
+
+	// Delete each API group's CRDs sequentially, but process groups in parallel.
+	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cleanupCancel()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(crdsByGroup))
+
+	for group, crds := range crdsByGroup {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := deleteAndWaitForCRDs(cleanupCtx, crdClient, dynamicClient, group, crds); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// deleteAndWaitForCRDs deletes CRDs one at a time within a single API group,
+// waiting for each to be fully finalized before deleting the next. This avoids
+// the handler rebuild cascade that causes the CRD finalizer to fail.
+func deleteAndWaitForCRDs(
+	ctx context.Context,
+	crdClient apiextensionsv1client.CustomResourceDefinitionInterface,
+	dynamicClient dynamic.Interface,
+	group string,
+	crds []*apiextensionsv1.CustomResourceDefinition,
+) error {
+	for _, crd := range crds {
+		klog.InfoS("Deleting unused CRD", "crd", crd.Name, "group", group)
+
+		// Warm the watch cache so the CRD finalizer can list instances
+		// without hitting a 429 "storage is (re)initializing" error.
+		warmCRDCache(ctx, dynamicClient, crd)
+
+		if err := crdClient.Delete(ctx, crd.Name, metav1.DeleteOptions{}); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			if err != nil {
-				return false, fmt.Errorf("failed to check CRD %s: %w", crd.Name, err)
-			}
-			warmCRDCache(ctx, dynamicClient, crd)
-			allGone = false
+			return fmt.Errorf("failed to delete CRD %s: %w", crd.Name, err)
 		}
-		return allGone, nil
-	})
+
+		// Wait for finalization before deleting the next CRD in this group.
+		err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+			_, err := crdClient.Get(ctx, crd.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			if err != nil {
+				klog.V(2).InfoS("CRD check failed, will retry", "crd", crd.Name, "err", err)
+				return false, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			return fmt.Errorf("timed out waiting for CRD %s to be deleted: %w", crd.Name, err)
+		}
+		klog.V(2).InfoS("CRD deleted", "crd", crd.Name)
+	}
+	return nil
 }
 
-// warmCRDCache issues a List request for a custom resource type to initialize
-// the API server's watch cache before the CRD finalizer needs it.
+// warmCRDCache waits for the watch cache for a custom resource type to be
+// initialized before the CRD finalizer needs it.
 //
 // On a fresh restart, the API server creates watch caches on demand. The CRD
 // finalizer lists instances during deletion, which triggers lazy cache creation
@@ -644,10 +701,6 @@ func (scm *SharedControllerManager) cleanupUnusedCRDs(ctx context.Context, contr
 // ResilientWatchCacheInitialization (locked on since K8s v1.34) rejects
 // immediately instead of blocking. The finalizer enters exponential backoff,
 // which can exceed our cleanup timeout.
-//
-// Caches are not stable: any CRD deletion or finalization triggers an API group
-// handler rebuild that tears down all watch caches in the group. Callers must
-// re-warm repeatedly, not just once.
 func warmCRDCache(ctx context.Context, dynamicClient dynamic.Interface, crd *apiextensionsv1.CustomResourceDefinition) {
 	version, err := apihelpers.GetCRDStorageVersion(crd)
 	if err != nil {
@@ -660,16 +713,13 @@ func warmCRDCache(ctx context.Context, dynamicClient dynamic.Interface, crd *api
 		Resource: crd.Spec.Names.Plural,
 	}
 
-	// The cache typically initializes in under 25ms, so a few short retries suffice.
-	// Only retry on 429 (storage initializing); any other result means the cache is ready
-	// or the error is unrelated and not worth blocking on.
-	err = wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		_, listErr := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
-		return !apierrors.IsTooManyRequests(listErr), nil
+	// Retry until the List succeeds, meaning the watch cache is initialized.
+	// A 429 ("storage is (re)initializing") means cache creation is still in
+	// progress; keep retrying so the CRD finalizer finds a warm cache.
+	_ = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
+		return err == nil, nil
 	})
-	if err != nil {
-		klog.V(2).InfoS("Cache warm-up timed out; proceeding with CRD deletion", "crd", crd.Name, "gvr", gvr)
-	}
 }
 
 // setupSharedWebhookCertificates generates webhook certificates for all controllers that need them.

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -713,13 +713,21 @@ func warmCRDCache(ctx context.Context, dynamicClient dynamic.Interface, crd *api
 		Resource: crd.Spec.Names.Plural,
 	}
 
-	// Retry until the List succeeds, meaning the watch cache is initialized.
-	// A 429 ("storage is (re)initializing") means cache creation is still in
-	// progress; keep retrying so the CRD finalizer finds a warm cache.
-	_ = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-		_, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
-		return err == nil, nil
-	})
+	// Retry on 429 ("storage is (re)initializing"), which means cache creation
+	// is still in progress. Any other error is unrelated to cache warming, so
+	// stop retrying and let the CRD finalizer proceed without a warm cache.
+	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, listErr := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
+		if listErr == nil {
+			return true, nil
+		}
+		if apierrors.IsTooManyRequests(listErr) {
+			return false, nil
+		}
+		return false, listErr
+	}); err != nil {
+		klog.V(1).InfoS("Failed to warm CRD cache", "crd", crd.Name, "err", err)
+	}
 }
 
 // setupSharedWebhookCertificates generates webhook certificates for all controllers that need them.


### PR DESCRIPTION
Each CRD deletion triggers an API group handler rebuild that tears down watch caches for all sibling CRDs in that group. Deleting all CRDs at once creates a thundering herd: the CRD finalizer hits 429 "storage is (re)initializing" errors, retries conflict with handler rebuilds, and work items get permanently dropped on 409 Conflict.

Delete CRDs sequentially within each API group, waiting for full finalization before deleting the next. Different API groups are independent, so they run in parallel. Warm each CRD's watch cache before deletion so the finalizer finds a ready cache.