### PR TITLE
Preserve Lima serial logs across VM restarts

### DIFF
--- a/.github/actions/spelling/expect/rd.txt
+++ b/.github/actions/spelling/expect/rd.txt
@@ -29,5 +29,7 @@ limactl
 limavm
 pidfile
 rosetta
+serialp
+serialv
 syncer
 workdir

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -101,6 +101,9 @@ Sends SIGTERM signal to control plane process (`rdd.pid`).
 
 ### `rdd service delete`
 
+Stops the control plane and removes the instance directory, the short directory
+(which contains the Lima home), and — unless `RDD_KEEP_LOGS` is set — the log
+directory.
 
 ### `rdd service reset`
 

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -10,7 +10,7 @@ These variables control RDD behavior. Set them before running `rdd` commands.
 | --- | --- | --- |
 | `RDD_INSTANCE` | Instance identifier. Determines which control plane and directories to use. Also settable via `rdd --instance`. | `2` |
 | `RDD_DEVELOPER_MODE` | Enables developer mode: exposes hidden CLI flags, detects source tree for local builds. | unset |
-| `RDD_KEEP_LOGS` | When set to any non-empty value, preserves numbered log files instead of pruning old ones. Also prevents log directory removal on `rdd svc delete`. | unset |
+| `RDD_KEEP_LOGS` | Preserves logs for post-mortem debugging. See [Log Preservation](#log-preservation) for details. | unset |
 | `RDD_LOG_LEVEL` | Sets the log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`). Overridden by `--log-level` flag. When unset, defaults to `debug` in developer mode, `warn` otherwise. | unset |
 | `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
 
@@ -50,3 +50,19 @@ Path variables are listed alphabetically. To retrieve a single path, pass the ke
 ```shell
 rdd svc paths log_dir
 ```
+
+## Log Preservation
+
+When `RDD_KEEP_LOGS` is set to any non-empty value, RDD preserves logs that would otherwise be lost:
+
+- **No pruning.** Log rotation normally keeps the five most recent backups and deletes older ones. With `RDD_KEEP_LOGS`, all numbered backups are retained.
+- **Survives `svc delete`.** `rdd svc delete` normally removes the log directory. With `RDD_KEEP_LOGS`, the log directory is preserved.
+- **Instance logs survive VM deletion.** When a LimaVM resource is deleted, Lima removes the instance directory (which contains hostagent and serial console logs). With `RDD_KEEP_LOGS`, the controller moves all `.log` files to a subdirectory of `RDD_LOG_DIR` named after the instance before deletion. If the subdirectory already exists (from a previous deletion), a numbered suffix is used (e.g., `opensuse.2/`).
+
+### Log rotation
+
+Both service logs (`rdd.stdout`, `rdd.stderr`) and hostagent logs (`ha.stdout`, `ha.stderr`) are rotated on each start: the active file is renamed to a numbered backup (e.g., `ha.stderr.1.log`), and a fresh file is created. Serial console logs (`serial`, `serialp`, `serialv`) are rotated the same way, but no new file is created — the VM driver creates it.
+
+### BATS defaults
+
+BATS tests set `RDD_KEEP_LOGS=1` by default (in `bats/helpers/defaults.bash`), so all test logs are preserved for CI artifact collection. The collection script (`scripts/collect-bats-logs.sh`) gathers both service logs and preserved instance logs into a single output directory.

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -402,6 +402,14 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 		}{title})
 		header = string(b) + "\n"
 	}
+	// Rotate serial logs before creating hostagent logs. The VM driver
+	// overwrites serial.log on each start; rotating preserves previous boots.
+	for _, name := range []string{"serial", "serialp", "serialv"} {
+		if err := logfile.Rotate(inst.Dir, name, keepLogs); err != nil {
+			logger.Error(err, "Failed to rotate serial log", "name", name)
+		}
+	}
+
 	haStdoutW, err := logfile.Create(inst.Dir, "ha.stdout", keepLogs, header)
 	if err != nil {
 		logger.Error(err, "Failed to create stdout log file")

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,6 +30,7 @@ import (
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/logfile"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
 )
@@ -73,6 +76,7 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 			existingInst.DriverPID = 0
 			existingInst.HostAgentPID = 0
 		}
