### PR TITLE
Add support for running BATS tests under MSYS2

### DIFF
--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -4,6 +4,7 @@ buildvcs
 coreutils
 cpanm
 cpanminus
+cygpath
 gnubin
 libexec
 ltag
@@ -14,6 +15,8 @@ mktemp
 moby
 netcat
 nproc
+openssh
+pacman
 printenv
 pulumi
 Trivy
@@ -57,6 +60,7 @@ RSTART
 # bash
 neq
 nullglob
+PATHCONV
 
 # bats
 batslib

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -30,7 +30,13 @@ ifneq ($(shell sh -c 'command -v winver.exe'),)
 # On Windows, make sure we pass the environment variables back to RDD
 export WSLENV := $(WSLENV):RDD_INSTANCE:RDD_DEVELOPER_MODE
 # Use the Windows temporary directory
+ifeq ($(shell sh -c 'command -v wslpath'),)
+# MSYS2: convert Windows TEMP path using cygpath
+export TMPDIR := $(shell cygpath -u '$(TEMP)')
+else
+# WSL: convert Windows TEMP path using wslpath
 export TMPDIR := $(shell wslpath -u $$(cmd.exe /c "echo %TEMP%"))
+endif
 endif
 
 # Run BATS tests for BATS helpers

--- a/bats/helpers/commands.bash
+++ b/bats/helpers/commands.bash
@@ -1,10 +1,12 @@
 EXE=""
 PLATFORM=${OS}
 if is_windows; then
-    PLATFORM=linux
     if using_windows_exe; then
         EXE=".exe"
         PLATFORM=win32
+    else
+        # WSL with Linux binary (not yet supported).
+        PLATFORM=linux
     fi
 fi
 
