### PR TITLE
Use instance-offset ports and resolve them at bind time

### DIFF
--- a/cmd/rdd/kubectl.go
+++ b/cmd/rdd/kubectl.go
@@ -33,7 +33,7 @@ func newCtlCommand() *cobra.Command {
 
 func ctlAction(cmd *cobra.Command, args []string) error {
 	if !service.Exists() {
-		if err := service.Create(cmd.Context(), nil); err != nil {
+		if err := service.Create(nil); err != nil {
 			return err
 		}
 	}

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -65,7 +65,7 @@ func newServiceConfigCommand() *cobra.Command {
 
 func ensureServiceRunning(ctx context.Context) error {
 	if !service.Exists() {
-		if err := service.Create(ctx, nil); err != nil {
+		if err := service.Create(nil); err != nil {
 			return err
 		}
 	}
@@ -127,7 +127,7 @@ func serviceCreateAction(cmd *cobra.Command, args []string) error {
 	}
 	args = append(args, "-v", logrusLevelToKlog())
 
-	if err := service.Create(cmd.Context(), args); err != nil {
+	if err := service.Create(args); err != nil {
 		return err
 	}
 	logrus.Infof("successfully created %q control plane", instance.Name())
@@ -154,7 +154,7 @@ func newServiceStartCommand() *cobra.Command {
 
 func serviceStartAction(cmd *cobra.Command, args []string) error {
 	if !service.Exists() {
-		if err := service.Create(cmd.Context(), args); err != nil {
+		if err := service.Create(args); err != nil {
 			return err
 		}
 		logrus.Infof("successfully created %q control plane", instance.Name())

--- a/pkg/external/main.go
+++ b/pkg/external/main.go
@@ -19,6 +19,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
 )
 
@@ -26,11 +27,14 @@ import (
 // It handles command line parsing, kubeconfig retrieval, discovery checking, and shared manager setup.
 // It returns the command's exit code.
 func RunControllers(apiGroupName string) int {
+	// Each instance reserves 4 consecutive ports starting at 8080:
+	// +0 external metrics, +1 external health, +2 embedded metrics, +3 embedded health.
+	instanceOffset := 4 * instance.Index()
 	var desiredMetricsPort int
 	var desiredHealthPort int
 
-	flag.IntVar(&desiredMetricsPort, "metrics-port", 8080, "The desired port the metric endpoint binds to.")
-	flag.IntVar(&desiredHealthPort, "health-port", 8081, "The desired port the health probe endpoint binds to.")
+	flag.IntVar(&desiredMetricsPort, "metrics-port", 8080+instanceOffset, "The desired port the metric endpoint binds to.")
+	flag.IntVar(&desiredHealthPort, "health-port", 8081+instanceOffset, "The desired port the health probe endpoint binds to.")
 
 	klog.InitFlags(nil)
 	//revive:disable-next-line:deep-exit
@@ -87,21 +91,9 @@ func RunControllers(apiGroupName string) int {
 		})
 	}()
 
-	// Get available ports for metrics and health endpoints
-	metricsPort, err := controllers.GetAvailablePort(ctx, desiredMetricsPort)
-	if err != nil {
-		setupLog.Error(err, "Failed to get available metrics port")
-		return 1
-	}
-
-	healthPort, err := controllers.GetAvailablePort(ctx, desiredHealthPort)
-	if err != nil {
-		setupLog.Error(err, "Failed to get available health port")
-		return 1
-	}
-
-	// Create shared controller manager for this API group
-	sharedManager, err := controllers.NewSharedControllerManager(ctx, apiGroupName, config, metricsPort, healthPort)
+	// Create shared controller manager for this API group.
+	// Start() resolves ports to available ones immediately before binding.
+	sharedManager, err := controllers.NewSharedControllerManager(apiGroupName, config, desiredMetricsPort, desiredHealthPort)
 	if err != nil {
 		setupLog.Error(err, "Failed to create shared controller manager")
 		return 1

--- a/pkg/service/cmd/options/options.go
+++ b/pkg/service/cmd/options/options.go
@@ -198,11 +198,11 @@ func (o *Options) Complete(ctx context.Context) (*CompletedOptions, error) {
 	o.ControlPlane.SecureServing.ExternalAddress = net.IPv4(127, 0, 0, 1)
 	o.ControlPlane.SecureServing.BindAddress = net.IPv4(127, 0, 0, 1)
 
-	// Handle port fallback mechanism - if the requested port is not available, find an alternative
+	// Fall back to a random port if the configured port is busy.
 	if o.ControlPlane.SecureServing.BindPort != 0 {
-		actualPort, err := controllers.GetAvailablePort(ctx, o.ControlPlane.SecureServing.BindPort)
+		actualPort, err := controllers.ResolvePort(ctx, o.ControlPlane.SecureServing.BindPort)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get available secure port: %w", err)
+			return nil, fmt.Errorf("failed to resolve secure port: %w", err)
 		}
 		o.ControlPlane.SecureServing.BindPort = actualPort
 	}

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -158,7 +158,7 @@ func Running() bool {
 	return PID() != PIDNotFound
 }
 
-func Create(ctx context.Context, args []string) error {
+func Create(args []string) error {
 	if Exists() {
 		return fmt.Errorf("%q control plane already exists", instance.Name())
 	}
@@ -166,11 +166,7 @@ func Create(ctx context.Context, args []string) error {
 		return err
 	}
 	// Add default secure port first, then append user args (which may override it if specified).
-	desiredSecurePort := 6443 + instance.Index()
-	securePort, err := controllers.GetAvailablePort(ctx, desiredSecurePort)
-	if err != nil {
-		return fmt.Errorf("failed to get available secure port: %w", err)
-	}
+	securePort := 6443 + instance.Index()
 	args = append([]string{"--secure-port", strconv.Itoa(securePort)}, args...)
 
 	data, err := json.MarshalIndent(args, "", "  ")
@@ -513,7 +509,7 @@ func NewServeCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("control plane %q is already running", instance.Name())
 			}
 			if !Exists() {
-				if err := Create(cmd.Context(), nil); err != nil {
+				if err := Create(nil); err != nil {
 					return err
 				}
 			}
@@ -682,23 +678,15 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 			defer mgrWg.Done()
 			klog.InfoS("Starting shared controller manager", "controllers", len(enabledControllers))
 
-			// Get available ports for metrics and health endpoints with instance offset
-			instanceOffset := 2 * instance.Index()
-			metricsPort, err := controllers.GetAvailablePort(ctx, 8082+instanceOffset)
-			if err != nil {
-				klog.Error(err, "Failed to get available metrics port")
-				return
-			}
+			// Each instance reserves 4 consecutive ports starting at 8080:
+			// +0 external metrics, +1 external health, +2 embedded metrics, +3 embedded health.
+			// Start() resolves these to available ports immediately before binding.
+			instanceOffset := 4 * instance.Index()
+			metricsPort := 8082 + instanceOffset
+			healthPort := 8083 + instanceOffset
 
-			healthPort, err := controllers.GetAvailablePort(ctx, 8083+instanceOffset)
-			if err != nil {
-				klog.Error(err, "Failed to get available health port")
-				return
-			}
-
-			// Create shared controller manager with dynamic ports
+			// Create shared controller manager
 			sharedManager, err := controllers.NewSharedControllerManager(
-				ctx,
 				"embedded",
 				completed.ControlPlane.Generic.LoopbackClientConfig,
 				metricsPort,

--- a/pkg/service/controllers/manager.go
+++ b/pkg/service/controllers/manager.go
@@ -64,24 +64,12 @@ type SharedControllerManager struct {
 }
 
 // NewSharedControllerManager creates a new shared controller manager.
-func NewSharedControllerManager(ctx context.Context, name string, kubeConfig *rest.Config, metricsPort, healthPort int) (*SharedControllerManager, error) {
-	// Create discovery service (errors handled in Start method)
+// The metricsPort and healthPort are desired ports; Start resolves them
+// to available ports immediately before binding.
+func NewSharedControllerManager(name string, kubeConfig *rest.Config, metricsPort, healthPort int) (*SharedControllerManager, error) {
 	discovery, err := NewControllerManagerDiscoveryGroup(kubeConfig, name)
 	if err != nil {
 		return nil, err
-	}
-
-	// Calculate webhook port with instance offset
-	desiredWebhookPort := 9443 + instance.Index()
-	webhookPort, err := GetAvailablePort(ctx, desiredWebhookPort)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get available webhook port: %w", err)
-	}
-
-	desiredPassthroughPort := 9090 + instance.Index()
-	passthroughPort, err := GetAvailablePort(ctx, desiredPassthroughPort)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get available pass through port: %w", err)
 	}
 
 	return &SharedControllerManager{
@@ -89,8 +77,8 @@ func NewSharedControllerManager(ctx context.Context, name string, kubeConfig *re
 		kubeConfig:      kubeConfig,
 		metricsPort:     metricsPort,
 		healthPort:      healthPort,
-		webhookPort:     webhookPort,
-		passthroughPort: passthroughPort,
+		webhookPort:     9443 + instance.Index(),
+		passthroughPort: 9090 + instance.Index(),
 		registrations:   make([]base.Controller, 0),
 		started:         false,
 		discovery:       discovery,
@@ -148,6 +136,26 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 	// Modify kubeconfig to force JSON content type to avoid protobuf issues
 	configCopy := *scm.kubeConfig
 	configCopy.ContentType = "application/json"
+
+	// Resolve all ports immediately before use to minimize the window
+	// between releasing the test listener and controller-runtime rebinding.
+	var err error
+	scm.metricsPort, err = ResolvePort(ctx, scm.metricsPort)
+	if err != nil {
+		return fmt.Errorf("failed to resolve metrics port: %w", err)
+	}
+	scm.healthPort, err = ResolvePort(ctx, scm.healthPort)
+	if err != nil {
+		return fmt.Errorf("failed to resolve health port: %w", err)
+	}
+	scm.webhookPort, err = ResolvePort(ctx, scm.webhookPort)
+	if err != nil {
+		return fmt.Errorf("failed to resolve webhook port: %w", err)
+	}
+	scm.passthroughPort, err = ResolvePort(ctx, scm.passthroughPort)
+	if err != nil {
+		return fmt.Errorf("failed to resolve passthrough port: %w", err)
+	}
 
 	// Create the shared controller-runtime manager
 	managerOptions := ctrl.Options{

--- a/pkg/service/controllers/ports.go
+++ b/pkg/service/controllers/ports.go
@@ -6,43 +6,26 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
 )
 
-// GetAvailablePort tries to use the desired port, but picks a random available port if it's not available.
-// Returns the port number that was successfully bound.
-func GetAvailablePort(ctx context.Context, desiredPort int) (int, error) {
-	// First, try the desired port
-	if desiredPort != 0 {
-		if port, err := isPortAvailable(ctx, desiredPort); err == nil {
-			return port, nil
+// ResolvePort binds a TCP port on localhost to confirm availability. If the
+// desired port is occupied, the OS assigns a random port instead. The listener
+// is closed before returning so the caller can rebind it. Call this immediately
+// before the port is needed to minimize the window between releasing and
+// rebinding.
+func ResolvePort(ctx context.Context, desired int) (int, error) {
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:"+strconv.Itoa(desired))
+	if err != nil {
+		ln, err = lc.Listen(ctx, "tcp", "127.0.0.1:0")
+		if err != nil {
+			return 0, fmt.Errorf("find available port (desired %d): %w", desired, err)
 		}
 	}
-
-	// If desired port is not available, let the system pick a random available port
-	port, err := isPortAvailable(ctx, 0)
-	if err != nil {
-		return 0, fmt.Errorf("failed to find available port: %w", err)
-	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
 	return port, nil
-}
-
-// isPortAvailable checks if a port is available by trying to bind to it on localhost,
-// and returns the port bound.  The listener is closed before returning.  If it
-// fails, returns zero.  The returned port is never zero on success.
-func isPortAvailable(ctx context.Context, port int) (int, error) {
-	address := "127.0.0.1:" + strconv.Itoa(port)
-	listenConfig := net.ListenConfig{}
-	listener, err := listenConfig.Listen(ctx, "tcp", address)
-	if err != nil {
-		return 0, err
-	}
-	defer listener.Close()
-	if addr, ok := listener.Addr().(*net.TCPAddr); ok && addr.Port != 0 {
-		return addr.Port, nil
-	}
-	return 0, errors.New("failed to get listener port")
 }


### PR DESCRIPTION
External controllers (`rdd-controller`, `mock-controller`) defaulted to ports `8080`/`8081` without instance offsets, causing collisions when parallel CI test suites started controllers for different instances on the same machine.

Replace `GetAvailablePort` with a two-part fix:

1. All port defaults now include instance offsets. Each instance reserves 4 consecutive ports starting at `8080` (external metrics, external health, embedded metrics, embedded health), plus per-instance offsets for webhook, passthrough, and apiserver ports.

2. Ports are resolved in `SharedControllerManager.Start()`, immediately before `controller-runtime` binds them. The old approach checked ports in `NewSharedControllerManager` or earlier, leaving a multi-second window (during CRD installation) for another process to claim the port.

`resolvePort` tries the desired port first and falls back to a system-assigned port if it is occupied.