+		preserveInstanceLogs(ctx, existingInst)
 		logger.Info("Deleting Lima instance", "instance", limaVM.Name)
 		// Use a timeout because Lima's WSL2 driver calls wsl.exe --unregister
 		// which can hang indefinitely if the WSL subsystem is degraded.
@@ -695,4 +699,74 @@ func terminateWSL2Distro(ctx context.Context, logger logr.Logger, instName strin
 	if err := exec.CommandContext(wslCtx, "wsl.exe", "--terminate", distroName).Run(); err != nil {
 		logger.V(1).Info("Failed to terminate WSL2 distro", "distro", distroName, "error", err)
 	}
+}
+
+// preserveInstanceLogs moves log files from the Lima instance directory to
+// a subdirectory of the service log directory before the instance is deleted.
+// This is a no-op unless RDD_KEEP_LOGS is set.
+//
+// Errors are logged but do not prevent deletion. On Windows, os.Rename
+// requires FILE_SHARE_DELETE on the source; Go sets this flag since 1.14,
+// but non-Go processes (e.g., QEMU) may not. If rename fails because a
+// process still holds a lock, the logs are lost when the instance directory
+// is deleted afterward.
+func preserveInstanceLogs(ctx context.Context, inst *limatype.Instance) {
+	if os.Getenv("RDD_KEEP_LOGS") == "" {
+		return
+	}
+
+	logger := log.FromContext(ctx)
+	logDir := instance.LogDir()
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		logger.Error(err, "Failed to create log directory for preservation")
+		return
+	}
+
+	destDir, err := nextAvailableDir(logDir, inst.Name)
+	if err != nil {
+		logger.Error(err, "Failed to create log preservation directory")
+		return
+	}
+
+	entries, err := os.ReadDir(inst.Dir)
+	if err != nil {
+		logger.Error(err, "Failed to read instance directory for log preservation")
+		return
+	}
+
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		src := filepath.Join(inst.Dir, entry.Name())
+		dst := filepath.Join(destDir, entry.Name())
+		if err := os.Rename(src, dst); err != nil {
+			logger.Error(err, "Failed to preserve log file", "file", entry.Name())
+			continue
+		}
+		count++
+	}
+
+	logger.Info("Preserved instance logs", "dest", destDir, "count", count)
+}
+
+// nextAvailableDir creates a new directory named {name} under parent. If it
+// already exists, it tries {name}.2, {name}.3, etc.
+func nextAvailableDir(parent, name string) (string, error) {
+	dir := filepath.Join(parent, name)
+	if err := os.Mkdir(dir, 0o700); err == nil {
+		return dir, nil
+	} else if !errors.Is(err, fs.ErrExist) {
+		return "", fmt.Errorf("create directory %s: %w", dir, err)
+	}
+	for n := 2; n <= 1000; n++ {
+		dir = filepath.Join(parent, fmt.Sprintf("%s.%d", name, n))
+		if err := os.Mkdir(dir, 0o700); err == nil {
+			return dir, nil
+		} else if !errors.Is(err, fs.ErrExist) {
+			return "", fmt.Errorf("create directory %s: %w", dir, err)
+		}
+	}
+	return "", fmt.Errorf("exhausted directory names for %s in %s", name, parent)
 }

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -716,57 +714,12 @@ func preserveInstanceLogs(ctx context.Context, inst *limatype.Instance) {
 	}
 
 	logger := log.FromContext(ctx)
-	logDir := instance.LogDir()
-	if err := os.MkdirAll(logDir, 0o700); err != nil {
-		logger.Error(err, "Failed to create log directory for preservation")
-		return
-	}
-
-	destDir, err := nextAvailableDir(logDir, inst.Name)
+	count, err := instance.PreserveLogs(inst.Dir, inst.Name)
 	if err != nil {
-		logger.Error(err, "Failed to create log preservation directory")
+		logger.Error(err, "Failed to preserve instance logs")
 		return
 	}
