### PR TITLE
Read templateRef ConfigMap directly from the API server

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -43,7 +43,7 @@ assert_created() {
     # Create VM with ConfigMap template
     run_e -1 rdd limavm create "test-missing-vm" "test-missing-template" --namespace "${LIMA_TEST_NS}"
     assert_stderr_line --partial 'denied the request'
-    assert_stderr_line --partial 'ConfigMap \"test-missing-template\" not found'
+    assert_stderr_line --partial '\"test-missing-template\" not found'
 
     # Verify the ConfigMap was not created, or at least deleted after.
     run -1 rdd ctl get configmap "test-missing-template" --namespace "${LIMA_TEST_NS}" --output=name

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -117,7 +117,7 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 			admissionregistrationv1.Create, // Only on CREATE - UPDATE doesn't need to create ConfigMap again
 		},
 		SideEffects: &sideEffectsNoneOnDryRun, // Creates ConfigMap normally, but not during dry-run
-		Defaulter:   &defaulter{Client: mgr.GetClient()},
+		Defaulter:   &defaulter{Client: mgr.GetClient(), Reader: mgr.GetAPIReader()},
 	}
 
 	managers, err := base.SetupWebhookForResource(mgr, &v1alpha1.LimaVM{}, mutatingConfig)
@@ -175,6 +175,10 @@ func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 // It validates cross-namespace name uniqueness, then creates the template ConfigMap synchronously during admission.
 type defaulter struct {
 	Client client.Client
+	// Reader bypasses the informer cache to read directly from the API server.
+	// The templateRef ConfigMap may have been created moments before the LimaVM,
+	// so the informer cache may not have synced it yet.
+	Reader client.Reader
 }
 
 var _ ctrlwebhookadmission.Defaulter[*v1alpha1.LimaVM] = &defaulter{}
@@ -243,7 +247,7 @@ func (d *defaulter) fetchTemplateRefData(ctx context.Context, limavm *v1alpha1.L
 		configMapKey.Namespace = limavm.Namespace
 	}
 	configMap := &corev1.ConfigMap{}
-	if err := d.Client.Get(ctx, configMapKey, configMap); err != nil {
+	if err := d.Reader.Get(ctx, configMapKey, configMap); err != nil {
 		return "", fmt.Errorf("failed to get templateRef ConfigMap %q in namespace %q: %w", configMapKey.Name, configMapKey.Namespace, err)
 	}
 	return configMap.Data[v1alpha1.TemplateConfigMapKey], nil


### PR DESCRIPTION
The defaulter webhook looked up the templateRef ConfigMap through the informer cache. When the CLI creates a ConfigMap and immediately creates a LimaVM, the informer may not have synced the ConfigMap yet, causing a "not found" error. Use the API reader to bypass the cache.