### PR TITLE
Fix kine startup and shutdown ordering to reduce gRPC warnings

### DIFF
--- a/pkg/service/cmd/options/config.go
+++ b/pkg/service/cmd/options/config.go
@@ -17,14 +17,12 @@ import (
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
-	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/datastore"
 )
 
 // Config holds the configuration for the controlplane server.
 type Config struct {
 	Options CompletedOptions
 
-	Datastore     *datastore.Config
 	Aggregator    *aggregatorapiserver.Config
 	ControlPlane  *controlplaneapiserver.Config
 	APIExtensions *apiextensionsapiserver.Config
@@ -43,7 +41,6 @@ type ExtraConfig struct {
 type completedConfig struct {
 	Options CompletedOptions
 
-	Datastore     datastore.CompletedConfig
 	Aggregator    aggregatorapiserver.CompletedConfig
 	ControlPlane  controlplaneapiserver.CompletedConfig
 	APIExtensions apiextensionsapiserver.CompletedConfig
@@ -62,7 +59,6 @@ func (c *Config) Complete() (CompletedConfig, error) {
 	return CompletedConfig{&completedConfig{
 		Options: c.Options,
 
-		Datastore:     c.Datastore.Complete(),
 		ControlPlane:  c.ControlPlane.Complete(),
 		Aggregator:    c.Aggregator.Complete(),
 		APIExtensions: c.APIExtensions.Complete(),
@@ -78,14 +74,6 @@ func NewConfig(opts CompletedOptions) (*Config, error) {
 		ExtraConfig: ExtraConfig{
 			Controllers: opts.Controllers,
 		},
-	}
-
-	var err error
-	if opts.Datastore.Enabled {
-		c.Datastore, err = datastore.NewConfig(opts.Datastore)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	genericConfig, versionedInformers, storageFactory, err := controlplaneapiserver.BuildGenericConfig(

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -603,6 +603,25 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 	klog.Infof("Version: %+v", version.Get())
 	klog.InfoS("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
 
+	// Start kine before NewConfig because BuildGenericConfig opens gRPC
+	// connections to the etcd backend immediately. Kine uses a child context
+	// cancelled after the controller manager shuts down, so the etcd client
+	// connections drain before the socket disappears.
+	var kineCancel context.CancelFunc
+	if opts.Datastore.Enabled {
+		dsConfig, err := datastore.NewConfig(opts.Datastore)
+		if err != nil {
+			return err
+		}
+		var kineCtx context.Context
+		kineCtx, kineCancel = context.WithCancel(ctx)
+		defer kineCancel()
+		klog.Infof("Starting kine/sqlite server listening on %s", opts.Datastore.EndpointConfig.Listener)
+		if err := datastore.NewServer(dsConfig.Complete()).Run(kineCtx); err != nil {
+			return fmt.Errorf("failed to start kine server: %w", err)
+		}
+	}
+
 	config, err := options.NewConfig(opts)
 	if err != nil {
 		return err
@@ -610,14 +629,6 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 	completed, err := config.Complete()
 	if err != nil {
 		return err
-	}
-
-	// the etcd server must be up before NewServer because storage decorators access it right away
-	if completed.Datastore.Config != nil {
-		klog.Warningf("Starting kine/sqlite server listening on %s", completed.Datastore.EndpointConfig.Listener)
-		if err := datastore.NewServer(completed.Datastore).Run(ctx); err != nil {
-			return fmt.Errorf("failed to start kine server: %w", err)
-		}
 	}
 
 	server, err := createServerChain(completed)

--- a/pkg/service/datastore/config.go
+++ b/pkg/service/datastore/config.go
@@ -47,9 +47,12 @@ func NewServer(config CompletedConfig) *Server {
 	}
 }
 
-// Run starts the embedded etcd server. It blocks until it is ready for up to a minute.
+// Run starts the embedded etcd server. endpoint.Listen starts the gRPC server
+// in a background goroutine and returns once the listener is bound. Some gRPC
+// "server preface" warnings from the kube-apiserver's etcd client are expected
+// during the initial connection burst — these resolve via automatic retry and
+// do not affect functionality.
 func (s *Server) Run(ctx context.Context) error {
 	_, err := endpoint.Listen(ctx, s.config.EndpointConfig)
-	// TODO: is the endpoint guaranteed to be ready by the time Listen() returns?
 	return err
 }


### PR DESCRIPTION
Start kine before `BuildGenericConfig`, which opens gRPC connections to the etcd backend immediately. Use a child context cancelled only after the controller manager finishes shutting down, so etcd client connections drain before the socket disappears.

Remove the `Datastore` field from the service config structs — nothing reads it now that kine starts directly in `Run()`.