-
-	entries, err := os.ReadDir(inst.Dir)
-	if err != nil {
-		logger.Error(err, "Failed to read instance directory for log preservation")
-		return
+	if count > 0 {
+		logger.Info("Preserved instance logs", "instance", inst.Name, "count", count)
 	}
-
-	count := 0
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".log") {
-			continue
-		}
-		src := filepath.Join(inst.Dir, entry.Name())
-		dst := filepath.Join(destDir, entry.Name())
-		if err := os.Rename(src, dst); err != nil {
-			logger.Error(err, "Failed to preserve log file", "file", entry.Name())
-			continue
-		}
-		count++
-	}
-
-	logger.Info("Preserved instance logs", "dest", destDir, "count", count)
-}
-
-// nextAvailableDir creates a new directory named {name} under parent. If it
-// already exists, it tries {name}.2, {name}.3, etc.
-func nextAvailableDir(parent, name string) (string, error) {
-	dir := filepath.Join(parent, name)
-	if err := os.Mkdir(dir, 0o700); err == nil {
-		return dir, nil
-	} else if !errors.Is(err, fs.ErrExist) {
-		return "", fmt.Errorf("create directory %s: %w", dir, err)
-	}
-	for n := 2; n <= 1000; n++ {
-		dir = filepath.Join(parent, fmt.Sprintf("%s.%d", name, n))
-		if err := os.Mkdir(dir, 0o700); err == nil {
-			return dir, nil
-		} else if !errors.Is(err, fs.ErrExist) {
-			return "", fmt.Errorf("create directory %s: %w", dir, err)
-		}
-	}
-	return "", fmt.Errorf("exhausted directory names for %s in %s", name, parent)
 }

--- a/pkg/instance/logs.go
+++ b/pkg/instance/logs.go
@@ -27,9 +27,11 @@ func PreserveLogs(srcDir, instanceName string) (int, error) {
 
 	// Filter to .log files before creating the destination directory,
 	// so we don't leave empty directories when no logs exist.
+	// Symlinked log files are not expected and not supported; they
+	// would become dangling after the source directory is removed.
 	var logFiles []os.DirEntry
 	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".log") {
+		if entry.Type().IsRegular() && strings.HasSuffix(entry.Name(), ".log") {
 			logFiles = append(logFiles, entry)
 		}
 	}
@@ -47,20 +49,22 @@ func PreserveLogs(srcDir, instanceName string) (int, error) {
 		return 0, err
 	}
 
+	var errs []error
 	count := 0
 	for _, entry := range logFiles {
 		src := filepath.Join(srcDir, entry.Name())
 		dst := filepath.Join(destDir, entry.Name())
 		if err := os.Rename(src, dst); err != nil {
-			if count == 0 {
-				os.Remove(destDir)
-			}
-			return count, fmt.Errorf("preserve %s: %w", entry.Name(), err)
+			errs = append(errs, fmt.Errorf("preserve %s: %w", entry.Name(), err))
+			continue
 		}
 		count++
 	}
+	if count == 0 {
+		os.Remove(destDir)
+	}
 
-	return count, nil
+	return count, errors.Join(errs...)
 }
 
 // nextAvailableDir creates a directory named {name} under parent. If it

