### PR TITLE
Fix stale Running condition after controller restart

### DIFF
--- a/bats/tests/20-service/2-create.bats
+++ b/bats/tests/20-service/2-create.bats
@@ -64,7 +64,7 @@ EOT
 @test 'stop instance' {
     run -0 rdd svc stop
     run -0 extract_msg
-    assert_output "successfully stopped \"rancher-desktop-${RDD_INSTANCE}\" control plane"
+    assert_output "\"rancher-desktop-${RDD_INSTANCE}\" control plane has stopped"
     assert_dir_exist "${RDD_DIR}"
 }
 
@@ -79,7 +79,7 @@ EOT
 @test 'Delete instance' {
     run -0 rdd svc delete
     run -0 extract_msg
-    assert_output "successfully deleted \"rancher-desktop-${RDD_INSTANCE}\" control plane"
+    assert_output "\"rancher-desktop-${RDD_INSTANCE}\" control plane has been deleted"
     assert_dir_not_exist "${RDD_DIR}"
 }
 

--- a/bats/tests/31-rdd-controllers/notary-external.bats
+++ b/bats/tests/31-rdd-controllers/notary-external.bats
@@ -23,9 +23,10 @@ assert_process_exited() {
     run -0 rdd ctl get namespaces -o name
     assert_line namespace/default
 
-    # Verify that no embedded controller manager is running (fresh control plane)
-    run -1 rdd ctl get configmap rdd-controller-manager --namespace rdd-system
-    assert_output --partial "not found"
+    # Verify that no embedded controllers are registered (--controllers="" disables all)
+    run_e -0 rdd ctl get configmap rdd-controller-manager --namespace rdd-system --output jsonpath='{.data.embedded}'
+    run -0 jq_output '.enabledControllers // []'
+    assert_output "[]"
 }
 
 @test "external controller starts and registers" {
@@ -36,10 +37,10 @@ assert_process_exited() {
     echo "$!" >"${BATS_FILE_TMPDIR}/controller_pid"
 
     # Wait for external controller to register in discovery system
-    try --max 20 --delay 1 -- rdd ctl get configmap rdd-controller-manager --namespace rdd-system
+    try --max 20 --delay 1 -- rdd ctl get configmap rdd-controller-manager --namespace rdd-system --allow-missing-template-keys=false --output jsonpath='{.data.rdd}'
 
     # Verify the discovery ConfigMap contains notary controller
-    run_e -0 rdd ctl get configmap rdd-controller-manager --namespace rdd-system -o jsonpath='{.data.rdd}'
+    run_e -0 rdd ctl get configmap rdd-controller-manager --namespace rdd-system --output jsonpath='{.data.rdd}'
     run -0 jq_output '.enabledControllers[]'
     assert_line "notary"
 }

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -60,30 +60,6 @@ spec:
 EOF
 }
 
