### PR TITLE
Verify generated files in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,6 +31,19 @@ jobs:
         --jq '.[0].number // 0')
       env:
         GH_TOKEN: ${{ github.token }}
+  verify-generate:
+    name: Verify generated files
+    needs: get-pr-number
+    runs-on: ubuntu-latest
+    if: ${{ ! needs.get-pr-number.outputs.number }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      with:
+        go-version-file: go.mod
+    - run: make verify-generate
   lint-rdd:
     name: Lint RDD
     needs: get-pr-number

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,14 @@ generate-crds:
 generate: generate-deepcopy generate-crds
 .PHONY: generate
 
+verify-generate: generate
+	@if [ -n "$$(git diff --name-only)" ]; then \
+		echo "ERROR: Generated files are out of date. Run 'make generate' and commit the result." >&2; \
+		git diff --stat; \
+		exit 1; \
+	fi
+.PHONY: verify-generate
+
 run: bin/rdd$(EXE)
 	$< service start
 .PHONY: run

--- a/pkg/apis/lima/v1alpha1/applyconfiguration/lima/v1alpha1/limavmstatus.go
+++ b/pkg/apis/lima/v1alpha1/applyconfiguration/lima/v1alpha1/limavmstatus.go
@@ -28,8 +28,8 @@ type LimaVMStatusApplyConfiguration struct {
 	TemplateConfigMap *string `json:"templateConfigMap,omitempty"`
 	// restartNeeded indicates a restart has been requested but not yet executed.
 	// Set by the reconciler when it processes a restartRequested annotation or
-	// detects a template change on a running instance. Cleared when the restart
-	// completes or the instance is already stopped.
+	// detects a template change on a running instance. Cleared when the instance
+	// stops (before the restart starts) or immediately if already stopped.
 	RestartNeeded *bool `json:"restartNeeded,omitempty"`
 	// restartCount tracks how many times the instance has reached the Running state.
 	// Incremented each time the controller sets Running=True/Started.

--- a/pkg/controllers/lima/limavm/crd.yaml
+++ b/pkg/controllers/lima/limavm/crd.yaml
@@ -158,8 +158,8 @@ spec:
                 description: |-
                   restartNeeded indicates a restart has been requested but not yet executed.
                   Set by the reconciler when it processes a restartRequested annotation or
-                  detects a template change on a running instance. Cleared when the restart
-                  completes or the instance is already stopped.
+                  detects a template change on a running instance. Cleared when the instance
+                  stops (before the restart starts) or immediately if already stopped.
                 type: boolean
               templateConfigMap:
                 description: |-


### PR DESCRIPTION
Add a verify-generate job to the lint workflow that runs `make generate` and fails if the working tree is dirty afterward. This catches stale CRDs and deepcopy files before they merge.