--- a/pkg/instance/logs.go
+++ b/pkg/instance/logs.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package instance
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PreserveLogs moves .log files from srcDir into a uniquely named
+// subdirectory of LogDir(). The subdirectory uses instanceName as a
+// base, with a numeric suffix to avoid collisions (.2, .3, etc.).
+//
+// Returns the number of files moved. Skips srcDir entries that are
+// directories or do not end in ".log".
+func PreserveLogs(srcDir, instanceName string) (int, error) {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return 0, fmt.Errorf("read instance directory %s: %w", srcDir, err)
+	}
+
+	// Filter to .log files before creating the destination directory,
+	// so we don't leave empty directories when no logs exist.
+	var logFiles []os.DirEntry
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".log") {
+			logFiles = append(logFiles, entry)
+		}
+	}
+	if len(logFiles) == 0 {
+		return 0, nil
+	}
+
+	logDir := LogDir()
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return 0, fmt.Errorf("create log directory %s: %w", logDir, err)
+	}
+
+	destDir, err := nextAvailableDir(logDir, instanceName)
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, entry := range logFiles {
+		src := filepath.Join(srcDir, entry.Name())
+		dst := filepath.Join(destDir, entry.Name())
+		if err := os.Rename(src, dst); err != nil {
+			if count == 0 {
+				os.Remove(destDir)
+			}
+			return count, fmt.Errorf("preserve %s: %w", entry.Name(), err)
+		}
+		count++
+	}
+
+	return count, nil
+}
+
+// nextAvailableDir creates a directory named {name} under parent. If it
+// already exists, it tries {name}.2, {name}.3, etc., up to {name}.1000.
+func nextAvailableDir(parent, name string) (string, error) {
+	dir := filepath.Join(parent, name)
+	if err := os.Mkdir(dir, 0o700); err == nil {
+		return dir, nil
+	} else if !errors.Is(err, fs.ErrExist) {
+		return "", fmt.Errorf("create directory %s: %w", dir, err)
+	}
+	for n := 2; n <= 1000; n++ {
+		dir = filepath.Join(parent, fmt.Sprintf("%s.%d", name, n))
+		if err := os.Mkdir(dir, 0o700); err == nil {
+			return dir, nil
+		} else if !errors.Is(err, fs.ErrExist) {
+			return "", fmt.Errorf("create directory %s: %w", dir, err)
+		}
+	}
+	return "", fmt.Errorf("exhausted directory names for %s in %s", name, parent)
+}

--- a/pkg/instance/logs_test.go
+++ b/pkg/instance/logs_test.go
@@ -41,7 +41,7 @@ func TestNextAvailableDir_Collision(t *testing.T) {
 }
 
 func TestNextAvailableDir_ParentNotExist(t *testing.T) {
-	_, err := nextAvailableDir("/nonexistent/path", "instance")
+	_, err := nextAvailableDir(filepath.Join(t.TempDir(), "nonexistent"), "instance")
 	assert.Assert(t, err != nil, "expected error for nonexistent parent")
 }
 
@@ -93,7 +93,7 @@ func TestPreserveLogs_NoLogFiles(t *testing.T) {
 }
 
 func TestPreserveLogs_SrcDirNotExist(t *testing.T) {
-	_, err := PreserveLogs("/nonexistent/path", "instance")
+	_, err := PreserveLogs(filepath.Join(t.TempDir(), "nonexistent"), "instance")
 	assert.Assert(t, err != nil, "expected error for nonexistent source directory")
 }
 