-assert_instance_created_condition() {
-    local name=$1
-    local expected=$2
-    run -0 rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
-        --output jsonpath='{.status.conditions[?(@.type=="Created")].status}'
-    assert_output "${expected}"
-}
-
-assert_instance_running_condition() {
-    local name=$1
-    local expected=$2
-    run -0 rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
-        --output jsonpath='{.status.conditions[?(@.type=="Running")].status}'
-    assert_output "${expected}"
-}
-
-assert_instance_running_reason() {
-    local name=$1
-    local expected=$2
-    run -0 rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
-        --output jsonpath='{.status.conditions[?(@.type=="Running")].reason}'
-    assert_output "${expected}"
-}
-
 assert_stdout_logs_contain() {
     local name=$1
     local expected=$2
@@ -107,11 +83,6 @@ get_hostagent_pid() {
     cat "${RDD_LIMA_HOME}/${name}/ha.pid"
 }
 
-assert_limavm_not_exists() {
-    local name=$1
-    run ! rdd ctl get limavm "${name}" --namespace "${NAMESPACE}"
-}
-
 assert_shell_succeeds() {
     local name=$1
     shift
@@ -131,16 +102,13 @@ assert_shell_succeeds() {
 }
 
 @test "wait for Created condition" {
-    try --max 120 --delay 1 -- assert_instance_created_condition "${VM_NAME}" "True"
+    rdd ctl wait --for=condition=Created \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=120s
 }
 
-@test "verify initial Running condition is False" {
-    # Wait a bit for the controller to set the initial condition
-    try --max 30 --delay 1 -- assert_instance_running_condition "${VM_NAME}" "False"
-}
-
-@test "verify initial Running reason is Stopped" {
-    assert_instance_running_reason "${VM_NAME}" "Stopped"
+@test "verify initial Running condition is False/Stopped" {
+    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
+        --for=condition=Running=False --reason=Stopped --timeout=30s
 }
 
 @test "start the VM by setting running=true" {
@@ -152,13 +120,9 @@ assert_shell_succeeds() {
     assert_output "true"
 }
 
-@test "wait for Running condition to become True" {
-    # VM boot can take several minutes
-    try --max 60 --delay 5 -- assert_instance_running_condition "${VM_NAME}" "True"
-}
-
-@test "verify Running reason is Started" {
-    assert_instance_running_reason "${VM_NAME}" "Started"
+@test "wait for Running condition to become True/Started" {
+    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
+        --for=condition=Running --reason=Started --timeout=300s
 }
 
 @test "verify hostagent PID file exists" {
@@ -196,8 +160,8 @@ spec:
     namespace: ${NAMESPACE}
   running: false
 EOF
-    # Wait for instance to be created
-    try --max 120 --delay 1 -- assert_instance_created_condition "stopped-vm" "True"
+    rdd ctl wait --for=condition=Created \
+        "limavm/stopped-vm" --namespace "${NAMESPACE}" --timeout=120s
 
     run -1 rdd lima shell "stopped-vm"
     assert_output --partial "is not running"
@@ -215,13 +179,9 @@ EOF
     assert_output "false"
 }
 
-@test "wait for Running condition to become False" {
-    # Graceful shutdown can take up to 3 minutes
-    try --max 60 --delay 5 -- assert_instance_running_condition "${VM_NAME}" "False"
-}
-
-@test "verify Running reason is Stopped after stop" {
-    assert_instance_running_reason "${VM_NAME}" "Stopped"
+@test "wait for Running condition to become False/Stopped" {
+    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
+        --for=condition=Running=False --reason=Stopped --timeout=300s
 }
 
 @test "verify hostagent PID file is removed" {
@@ -237,7 +197,8 @@ EOF
 @test "start VM for crash recovery test" {
     rdd ctl patch limavm "${VM_NAME}" --namespace "${NAMESPACE}" \
         --type=merge --patch '{"spec":{"running":true}}'
-    try --max 60 --delay 5 -- assert_instance_running_condition "${VM_NAME}" "True"
+    rdd ctl wait --for=condition=Running=True \
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=300s
 }
 
 @test "simulate crash by killing hostagent" {
@@ -373,8 +334,8 @@ EOF
     rdd svc start
 
     # VM should start fresh (no orphan — graceful shutdown killed it).
-    try --max 60 --delay 5 -- assert_instance_running_condition "${VM_NAME}" "True"
-    assert_instance_running_reason "${VM_NAME}" "Started"
+    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
+        --for=condition=Running --reason=Started --since=startup --timeout=300s
 }
 
 # Restart tests
@@ -429,8 +390,8 @@ assert_restart_annotation_absent() {
     refute_output # restartNeeded has omitempty; false means absent
 
     # VM should stay stopped because spec.running=false
-    assert_instance_running_condition "${VM_NAME}" "False"
-    assert_instance_running_reason "${VM_NAME}" "Stopped"
+    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
+        --for=condition=Running=False --reason=Stopped --timeout=30s
 }
 
 @test "restart command on stopped VM starts it" {
@@ -444,7 +405,7 @@ assert_restart_annotation_absent() {
 
 @test "cleanup LimaVM running test" {
     rdd ctl delete limavm "${VM_NAME}" --namespace "${NAMESPACE}"
-    try --max 60 --delay 1 -- assert_limavm_not_exists "${VM_NAME}"
+    rdd ctl wait --for=delete "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=60s
 }
 
 @test "limavm edit command updates template ConfigMap" {

--- a/cmd/rdd/ctl_await.go
+++ b/cmd/rdd/ctl_await.go
@@ -108,16 +108,13 @@ func ctlAwaitAction(cmd *cobra.Command, rawArgs []string) error {
 
 // parseConditionFlag parses "condition=TYPE[=STATUS]" from the --for flag.
 func parseConditionFlag(flag string) (condType, condStatus string, err error) {
-	prefix := "condition="
-	if !strings.HasPrefix(flag, prefix) {
+	value, found := strings.CutPrefix(flag, "condition=")
+	if !found {
 		return "", "", fmt.Errorf("--for must start with \"condition=\", got %q", flag)
 	}
-	value := flag[len(prefix):]
-	parts := strings.SplitN(value, "=", 2)
-	condType = parts[0]
-	condStatus = "True"
-	if len(parts) == 2 {
-		condStatus = parts[1]
+	condType, condStatus, _ = strings.Cut(value, "=")
+	if condStatus == "" {
+		condStatus = "True"
 	}
 	if condType == "" {
 		return "", "", fmt.Errorf("condition type must not be empty in --for=%q", flag)
@@ -127,12 +124,10 @@ func parseConditionFlag(flag string) (condType, condStatus string, err error) {
 
 // parseResourceArg parses "TYPE[.GROUP]/NAME" into resource type and name.
 func parseResourceArg(arg string) (resourceType, name string, err error) {
-	slash := strings.IndexByte(arg, '/')
-	if slash < 0 {
+	resourceType, name, found := strings.Cut(arg, "/")
+	if !found {
 		return "", "", fmt.Errorf("expected TYPE/NAME, got %q", arg)
 	}
-	resourceType = arg[:slash]
-	name = arg[slash+1:]
 	if resourceType == "" || name == "" {
 		return "", "", fmt.Errorf("both TYPE and NAME must be non-empty in %q", arg)
 	}
@@ -142,13 +137,7 @@ func parseResourceArg(arg string) (resourceType, name string, err error) {
 // resolveGVR finds the GroupVersionResource for a resource type string like
 // "limavm" or "limavm.lima.rancherdesktop.io".
 func resolveGVR(client discovery.DiscoveryInterface, resourceType string) (schema.GroupVersionResource, error) {
-	var resourceName, group string
-	if dot := strings.IndexByte(resourceType, '.'); dot >= 0 {
-		resourceName = resourceType[:dot]
-		group = resourceType[dot+1:]
-	} else {
-		resourceName = resourceType
-	}
+	resourceName, group, _ := strings.Cut(resourceType, ".")
 
 	_, apiResourceLists, err := client.ServerGroupsAndResources()
 	if err != nil {

--- a/cmd/rdd/ctl_await.go
+++ b/cmd/rdd/ctl_await.go
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
+)
+
+// ctlAwaitAction waits for a resource condition to reach a specific state,
+// optionally requiring the transition to have occurred after a given timestamp.
+func ctlAwaitAction(cmd *cobra.Command, rawArgs []string) error {
+	flags := pflag.NewFlagSet("await", pflag.ContinueOnError)
+	forFlag := flags.String("for", "", "Condition to wait for: condition=TYPE[=STATUS] (STATUS defaults to True)")
+	reason := flags.String("reason", "", "Required condition reason")
+	since := flags.String("since", "", "Require lastTransitionTime after this value (ISO 8601 timestamp or \"startup\")")
+	timeout := flags.Duration("timeout", 30*time.Second, "How long to wait")
+	namespace := flags.StringP("namespace", "n", "default", "Resource namespace")
+
+	if err := flags.Parse(rawArgs); err != nil {
+		return err
+	}
+	positional := flags.Args()
+	if len(positional) != 1 {
+		return fmt.Errorf("expected TYPE/NAME argument, got %d arguments", len(positional))
+	}
+	if *forFlag == "" {
+		return errors.New("--for is required (e.g. --for=condition=Running)")
+	}
+
+	condType, condStatus, err := parseConditionFlag(*forFlag)
+	if err != nil {
+		return err
+	}
+	resourceType, resourceName, err := parseResourceArg(positional[0])
+	if err != nil {
+		return err
+	}
+
+	restConfig, err := service.GetKubeRestConfig()
+	if err != nil {
+		return err
+	}
+
+	// Resolve --since=startup to a concrete timestamp.
+	var sinceTime time.Time
+	if *since == "startup" {
+		sinceTime, err = resolveStartupTime(cmd.Context(), restConfig)
+		if err != nil {
+			return fmt.Errorf("failed to resolve startup time: %w", err)
+		}
+	} else if *since != "" {
+		sinceTime, err = time.Parse(time.RFC3339, *since)
+		if err != nil {
+			return fmt.Errorf("invalid --since timestamp %q: %w", *since, err)
+		}
+	}
+
+	// Resolve resource type to a GVR using the discovery API.
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	gvr, err := resolveGVR(discoveryClient, resourceType)
+	if err != nil {
+		return err
+	}
+
+	dynClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), *timeout)
+	defer cancel()
+
+	checker := conditionChecker{
+		condType:   condType,
+		condStatus: condStatus,
+		reason:     *reason,
+		sinceTime:  sinceTime,
+	}
+
+	return watchUntilCondition(ctx, dynClient, gvr, *namespace, resourceName, checker.check)
+}
+
+// parseConditionFlag parses "condition=TYPE[=STATUS]" from the --for flag.
+func parseConditionFlag(flag string) (condType, condStatus string, err error) {
+	prefix := "condition="
+	if !strings.HasPrefix(flag, prefix) {
+		return "", "", fmt.Errorf("--for must start with \"condition=\", got %q", flag)
+	}
+	value := flag[len(prefix):]
+	parts := strings.SplitN(value, "=", 2)
+	condType = parts[0]
+	condStatus = "True"
+	if len(parts) == 2 {
+		condStatus = parts[1]
+	}
+	if condType == "" {
+		return "", "", fmt.Errorf("condition type must not be empty in --for=%q", flag)
+	}
+	return condType, condStatus, nil
+}
+
+// parseResourceArg parses "TYPE[.GROUP]/NAME" into resource type and name.
+func parseResourceArg(arg string) (resourceType, name string, err error) {
+	slash := strings.IndexByte(arg, '/')
+	if slash < 0 {
+		return "", "", fmt.Errorf("expected TYPE/NAME, got %q", arg)
+	}
+	resourceType = arg[:slash]
+	name = arg[slash+1:]
+	if resourceType == "" || name == "" {
+		return "", "", fmt.Errorf("both TYPE and NAME must be non-empty in %q", arg)
+	}
+	return resourceType, name, nil
+}
+
+// resolveGVR finds the GroupVersionResource for a resource type string like
+// "limavm" or "limavm.lima.rancherdesktop.io".
+func resolveGVR(client discovery.DiscoveryInterface, resourceType string) (schema.GroupVersionResource, error) {
+	var resourceName, group string
+	if dot := strings.IndexByte(resourceType, '.'); dot >= 0 {
+		resourceName = resourceType[:dot]
+		group = resourceType[dot+1:]
+	} else {
+		resourceName = resourceType
+	}
+
+	_, apiResourceLists, err := client.ServerGroupsAndResources()
+	if err != nil {
+		return schema.GroupVersionResource{}, fmt.Errorf("failed to discover API resources: %w", err)
+	}
+
+	for _, list := range apiResourceLists {
+		gv, parseErr := schema.ParseGroupVersion(list.GroupVersion)
+		if parseErr != nil {
+			continue
+		}
+		if group != "" && gv.Group != group {
+			continue
+		}
+		for _, r := range list.APIResources {
+			if r.Name == resourceName || r.SingularName == resourceName {
+				return schema.GroupVersionResource{
+					Group:    gv.Group,
+					Version:  gv.Version,
+					Resource: r.Name,
+				}, nil
+			}
+		}
+	}
+	return schema.GroupVersionResource{}, fmt.Errorf("resource type %q not found", resourceType)
+}
+
+// resolveStartupTime reads the earliest startTime from the controller manager
+// discovery ConfigMap. The ConfigMap is guaranteed to be fresh because
+// ensureServiceRunning waits for it after a restart.
+func resolveStartupTime(ctx context.Context, config *rest.Config) (time.Time, error) {
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(controllers.RDDSystemNamespace).Get(
+		ctx, "rdd-controller-manager", metav1.GetOptions{},
+	)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	var earliest time.Time
+	for _, data := range cm.Data {
+		var info controllers.ControllerManagerInfo
+		if err := json.Unmarshal([]byte(data), &info); err != nil {
+			continue
+		}
+		t := info.StartTime.Time
+		if earliest.IsZero() || t.Before(earliest) {
+			earliest = t
+		}
+	}
+	if earliest.IsZero() {
+		return time.Time{}, errors.New("no controller manager entries in discovery ConfigMap")
+	}
+	return earliest, nil
+}
+
+type conditionChecker struct {
+	condType   string
+	condStatus string
+	reason     string
+	sinceTime  time.Time
+}
+
+func (c *conditionChecker) check(obj *unstructured.Unstructured) bool {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, item := range conditions {
+		cond, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := cond["type"].(string); typ != c.condType {
+			continue
+		}
+		if status, _ := cond["status"].(string); status != c.condStatus {
+			return false // Found the condition type but wrong status — keep waiting.
+		}
+		if c.reason != "" {
+			if r, _ := cond["reason"].(string); r != c.reason {
+				return false
+			}
+		}
+		if !c.sinceTime.IsZero() {
+			transitionStr, _ := cond["lastTransitionTime"].(string)
+			transitionTime, parseErr := time.Parse(time.RFC3339, transitionStr)
+			if parseErr != nil || !transitionTime.After(c.sinceTime) {
+				return false
+			}
+		}
+		return true
+	}
+	return false // Condition type not present yet.
+}
+
+// isResourceVersionStale returns true if the error indicates the resource
+// version is too old. The API server returns 410 with reason "Gone" or
+// "Expired" depending on the storage backend.
+func isResourceVersionStale(err error) bool {
+	return apierrors.IsGone(err) || apierrors.IsResourceExpired(err)
+}
+
+// watchUntilCondition watches a namespaced resource until the check function
+// returns true. It reads the current state first, then watches from that
+// resource version to avoid missing events. On 410 Gone/Expired (resource
+// version too old), it retries the entire Get+Watch cycle.
+func watchUntilCondition(
+	ctx context.Context,
+	client dynamic.Interface,
+	gvr schema.GroupVersionResource,
+	namespace, name string,
+	check func(*unstructured.Unstructured) bool,
+) error {
+	resource := client.Resource(gvr).Namespace(namespace)
+
+	for {
+		obj, err := resource.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get %s/%s: %w", gvr.Resource, name, err)
+		}
+		if check(obj) {
+			return nil
+		}
+
+		retry, err := watchOnce(ctx, resource, name, obj.GetResourceVersion(), check)
+		if err != nil {
+			return err
+		}
+		if !retry {
+			return ctx.Err()
+		}
+		// 410 Gone — resource version was compacted; restart the Get+Watch cycle.
+	}
+}
+
+// watchOnce runs a single Watch from the given resource version. It returns
+// (true, nil) if the watch expired with 410 Gone and should be retried.
+func watchOnce(
+	ctx context.Context,
+	resource dynamic.ResourceInterface,
+	name, resourceVersion string,
+	check func(*unstructured.Unstructured) bool,
+) (retry bool, err error) {
+	watcher, err := resource.Watch(ctx, metav1.ListOptions{
+		FieldSelector:   "metadata.name=" + name,
+		ResourceVersion: resourceVersion,
+	})
+	if isResourceVersionStale(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to watch: %w", err)
+	}
+	defer watcher.Stop()
+
+	for event := range watcher.ResultChan() {
+		switch event.Type {
+		case watch.Error:
+			if isResourceVersionStale(apierrors.FromObject(event.Object)) {
+				return true, nil
+			}
+			return false, fmt.Errorf("watch error: %v", event.Object)
+		case watch.Deleted:
+			return false, errors.New("resource was deleted while waiting")
+		}
+		updated, ok := event.Object.(*unstructured.Unstructured)
+		if ok && check(updated) {
+			return false, nil
+		}
+	}
+	return false, nil
+}

--- a/cmd/rdd/ctl_await.go
+++ b/cmd/rdd/ctl_await.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -15,15 +14,19 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
 
 	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
@@ -83,7 +86,9 @@ func ctlAwaitAction(cmd *cobra.Command, rawArgs []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create discovery client: %w", err)
 	}
-	gvr, err := resolveGVR(discoveryClient, resourceType)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
+	typeName, group, _ := strings.Cut(resourceType, ".")
+	gvr, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: typeName, Group: group})
 	if err != nil {
 		return err
 	}
@@ -103,7 +108,34 @@ func ctlAwaitAction(cmd *cobra.Command, rawArgs []string) error {
 		sinceTime:  sinceTime,
 	}
 
-	return watchUntilCondition(ctx, dynClient, gvr, *namespace, resourceName, checker.check)
+	// Watch the single named resource for condition changes.
+	// UntilWithSync handles the initial List, Watch setup, and 410 Gone
+	// recovery (re-list on compacted resource versions).
+	resource := dynClient.Resource(gvr).Namespace(*namespace)
+	fieldSelector := "metadata.name=" + resourceName
+	lw := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSelector
+			return resource.List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSelector
+			return resource.Watch(ctx, opts)
+		},
+	}
+	_, err = watchtools.UntilWithSync(ctx, lw, &unstructured.Unstructured{}, nil,
+		func(event watch.Event) (bool, error) {
+			if event.Type == watch.Deleted {
+				return false, errors.New("resource was deleted while waiting")
+			}
+			obj, ok := event.Object.(*unstructured.Unstructured)
+			if !ok {
+				return false, nil
+			}
+			return checker.check(obj), nil
+		},
+	)
+	return err
 }
 
 // parseConditionFlag parses "condition=TYPE[=STATUS]" from the --for flag.
@@ -134,40 +166,9 @@ func parseResourceArg(arg string) (resourceType, name string, err error) {
 	return resourceType, name, nil
 }
 
-// resolveGVR finds the GroupVersionResource for a resource type string like
-// "limavm" or "limavm.lima.rancherdesktop.io".
-func resolveGVR(client discovery.DiscoveryInterface, resourceType string) (schema.GroupVersionResource, error) {
-	resourceName, group, _ := strings.Cut(resourceType, ".")
-
-	_, apiResourceLists, err := client.ServerGroupsAndResources()
-	if err != nil {
-		return schema.GroupVersionResource{}, fmt.Errorf("failed to discover API resources: %w", err)
-	}
-
-	for _, list := range apiResourceLists {
-		gv, parseErr := schema.ParseGroupVersion(list.GroupVersion)
-		if parseErr != nil {
-			continue
-		}
-		if group != "" && gv.Group != group {
-			continue
-		}
-		for _, r := range list.APIResources {
-			if r.Name == resourceName || r.SingularName == resourceName {
-				return schema.GroupVersionResource{
-					Group:    gv.Group,
-					Version:  gv.Version,
-					Resource: r.Name,
-				}, nil
-			}
-		}
-	}
-	return schema.GroupVersionResource{}, fmt.Errorf("resource type %q not found", resourceType)
-}
-
-// resolveStartupTime reads the earliest startTime from the controller manager
-// discovery ConfigMap. The ConfigMap is guaranteed to be fresh because
-// ensureServiceRunning waits for it after a restart.
+// resolveStartupTime returns the control plane start time from the discovery
+// ConfigMap's creationTimestamp. The serve command recreates the ConfigMap on
+// every startup, so its creation time reflects the current instance.
 func resolveStartupTime(ctx context.Context, config *rest.Config) (time.Time, error) {
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -175,27 +176,12 @@ func resolveStartupTime(ctx context.Context, config *rest.Config) (time.Time, er
 	}
 
 	cm, err := client.CoreV1().ConfigMaps(controllers.RDDSystemNamespace).Get(
-		ctx, "rdd-controller-manager", metav1.GetOptions{},
+		ctx, controllers.ControllerManagerConfigMapName, metav1.GetOptions{},
 	)
 	if err != nil {
 		return time.Time{}, err
 	}
-
-	var earliest time.Time
-	for _, data := range cm.Data {
-		var info controllers.ControllerManagerInfo
-		if err := json.Unmarshal([]byte(data), &info); err != nil {
-			continue
-		}
-		t := info.StartTime.Time
-		if earliest.IsZero() || t.Before(earliest) {
-			earliest = t
-		}
-	}
-	if earliest.IsZero() {
-		return time.Time{}, errors.New("no controller manager entries in discovery ConfigMap")
-	}
-	return earliest, nil
+	return cm.CreationTimestamp.Time, nil
 }
 
 type conditionChecker struct {
@@ -236,82 +222,4 @@ func (c *conditionChecker) check(obj *unstructured.Unstructured) bool {
 		return true
 	}
 	return false // Condition type not present yet.
-}
-
-// isResourceVersionStale returns true if the error indicates the resource
-// version is too old. The API server returns 410 with reason "Gone" or
-// "Expired" depending on the storage backend.
-func isResourceVersionStale(err error) bool {
-	return apierrors.IsGone(err) || apierrors.IsResourceExpired(err)
-}
-
-// watchUntilCondition watches a namespaced resource until the check function
-// returns true. It reads the current state first, then watches from that
-// resource version to avoid missing events. On 410 Gone/Expired (resource
-// version too old), it retries the entire Get+Watch cycle.
-func watchUntilCondition(
-	ctx context.Context,
-	client dynamic.Interface,
-	gvr schema.GroupVersionResource,
-	namespace, name string,
-	check func(*unstructured.Unstructured) bool,
-) error {
-	resource := client.Resource(gvr).Namespace(namespace)
-
-	for {
-		obj, err := resource.Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to get %s/%s: %w", gvr.Resource, name, err)
-		}
-		if check(obj) {
-			return nil
-		}
-
-		retry, err := watchOnce(ctx, resource, name, obj.GetResourceVersion(), check)
-		if err != nil {
-			return err
-		}
-		if !retry {
-			return ctx.Err()
-		}
-		// 410 Gone — resource version was compacted; restart the Get+Watch cycle.
-	}
-}
-
-// watchOnce runs a single Watch from the given resource version. It returns
-// (true, nil) if the watch expired with 410 Gone and should be retried.
-func watchOnce(
-	ctx context.Context,
-	resource dynamic.ResourceInterface,
-	name, resourceVersion string,
-	check func(*unstructured.Unstructured) bool,
-) (retry bool, err error) {
-	watcher, err := resource.Watch(ctx, metav1.ListOptions{
-		FieldSelector:   "metadata.name=" + name,
-		ResourceVersion: resourceVersion,
-	})
-	if isResourceVersionStale(err) {
-		return true, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("failed to watch: %w", err)
-	}
-	defer watcher.Stop()
-
-	for event := range watcher.ResultChan() {
-		switch event.Type {
-		case watch.Error:
-			if isResourceVersionStale(apierrors.FromObject(event.Object)) {
-				return true, nil
-			}
-			return false, fmt.Errorf("watch error: %v", event.Object)
-		case watch.Deleted:
-			return false, errors.New("resource was deleted while waiting")
-		}
-		updated, ok := event.Object.(*unstructured.Unstructured)
-		if ok && check(updated) {
-			return false, nil
-		}
-	}
-	return false, nil
 }

--- a/cmd/rdd/kubectl.go
+++ b/cmd/rdd/kubectl.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
-	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
 )
 
 func newCtlCommand() *cobra.Command {
@@ -32,18 +31,11 @@ func newCtlCommand() *cobra.Command {
 }
 
 func ctlAction(cmd *cobra.Command, args []string) error {
-	if !service.Exists() {
-		if err := service.Create(nil); err != nil {
-			return err
-		}
-	}
-	if !service.Running() {
-		if err := service.Start(cmd.Context(), nil); err != nil {
-			return err
-		}
-	}
-	if err := service.WaitWithTimeout(cmd.Context()); err != nil {
+	if err := ensureServiceRunning(cmd.Context()); err != nil {
 		return err
+	}
+	if len(args) > 0 && args[0] == "await" {
+		return ctlAwaitAction(cmd, args[1:])
 	}
 	if err := os.Setenv("KUBECONFIG", instance.Config()); err != nil {
 		return fmt.Errorf("failed to set KUBECONFIG: %w", err)

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -6,16 +6,23 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/developer"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/tail"
 )
 
@@ -69,15 +76,70 @@ func ensureServiceRunning(ctx context.Context) error {
 			return err
 		}
 	}
-	if !service.Running() {
-		if err := service.Start(ctx, nil); err != nil {
-			return err
-		}
+	if service.Running() {
+		return service.WaitWithTimeout(ctx)
 	}
-	if err := service.WaitWithTimeout(ctx); err != nil {
+	return startAndWaitForReady(ctx, nil)
+}
+
+// startAndWaitForReady starts the service, waits for the API server and the
+// discovery ConfigMap to be ready. The ConfigMap persists across restarts, so
+// the freshness check prevents consumers from seeing stale data.
+//
+// Both the API server readiness and ConfigMap freshness polls share a single
+// 90-second timeout, because the apiserver may become ready before the
+// controller manager writes the ConfigMap.
+func startAndWaitForReady(ctx context.Context, serveArgs []string) error {
+	// Truncate to second precision because metav1.Time drops sub-seconds
+	// during JSON serialization. Without this, a server that starts in the
+	// same second would appear to have a startTime *before* beforeStart.
+	beforeStart := time.Now().Truncate(time.Second)
+	if err := service.Start(ctx, serveArgs); err != nil {
 		return err
 	}
-	return nil
+
+	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+
+	if err := service.Wait(ctx); err != nil {
+		return err
+	}
+	return waitForFreshDiscoveryConfigMap(ctx, beforeStart)
+}
+
+// waitForFreshDiscoveryConfigMap polls the controller manager discovery
+// ConfigMap until every entry has a startTime at or after beforeStart.
+func waitForFreshDiscoveryConfigMap(ctx context.Context, beforeStart time.Time) error {
+	restConfig, err := service.GetKubeRestConfig()
+	if err != nil {
+		return err
+	}
+	client, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		cm, err := client.CoreV1().ConfigMaps(controllers.RDDSystemNamespace).Get(
+			ctx, "rdd-controller-manager", metav1.GetOptions{},
+		)
+		if err != nil {
+			return false, nil // Retry on transient errors.
+		}
+		if len(cm.Data) == 0 {
+			return false, nil
+		}
+		for _, data := range cm.Data {
+			var info controllers.ControllerManagerInfo
+			if err := json.Unmarshal([]byte(data), &info); err != nil {
+				return false, nil
+			}
+			if info.StartTime.Time.Before(beforeStart) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
 }
 
 func serviceConfigAction(cmd *cobra.Command, _ []string) error {
@@ -161,37 +223,43 @@ func serviceStartAction(cmd *cobra.Command, args []string) error {
 	}
 	if service.Running() {
 		logrus.Infof("%q control plane is already running", instance.Name())
-	} else {
-		// Collect all provided flags as arguments for serve subprocess
-		var serveArgs []string
-		if cmd.Flags().Changed("controllers") {
-			controllers, err := cmd.Flags().GetString("controllers")
-			if err != nil {
-				return err
-			}
-			serveArgs = append(serveArgs, "--controllers", controllers)
+		wait, err := cmd.Flags().GetBool("wait")
+		if err == nil && wait {
+			logrus.Infof("waiting for %q control plane to be ready", instance.Name())
+			err = service.WaitWithTimeout(cmd.Context())
 		}
-		if cmd.Flags().Changed("secure-port") {
-			securePort, err := cmd.Flags().GetInt("secure-port")
-			if err != nil {
-				return err
-			}
-			serveArgs = append(serveArgs, "--secure-port", strconv.Itoa(securePort))
-		}
-		serveArgs = append(serveArgs, "-v", logrusLevelToKlog())
-		serveArgs = append(serveArgs, args...)
+		return err
+	}
 
-		if err := service.Start(cmd.Context(), serveArgs); err != nil {
+	// Collect all provided flags as arguments for serve subprocess
+	var serveArgs []string
+	if cmd.Flags().Changed("controllers") {
+		controllers, err := cmd.Flags().GetString("controllers")
+		if err != nil {
 			return err
 		}
-		logrus.Infof("successfully started %q control plane", instance.Name())
+		serveArgs = append(serveArgs, "--controllers", controllers)
 	}
+	if cmd.Flags().Changed("secure-port") {
+		securePort, err := cmd.Flags().GetInt("secure-port")
+		if err != nil {
+			return err
+		}
+		serveArgs = append(serveArgs, "--secure-port", strconv.Itoa(securePort))
+	}
+	serveArgs = append(serveArgs, "-v", logrusLevelToKlog())
+	serveArgs = append(serveArgs, args...)
+
 	wait, err := cmd.Flags().GetBool("wait")
 	if err == nil && wait {
 		logrus.Infof("waiting for %q control plane to be ready", instance.Name())
-		err = service.WaitWithTimeout(cmd.Context())
+		return startAndWaitForReady(cmd.Context(), serveArgs)
 	}
-	return err
+	if err := service.Start(cmd.Context(), serveArgs); err != nil {
+		return err
+	}
+	logrus.Infof("successfully started %q control plane", instance.Name())
+	return nil
 }
 
 func serviceStopAction(cmd *cobra.Command, _ []string) error {

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -77,18 +77,24 @@ func ensureServiceRunning(ctx context.Context) error {
 		}
 	}
 	if service.Running() {
-		return service.WaitWithTimeout(ctx)
+		ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		defer cancel()
+		if err := service.Wait(ctx); err != nil {
+			return err
+		}
+		return waitForDiscoveryConfigMap(ctx)
 	}
 	return startAndWaitForReady(ctx, nil)
 }
 
 // startAndWaitForReady starts the service, waits for the API server and the
-// discovery ConfigMap to be ready. The ConfigMap persists across restarts, so
-// the freshness check prevents consumers from seeing stale data.
+// discovery ConfigMap to be ready. After an unclean shutdown the ConfigMap may
+// survive with stale data, so the freshness check waits for a ConfigMap whose
+// creationTimestamp is at or after the current startup.
 //
 // Both the API server readiness and ConfigMap freshness polls share a single
 // 90-second timeout, because the apiserver may become ready before the
-// controller manager writes the ConfigMap.
+// serve command creates the ConfigMap.
 func startAndWaitForReady(ctx context.Context, serveArgs []string) error {
 	// Truncate to second precision because metav1.Time drops sub-seconds
 	// during JSON serialization. Without this, a server that starts in the
@@ -107,8 +113,15 @@ func startAndWaitForReady(ctx context.Context, serveArgs []string) error {
 	return waitForFreshDiscoveryConfigMap(ctx, beforeStart)
 }
 
-// waitForFreshDiscoveryConfigMap polls the controller manager discovery
-// ConfigMap until every entry has a startTime at or after beforeStart.
+// waitForDiscoveryConfigMap polls until the discovery ConfigMap exists.
+func waitForDiscoveryConfigMap(ctx context.Context) error {
+	return waitForFreshDiscoveryConfigMap(ctx, time.Time{})
+}
+
+// waitForFreshDiscoveryConfigMap polls until the discovery ConfigMap has a
+// creationTimestamp at or after beforeStart. The serve command recreates the
+// ConfigMap on every startup, so a fresh timestamp means this control plane
+// instance is ready. Pass zero time to wait for existence only.
 func waitForFreshDiscoveryConfigMap(ctx context.Context, beforeStart time.Time) error {
 	restConfig, err := service.GetKubeRestConfig()
 	if err != nil {
@@ -121,24 +134,15 @@ func waitForFreshDiscoveryConfigMap(ctx context.Context, beforeStart time.Time) 
 
 	return wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 		cm, err := client.CoreV1().ConfigMaps(controllers.RDDSystemNamespace).Get(
-			ctx, "rdd-controller-manager", metav1.GetOptions{},
+			ctx, controllers.ControllerManagerConfigMapName, metav1.GetOptions{},
 		)
+		if apierrors.IsNotFound(err) {
+			return false, nil // ConfigMap not created yet; retry.
+		}
 		if err != nil {
-			return false, nil // Retry on transient errors.
+			return false, err
 		}
-		if len(cm.Data) == 0 {
-			return false, nil
-		}
-		for _, data := range cm.Data {
-			var info controllers.ControllerManagerInfo
-			if err := json.Unmarshal([]byte(data), &info); err != nil {
-				return false, nil
-			}
-			if info.StartTime.Time.Before(beforeStart) {
-				return false, nil
-			}
-		}
-		return true, nil
+		return !cm.CreationTimestamp.Time.Before(beforeStart), nil
 	})
 }
 
@@ -252,13 +256,16 @@ func serviceStartAction(cmd *cobra.Command, args []string) error {
 
 	wait, err := cmd.Flags().GetBool("wait")
 	if err == nil && wait {
-		logrus.Infof("waiting for %q control plane to be ready", instance.Name())
-		return startAndWaitForReady(cmd.Context(), serveArgs)
+		if err := startAndWaitForReady(cmd.Context(), serveArgs); err != nil {
+			return err
+		}
+		logrus.Infof("%q control plane is ready", instance.Name())
+	} else {
+		if err := service.Start(cmd.Context(), serveArgs); err != nil {
+			return err
+		}
+		logrus.Infof("%q control plane is starting", instance.Name())
 	}
-	if err := service.Start(cmd.Context(), serveArgs); err != nil {
-		return err
-	}
-	logrus.Infof("successfully started %q control plane", instance.Name())
 	return nil
 }
 
@@ -280,7 +287,11 @@ func serviceStopAction(cmd *cobra.Command, _ []string) error {
 	if err := service.StopWithWait(wait); err != nil {
 		return err
 	}
-	logrus.Infof("successfully stopped %q control plane", instance.Name())
+	if wait {
+		logrus.Infof("%q control plane has stopped", instance.Name())
+	} else {
+		logrus.Infof("%q control plane is stopping", instance.Name())
+	}
 	return nil
 }
 
@@ -306,7 +317,7 @@ func newServiceDeleteCommand() *cobra.Command {
 			if err := service.Delete(); err != nil {
 				return err
 			}
-			logrus.Infof("successfully deleted %q control plane", instance.Name())
+			logrus.Infof("%q control plane has been deleted", instance.Name())
 			return nil
 		},
 	}

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -185,6 +185,35 @@ Example to list all `vms` in all namespaces:
 rdd ctl get vm -A
 ```
 
+### `rdd ctl await`
+
+Waits for a resource condition to reach a specific state. Unlike `kubectl wait`, this command can filter by `lastTransitionTime` and condition `reason`.
+
+```shell
+rdd ctl await TYPE[.GROUP]/NAME --for=condition=TYPE[=STATUS] [flags]
+```
+
+Flags:
+
+- `--for=condition=TYPE[=STATUS]` (required): condition to match; STATUS defaults to `True`
+- `--reason=REASON`: require the condition's `.reason` field to match
+- `--since=TIMESTAMP|startup`: require `lastTransitionTime` after this value; `startup` reads the controller manager's start time from the discovery ConfigMap
+- `--timeout=DURATION`: how long to wait (default `30s`)
+- `--namespace`, `-n`: resource namespace (default `default`)
+
+Examples:
+
+```shell
+# Wait for Running=True with reason Started, transitioned since controller startup
+rdd ctl await limavm/default --for=condition=Running --reason=Started --since=startup --timeout=60s
+
+# Wait for a condition after a specific timestamp
+rdd ctl await limavm/default --for=condition=Running --since=2024-01-15T10:30:00Z
+
+# Wait for Running=False
+rdd ctl await limavm/default --for=condition=Running=False --timeout=60s
+```
+
 ### `rdd ctl logs`
 
 The `kubectl logs` command talks directly to `kubelet` to fetch container logs, so won't be able to return logs for a virtual machine. The `lima` controller will have to implement a custom `/logs` endpoint, and `rdd ctl logs` will not use the `kubectl logs` code, but a custom implementation.

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -71,6 +71,10 @@ const (
 	// ReasonStopFailed is used when the Lima instance failed to stop.
 	ReasonStopFailed = "StopFailed"
 
+	// ReasonReconciling is used when the controller has restarted and
+	// the Running condition has not yet been verified.
+	ReasonReconciling = "Reconciling"
+
 	// preparingSentinel is a marker file created during instance preparation.
 	// Its presence indicates that preparation is in progress or failed.
 	preparingSentinel = ".preparing"

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -120,6 +120,18 @@ func (r *LimaVMReconciler) handleRunningState(ctx context.Context, limaVM *v1alp
 
 	logger.Info("Checking running state", "shouldRun", shouldRun, "phase", phase)
 
+	// After a controller restart, the Running condition may be stale (persisted
+	// in kine from the previous controller lifetime). Without a watcher, we
+	// cannot verify it, so reset it to Unknown before proceeding.
+	if phase == phaseUnknown && !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionUnknown, ReasonReconciling) {
+		logger.Info("No watcher for instance, resetting Running condition to Unknown")
+		if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionUnknown, ReasonReconciling, "Verifying instance state after controller restart"); err != nil {
+			logger.Error(err, "Failed to reset Running condition")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
 	if limaVM.Status.RestartNeeded {
 		return r.handleRestartNeeded(ctx, limaVM, phase)
 	}

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -665,6 +665,26 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 		}
 	}()
 
+	klog.Info("Waiting for control plane to be ready")
+
+	restConfig, err := GetKubeRestConfig()
+	if err != nil {
+		return err
+	}
+	if err := readiness.WaitForReady(ctx, restConfig, true); err != nil {
+		return err
+	}
+
+	// Create the discovery ConfigMap before any controller managers register.
+	// Its creationTimestamp serves as the control plane start time.
+	initClient, err := kubernetes.NewForConfig(completed.ControlPlane.Generic.LoopbackClientConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client for discovery init: %w", err)
+	}
+	if err := controllers.InitDiscovery(ctx, initClient); err != nil {
+		return fmt.Errorf("failed to initialize discovery: %w", err)
+	}
+
 	// Start shared controller manager for enabled controllers
 	var enabledControllers []base.Controller
 
@@ -721,17 +741,6 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 				klog.Error(err, "Failed to start shared controller manager")
 			}
 		}()
-	}
-
-	klog.Info("Waiting for control plane to be ready")
-
-	restConfig, err := GetKubeRestConfig()
-	if err != nil {
-		return err
-	}
-	err = readiness.WaitForReady(ctx, restConfig, true)
-	if err != nil {
-		return err
 	}
 
 	<-ctx.Done()

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	// controllerManagerConfigMapName is the name of the ConfigMap that stores controller manager information.
-	controllerManagerConfigMapName = "rdd-controller-manager"
+	// ControllerManagerConfigMapName is the name of the ConfigMap that stores controller manager information.
+	ControllerManagerConfigMapName = "rdd-controller-manager"
 
 	// RDDSystemNamespace is the namespace where RDD stores its control plane information.
 	RDDSystemNamespace = "rdd-system"
@@ -125,7 +125,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 	}
 	_, err = d.client.CoreV1().ConfigMaps(d.namespace).Patch(
 		ctx,
-		controllerManagerConfigMapName,
+		ControllerManagerConfigMapName,
 		types.StrategicMergePatchType,
 		patchData,
 		metav1.PatchOptions{},
@@ -133,7 +133,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 	if err == nil {
 		klog.InfoS("Registered controller manager in cluster",
 			"namespace", d.namespace,
-			"configmap", controllerManagerConfigMapName,
+			"configmap", ControllerManagerConfigMapName,
 			"name", d.name,
 			"controllers", len(info.EnabledControllers))
 		return nil
@@ -145,7 +145,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 	// Create the config map
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controllerManagerConfigMapName,
+			Name:      ControllerManagerConfigMapName,
 			Namespace: d.namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/name":      "rancher-desktop-daemon",
@@ -169,7 +169,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 
 	klog.InfoS("Registered initial controller manager in cluster",
 		"namespace", d.namespace,
-		"configmap", controllerManagerConfigMapName,
+		"configmap", ControllerManagerConfigMapName,
 		"name", d.name,
 		"controllers", len(info.EnabledControllers))
 
@@ -189,7 +189,7 @@ func (d *ControllerManagerDiscoveryGroup) UnregisterControllerManager(ctx contex
 
 	cm, err := d.client.CoreV1().ConfigMaps(d.namespace).Patch(
 		ctx,
-		controllerManagerConfigMapName,
+		ControllerManagerConfigMapName,
 		types.StrategicMergePatchType,
 		patchData,
 		metav1.PatchOptions{},
@@ -205,7 +205,7 @@ func (d *ControllerManagerDiscoveryGroup) UnregisterControllerManager(ctx contex
 		// No more entries, delete the ConfigMap
 		err = d.client.CoreV1().ConfigMaps(d.namespace).Delete(
 			ctx,
-			controllerManagerConfigMapName,
+			ControllerManagerConfigMapName,
 			metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{
 					ResourceVersion: &cm.ResourceVersion,
@@ -216,7 +216,7 @@ func (d *ControllerManagerDiscoveryGroup) UnregisterControllerManager(ctx contex
 		if err == nil {
 			klog.InfoS("Unregistered final controller manager from cluster",
 				"namespace", d.namespace,
-				"configmap", controllerManagerConfigMapName,
+				"configmap", ControllerManagerConfigMapName,
 				"name", d.name)
 			return nil
 		}
@@ -230,7 +230,7 @@ func (d *ControllerManagerDiscoveryGroup) UnregisterControllerManager(ctx contex
 
 	klog.InfoS("Unregistered controller manager from cluster",
 		"namespace", d.namespace,
-		"configmap", controllerManagerConfigMapName,
+		"configmap", ControllerManagerConfigMapName,
 		"name", d.name)
 
 	return nil
@@ -238,7 +238,7 @@ func (d *ControllerManagerDiscoveryGroup) UnregisterControllerManager(ctx contex
 
 // DiscoverControllerManager finds running controller manager information.
 func (d *ControllerManagerDiscoveryGroup) DiscoverControllerManager(ctx context.Context) (*ControllerManagerInfo, error) {
-	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, ControllerManagerConfigMapName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil // No controller manager running
 	}
@@ -261,7 +261,7 @@ func (d *ControllerManagerDiscoveryGroup) DiscoverControllerManager(ctx context.
 // GetEnabledControllers returns the list of all enabled controllers, across all
 // controller managers.  Note that the returned controllers may not be running.
 func (d *ControllerManagerDiscovery) GetEnabledControllers(ctx context.Context) ([]string, error) {
-	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, ControllerManagerConfigMapName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil // No controller manager running
 	}
@@ -285,7 +285,7 @@ func (d *ControllerManagerDiscovery) GetEnabledControllers(ctx context.Context) 
 // IsControllerRunning checks if a specific controller is running in any of the
 // shared controller managers.
 func (d *ControllerManagerDiscovery) IsControllerRunning(ctx context.Context, controllerName string) (bool, *ControllerManagerInfo, error) {
-	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, ControllerManagerConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil, nil // No controller manager running
@@ -314,7 +314,7 @@ func (d *ControllerManagerDiscovery) IsControllerRunning(ctx context.Context, co
 // endpoint name across all controller managers.  If the endpoint is not found,
 // an empty string is returned.
 func (d *ControllerManagerDiscovery) LookupPassthroughEndpoint(ctx context.Context, controllerName, endpointName string) (string, error) {
-	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, controllerManagerConfigMapName, metav1.GetOptions{})
+	configMap, err := d.client.CoreV1().ConfigMaps(d.namespace).Get(ctx, ControllerManagerConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return "", nil // No controller manager running
@@ -375,8 +375,44 @@ func (d *ControllerManagerDiscovery) ensureNamespace(ctx context.Context) error 
 	return err
 }
 
+// InitDiscovery deletes any stale discovery ConfigMap and creates an empty one.
+// The ConfigMap's creationTimestamp serves as the control plane start time.
+// This must be called after the API server is ready and before any controller
+// managers register.
+func InitDiscovery(ctx context.Context, client kubernetes.Interface) error {
+	d := &ControllerManagerDiscovery{client: client, namespace: RDDSystemNamespace}
+	if err := d.ensureNamespace(ctx); err != nil {
+		return fmt.Errorf("failed to ensure namespace: %w", err)
+	}
+
+	// Delete stale ConfigMap from a previous run (e.g. unclean shutdown).
+	err := client.CoreV1().ConfigMaps(RDDSystemNamespace).Delete(ctx, ControllerManagerConfigMapName, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete stale discovery configmap: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ControllerManagerConfigMapName,
+			Namespace: RDDSystemNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "rancher-desktop-daemon",
+				"app.kubernetes.io/component": "controller-manager",
+			},
+		},
+	}
+	if _, err := client.CoreV1().ConfigMaps(RDDSystemNamespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create discovery configmap: %w", err)
+	}
+
+	klog.InfoS("Initialized discovery configmap",
+		"namespace", RDDSystemNamespace,
+		"configmap", ControllerManagerConfigMapName)
+	return nil
+}
+
 func CleanupDiscovery(ctx context.Context, client *kubernetes.Clientset) error {
-	err := client.CoreV1().ConfigMaps(RDDSystemNamespace).Delete(ctx, controllerManagerConfigMapName, metav1.DeleteOptions{})
+	err := client.CoreV1().ConfigMaps(RDDSystemNamespace).Delete(ctx, ControllerManagerConfigMapName, metav1.DeleteOptions{})
 	if errors.IsNotFound(err) {
 		return nil // Already deleted, no error
 	}
@@ -386,7 +422,7 @@ func CleanupDiscovery(ctx context.Context, client *kubernetes.Clientset) error {
 
 	klog.InfoS("Cleaned up stale controller manager discovery configmap",
 		"namespace", RDDSystemNamespace,
-		"configmap", controllerManagerConfigMapName)
+		"configmap", ControllerManagerConfigMapName)
 
 	return nil
 }

--- a/pkg/service/controllers/discovery_test.go
+++ b/pkg/service/controllers/discovery_test.go
@@ -66,7 +66,7 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	}), "failed to register controller manager")
 
 	// Check that the config map exists.
-	cm, err := client.CoreV1().ConfigMaps(d1.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
+	cm, err := client.CoreV1().ConfigMaps(d1.namespace).Get(t.Context(), ControllerManagerConfigMapName, metav1.GetOptions{})
 	assert.NilError(t, err, "failed to get controller manager config map")
 	assert.Assert(t, cmp.Len(cm.Data, 1), "expected config map to have one entry")
 	assert.Check(t, cmp.Contains(cm.Data, d1.name))
@@ -106,7 +106,7 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	}), "failed to register second controller manager")
 
 	// Check that the config map is updated.
-	cm, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
+	cm, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), ControllerManagerConfigMapName, metav1.GetOptions{})
 	assert.NilError(t, err, "failed to get controller manager config map after second registration")
 	assert.Assert(t, cmp.Len(cm.Data, 2), "expected config map to have two entries after second registration")
 	assert.Check(t, cmp.Contains(cm.Data, d1.name))
@@ -151,7 +151,7 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	assert.Check(t, info != nil, "expected non-nil info for second controller manager")
 
 	// Check that the config map still exists with one entry.
-	cm, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
+	cm, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), ControllerManagerConfigMapName, metav1.GetOptions{})
 	assert.NilError(t, err, "failed to get controller manager config map after first unregistered")
 	assert.Assert(t, cmp.Len(cm.Data, 1), "expected config map to have one entry after first unregistered")
 	assert.Check(t, cmp.Contains(cm.Data, d2.name))
@@ -182,6 +182,6 @@ func TestControllerManagerDiscoveryGroup(t *testing.T) {
 	assert.NilError(t, d2.UnregisterControllerManager(t.Context()), "failed to unregister second controller manager")
 
 	// Check that the config map is removed.
-	_, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), controllerManagerConfigMapName, metav1.GetOptions{})
+	_, err = client.CoreV1().ConfigMaps(d2.namespace).Get(t.Context(), ControllerManagerConfigMapName, metav1.GetOptions{})
 	assert.Assert(t, errors.IsNotFound(err), "expected config map to be deleted after all controller managers unregistered")
 }

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -345,11 +345,6 @@ func (scm *SharedControllerManager) registerDiscovery(ctx context.Context) error
 		}
 	}
 
-	// Only register if there are non-builtin controllers.
-	if len(controllerNames) == 0 {
-		return nil
-	}
-
 	return scm.discovery.RegisterControllerManager(ctx, ControllerManagerInput{
 		HealthPort:          scm.healthPort,
 		MetricsPort:         scm.metricsPort,


### PR DESCRIPTION
- Add `rdd ctl await`, a condition-aware wait command with `--reason` and `--since` filters that `kubectl wait` lacks
- Reset the `Running` condition to `Unknown` on controller restart so consumers never act on stale status
- Replace `try`-polling helpers in BATS tests with `rdd ctl await`

### Problem

After a service restart, the `Running` condition persisted in kine reflects the previous run's state. Tests polling with `kubectl get` + jsonpath could read the stale condition before the controller reconciled, causing flaky assertions.

### Approach

**`rdd ctl await`** watches a resource via List+Watch (with automatic 410 Gone recovery) and supports `--reason` and `--since` flags. `--since=startup` resolves to the discovery ConfigMap's `creationTimestamp`, which the serve command recreates on every startup.

**`ensureServiceRunning`** waits for the discovery ConfigMap after both the "I started the service" and "service is already running" paths. The former also checks that the ConfigMap's `creationTimestamp` postdates the current startup, so `--since=startup` never reads a stale timestamp from a previous run.

**Controller reset** sets `Running` to `Unknown`/`Reconciling` on first reconcile when no watcher exists, preventing consumers from seeing a stale `True`/`False`.