### PR TITLE
Implement App controller lifecycle for LimaVM

### DIFF
--- a/.github/actions/spelling/expect/rd.txt
+++ b/.github/actions/spelling/expect/rd.txt
@@ -28,5 +28,6 @@ guestagent
 limactl
 limavm
 pidfile
+rosetta
 syncer
 workdir

--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# App controller lifecycle bats tests controller's singleton creation, LimaVM ownership,
+# running propagation, condition mirroring, and deletion.
+
+APP_NAME="app"
+VM_NAME="rd"
+INPUT_CM_NAME="rd"
+
+delete_app() {
+    rdd ctl delete app "${APP_NAME}" --ignore-not-found
+    # Wait for full deletion so that create_app always starts with no
+    # pre-existing App resource. Without this, rdd ctl apply in create_app
+    # can update a still-terminating App, which the controller treats as a
+    # deletion request — no LimaVM is ever created.
+    rdd ctl wait --for=delete app/"${APP_NAME}" --timeout=120s 2>/dev/null || true
+}
+
+create_app() {
+    local running=${1:-false}
+    delete_app
+
+    rdd ctl apply -f - <<EOF
+apiVersion: app.rancherdesktop.io/v1alpha1
+kind: App
+metadata:
+  name: ${APP_NAME}
+spec:
+  namespace: ${RDD_NAMESPACE}
+  running: ${running}
+EOF
+}
+
+local_setup_file() {
+    setup_rdd_control_plane "app,limavm"
+}
+
+local_setup() {
+    skip_on_windows
+}
+
+@test "create App resource" {
+    create_app false
+}
+
+@test "verify App is cluster-scoped and accessible without a namespace" {
+    run -0 rdd ctl get app "${APP_NAME}"
+}
+
+@test "verify App has cleanup finalizer" {
+    run -0 rdd ctl get app "${APP_NAME}" -o jsonpath='{.metadata.finalizers}'
+    assert_output --partial "rdd.rancherdesktop.io/cleanup"
+}
+
+@test "wait for LimaVM to be created" {
+    rdd ctl wait --for=create limavm/"${VM_NAME}" \
+        --namespace "${RDD_NAMESPACE}" --timeout=60s
+}
+
+@test "verify LimaVM is named rd" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" -o name
+    assert_output "limavm.lima.rancherdesktop.io/${VM_NAME}"
+}
+
+@test "verify LimaVM has owned finalizer set by App controller" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" \
+        -o jsonpath='{.metadata.finalizers}'
+    assert_output --partial "rdd.rancherdesktop.io/owned-by-App"
+}
+
+@test "verify LimaVM has cleanup finalizer set by LimaVM webhook" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" \
+        -o jsonpath='{.metadata.finalizers}'
+    assert_output --partial "rdd.rancherdesktop.io/cleanup"
+}
+
+@test "verify LimaVM has owner reference pointing to App" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" -o json
+    local json="${output}"
+
+    run -0 jq -r '.metadata.ownerReferences[0].kind' <<<"${json}"
+    assert_output "App"
+
+    run -0 jq -r '.metadata.ownerReferences[0].name' <<<"${json}"
+    assert_output "${APP_NAME}"
+
+    run -0 jq -r '.metadata.ownerReferences[0].controller' <<<"${json}"
+    assert_output "true"
+}
+
+@test "verify LimaVM templateRef points to input ConfigMap" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" \
+        -o jsonpath='{.spec.templateRef.name}'
+    assert_output "${INPUT_CM_NAME}"
+}
+
+@test "verify LimaVM spec.running starts as false" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" \
+        -o jsonpath='{.spec.running}'
+    assert_output "false"
+}
+
+@test "wait for LimaVM webhook to copy template into rd-template ConfigMap" {
+    rdd ctl wait --for=jsonpath='{.status.templateConfigMap}'="${VM_NAME}-template" \
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=30s
+}
+
+@test "verify input ConfigMap is deleted after LimaVM copies it" {
+    rdd ctl wait --for=delete configmap/"${INPUT_CM_NAME}" \
+        --namespace "${RDD_NAMESPACE}" --timeout=30s
+}
+
+@test "verify rd-template ConfigMap exists and contains template data" {
+    run -0 rdd ctl get configmap "${VM_NAME}-template" \
+        --namespace "${RDD_NAMESPACE}" -o jsonpath='{.data.template}'
+    [[ -n "${output}" ]]
+}
+
+@test "wait for LimaVM Created condition to be set" {
+    rdd ctl wait --for=condition=Created \
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=60s
+}
+
+@test "verify App status mirrors LimaVM Created condition" {
+    run -0 rdd ctl get app "${APP_NAME}" -o json
+    local json="${output}"
+
+    run -0 jq -r '.status | has("conditions")' <<<"${json}"
+    assert_output "true"
+
+    run -0 jq -r '.status.conditions[] | select(.type == "Created") | .status' <<<"${json}"
+    assert_output "True"
+}
+
+@test "verify App conditions preserve LimaVM LastTransitionTime" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" -o json
+    local limavm_ts
+    limavm_ts=$(jq -r '.status.conditions[] | select(.type == "Created") | .lastTransitionTime' <<<"${output}")
+
+    run -0 rdd ctl get app "${APP_NAME}" -o json
+    local app_ts
+    app_ts=$(jq -r '.status.conditions[] | select(.type == "Created") | .lastTransitionTime' <<<"${output}")
+
+    [[ "${limavm_ts}" == "${app_ts}" ]]
+}
+
+@test "propagating running=true updates LimaVM spec.running" {
+    rdd ctl patch app "${APP_NAME}" --type='merge' -p='{"spec":{"running":true}}'
+    rdd ctl wait --for=jsonpath='{.spec.running}'=true \
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=30s
+}
+
+@test "propagating running=false updates LimaVM spec.running" {
+    rdd ctl patch app "${APP_NAME}" --type='merge' -p='{"spec":{"running":false}}'
+    rdd ctl wait --for=jsonpath='{.spec.running}'=false \
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=30s
+}
+
+@test "reject App resource with a name other than 'app'" {
+    run -1 rdd ctl apply -f - <<EOF
+apiVersion: app.rancherdesktop.io/v1alpha1
+kind: App
+metadata:
+  name: not-app
+spec:
+  namespace: ${RDD_NAMESPACE}
+  running: false
+EOF
+    assert_output --partial "App resource must be named 'app'"
+}
+
+@test "reject mutation of spec.namespace after creation" {
+    run -1 rdd ctl patch app "${APP_NAME}" --type='merge' \
+        -p='{"spec":{"namespace":"other-ns"}}'
+    assert_output --partial "spec.namespace is immutable"
+}
+
+@test "reject direct deletion of LimaVM while owned by App" {
+    run -1 rdd ctl delete limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" --grace-period=0
+    assert_output --partial "Forbidden"
+    assert_output --partial "owned by App"
+    assert_output --partial "delete the App resource instead"
+
+    # Verify the LimaVM still exists and is not stuck in Terminating
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}"
+}
+
+@test "delete App resource" {
+    delete_app
+}
+
+@test "wait for App to be fully deleted" {
+    # The App finalizer stays until the LimaVM controller finishes teardown.
+    rdd ctl wait --for=delete app/"${APP_NAME}" --timeout=90s
+}
+
+@test "verify LimaVM rd is deleted when App is deleted" {
+    run -1 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}"
+    assert_output --partial "not found"
+}
+
+@test "verify App can be recreated after deletion" {
+    create_app false
+    rdd ctl wait --for=create limavm/"${VM_NAME}" \
+        --namespace "${RDD_NAMESPACE}" --timeout=60s
+    delete_app
+}

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -7,6 +7,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// AppKind is the Kind string for App resources.
+const AppKind = "App"
+
 // AppSpec defines the desired state of App.
 type AppSpec struct {
 	// running specifies whether the VM should be running.
@@ -15,8 +18,11 @@ type AppSpec struct {
 	// Namespace is the namespace where this cluster-scoped App resource
 	// creates and manages its owned namespaced resources (e.g., rancher-desktop).
 	// Defaults to "default" if not specified.
+	// This field is immutable after creation: changing it would orphan existing
+	// owned resources (LimaVM, ConfigMaps) in the original namespace.
 	// +optional
 	// +kubebuilder:default="default"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.namespace is immutable"
 	Namespace string `json:"namespace,omitempty"`
 }
 

--- a/pkg/controllers/app/app/controller.go
+++ b/pkg/controllers/app/app/controller.go
@@ -10,9 +10,15 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/app/controllers"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 )
+
+// This is temporary and will be removed once the app controller is fully implemented.
+//
+//go:embed lima.yaml
+var limaTemplateData string
 
 func init() {
 	base.RegisterController(newController())
@@ -53,16 +59,19 @@ func (c *controller) GetCRDData() string {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
+// It registers the CRD types with the scheme and sets up the controller with the manager.
+// It also registers Lima types, which allows App controller to create and watch LimaVM resources.
 func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
-	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
+	if err := limav1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
 
-	// Create and set up the controller with the manager
 	return (&controllers.AppReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder(ControllerName + "-controller"),
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		LimaTemplateData: limaTemplateData,
 	}).SetupWithManager(mgr)
 }

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -6,31 +6,36 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 )
 
 const (
-	appName = "app"
+	appName                        = "app"
+	limaVMName, inputConfigMapName = "rd", "rd"
 
-	ConditionCreated = "Created"
-	ConditionRunning = "Running"
+	// requeueAfterDeletion is how long to wait between checks while the LimaVM
+	// controller is running its teardown (stopping the VM, removing disk files).
+	requeueAfterDeletion = 2 * time.Second
 )
 
 type AppReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