--- a/pkg/instance/logs_test.go
+++ b/pkg/instance/logs_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package instance
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestNextAvailableDir_FirstCall(t *testing.T) {
+	parent := t.TempDir()
+	dir, err := nextAvailableDir(parent, "instance")
+	assert.NilError(t, err)
+	assert.Equal(t, filepath.Base(dir), "instance")
+	info, err := os.Stat(dir)
+	assert.NilError(t, err)
+	assert.Assert(t, info.IsDir())
+}
+
+func TestNextAvailableDir_Collision(t *testing.T) {
+	parent := t.TempDir()
+
+	dir1, err := nextAvailableDir(parent, "instance")
+	assert.NilError(t, err)
+	assert.Equal(t, filepath.Base(dir1), "instance")
+
+	dir2, err := nextAvailableDir(parent, "instance")
+	assert.NilError(t, err)
+	assert.Equal(t, filepath.Base(dir2), "instance.2")
+
+	dir3, err := nextAvailableDir(parent, "instance")
+	assert.NilError(t, err)
+	assert.Equal(t, filepath.Base(dir3), "instance.3")
+}
+
+func TestNextAvailableDir_ParentNotExist(t *testing.T) {
+	_, err := nextAvailableDir("/nonexistent/path", "instance")
+	assert.Assert(t, err != nil, "expected error for nonexistent parent")
+}
+
+func TestPreserveLogs_MovesLogFiles(t *testing.T) {
+	origLogDir := LogDir
+	logDir := t.TempDir()
+	LogDir = func() string { return logDir }
+	defer func() { LogDir = origLogDir }()
+
+	srcDir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(srcDir, "serial.log"), []byte("serial output"), 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(srcDir, "ha.stderr.log"), []byte("stderr output"), 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(srcDir, "lima.yaml"), []byte("not a log"), 0o644))
+	assert.NilError(t, os.Mkdir(filepath.Join(srcDir, "nested.log"), 0o700))
+
+	count, err := PreserveLogs(srcDir, "source")
+	assert.NilError(t, err)
+	assert.Equal(t, count, 2)
+
+	// Verify files moved to destination.
+	destDir := filepath.Join(logDir, "source")
+	assertFileContent(t, filepath.Join(destDir, "serial.log"), "serial output")
+	assertFileContent(t, filepath.Join(destDir, "ha.stderr.log"), "stderr output")
+
+	// Verify non-log file was not moved.
+	assertFileContent(t, filepath.Join(srcDir, "lima.yaml"), "not a log")
+
+	// Verify source logs were removed (renamed away).
+	_, err = os.Stat(filepath.Join(srcDir, "serial.log"))
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected serial.log to be removed from source")
+}
+
+func TestPreserveLogs_NoLogFiles(t *testing.T) {
+	origLogDir := LogDir
+	logDir := t.TempDir()
+	LogDir = func() string { return logDir }
+	defer func() { LogDir = origLogDir }()
+
+	srcDir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(srcDir, "lima.yaml"), []byte("config"), 0o644))
+
+	count, err := PreserveLogs(srcDir, "empty")
+	assert.NilError(t, err)
+	assert.Equal(t, count, 0)
+
+	// Verify no destination directory was created.
+	_, err = os.Stat(filepath.Join(logDir, "empty"))
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected no destination directory for instance with no logs")
+}
+
+func TestPreserveLogs_SrcDirNotExist(t *testing.T) {
+	_, err := PreserveLogs("/nonexistent/path", "instance")
+	assert.Assert(t, err != nil, "expected error for nonexistent source directory")
+}
+
+func assertFileContent(t *testing.T, path, expected string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err, "failed to read %s", path)
+	assert.Equal(t, string(data), expected)
+}

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -460,7 +460,7 @@ func preserveAllInstanceLogs() {
 			continue
 		}
 		if count > 0 {
-			logrus.WithFields(logrus.Fields{"instance": entry.Name(), "count": count}).Info("Preserved instance logs")
+			logrus.WithFields(logrus.Fields{"instance": entry.Name(), "count": count}).Debug("Preserved instance logs")
 		}
 	}
 }

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -423,6 +423,7 @@ func Delete() error {
 	if os.Getenv("RDD_KEEP_LOGS") == "" {
 		_ = os.RemoveAll(instance.LogDir())
 	}
+	_ = os.RemoveAll(instance.ShortDir())
 	return os.RemoveAll(instance.Dir())
 }
 

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -420,11 +421,48 @@ func Delete() error {
 		return fmt.Errorf("%q control plane does not exist", instance.Name())
 	}
 	_ = Stop()
+	preserveAllInstanceLogs()
 	if os.Getenv("RDD_KEEP_LOGS") == "" {
 		_ = os.RemoveAll(instance.LogDir())
 	}
 	_ = os.RemoveAll(instance.ShortDir())
 	return os.RemoveAll(instance.Dir())