@@ -24,29 +26,45 @@ curl() {
 rdd() {
     local arg
     local args=("$@")
-    local env
-    local envs=()
     if is_windows; then
         args=()
-        for arg in "$@"; do
-            if [[ "${arg}" != "${arg#/mnt/}" ]]; then
-                args+=("$(wslpath -w "${arg}")")
-            else
-                args+=("${arg}")
-            fi
-        done
-        # Adjust WSLENV to include everything starting with RDD_
-        mapfile -t envs < <({
-            tr : '\n' <<<"${WSLENV}"
-            env | awk -F= '/^RDD_/ { print $1 }'
-        } | sort -u || true)
-        WSLENV=""
-        for env in "${envs[@]}"; do
-            WSLENV="${WSLENV}:${env}"
-        done
-        WSLENV=${WSLENV#:}
-
-        export WSLENV
+        if is_msys; then
+            # MSYS_NO_PATHCONV is set globally to protect URL-like paths
+            # (e.g. /passthrough/demo/hello), so convert filesystem paths
+            # to Windows format manually.
+            for arg in "$@"; do
+                if [[ "${arg}" =~ ^/([a-zA-Z]/|tmp(/|$)) ]]; then
+                    # Drive-letter mounts (/c/...) and /tmp are always
+                    # filesystem paths; convert without existence check.
+                    args+=("$(cygpath -w "${arg}")")
+                elif [[ "${arg}" == /* ]] && [[ -e "${arg}" ]]; then
+                    args+=("$(cygpath -w "${arg}")")
+                else
+                    args+=("${arg}")
+                fi
+            done
+        else
+            # WSL: convert /mnt/... paths.
+            for arg in "$@"; do
+                if [[ "${arg}" != "${arg#/mnt/}" ]]; then
+                    args+=("$(wslpath -w "${arg}")")
+                else
+                    args+=("${arg}")
+                fi
+            done
+            # Adjust WSLENV to include everything starting with RDD_
+            local env envs
+            mapfile -t envs < <({
+                tr : '\n' <<<"${WSLENV}"
+                env | awk -F= '/^RDD_/ { print $1 }'
+            } | sort -u || true)
+            WSLENV=""
+            for env in "${envs[@]}"; do
+                WSLENV="${WSLENV}:${env}"
+            done
+            WSLENV=${WSLENV#:}
+            export WSLENV
+        fi
     fi
     "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${args[@]}"
 }

--- a/bats/helpers/defaults.bash
+++ b/bats/helpers/defaults.bash
@@ -8,5 +8,11 @@ export RDD_INSTANCE
 export RDD_KEEP_LOGS
 
 using_windows_exe() {
-    true # TODO: WSL testing, later.
+    # MSYS2 always uses Windows executables; there is no Linux alternative.
+    if is_msys; then
+        return 0
+    fi
+    # WSL: currently always uses Windows executables.
+    # TODO: Support testing with the Linux binary on WSL.
+    true
 }

--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -3,6 +3,10 @@ set -o errexit -o nounset -o pipefail
 # Make sure run() will execute all functions with errexit enabled
 export BATS_RUN_ERREXIT=1
 
+# Prevent MSYS from converting POSIX paths in arguments to Windows paths.
+# Without this, arguments like '/passthrough/demo/hello' get mangled.
+export MSYS_NO_PATHCONV=1
+
 bats_require_minimum_version 1.10.0
 
 absolute_path() {

--- a/bats/helpers/os.bash
+++ b/bats/helpers/os.bash
@@ -17,6 +17,9 @@ Linux)
         OS=linux
     fi
     ;;
+MSYS* | MINGW*)
+    OS=windows
+    ;;
 *)
     echo "Unexpected uname: ${UNAME}" >&2
     exit 1
@@ -45,6 +48,12 @@ is_windows() {
     else
         test "${OS}" = windows -a "${ARCH}" = "$1"
     fi
+}
+
+# Detect MSYS2 environment (MSYS or MINGW shells).
+# Both report OS=windows, but behave differently from WSL.
+is_msys() {
+    [[ "${UNAME}" == MSYS* || "${UNAME}" == MINGW* ]]
 }
 
 is_unix() {

--- a/bats/helpers/paths.bash
+++ b/bats/helpers/paths.bash
@@ -6,11 +6,15 @@ inside_repo_clone() {
     [[ -d "${PATH_REPO_ROOT}/pkg/rancher-desktop-daemon" ]]
 }
 
-# Convert 'export KEY="C:\win\path"' to 'export KEY="/mnt/c/wsl/path"'.
-win_to_wsl_exports() {
+# Convert 'export KEY="C:\win\path"' to POSIX paths (WSL or MSYS2).
+win_to_posix_exports() {
     tr -d "\r" | while IFS= read -r line; do
         if [[ "${line}" =~ ^(export\ [A-Z_]+=)\"(.+)\"$ ]]; then
-            printf '%s"%s"\n' "${BASH_REMATCH[1]}" "$(wslpath -u "${BASH_REMATCH[2]}")"
+            if command -v wslpath >/dev/null 2>&1; then
+                printf '%s"%s"\n' "${BASH_REMATCH[1]}" "$(wslpath -u "${BASH_REMATCH[2]}")"
+            else
+                printf '%s"%s"\n' "${BASH_REMATCH[1]}" "$(cygpath -u "${BASH_REMATCH[2]}")"
+            fi
         fi
     done
 }
@@ -18,7 +22,7 @@ win_to_wsl_exports() {
 # Get instance paths from rdd (single source of truth).
 # shellcheck disable=SC1090
 if is_windows; then
-    source <("${PATH_REPO_ROOT}/bin/rdd.exe" svc paths --output=shell | win_to_wsl_exports)
+    source <("${PATH_REPO_ROOT}/bin/rdd.exe" svc paths --output=shell | win_to_posix_exports)
 else
     source <("${PATH_REPO_ROOT}/bin/rdd" svc paths --output=shell)
 fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,12 +31,34 @@ generally the latest release versions.
 On macOS, we expect Xcode command line tools to be available.
 
 ### Windows
-Development should be done inside WSL.  Development using `cmd.exe` / PowerShell
-/ MSYS2 / Git Bash / Cygwin / etc. is explicitly not supported.  We may
-occasionally let things work to make CI easier, but that is the extent of it.
-All Rancher Desktop Daemon processes will be run under Win32 (instead of under
-WSL); developing for Linux on a Windows host is only supported when using a
-full Linux VM (instead of using the WSL VM), whether or not WSL integration is
-enabled.
+
+Development is supported under WSL2 and MSYS2.  Development using `cmd.exe`,
+PowerShell, Git Bash, or Cygwin is not supported.
+
+All RDD processes run as Win32 executables.  Developing for Linux on a Windows
+host is only supported when using a full Linux VM, whether or not WSL
+integration is enabled.
+
+#### WSL2
 
 WSL interop must be enabled (we test for `winver.exe` being around).
+
+#### MSYS2
+
+Install MSYS2, Git, and Go natively on Windows (e.g. via scoop) rather than
+through pacman; the MSYS2 versions may behave differently from what CI uses.
+
+```
+scoop install msys2 git go
+```
+
+Then install build dependencies inside MSYS2:
+
+```bash
+pacman --sync --needed jq make mingw-w64-x86_64-gcc openbsd-netcat openssh
+```
+
+The BATS test harness exports `MSYS_NO_PATHCONV=1` to prevent MSYS2 from
+converting URL-like arguments (e.g. `/passthrough/demo/hello`) into Windows
+paths.  The `rdd()` wrapper in `bats/helpers/commands.bash` handles explicit
+path conversion for arguments that need it.


### PR DESCRIPTION
The test harness assumed WSL2 as the only Windows environment. MSYS2 (both MSYS and MINGW shells) requires different path conversion and environment handling.

Changes:
- Detect MSYS2 via uname (MSYS* and MINGW* patterns)
- Add is_msys() helper to distinguish MSYS2 from WSL
- Export MSYS_NO_PATHCONV=1 to prevent argument path mangling
- Convert drive-letter paths (/c/...) via cygpath in rdd() wrapper
- Rename win_to_wsl_exports to win_to_posix_exports
- Resolve TMPDIR via cygpath on MSYS2, wslpath on WSL