+	Scheme           *runtime.Scheme
+	LimaTemplateData string
 }
 
 // Reconcile implements a singleton app reconciliation loop.
@@ -40,21 +45,156 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 
 	var app v1alpha1.App
 	if err := r.Get(ctx, client.ObjectKey{Name: appName}, &app); err != nil {
-		if client.IgnoreNotFound(err) != nil {
+		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Unable to fetch App singleton")
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// Handle deletion, delete the LimaVM and wait for it to finish cleaning up.
 	if base.IsBeingDeleted(&app) {
 		log.Info("App resource is being deleted, performing cleanup")
+
+		namespace := app.GetResourceNamespace()
+		limaVM := &limav1alpha1.LimaVM{}
+		err := r.Get(ctx, client.ObjectKey{Name: limaVMName, Namespace: namespace}, limaVM)
+		switch {
+		case apierrors.IsNotFound(err):
+			// LimaVM is gone. Clean up any ConfigMaps that may have been left behind.
+			inputCM := &corev1.ConfigMap{}
+			if cmErr := r.Get(ctx, client.ObjectKey{Name: inputConfigMapName, Namespace: namespace}, inputCM); cmErr == nil {
+				if cmErr := r.Delete(ctx, inputCM); cmErr != nil && !apierrors.IsNotFound(cmErr) {
+					return ctrl.Result{}, fmt.Errorf("failed to delete input ConfigMap during cleanup: %w", cmErr)
+				}
+			} else if !apierrors.IsNotFound(cmErr) {
+				log.Error(cmErr, "Failed to fetch input ConfigMap during cleanup")
+			}
+			return ctrl.Result{}, base.RemoveCleanupFinalizer(ctx, r.Client, &app)
+		case err != nil:
+			return ctrl.Result{}, err
+		default:
+			if err := base.RemoveOwnedFinalizer(ctx, r.Client, limaVM, v1alpha1.AppKind); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to remove owned finalizer from LimaVM: %w", err)
+			}
+			if !base.IsBeingDeleted(limaVM) {
+				if err := r.Delete(ctx, limaVM); err != nil && !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, fmt.Errorf("failed to delete LimaVM: %w", err)
+				}
+				log.Info("Requested LimaVM deletion, waiting for teardown")
+			} else {
+				log.Info("Waiting for LimaVM deletion to complete")
+			}
+			return ctrl.Result{RequeueAfter: requeueAfterDeletion}, nil
+		}
+	}
+
+	// Make sure the App is finalized so deletion goes through cleanup.
+	if added, err := base.EnsureCleanupFinalizer(ctx, r.Client, &app); err != nil {
+		return ctrl.Result{}, err
+	} else if added {
 		return ctrl.Result{}, nil
 	}
 