+}
+
+// preserveAllInstanceLogs moves .log files from each Lima instance directory
+// to the service log directory before the instance directories are deleted.
+// This is a no-op unless RDD_KEEP_LOGS is set.
+//
+// Errors are logged but do not prevent deletion. On Windows, os.Rename
+// requires FILE_SHARE_DELETE on the source; Go sets this flag since 1.14,
+// but non-Go processes (e.g., QEMU) may not. If rename fails because a
+// process still holds a lock, the logs are lost when the instance directory
+// is deleted afterward.
+func preserveAllInstanceLogs() {
+	if os.Getenv("RDD_KEEP_LOGS") == "" {
+		return
+	}
+	entries, err := os.ReadDir(instance.LimaHome())
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logrus.WithError(err).Warn("Failed to read Lima instance directory")
+		}
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		instDir := filepath.Join(instance.LimaHome(), entry.Name())
+		count, err := instance.PreserveLogs(instDir, entry.Name())
+		if err != nil {
+			logrus.WithError(err).WithField("instance", entry.Name()).Warn("Failed to preserve instance logs")
+			continue
+		}
+		if count > 0 {
+			logrus.WithFields(logrus.Fields{"instance": entry.Name(), "count": count}).Info("Preserved instance logs")
+		}
+	}
 }
 
 func ServeArgs() []string {

--- a/pkg/util/logfile/logfile.go
+++ b/pkg/util/logfile/logfile.go
@@ -9,7 +9,9 @@
 package logfile
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -33,11 +35,42 @@ func Create(dir, name string, keepAll bool, header string) (*os.File, error) {
 		return nil, fmt.Errorf("create log directory %s: %w", dir, err)
 	}
 
+	if err := Rotate(dir, name, keepAll); err != nil {
+		return nil, err
+	}
+
+	filePath := filepath.Join(dir, name+".log")
+	f, err := os.Create(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("create log file %s: %w", filePath, err)
+	}
+
+	if header != "" {
+		if _, err := f.WriteString(header); err != nil {
+			f.Close()
+			os.Remove(filePath)
+			return nil, fmt.Errorf("write header to %s: %w", filePath, err)
+		}
+	}
+
+	return f, nil
+}
+
+// Rotate renames {name}.log to {name}.{N}.log without creating a new file.
+// Use this for logs managed by an external process (e.g., VM serial console
+// output written by the VM driver) that would be overwritten on next start.
+//
+// When keepAll is false, old numbered files beyond the retention count
+// are removed.
+func Rotate(dir, name string, keepAll bool) error {
 	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `\.(\d+)\.log$`)
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("read log directory %s: %w", dir, err)
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read log directory %s: %w", dir, err)
 	}
 
 	// Find the highest existing sequence number.
@@ -65,29 +98,16 @@ func Create(dir, name string, keepAll bool, header string) (*os.File, error) {
 	if _, err := os.Lstat(filePath); err == nil {
 		numberedName := fmt.Sprintf("%s.%d.log", name, nextN)
 		if err := os.Rename(filePath, filepath.Join(dir, numberedName)); err != nil {
-			return nil, fmt.Errorf("rename %s to %s: %w", filePath, numberedName, err)
+			return fmt.Errorf("rename %s to %s: %w", filePath, numberedName, err)
 		}
 		numberedFiles = append(numberedFiles, numberedFile{n: nextN, name: numberedName})
-	}
-
-	f, err := os.Create(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("create log file %s: %w", filePath, err)
-	}
-
-	if header != "" {
-		if _, err := f.WriteString(header); err != nil {
-			f.Close()
-			os.Remove(filePath)
-			return nil, fmt.Errorf("write header to %s: %w", filePath, err)
-		}
 	}
 
 	if !keepAll {
 		pruneOldFiles(dir, numberedFiles, nextN)
 	}
 
-	return f, nil
+	return nil
 }
 
 // pruneOldFiles removes numbered log files beyond the retention count,

--- a/pkg/util/logfile/logfile_test.go
+++ b/pkg/util/logfile/logfile_test.go
@@ -184,6 +184,80 @@ func TestRenamePreservesContent(t *testing.T) {
 	assert.Equal(t, string(data), "second log\n")
 }
 
