### PR TITLE
Split RDD finalizer into /cleanup and /owned

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-lifecycle.bats
+++ b/bats/tests/33-lima-controllers/limavm-lifecycle.bats
@@ -72,9 +72,9 @@ EOF
     assert_output "true"
 }
 
-@test "verify template ConfigMap has protection finalizer" {
+@test "verify template ConfigMap has owned finalizer" {
     run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.metadata.finalizers}'
-    assert_output --partial "rdd.rancherdesktop.io/cleanup"
+    assert_output --partial "rdd.rancherdesktop.io/owned"
 }
 
 @test "verify template ConfigMap has owner reference" {

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -49,7 +49,7 @@ The `--instance` flag takes precedence over the `RDD_INSTANCE` environment varia
 
 ### API Groups / Controllers
 
-RDD includes controllers for multiple API groups. Each group can be separately versioned, updated, disabled, etc.
+RDD includes controllers for multiple API groups. Each group can be separately versioned, updated, disabled, etc. The [controller framework](controllers.md) documents the shared base infrastructure all groups use: registration, finalizers, owned-resource cleanup, and webhook helpers.
 
 #### `rdd.rancherdesktop.io`
 

--- a/docs/design/controllers.md
+++ b/docs/design/controllers.md
@@ -1,0 +1,109 @@
+# Controller Framework
+
+The `pkg/controllers/base` package provides shared utilities for RDD controllers: registration, finalizers, owned-resource cleanup, and webhook helpers.
+
+## Controller Registration
+
+See also [controller manager discovery](discovery.md) for how multiple controller managers find each other at runtime.
+
+Each controller implements `base.Controller` and registers itself via `init()`:
+
+```go
+func init() {
+    base.RegisterController(&controller{})
+}
+```
+
+`base.SharedControllerManager` discovers and starts all registered controllers.
+
+## Finalizers
+
+RDD uses two finalizers. Each serves a distinct purpose:
+
+### `rdd.rancherdesktop.io/cleanup` (Self-Protection)
+
+A resource's own controller sets this finalizer to run cleanup before deletion. For example, the LimaVM controller stops the VM and deletes disk files before removing the finalizer.
+
+| Function | Purpose |
+|----------|---------|
+| `EnsureCleanupFinalizer` | Add cleanup finalizer to the resource |
+| `RemoveCleanupFinalizer` | Remove cleanup finalizer after cleanup completes |
+| `HasCleanupFinalizer` | Check whether the cleanup finalizer is present |
+
+`DeleteOwnedResources` does **not** strip this finalizer. Only the resource's own controller removes it.
+
+### `rdd.rancherdesktop.io/owned` (Cascade Blocking)
+
+An owner controller sets this on child resources to block their deletion until the owner explicitly releases them via `DeleteOwnedResources`.
+
+| Function | Purpose |
+|----------|---------|
+| `EnsureOwnedFinalizer` | Add owned finalizer to a child resource |
+| `RemoveOwnedFinalizer` | Remove owned finalizer from a child resource |
+| `HasOwnedFinalizer` | Check whether the owned finalizer is present |
+
+### Why Two Finalizers?
+
+A resource can need both finalizers. Consider a LimaVM owned by the App controller. The App controller sets `/owned` on the LimaVM so `DeleteOwnedResources` can release it during App deletion. The LimaVM controller sets `/cleanup` on itself to stop the VM and delete disk files before the resource disappears. With a single finalizer, `DeleteOwnedResources` would strip it, and the LimaVM would be deleted without ever running its cleanup — leaking the VM on disk.
+
+## DeleteOwnedResources
+
+`DeleteOwnedResources` finds all resources owned by a given object (via owner references), strips their `/owned` finalizer, and deletes them. It uses dynamic resource discovery to find all namespaced resource types without a hardcoded list.
+
+For cluster-scoped owners, the resource must implement `ResourceNamespace` to specify which namespace contains its children.
+
+## Owner References
+
+RDD uses standard Kubernetes owner references (`metav1.OwnerReference`) to track parent-child relationships. `DeleteOwnedResources` checks `ownerReferences[].uid` to identify children. Controllers typically set owner references via `controllerutil.SetControllerReference`.
+
+## Webhooks
+
+Controllers that need admission webhooks implement the `base.WebhookController` interface:
+
+```go
+type WebhookController interface {
+    SetWebhookPort(port int)
+    GetWebhookServiceName() string
+    GetWebhookManagers() []WebhookManager
+}
+```
+
+`SharedControllerManager` calls `SetWebhookPort` with an allocated port before registration. The controller stores this port and uses it when building its `WebhookConfig`.
+
+### WebhookConfig
+
+`WebhookConfig[T]` describes a single webhook. Provide a `Validator`, a `Defaulter`, or both:
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `Name` | — | Kubernetes resource name for the webhook configuration |
+| `WebhookName` | — | Hook name within the configuration (FQDN convention) |
+| `WebhookPort` | — | Port from `SetWebhookPort` |
+| `Operations` | Create, Update | Which admission operations trigger the webhook |
+| `FailurePolicy` | Fail | How the API server handles webhook failures |
+| `SideEffects` | None | Whether the webhook has side effects |
+| `ObjectSelector` | nil | Label selector to filter which objects reach the webhook |
+| `Validator` | nil | Validating admission handler |
+| `Defaulter` | nil | Mutating admission handler |
+
+### Setup Flow
+
+Registration happens in two phases:
+
+1. **During `RegisterWithManager`**, the controller calls `SetupWebhookForResource` for each webhook. This registers handlers with controller-runtime and returns `WebhookManager` instances (one per webhook type — validating and/or mutating). The controller appends these to an internal slice that `GetWebhookManagers()` exposes.
+
+2. **After registration**, `SharedControllerManager` calls `Setup()` on each `WebhookManager` in parallel. This creates the actual `ValidatingWebhookConfiguration` or `MutatingWebhookConfiguration` resources in the API server, with retry logic for transient failures.
+
+### Certificate Management
+
+`SharedWebhookCertificateManager` generates self-signed certificates for webhook TLS:
+
+- **CA certificate** (10-year validity) is persisted and reused across restarts.
+- **Server certificate** (1-year validity) is regenerated on each startup. DNS SANs cover all service name variations (e.g., `limavm-webhook`, `limavm-webhook.default`, `limavm-webhook.default.svc.cluster.local`).
+- Certificates regenerate automatically when a new controller adds service names or when the server cert has fewer than 30 days remaining.
+
+The CA bundle is injected into each webhook configuration so the API server can verify the webhook's TLS certificate.
+
+### Helpers
+
+- `base.IsDryRun(ctx)` extracts the admission request from context and returns true if the request is a dry run. Controllers use this to skip side effects (e.g., creating child resources) during dry-run admission.

--- a/docs/design/discovery.md
+++ b/docs/design/discovery.md
@@ -1,5 +1,7 @@
 # Controller Manager Discovery
 
+See also the [controller framework](controllers.md) for base controller utilities (registration, finalizers, owned-resource cleanup).
+
 Controller managers register themselves in a shared ConfigMap so that other components can find them. The control plane uses this to determine which controllers are running, to route passthrough requests, and to detect when an external controller manager has gone away.
 
 ## ConfigMap

--- a/pkg/controllers/base/finalizer.go
+++ b/pkg/controllers/base/finalizer.go
@@ -22,31 +22,56 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// FinalizerName is the shared finalizer name used by all RDD controllers for deletion protection.
-// This finalizer blocks resource deletion until cleanup work is complete.
-// Owner references indicate which resources need cleanup; the finalizer ensures cleanup happens
-// before deletion proceeds. This acts as RDD's replacement for Kubernetes garbage collection.
-const FinalizerName = "rdd.rancherdesktop.io/cleanup"
+// CleanupFinalizerName is the self-protection finalizer. A resource's own controller sets it
+// to ensure cleanup runs before deletion (e.g., LimaVM stops the VM and deletes disk files).
+// DeleteOwnedResources does NOT strip this finalizer.
+const CleanupFinalizerName = "rdd.rancherdesktop.io/cleanup"
 
-// EnsureFinalizer adds the finalizer to the object if it's not already present.
+// OwnedFinalizerName is the cascade-blocking finalizer. An owner controller sets it on
+// child resources so that DeleteOwnedResources can strip it to unblock deletion.
+const OwnedFinalizerName = "rdd.rancherdesktop.io/owned"
+
+// EnsureCleanupFinalizer adds the cleanup finalizer to the object if not already present.
 // Returns true if the finalizer was added and the object has been updated.
 // When true is returned, controllers should return immediately to allow re-reconciliation
 // with the updated object (avoids stale resourceVersion conflicts).
-func EnsureFinalizer(ctx context.Context, c client.Client, obj client.Object) (bool, error) {
-	if !controllerutil.AddFinalizer(obj, FinalizerName) {
+func EnsureCleanupFinalizer(ctx context.Context, c client.Client, obj client.Object) (bool, error) {
+	if !controllerutil.AddFinalizer(obj, CleanupFinalizerName) {
 		return false, nil
 	}
 	if err := c.Update(ctx, obj); err != nil {
-		return false, fmt.Errorf("failed to add finalizer: %w", err)
+		return false, fmt.Errorf("failed to add cleanup finalizer: %w", err)
 	}
 	return true, nil
 }
 
-// RemoveFinalizer removes the finalizer from the object and updates it.
-func RemoveFinalizer(ctx context.Context, c client.Client, obj client.Object) error {
-	if controllerutil.RemoveFinalizer(obj, FinalizerName) {
+// RemoveCleanupFinalizer removes the cleanup finalizer from the object and updates it.
+func RemoveCleanupFinalizer(ctx context.Context, c client.Client, obj client.Object) error {
+	if controllerutil.RemoveFinalizer(obj, CleanupFinalizerName) {
 		if err := c.Update(ctx, obj); err != nil {
-			return fmt.Errorf("failed to remove finalizer: %w", err)
+			return fmt.Errorf("failed to remove cleanup finalizer: %w", err)
+		}
+	}
+	return nil
+}
+
+// EnsureOwnedFinalizer adds the owned finalizer to a child object if not already present.
+// Returns true if the finalizer was added and the object has been updated.
+func EnsureOwnedFinalizer(ctx context.Context, c client.Client, obj client.Object) (bool, error) {
+	if !controllerutil.AddFinalizer(obj, OwnedFinalizerName) {
+		return false, nil
+	}
+	if err := c.Update(ctx, obj); err != nil {
+		return false, fmt.Errorf("failed to add owned finalizer: %w", err)
+	}
+	return true, nil
+}
+
+// RemoveOwnedFinalizer removes the owned finalizer from the object and updates it.
+func RemoveOwnedFinalizer(ctx context.Context, c client.Client, obj client.Object) error {
+	if controllerutil.RemoveFinalizer(obj, OwnedFinalizerName) {
+		if err := c.Update(ctx, obj); err != nil {
+			return fmt.Errorf("failed to remove owned finalizer: %w", err)
 		}
 	}
 	return nil
@@ -131,9 +156,10 @@ func DeleteOwnedResources(ctx context.Context, c client.Client, owner client.Obj
 				continue
 			}
 
-			// Remove only the RDD finalizer before deletion to allow other controllers to still perform their own cleanup.
+			// Strip the owned finalizer to unblock deletion. The cleanup finalizer (if any)
+			// remains so the child's own controller can still run its cleanup logic.
 			patch := client.MergeFrom(item.DeepCopy())
-			if controllerutil.RemoveFinalizer(&item, FinalizerName) {
+			if controllerutil.RemoveFinalizer(&item, OwnedFinalizerName) {
 				// Use Patch instead of Update for PartialObjectMetadata
 				if err := c.Patch(ctx, &item, patch); err != nil {
 					itemLogger := logger.V(1).WithValues("namespace", item.GetNamespace(), "name", item.GetName(), "gvk", gvk.String())
@@ -211,9 +237,14 @@ func DiscoverNamespacedResources(ctx context.Context, mgr ctrl.Manager) ([]schem
 	return resourceTypes, nil
 }
 
-// HasFinalizer checks if a resource has the RDD finalizer.
-func HasFinalizer(obj client.Object) bool {
-	return controllerutil.ContainsFinalizer(obj, FinalizerName)
+// HasCleanupFinalizer checks if a resource has the cleanup finalizer.
+func HasCleanupFinalizer(obj client.Object) bool {
+	return controllerutil.ContainsFinalizer(obj, CleanupFinalizerName)
+}
+
+// HasOwnedFinalizer checks if a resource has the owned finalizer.
+func HasOwnedFinalizer(obj client.Object) bool {
+	return controllerutil.ContainsFinalizer(obj, OwnedFinalizerName)
 }
 
 // IsOwnedByUID checks if a resource is owned by an owner with the given UID.

--- a/pkg/controllers/base/finalizer_test.go
+++ b/pkg/controllers/base/finalizer_test.go
@@ -58,13 +58,24 @@ func TestDeleteOwnedResources(t *testing.T) {
 	testCases := []struct {
 		name       string
 		finalizers []string
+		// expectDeleted is true when the owned resource should be fully deleted
+		// (NotFound) after DeleteOwnedResources. When false, the resource still
+		// exists because a remaining finalizer blocks deletion.
+		expectDeleted bool
 	}{
 		{
-			name: "config map without finalizers",
+			name:          "config map without finalizers",
+			expectDeleted: true,
 		},
 		{
-			name:       "config map with finalizer",
-			finalizers: []string{FinalizerName},
+			name:          "config map with owned finalizer only",
+			finalizers:    []string{OwnedFinalizerName},
+			expectDeleted: true,
+		},
+		{
+			name:          "config map with both finalizers strips only owned",
+			finalizers:    []string{CleanupFinalizerName, OwnedFinalizerName},
+			expectDeleted: false,
 		},
 	}
 
@@ -116,7 +127,7 @@ func TestDeleteOwnedResources(t *testing.T) {
 			}})
 			assert.NilError(t, c.Update(t.Context(), unrelated), "failed to update unrelated config map")
 
-			// Delete owned sources
+			// Delete owned resources
 			err = DeleteOwnedResources(
 				t.Context(),
 				c,
@@ -124,9 +135,16 @@ func TestDeleteOwnedResources(t *testing.T) {
 				mgr)
 			assert.NilError(t, err, "failed to delete owned resources")
 
-			// Check that only the owned config map was deleted
 			err = c.Get(t.Context(), client.ObjectKeyFromObject(owned), owned)
-			assert.Check(t, apierrors.IsNotFound(err), "owned config map was not deleted: %s", err)
+			if tc.expectDeleted {
+				assert.Check(t, apierrors.IsNotFound(err), "owned config map was not deleted: %s", err)
+			} else {
+				// Resource still exists because cleanup finalizer blocks deletion
+				assert.NilError(t, err, "failed to get owned config map")
+				assert.Check(t, !owned.GetDeletionTimestamp().IsZero(), "owned config map should be marked for deletion")
+				assert.Check(t, HasCleanupFinalizer(owned), "cleanup finalizer should remain")
+				assert.Check(t, !HasOwnedFinalizer(owned), "owned finalizer should be stripped")
+			}
 			err = c.Get(t.Context(), client.ObjectKeyFromObject(owner), owner)
 			assert.Check(t, cmp.ErrorIs(err, nil), "failed to get owner object")
 			err = c.Get(t.Context(), client.ObjectKeyFromObject(unrelated), unrelated)

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -185,7 +185,7 @@ var _ ctrlwebhookadmission.Defaulter[*v1alpha1.LimaVM] = &defaulter{}
 
 // Default is called during CREATE operations to add finalizer and create the template ConfigMap.
 func (d *defaulter) Default(ctx context.Context, limavm *v1alpha1.LimaVM) error {
-	controllerutil.AddFinalizer(limavm, base.FinalizerName)
+	controllerutil.AddFinalizer(limavm, base.CleanupFinalizerName)
 
 	// Validate name uniqueness BEFORE creating ConfigMap
 	// This prevents orphaned ConfigMaps when validation fails
@@ -208,7 +208,7 @@ func (d *defaulter) Default(ctx context.Context, limavm *v1alpha1.LimaVM) error 
 				controllers.TemplateConfigMapLabel: "true",
 			},
 			Finalizers: []string{
-				base.FinalizerName,
+				base.OwnedFinalizerName,
 			},
 		},
 		Data: map[string]string{
@@ -273,7 +273,7 @@ func (v *ConfigMapValidator) ValidateDelete(ctx context.Context, configMap *core
 	if base.IsDryRun(ctx) {
 		klog.V(1).Infof("[DryRun] Webhook validating ConfigMap deletion %s/%s\n", configMap.Namespace, configMap.Name)
 	}
-	if base.HasFinalizer(configMap) {
+	if base.HasOwnedFinalizer(configMap) {
 		return nil, fmt.Errorf("cannot delete template ConfigMap %q: it is protected by the LimaVM controller; delete the owning LimaVM resource instead", configMap.Name)
 	}
 	return nil, nil

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -68,7 +68,7 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 	}
 
 	// Remove finalizer
-	if err := base.RemoveFinalizer(ctx, r.Client, limaVM); err != nil {
+	if err := base.RemoveCleanupFinalizer(ctx, r.Client, limaVM); err != nil {
 		logger.Error(err, "Failed to remove finalizer")
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/rdd/configmapreplicaset/controllers/configmapreplicaset_controller.go
+++ b/pkg/controllers/rdd/configmapreplicaset/controllers/configmapreplicaset_controller.go
@@ -72,7 +72,7 @@ func (r *ConfigMapReplicaSetReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	// Add finalizer if not present
-	if added, err := base.EnsureFinalizer(ctx, r.Client, &configMapReplicaSet); err != nil {
+	if added, err := base.EnsureCleanupFinalizer(ctx, r.Client, &configMapReplicaSet); err != nil {
 		logger.Error(err, "Failed to add finalizer")
 		return ctrl.Result{}, err
 	} else if added {
@@ -160,7 +160,7 @@ func (r *ConfigMapReplicaSetReconciler) handleDeletion(ctx context.Context, conf
 	}
 
 	// Remove finalizer to allow deletion
-	if err := base.RemoveFinalizer(ctx, r.Client, configMapReplicaSet); err != nil {
+	if err := base.RemoveCleanupFinalizer(ctx, r.Client, configMapReplicaSet); err != nil {
 		logger.Error(err, "Failed to remove finalizer")
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/rdd/notary/controllers/notary_controller.go
+++ b/pkg/controllers/rdd/notary/controllers/notary_controller.go
@@ -66,7 +66,7 @@ func (r *NotaryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// Add finalizer if not present
-	if added, err := base.EnsureFinalizer(ctx, r.Client, &notary); err != nil {
+	if added, err := base.EnsureCleanupFinalizer(ctx, r.Client, &notary); err != nil {
 		log.Error(err, "Failed to add finalizer")
 		return ctrl.Result{}, err
 	} else if added {
@@ -122,7 +122,7 @@ func (r *NotaryReconciler) handleDeletion(ctx context.Context, notary *v1alpha1.
 	}
 
 	// Remove finalizer to allow deletion
-	if err := base.RemoveFinalizer(ctx, r.Client, notary); err != nil {
+	if err := base.RemoveCleanupFinalizer(ctx, r.Client, notary); err != nil {
 		log.Error(err, "Failed to remove finalizer")
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
A single finalizer served two purposes: self-protection (controller cleanup before deletion) and cascade blocking (preventing deletion until the owner strips it). When a resource served both roles, `DeleteOwnedResources` stripped the only finalizer and bypassed the resource's own controller cleanup.

Split into `CleanupFinalizerName` (`/cleanup`) for self-protection and `OwnedFinalizerName` (`/owned`) for cascade blocking. `DeleteOwnedResources` now strips only `/owned`, leaving `/cleanup` intact.