-	if apimeta.IsStatusConditionTrue(app.Status.Conditions, ConditionRunning) {
-		log.Info("App is running")
-	} else {
-		r.setCondition(&app, ConditionRunning, metav1.ConditionFalse, "NotRunning", "The app is not running")
+	namespace := app.GetResourceNamespace()
+
+	// Check whether the LimaVM already exists. If not, create the input ConfigMap and LimaVM.
+	limaVM := &limav1alpha1.LimaVM{}
+	limaVMErr := r.Get(ctx, client.ObjectKey{Name: limaVMName, Namespace: namespace}, limaVM)
+	if limaVMErr != nil && !apierrors.IsNotFound(limaVMErr) {
+		return ctrl.Result{}, limaVMErr
+	}
+
+	if apierrors.IsNotFound(limaVMErr) {
+		inputCM := &corev1.ConfigMap{}
+		err := r.Get(ctx, client.ObjectKey{Name: inputConfigMapName, Namespace: namespace}, inputCM)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		if apierrors.IsNotFound(err) {
+			inputCM = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      inputConfigMapName,
+					Namespace: namespace,
+				},
+				Data: map[string]string{
+					limav1alpha1.TemplateConfigMapKey: r.LimaTemplateData,
+				},
+			}
+			if err := ctrl.SetControllerReference(&app, inputCM, r.Scheme); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to set owner reference on input ConfigMap: %w", err)
+			}
+			if err := r.Create(ctx, inputCM); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to create input ConfigMap: %w", err)
+			}
+		}
+
+		limaVM = &limav1alpha1.LimaVM{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       limaVMName,
+				Namespace:  namespace,
+				Finalizers: []string{base.OwnedFinalizerFor(v1alpha1.AppKind)},
+			},
+			Spec: limav1alpha1.LimaVMSpec{
+				TemplateRef: limav1alpha1.TemplateReference{
+					Name:      inputConfigMapName,
+					Namespace: namespace,
+				},
+				Running: app.Spec.Running,
+			},
+		}
+		if err := ctrl.SetControllerReference(&app, limaVM, r.Scheme); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to set owner reference on LimaVM: %w", err)
+		}
+		if err := r.Create(ctx, limaVM); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create LimaVM: %w", err)
+		}
+		log.Info("Created LimaVM", "name", limaVMName, "namespace", namespace)
+		return ctrl.Result{}, nil
+	}
+
+	// LimaVM exists — clean up the input ConfigMap if it still lingers from the
+	// creation phase and return to requeueing on LimaVM updates.
+	inputConfigMap := &corev1.ConfigMap{}
+	if err := r.Get(ctx, client.ObjectKey{Name: inputConfigMapName, Namespace: namespace}, inputConfigMap); err == nil {
+		if err := r.Delete(ctx, inputConfigMap); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to delete input ConfigMap: %w", err)
+		}
+		log.Info("Deleted input ConfigMap after LimaVM created its own copy")
+		// ConfigMaps are not watched (no Owns(&corev1.ConfigMap{})), so deleting
+		// one produces no watch event. Requeue explicitly to guarantee the next
+		// reconcile runs rather than relying on implicit LimaVM status activity.
+		return ctrl.Result{Requeue: true}, nil
+	} else if !apierrors.IsNotFound(err) {
+		log.Error(err, "Failed to fetch input ConfigMap")
+	}
+
+	// Propagate spec.running from App into the LimaVM.
+	if limaVM.Spec.Running != app.Spec.Running {
+		limaVM.Spec.Running = app.Spec.Running
+		if err := r.Update(ctx, limaVM); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to propagate running state to LimaVM: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Mirror LimaVM status conditions onto the App status.
+	// The priority chain above returns after every other action, so the App's
+	// resourceVersion from the initial Get is still current — no re-read needed.
+	// Truncate messages defensively: the LimaVM controller already truncates at
+	// source, but guarding here ensures a future bypass can't cause the App
+	// status update to fail CRD validation.
+	statusChanged := false
+	for _, cond := range limaVM.Status.Conditions {
+		statusChanged = apimeta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
+			Type:               cond.Type,
+			Status:             cond.Status,
+			Reason:             cond.Reason,
+			Message:            base.TruncateConditionMessage(cond.Message),
+			ObservedGeneration: app.Generation,
+			LastTransitionTime: cond.LastTransitionTime,
+		}) || statusChanged
+	}
+	if statusChanged {
 		if err := r.Status().Update(ctx, &app); err != nil {
 			log.Error(err, "Unable to update App status")
 			return ctrl.Result{}, err
@@ -64,22 +204,10 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 	return ctrl.Result{}, nil
 }
 
-// setCondition updates or adds a condition in the App status.
-func (r *AppReconciler) setCondition(app *v1alpha1.App, conditionType string, status metav1.ConditionStatus, reason, message string) {
-	changed := apimeta.SetStatusCondition(&app.Status.Conditions, metav1.Condition{
-		Type:    conditionType,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
-	})
-	if changed && r.Recorder != nil {
-		r.Recorder.Eventf(app, nil, corev1.EventTypeNormal, "ConditionChanged", conditionType, message)
-	}
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.App{}).
+		Owns(&limav1alpha1.LimaVM{}).
 		Complete(r)
 }