+func TestRotateNoFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Rotate with no existing file should be a no-op.
+	err := Rotate(dir, "test", false)
+	assert.NilError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	assert.NilError(t, err)
+	assert.Equal(t, len(entries), 0, "expected empty directory after rotating nonexistent file")
+}
+
+func TestRotateRenamesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a file to rotate.
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "serial.log"), []byte("boot 1\n"), 0o644))
+
+	err := Rotate(dir, "serial", false)
+	assert.NilError(t, err)
+
+	// Original should be gone, numbered backup should exist with original content.
+	_, err = os.Stat(filepath.Join(dir, "serial.log"))
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected serial.log to be renamed")
+
+	data, err := os.ReadFile(filepath.Join(dir, "serial.1.log"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "boot 1\n")
+}
+
+func TestRotateSequentialNumbering(t *testing.T) {
+	dir := t.TempDir()
+
+	for i := 1; i <= 3; i++ {
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, "serial.log"), []byte(fmt.Sprintf("boot %d\n", i)), 0o644))
+		assert.NilError(t, Rotate(dir, "serial", true))
+	}
+
+	// No active file should remain.
+	_, err := os.Stat(filepath.Join(dir, "serial.log"))
+	assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected serial.log to be renamed")
+
+	// Three numbered backups should exist.
+	for i := 1; i <= 3; i++ {
+		data, err := os.ReadFile(filepath.Join(dir, fmt.Sprintf("serial.%d.log", i)))
+		assert.NilError(t, err, "expected serial.%d.log to exist", i)
+		assert.Equal(t, string(data), fmt.Sprintf("boot %d\n", i))
+	}
+}
+
+func TestRotatePruning(t *testing.T) {
+	dir := t.TempDir()
+
+	count := retentionCount + 2
+	for i := 1; i <= count; i++ {
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, "serial.log"), []byte(fmt.Sprintf("boot %d\n", i)), 0o644))
+		assert.NilError(t, Rotate(dir, "serial", false))
+	}
+
+	// Oldest files should be pruned.
+	for _, n := range []int{1, 2} {
+		name := filepath.Join(dir, fmt.Sprintf("serial.%d.log", n))
+		_, err := os.Stat(name)
+		assert.Assert(t, errors.Is(err, fs.ErrNotExist), "expected %s to be pruned", name)
+	}
+
+	// Recent files should still exist.
+	for n := 3; n <= count; n++ {
+		name := filepath.Join(dir, fmt.Sprintf("serial.%d.log", n))
+		_, err := os.Stat(name)
+		assert.NilError(t, err, "expected %s to exist", name)
+	}
+}
+
 func TestMultipleNamesInSameDir(t *testing.T) {
 	dir := t.TempDir()
 

--- a/scripts/collect-bats-logs.sh
+++ b/scripts/collect-bats-logs.sh
@@ -60,7 +60,15 @@ for instance in $(make --no-print-directory -C "${REPO_ROOT}/bats" bats-instance
         collect_logs "$log_dir" "$dest"
     fi
 
-    # Lima hostagent logs (ha.stdout, ha.stderr per VM)
+    # Preserved instance logs (moved to log_dir during instance deletion)
+    if [ -n "${log_dir:-}" ]; then
+        for vm_dir in "$log_dir"/*/; do
+            vm_name=$(basename "$vm_dir")
+            collect_logs "$vm_dir" "$dest/${vm_name}"
+        done
+    fi
+
+    # Lima instance logs (for instances that survived teardown)
     if lima_home=$(resolve_path lima_home); then
         for vm_dir in "$lima_home"/*/; do
             vm_name=$(basename "$vm_dir")

--- a/scripts/collect-bats-logs.sh
+++ b/scripts/collect-bats-logs.sh
@@ -4,15 +4,17 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-# Collect RDD service and Lima hostagent BATS logs into a single directory.
+# Collect BATS logs into a single directory: service logs, preserved instance
+# logs (moved to log_dir during deletion), and Lima instance logs.
 # Usage: scripts/collect-bats-logs.sh [output-dir]
 #
 # Iterates over all BATS instances, resolves their log and Lima home
 # directories via "rdd svc paths", and copies log files into output-dir.
 #
 # Output layout:
-#   output-dir/{instance}/           — service logs (rdd.stdout, rdd.stderr)
-#   output-dir/{instance}/lima-{vm}/ — hostagent logs (ha.stdout, ha.stderr)
+#   output-dir/{instance}/              — service logs (rdd.stdout, rdd.stderr)
+#   output-dir/{instance}/{vm}/         — preserved instance logs
+#   output-dir/{instance}/lima-{vm}/    — hostagent logs (ha.stdout, ha.stderr)
 
 set -o errexit -o nounset -o pipefail
 shopt -s nullglob


### PR DESCRIPTION
Serial logs (`serial.log`, `serialp.log`, `serialv.log`) are overwritten by the VM driver on each start. Add `logfile.Rotate()` to rename the active log to a numbered backup without creating a new file, and call it for serial logs in `startInstance()` before the hostagent launches.

Extract shared rotation logic from `Create()` into a `rotate()` helper so both `Create` and `Rotate` use the same numbering and pruning code.

Fixes #247