--- a/pkg/controllers/app/app/crd.yaml
+++ b/pkg/controllers/app/app/crd.yaml
@@ -51,7 +51,12 @@ spec:
                   Namespace is the namespace where this cluster-scoped App resource
                   creates and manages its owned namespaced resources (e.g., rancher-desktop).
                   Defaults to "default" if not specified.
+                  This field is immutable after creation: changing it would orphan existing
+                  owned resources (LimaVM, ConfigMaps) in the original namespace.
                 type: string
+                x-kubernetes-validations:
+                - message: spec.namespace is immutable
+                  rule: self == oldSelf
               running:
                 default: false
                 description: running specifies whether the VM should be running.

--- a/pkg/controllers/app/app/lima.yaml
+++ b/pkg/controllers/app/app/lima.yaml
@@ -1,0 +1,45 @@
+images:
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.2/distro.v0.1.2.amd64.qcow2
+  arch: x86_64
+  digest: "sha256:45de5c158399d5bc31e93f42d9c7fcfaf8dd3279ee157c702e9bd86bcaf9e088"
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.2/distro.v0.1.2.arm64.qcow2
+  arch: aarch64
+  digest: "sha256:39598a41ebe5c8da0baf428716a63c50598e8306e85bb85043877407eecc8991"
+cpus: 2
+memory: "6442450944"
+mounts:
+- location: "~"
+  writable: true
+ssh:
+  localPort: 51422
+  loadDotSSHPubKeys: false
+firmware:
+  legacyBIOS: false
+containerd:
+  system: false
+  user: false
+portForwards:
+- guestIPMustBeZero: true
+  guestPortRange:
+  - 1
+  - 65535
+  hostIP: 0.0.0.0
+  hostPortRange:
+  - 0
+  - 0
+- guestPortRange:
+  - 0
+  - 0
+  guestSocket: /var/run/docker.sock
+  hostPortRange:
+  - 0
+  - 0
+  hostSocket: "{{.Home}}/.rd/docker.sock"
+hostResolver:
+  hosts:
+    host.docker.internal: host.lima.internal
+    host.rancher-desktop.internal: host.lima.internal
+    lima-rancher-desktop: lima-0
+rosetta:
+  enabled: false
+  binfmt: false

--- a/pkg/controllers/base/conditions.go
+++ b/pkg/controllers/base/conditions.go
@@ -9,6 +9,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ConditionMessageMaxLen is the maximum number of runes allowed in a Kubernetes
+// condition message. CRD validation enforces a 32768-character limit on this
+// field; keeping messages within this bound avoids rejections from operations
+// that produce very long error strings (e.g. accumulated retry errors from
+// image downloads).
+const ConditionMessageMaxLen = 32768
+
+// TruncateConditionMessage ensures a condition message fits within
+// ConditionMessageMaxLen runes. If the message is longer it is cut and a
+// "… (truncated)" suffix is appended so observers know it is incomplete.
+func TruncateConditionMessage(msg string) string {
+	runes := []rune(msg)
+	if len(runes) <= ConditionMessageMaxLen {
+		return msg
+	}
+	const suffix = "… (truncated)"
+	return string(runes[:ConditionMessageMaxLen-len([]rune(suffix))]) + suffix
+}
+
 // HasConditionWithReason reports whether conditions contains a condition
 // of the given type with the given status and reason.
 func HasConditionWithReason(conditions []metav1.Condition, conditionType string, status metav1.ConditionStatus, reason string) bool {

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -44,6 +44,11 @@ const (
 	// limaVMDefaulterConfigName is the name of the LimaVM MutatingWebhookConfiguration.
 	limaVMDefaulterConfigName = "limavm-defaulter"
 
+	// limaVMValidatorWebhookName is the name used for the LimaVM validating webhook.
+	limaVMValidatorWebhookName = "limavm-validator.lima.rancherdesktop.io"
+	// limaVMValidatorConfigName is the name of the LimaVM ValidatingWebhookConfiguration.
+	limaVMValidatorConfigName = "limavm-validator"
+
 	// configMapValidatorWebhookName is the name used for the ConfigMap validation webhook.
 	configMapValidatorWebhookName = "limavm-configmap-validator.lima.rancherdesktop.io"
 	// configMapValidatorConfigName is the name of the ConfigMap ValidatingWebhookConfiguration.
@@ -121,6 +126,26 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 	}
 
 	managers, err := base.SetupWebhookForResource(mgr, &v1alpha1.LimaVM{}, mutatingConfig)
+	if err != nil {
+		return err
+	}
+	c.webhookManagers = append(c.webhookManagers, managers...)
+
+	// Set up LimaVM validating webhook to reject DELETE while an owned finalizer is
+	// present. Without this, a direct `rdd ctl delete limavm rd` is accepted by the
+	// API server; the LimaVM controller removes its cleanup finalizer but never
+	// removes the owned-by-App finalizer, leaving the LimaVM stuck in Terminating.
+	validatingConfig := base.WebhookConfig[*v1alpha1.LimaVM]{
+		Name:        limaVMValidatorConfigName,
+		WebhookName: limaVMValidatorWebhookName,
+		WebhookPort: c.webhookPort,
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Delete,
+		},
+		Validator: &base.OwnedDeletionGuard[*v1alpha1.LimaVM]{},
+	}
+
+	managers, err = base.SetupWebhookForResource(mgr, &v1alpha1.LimaVM{}, validatingConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -429,7 +429,7 @@ func (r *LimaVMReconciler) setCondition(limaVM *v1alpha1.LimaVM, conditionType s
 		Type:    conditionType,
 		Status:  status,
 		Reason:  reason,
-		Message: message,
+		Message: base.TruncateConditionMessage(message),
 	})
 	if changed && r.Recorder != nil {
 		r.Recorder.Eventf(limaVM, nil, corev1.EventTypeNormal, "ConditionChanged", conditionType, message)


### PR DESCRIPTION
Introduce the core reconciliation loop for the App controller singleton. The controller creates and manages the LimaVM instance from the temporary embedded template, propagates `spec.running`, mirrors VM status conditions onto the App resource, and watches the owned LimaVM for status updates.

Deletion is handled by a finalizer to ensure owned resources are cleaned up. The input template ConfigMap is created only for bootstrapping and then removed after the LimaVM webhook uses the managed template.

Addresses: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/227