### PR TITLE
Run Lima BATS tests on Windows via MSYS2

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -6,5 +6,6 @@ routable #https://en.wiktionary.org/wiki/routable#English
 standalone #https://en.wiktionary.org/wiki/standalone#English
 startable #https://en.wiktionary.org/wiki/startable
 unmarshal #https://en.wiktionary.org/wiki/unmarshal#English
+wslservice
 versioned #https://en.wiktionary.org/wiki/versioned#English
 whitespaces #https://en.wiktionary.org/wiki/whitespaces#English

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,17 +1,9 @@
 cooldown #https://en.wiktionary.org/wiki/cooldown#English
-keypair
-msystem
-nohup
-taskkill
-ucrt
 passthrough #https://en.wiktionary.org/wiki/passthrough
 passthroughs #https://en.wiktionary.org/wiki/passthrough
-pgid
-rootfs #https://en.wiktionary.org/wiki/rootfs
 routable #https://en.wiktionary.org/wiki/routable#English
 standalone #https://en.wiktionary.org/wiki/standalone#English
 startable #https://en.wiktionary.org/wiki/startable
 unmarshal #https://en.wiktionary.org/wiki/unmarshal#English
 versioned #https://en.wiktionary.org/wiki/versioned#English
 whitespaces #https://en.wiktionary.org/wiki/whitespaces#English
-wslservice

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,4 +1,5 @@
 cooldown #https://en.wiktionary.org/wiki/cooldown#English
+keypair
 nohup
 taskkill
 passthrough #https://en.wiktionary.org/wiki/passthrough

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,6 +1,7 @@
 cooldown #https://en.wiktionary.org/wiki/cooldown#English
 passthrough #https://en.wiktionary.org/wiki/passthrough
 passthroughs #https://en.wiktionary.org/wiki/passthrough
+pgid
 routable #https://en.wiktionary.org/wiki/routable#English
 standalone #https://en.wiktionary.org/wiki/standalone#English
 startable #https://en.wiktionary.org/wiki/startable

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,4 +1,6 @@
 cooldown #https://en.wiktionary.org/wiki/cooldown#English
+nohup
+taskkill
 passthrough #https://en.wiktionary.org/wiki/passthrough
 passthroughs #https://en.wiktionary.org/wiki/passthrough
 pgid
@@ -6,6 +8,6 @@ routable #https://en.wiktionary.org/wiki/routable#English
 standalone #https://en.wiktionary.org/wiki/standalone#English
 startable #https://en.wiktionary.org/wiki/startable
 unmarshal #https://en.wiktionary.org/wiki/unmarshal#English
-wslservice
 versioned #https://en.wiktionary.org/wiki/versioned#English
 whitespaces #https://en.wiktionary.org/wiki/whitespaces#English
+wslservice

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,10 +1,13 @@
 cooldown #https://en.wiktionary.org/wiki/cooldown#English
 keypair
+msystem
 nohup
 taskkill
+ucrt
 passthrough #https://en.wiktionary.org/wiki/passthrough
 passthroughs #https://en.wiktionary.org/wiki/passthrough
 pgid
+rootfs #https://en.wiktionary.org/wiki/rootfs
 routable #https://en.wiktionary.org/wiki/routable#English
 standalone #https://en.wiktionary.org/wiki/standalone#English
 startable #https://en.wiktionary.org/wiki/startable

--- a/.github/actions/spelling/expect/tech.txt
+++ b/.github/actions/spelling/expect/tech.txt
@@ -1,12 +1,13 @@
 # Generic technical terms
 backgrounding
-cooloff
 backquotes
+cooloff
 crt
 filewatcher
 FQDNs
 gui
 hyperlinks
+keypair
 lte
 NONINFRINGEMENT
 OIDC
@@ -32,8 +33,10 @@ kvm
 # out of memory
 OOM
 opensuse
+pgid
 pids
 qcow
+rootfs
 tarball
 veth
 zst
@@ -46,12 +49,16 @@ ERRORLEVEL
 LOCALAPPDATA
 mnt
 msys
-PROGRAMFILES
+MSYSTEM
 netsh
+PROGRAMFILES
 pwsh
 SYSTEMROOT
+taskkill
+UCRT
 usebackq
 winver
 wsl
 WSLENV
 wslpath
+wslservice

--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -14,6 +14,7 @@ mkfifo
 mktemp
 moby
 netcat
+nohup
 nproc
 openssh
 pacman

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -108,7 +108,7 @@ jobs:
         # openssh is required because Lima constructs SSH paths using cygpath
         # (/c/Users/...) which only MSYS2's ssh understands; Windows OpenSSH
         # needs native paths and fails with "No such file or directory".
-        C:\msys64\usr\bin\pacman.exe --noconfirm -S gzip jq make openbsd-netcat openssh
+        C:\msys64\usr\bin\pacman.exe --noconfirm --sync gzip jq make openbsd-netcat openssh
 
         # Set up MSYS2 wrapper script
         New-Item -ItemType Directory -Name bin -Force

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -57,14 +57,14 @@ jobs:
         if test $(cat /proc/sys/net/ipv4/ip_unprivileged_port_start) -gt 80; then
           sudo sh -c 'echo 80 > /proc/sys/net/ipv4/ip_unprivileged_port_start'
         fi
-        
+
         # Install QEMU for Lima VM operations
         sudo apt-get update
         sudo apt-get install --yes qemu-system-x86 qemu-utils
 
-        # Set up run-in-wsl helper script (as a symlink to bash)
+        # Set up run-in-shell helper script (as a symlink to bash)
         mkdir -p bin
-        ln -s $(which bash) bin/run-in-wsl
+        ln -s $(which bash) bin/run-in-shell
         readlink -f bin >> "$GITHUB_PATH"
 
         # Install a newer version of jq
@@ -77,9 +77,9 @@ jobs:
       run: |
         brew install bash coreutils make
 
-        # Set up run-in-wsl helper script (as a symlink to bash)
+        # Set up run-in-shell helper script (as a symlink to bash)
         mkdir -p bin
-        ln -s $(brew --prefix bash)/bin/bash bin/run-in-wsl
+        ln -s $(brew --prefix bash)/bin/bash bin/run-in-shell
         readlink -f bin >> "$GITHUB_PATH"
 
         # Use GNU make
@@ -100,43 +100,36 @@ jobs:
         # Setting the default version also lets WSL finish updating.
         wsl --set-default-version 2
 
-        # Install WSL2 Distribution
+        # Install a WSL2 distro. Lima's WSL2 driver requires at least one
+        # installed distribution, even though Lima creates its own distros.
         wsl --install --no-launch --version 2 --name openSUSE openSUSE-Leap-16.0
-        # Disable first-boot script
-        wsl --distribution openSUSE --exec sed -i '/^command =/d' /etc/wsl-distribution.conf
 
-        # Make sure WSL interop is enabled
-        wsl --distribution openSUSE --exec sh -c 'echo ":WSLInterop-custom:M::MZ::/init:PF" | tee /etc/binfmt.d/zzz-WSLInterop-custom.conf' # spellchecker:ignore
-        wsl --shutdown
+        # Install MSYS2 packages for BATS.
+        # openssh is required because Lima constructs SSH paths using cygpath
+        # (/c/Users/...) which only MSYS2's ssh understands; Windows OpenSSH
+        # needs native paths and fails with "No such file or directory".
+        C:\msys64\usr\bin\pacman.exe --noconfirm -S gzip jq make openbsd-netcat openssh
 
-        # Set up wrapper script PATH
+        # Set up MSYS2 wrapper script
         New-Item -ItemType Directory -Name bin -Force
-        Get-ItemPropertyValue -Path bin -Name FullName | Out-File -Encoding UTF8 -Append "$env:GITHUB_PATH"
+        Get-ItemPropertyValue -Path bin -Name FullName |
+          Out-File -Encoding UTF8 -Append "$env:GITHUB_PATH"
 
         # Set up git configuration
         git config --global --replace-all core.autocrlf false # spellchecker:ignore
         git config --global --replace-all core.eol lf # spellchecker:ignore
         git config --global --replace-all core.longpath true #spellchecker:ignore
 
-    - name: "Windows: write wrapper script"
-      # This is a separate step so that we can just set up the script as an
-      # inline YAML block.
+    - name: "Windows: write MSYS2 wrapper script"
       if: runner.os == 'Windows'
-      shell: cmd /c copy {0} run-in-wsl.cmd
+      shell: cmd /c copy {0} run-in-shell.cmd
       working-directory: ${{ runner.temp }}/bin
       run: |
-        IF NOT DEFINED DISTRO SET DISTRO=openSUSE
-        FOR /F "usebackq tokens=*" %%L IN (`wsl --distribution %DISTRO% --exec wslpath -ua %1`) DO (
-          wsl --distribution %DISTRO% --exec /bin/bash -c "tr -d '\r' < %%L | /bin/bash -e"
-          EXIT %%ERRORLEVEL%%
-        )
-
-    - name: "Windows: Install prerequisites in WSL"
-      if: runner.os == 'Windows'
-      shell: run-in-wsl {0}
-      run: >-
-        zypper --non-interactive install
-        gzip jq make netcat-openbsd
+        SET MSYSTEM=UCRT64
+        SET CHERE_INVOKING=1
+        SET MSYS2_PATH_TYPE=inherit
+        C:\msys64\usr\bin\bash.exe --login -e %1
+        EXIT %ERRORLEVEL%
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -146,28 +139,23 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: "Windows: WSL interop debugging"
+    - name: "Windows: WSL debugging"
       if: runner.os == 'Windows'
-      shell: run-in-wsl {0}
+      shell: pwsh
       run: |
-        set +e
-        ls -l /proc/sys/fs/binfmt_misc
-        for i in /proc/sys/fs/binfmt_misc/*; do
-          echo "$i"
-          cat "$i" || true
-        done
-        systemctl status systemd-binfmt.service || true
+        wsl --list --verbose
+        wsl --status
       continue-on-error: true
 
     - run: make -C bats --keep-going --jobs=$(nproc) --output-sync=target
-      shell: run-in-wsl {0}
+      shell: run-in-shell {0}
       env:
         RDD_TRACE: true
         RDD_LOG_LEVEL: trace
 
     - name: Collect RDD logs
       if: always()
-      shell: run-in-wsl {0}
+      shell: run-in-shell {0}
       run: scripts/collect-bats-logs.sh rdd-logs
 
     - name: Upload RDD service logs

--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -43,6 +43,7 @@ source "${PATH_BATS_ROOT}/lib/bats-assert/load.bash"
 source "${PATH_BATS_ROOT}/lib/bats-file/load.bash"
 
 source "${PATH_BATS_HELPERS}/os.bash"
+source "${PATH_BATS_HELPERS}/vm_template.bash"
 source "${PATH_BATS_HELPERS}/utils.bash"
 source "${PATH_BATS_HELPERS}/controller.bash"
 source "${PATH_BATS_HELPERS}/instance.bash"

--- a/bats/helpers/os.bash
+++ b/bats/helpers/os.bash
@@ -92,3 +92,26 @@ sudo_needs_password() {
     run sudo --non-interactive --reset-timestamp true
     ((status != 0))
 }
+
+# Cross-platform process management.
+# MSYS2's kill cannot reach Win32 processes, so use taskkill.exe on Windows.
+
+# Check if a process is alive. Returns 0 if alive, non-zero otherwise.
+assert_process_alive() {
+    local pid=$1
+    if is_windows; then
+        MSYS_NO_PATHCONV=1 tasklist.exe /FI "PID eq ${pid}" /NH 2>/dev/null | grep -qw "${pid}"
+    else
+        kill -0 "${pid}" 2>/dev/null
+    fi
+}
+
+# Send SIGKILL (or TerminateProcess on Windows) to a process.
+process_kill() {
+    local pid=$1
+    if is_windows; then
+        MSYS_NO_PATHCONV=1 taskkill.exe /PID "${pid}" /F >/dev/null 2>&1
+    else
+        kill -9 "${pid}"
+    fi
+}

--- a/bats/helpers/utils.bash
+++ b/bats/helpers/utils.bash
@@ -387,10 +387,11 @@ EOF
 # directories.
 create_file() {
     local dest=$1
-    # On Windows, avoid creating files from within WSL; this leads to issues
-    # where the WSL view of the filesystem is desynchronized from the Windows
-    # view, so we end up having ghost files that can't be deleted from Windows.
-    if ! is_windows; then
+    # On WSL, avoid creating files from within the Linux side; this leads to
+    # issues where the WSL view of the filesystem is desynchronized from the
+    # Windows view, so we end up having ghost files that can't be deleted from
+    # Windows. MSYS2 writes directly to the Windows filesystem, so it's safe.
+    if ! is_windows || is_msys; then
         mkdir -p "$(dirname "${dest}")"
         cat >"${dest}"
         return
@@ -404,8 +405,12 @@ create_file() {
     winParent="$(wslpath -w "$(dirname "${dest}")")"
     winDest="$(wslpath -w "${dest}")"
     PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "New-Item -ItemType Directory -ErrorAction SilentlyContinue '${winParent}'" || true
-    local command="[IO.File]::WriteAllBytes('${winDest}', \$([System.Convert]::FromBase64String('${contents}')))"
-    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "${command}"
+    if [[ -z "${contents}" ]]; then
+        PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "New-Item -ItemType File -Force '${winDest}'"
+    else
+        local command="[IO.File]::WriteAllBytes('${winDest}', \$([System.Convert]::FromBase64String('${contents}')))"
+        PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "${command}"
+    fi
 }
 
 # unique_filename /tmp/image .png

--- a/bats/helpers/vm_template.bash
+++ b/bats/helpers/vm_template.bash
@@ -5,21 +5,12 @@
 #   - "opensuse":           rancher-desktop-opensuse (the target distro for RD2)
 #
 # Usage in test files:
-#   VM_TEMPLATE=$(vm_template)         # for limavm-instance tests
-#   VM_TEMPLATE=$(vm_template_running) # for limavm-running tests
-# Both support RDD_VM_TYPE on Unix (expands to vmType: <value> when set).
+#   VM_TEMPLATE=$(vm_template)
+# Supports RDD_VM_TYPE on Unix (expands to vmType: <value> when set).
 
 : "${RDD_WSL_DISTRO:=finch}"
 
 vm_template() {
-    if is_windows; then
-        _wsl2_template
-    else
-        _unix_template
-    fi
-}
-
-vm_template_running() {
     if is_windows; then
         _wsl2_template
     else

--- a/bats/helpers/vm_template.bash
+++ b/bats/helpers/vm_template.bash
@@ -6,7 +6,7 @@
 #
 # Usage in test files:
 #   VM_TEMPLATE=$(vm_template)         # for limavm-instance tests
-#   VM_TEMPLATE=$(vm_template_running) # for limavm-running tests (supports RDD_VM_TYPE)
+#   VM_TEMPLATE=$(vm_template_running) # for limavm-running tests (supports RDD_VM_TYPE on Unix)
 
 : "${RDD_WSL_DISTRO:=finch}"
 

--- a/bats/helpers/vm_template.bash
+++ b/bats/helpers/vm_template.bash
@@ -1,0 +1,93 @@
+# Lima VM template selection for BATS tests.
+#
+# On Windows (WSL2), set RDD_WSL_DISTRO to choose between distros:
+#   - "finch"    (default): Finch rootfs (Fedora-based, stable for testing)
+#   - "opensuse":           rancher-desktop-opensuse (the target distro for RD2)
+#
+# Usage in test files:
+#   VM_TEMPLATE=$(vm_template)         # for limavm-instance tests
+#   VM_TEMPLATE=$(vm_template_running) # for limavm-running tests (supports RDD_VM_TYPE)
+
+: "${RDD_WSL_DISTRO:=finch}"
+
+vm_template() {
+    if is_windows; then
+        _wsl2_template
+    else
+        _unix_template
+    fi
+}
+
+vm_template_running() {
+    if is_windows; then
+        _wsl2_template
+    else
+        _unix_template_running
+    fi
+}
+
+_wsl2_template() {
+    case "${RDD_WSL_DISTRO}" in
+    finch)
+        cat <<'YAML'
+vmType: wsl2
+images:
+- location: https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1771357941.tar.gz
+  arch: x86_64
+  digest: sha256:423d1a0f1cabeaea6801995c90ed896dccc091180068626430f19fd87853fdf3
+mountType: wsl2
+containerd:
+  system: false
+  user: false
+YAML
+        ;;
+    opensuse)
+        cat <<'YAML'
+vmType: wsl2
+images:
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.2/distro.v0.1.2.amd64.tar.xz
+  arch: x86_64
+  digest: sha256:dab70ce152f163ad5c7ce45accb314b91a68f43efd9a153415eaab3e22b8cdf8
+mountType: wsl2
+containerd:
+  system: false
+  user: false
+YAML
+        ;;
+    *)
+        echo "Unknown RDD_WSL_DISTRO: ${RDD_WSL_DISTRO}" >&2
+        return 1
+        ;;
+    esac
+}
+
+_unix_template() {
+    cat <<'YAML'
+images:
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.amd64.qcow2
+  arch: x86_64
+  digest: sha256:6a0a2729781f7a412f2d4fd7cb3270104eb16d9965811d0a39cb9766afdf3fd3
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.arm64.qcow2
+  arch: aarch64
+  digest: sha256:8e8f9dfa8292dd4e3821f44542305b01c78ec8cb007065d1bba233899ce438e8
+containerd:
+  system: false
+  user: false
+YAML
+}
+
+_unix_template_running() {
+    cat <<YAML
+images:
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.amd64.qcow2
+  arch: x86_64
+  digest: sha256:6a0a2729781f7a412f2d4fd7cb3270104eb16d9965811d0a39cb9766afdf3fd3
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.arm64.qcow2
+  arch: aarch64
+  digest: sha256:8e8f9dfa8292dd4e3821f44542305b01c78ec8cb007065d1bba233899ce438e8
+${RDD_VM_TYPE:+vmType: ${RDD_VM_TYPE}}
+containerd:
+  system: false
+  user: false
+YAML
+}

--- a/bats/helpers/vm_template.bash
+++ b/bats/helpers/vm_template.bash
@@ -6,7 +6,7 @@
 #
 # Usage in test files:
 #   VM_TEMPLATE=$(vm_template)
-# Supports RDD_VM_TYPE on Unix (expands to vmType: <value> when set).
+# Supports RDD_VM_TYPE on Unix (expands to `vmType: <value>` when set).
 
 : "${RDD_WSL_DISTRO:=finch}"
 

--- a/bats/helpers/vm_template.bash
+++ b/bats/helpers/vm_template.bash
@@ -6,7 +6,8 @@
 #
 # Usage in test files:
 #   VM_TEMPLATE=$(vm_template)         # for limavm-instance tests
-#   VM_TEMPLATE=$(vm_template_running) # for limavm-running tests (supports RDD_VM_TYPE on Unix)
+#   VM_TEMPLATE=$(vm_template_running) # for limavm-running tests
+# Both support RDD_VM_TYPE on Unix (expands to vmType: <value> when set).
 
 : "${RDD_WSL_DISTRO:=finch}"
 
@@ -22,7 +23,7 @@ vm_template_running() {
     if is_windows; then
         _wsl2_template
     else
-        _unix_template_running
+        _unix_template
     fi
 }
 
@@ -62,21 +63,6 @@ YAML
 }
 
 _unix_template() {
-    cat <<'YAML'
-images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.amd64.qcow2
-  arch: x86_64
-  digest: sha256:6a0a2729781f7a412f2d4fd7cb3270104eb16d9965811d0a39cb9766afdf3fd3
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.arm64.qcow2
-  arch: aarch64
-  digest: sha256:8e8f9dfa8292dd4e3821f44542305b01c78ec8cb007065d1bba233899ce438e8
-containerd:
-  system: false
-  user: false
-YAML
-}
-
-_unix_template_running() {
     cat <<YAML
 images:
 - location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.amd64.qcow2

--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -39,10 +39,6 @@ local_setup_file() {
     setup_rdd_control_plane "app,limavm"
 }
 
-local_setup() {
-    skip_on_windows
-}
-
 @test "create App resource" {
     create_app false
 }

--- a/bats/tests/33-lima-controllers/limavm-instance.bats
+++ b/bats/tests/33-lima-controllers/limavm-instance.bats
@@ -8,21 +8,9 @@ load '../../helpers/load'
 # after template verification, and deleted when the LimaVM is deleted.
 
 NAMESPACE="instance-test-ns"
-VM_NAME="opensuse-test"
+VM_NAME="test-instance"
 
-# Minimal template with openSUSE qcow2 images from rancher-desktop-opensuse.
-# vmType defaults to vz on macOS and qemu on Linux.
-OPENSUSE_TEMPLATE='
-images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.amd64.qcow2
-  arch: x86_64
-  digest: sha256:6a0a2729781f7a412f2d4fd7cb3270104eb16d9965811d0a39cb9766afdf3fd3
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.arm64.qcow2
-  arch: aarch64
-  digest: sha256:8e8f9dfa8292dd4e3821f44542305b01c78ec8cb007065d1bba233899ce438e8
-containerd:
-  system: false
-  user: false'
+INSTANCE_TEMPLATE=$(vm_template)
 
 local_setup_file() {
     setup_rdd_control_plane "lima"
@@ -36,10 +24,13 @@ local_teardown_file() {
             rm -rf "${RDD_LIMA_HOME:?}/${vm}"
         fi
     done
-}
-
-local_setup() {
-    skip_on_windows
+    # Clean up any WSL2 distros created by tests.
+    # Use a timeout because wsl.exe --unregister can hang.
+    if is_windows; then
+        for vm in "${VM_NAME}" "invalid-vm"; do
+            timeout 30 bash -c "MSYS_NO_PATHCONV=1 wsl.exe --unregister 'lima-${vm}'" 2>/dev/null || true
+        done
+    fi
 }
 
 create_limavm() {
@@ -65,15 +56,15 @@ lima_instance_exists() {
     [[ -d "${RDD_LIMA_HOME}/${name}" ]]
 }
 
-@test "create source template ConfigMap with openSUSE image" {
-    rdd ctl create configmap "opensuse-source" --namespace "${NAMESPACE}" --from-literal="template=${OPENSUSE_TEMPLATE}"
+@test "create source template ConfigMap" {
+    rdd ctl create configmap "source-template" --namespace "${NAMESPACE}" --from-literal="template=${INSTANCE_TEMPLATE}"
 
-    run -0 rdd ctl get configmap "opensuse-source" --namespace "${NAMESPACE}" --output jsonpath='{.data.template}'
-    assert_output --partial "rancher-desktop-opensuse"
+    run -0 rdd ctl get configmap "source-template" --namespace "${NAMESPACE}" --output jsonpath='{.data.template}'
+    assert_output --partial "images:"
 }
 
-@test "create LimaVM with openSUSE template" {
-    create_limavm "${VM_NAME}" "opensuse-source"
+@test "create LimaVM with source template" {
+    create_limavm "${VM_NAME}" "source-template"
 
     run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" --output name
     assert_output "limavm.lima.rancherdesktop.io/${VM_NAME}"
@@ -135,7 +126,7 @@ lima_instance_exists() {
 }
 
 @test "create LimaVM with leftover instance present" {
-    create_limavm "${VM_NAME}" "opensuse-source"
+    create_limavm "${VM_NAME}" "source-template"
     run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" --output name
     assert_output "limavm.lima.rancherdesktop.io/${VM_NAME}"
 }
@@ -150,7 +141,7 @@ lima_instance_exists() {
     assert_file_not_exists "${RDD_LIMA_HOME}/${VM_NAME}/.fake-leftover"
     # Real instance should have images from template
     run -0 cat "${RDD_LIMA_HOME}/${VM_NAME}/lima.yaml"
-    assert_output --partial "rancher-desktop-opensuse"
+    assert_output --partial "images:"
 }
 
 @test "cleanup LimaVM after leftover test" {

--- a/bats/tests/33-lima-controllers/limavm-instance.bats
+++ b/bats/tests/33-lima-controllers/limavm-instance.bats
@@ -77,7 +77,7 @@ lima_instance_exists() {
 
 @test "wait for Created condition to be True" {
     rdd ctl wait --for=condition=Created=True \
-        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=60s
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=120s
 }
 
 @test "verify Lima instance directory exists" {
@@ -133,7 +133,7 @@ lima_instance_exists() {
 
 @test "wait for Created after leftover cleanup" {
     rdd ctl wait --for=condition=Created=True \
-        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=60s
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=120s
 }
 
 @test "verify leftover was replaced with real instance" {

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -10,8 +10,8 @@ NAMESPACE="running-test-ns"
 VM_NAME="test-running"
 TEMPLATE_NAME="${VM_NAME}-template"
 
-# vm_template_running supports RDD_VM_TYPE on macOS/Linux (e.g. RDD_VM_TYPE=qemu).
-RUNNING_TEMPLATE=$(vm_template_running)
+# vm_template supports RDD_VM_TYPE on macOS/Linux (e.g. RDD_VM_TYPE=qemu).
+RUNNING_TEMPLATE=$(vm_template)
 
 local_setup_file() {
     setup_rdd_control_plane "lima"

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -7,23 +7,11 @@ load '../../helpers/load'
 # LimaVM running tests verify that Lima instances can be started and stopped.
 
 NAMESPACE="running-test-ns"
-VM_NAME="opensuse-running"
+VM_NAME="test-running"
 TEMPLATE_NAME="${VM_NAME}-template"
 
-# Minimal openSUSE template from rancher-desktop-opensuse.
-# Set RDD_VM_TYPE=qemu to reproduce QEMU-specific behavior on macOS.
-OPENSUSE_TEMPLATE="
-images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.amd64.qcow2
-  arch: x86_64
-  digest: sha256:6a0a2729781f7a412f2d4fd7cb3270104eb16d9965811d0a39cb9766afdf3fd3
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.1/distro.v0.1.1.arm64.qcow2
-  arch: aarch64
-  digest: sha256:8e8f9dfa8292dd4e3821f44542305b01c78ec8cb007065d1bba233899ce438e8
-${RDD_VM_TYPE:+vmType: ${RDD_VM_TYPE}}
-containerd:
-  system: false
-  user: false"
+# vm_template_running supports RDD_VM_TYPE on macOS/Linux (e.g. RDD_VM_TYPE=qemu).
+RUNNING_TEMPLATE=$(vm_template_running)
 
 local_setup_file() {
     setup_rdd_control_plane "lima"
@@ -35,10 +23,13 @@ local_teardown_file() {
     if [[ -d "${RDD_LIMA_HOME}/${VM_NAME}" ]]; then
         rm -rf "${RDD_LIMA_HOME:?}/${VM_NAME}"
     fi
-}
-
-local_setup() {
-    skip_on_windows
+    # Clean up any WSL2 distros created by tests.
+    # Use a timeout because wsl.exe --unregister can hang.
+    if is_windows; then
+        for vm in "${VM_NAME}" "stopped-vm"; do
+            timeout 30 bash -c "MSYS_NO_PATHCONV=1 wsl.exe --unregister 'lima-${vm}'" 2>/dev/null || true
+        done
+    fi
 }
 
 create_limavm_running() {
@@ -89,14 +80,25 @@ assert_shell_succeeds() {
     rdd lima shell "${name}" "$@"
 }
 
+# On Windows, rdd.exe can't execute MSYS2 paths directly. Use "bash <path>"
+# so the editor command is resolved by bash, and convert the path for Win32.
+editor_cmd() {
+    local script=$1
+    if is_msys; then
+        echo "bash '$(cygpath -m "${script}")'"
+    else
+        echo "${script}"
+    fi
+}
+
 @test "create source template ConfigMap for running tests" {
-    rdd ctl create configmap "opensuse-source" --namespace "${NAMESPACE}" --from-literal="template=${OPENSUSE_TEMPLATE}"
-    run -0 rdd ctl get configmap "opensuse-source" --namespace "${NAMESPACE}" --output jsonpath='{.data.template}'
-    assert_output --partial "rancher-desktop-opensuse"
+    rdd ctl create configmap "source-template" --namespace "${NAMESPACE}" --from-literal="template=${RUNNING_TEMPLATE}"
+    run -0 rdd ctl get configmap "source-template" --namespace "${NAMESPACE}" --output jsonpath='{.data.template}'
+    assert_output --partial "images:"
 }
 
 @test "create LimaVM with running=false" {
-    create_limavm_running "${VM_NAME}" "opensuse-source" "false"
+    create_limavm_running "${VM_NAME}" "source-template" "false"
     run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${NAMESPACE}" --output name
     assert_output "limavm.lima.rancherdesktop.io/${VM_NAME}"
 }
@@ -108,7 +110,7 @@ assert_shell_succeeds() {
 
 @test "verify initial Running condition is False/Stopped" {
     rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
-        --for=condition=Running=False --reason=Stopped --timeout=30s
+        --for=condition=Running=False --reason=Stopped --timeout=120s
 }
 
 @test "start the VM by setting running=true" {
@@ -156,7 +158,7 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   templateRef:
-    name: opensuse-source
+    name: source-template
     namespace: ${NAMESPACE}
   running: false
 EOF
@@ -208,9 +210,8 @@ EOF
     # shellcheck disable=SC2030 # Persisted via save_var, not subshell
     OLD_HA_PID=$(get_hostagent_pid "${VM_NAME}")
     assert [ -n "${OLD_HA_PID}" ]
-    # Verify the PID is a running process. On Windows the hostagent runs as a
-    # Win32 process but BATS runs inside WSL, so kill can't reach it.
-    kill -0 "${OLD_HA_PID}"
+    # Verify the PID is a running process.
+    assert_process_alive "${OLD_HA_PID}"
     save_var OLD_HA_PID
 
     # Save restart count before the kill. The watcher detects the crash
@@ -219,7 +220,7 @@ EOF
     BEFORE_KILL_COUNT=$(get_restart_count "${VM_NAME}")
     save_var BEFORE_KILL_COUNT
 
-    kill -9 "${OLD_HA_PID}"
+    process_kill "${OLD_HA_PID}"
 }
 
 @test "trigger reconcile and verify crash recovery" {
@@ -243,7 +244,7 @@ EOF
     local new_pid
     new_pid=$(get_hostagent_pid "${VM_NAME}")
     assert [ -n "${new_pid}" ]
-    kill -0 "${new_pid}"
+    assert_process_alive "${new_pid}"
 
     # Windows recycles PIDs quickly, so this assertion is only reliable on Unix.
     load_var OLD_HA_PID
@@ -257,12 +258,16 @@ EOF
 # When the service crashes (SIGKILL), the hostagent survives (own process group).
 # On restart, the controller detects the orphaned hostagent via store.Inspect(),
 # kills it, and starts a fresh one with a watcher.
+#
+# Not tested: whether the orphaned hostagent shuts down gracefully (via
+# CTRL_BREAK/SIGINT) or is force-killed. The test verifies the outcome
+# (recovery succeeds) but does not distinguish the shutdown mechanism.
 
 @test "save hostagent PID before service crash" {
     # shellcheck disable=SC2030 # Persisted via save_var, not subshell
     ORPHAN_HA_PID=$(get_hostagent_pid "${VM_NAME}")
     assert [ -n "${ORPHAN_HA_PID}" ]
-    kill -0 "${ORPHAN_HA_PID}"
+    assert_process_alive "${ORPHAN_HA_PID}"
     save_var ORPHAN_HA_PID
 
     # Save restart count to detect when recovery completes after restart.
@@ -276,16 +281,16 @@ EOF
     svc_pid=$(cat "${RDD_PID_FILE}")
     assert [ -n "${svc_pid}" ]
 
-    kill -9 "${svc_pid}"
+    process_kill "${svc_pid}"
 
     # Wait for the service process to be fully reaped
-    try --max 10 --delay 1 --until-fail -- kill -0 "${svc_pid}"
+    try --max 10 --delay 1 --until-fail -- assert_process_alive "${svc_pid}"
 }
 
 @test "verify hostagent survived service crash" {
     load_var ORPHAN_HA_PID
     # shellcheck disable=SC2031 # Loaded via load_var, not subshell
-    kill -0 "${ORPHAN_HA_PID}"
+    assert_process_alive "${ORPHAN_HA_PID}"
 }
 
 @test "restart service and verify orphaned hostagent recovery" {
@@ -296,7 +301,7 @@ EOF
 
     # Wait for the controller to detect and kill the orphaned hostagent.
     # shellcheck disable=SC2031 # Loaded via load_var, not subshell
-    try --max 30 --delay 1 --until-fail -- kill -0 "${ORPHAN_HA_PID}"
+    try --max 30 --delay 1 --until-fail -- assert_process_alive "${ORPHAN_HA_PID}"
 
     # restartCount increments when the new hostagent reaches Running.
     # shellcheck disable=SC2031 # Loaded via load_var, not subshell
@@ -306,7 +311,7 @@ EOF
     local new_pid
     new_pid=$(get_hostagent_pid "${VM_NAME}")
     assert [ -n "${new_pid}" ]
-    kill -0 "${new_pid}"
+    assert_process_alive "${new_pid}"
 
     # Windows recycles PIDs quickly, so this assertion is only reliable on Unix.
     # shellcheck disable=SC2031 # Loaded via load_var, not subshell
@@ -323,17 +328,23 @@ EOF
     local ha_pid
     ha_pid=$(get_hostagent_pid "${VM_NAME}")
     assert [ -n "${ha_pid}" ]
-    kill -0 "${ha_pid}"
+    assert_process_alive "${ha_pid}"
 
     rdd svc stop
 
-    try --max 15 --delay 1 --until-fail -- kill -0 "${ha_pid}"
+    # On Windows, child process handles (wsl.exe) keep the hostagent PID visible
+    # in the process table long after termination. The next test ("restart service
+    # after graceful shutdown") verifies the hostagent is functionally dead.
+    if is_unix; then
+        try --max 15 --delay 1 --until-fail -- assert_process_alive "${ha_pid}"
+    fi
 }
 
 @test "restart service after graceful shutdown" {
     rdd svc start
 
-    # VM should start fresh (no orphan — graceful shutdown killed it).
+    # shutdownAllHostagents runs during graceful shutdown, so the hostagent
+    # is already dead by the time the service exits.
     rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
         --for=condition=Running --reason=Started --since=startup --timeout=300s
 }
@@ -411,7 +422,7 @@ assert_restart_annotation_absent() {
 
 # Append an env variable to the original template.
 # Keep images identical so Lima doesn't re-download them.
-MODIFIED_TEMPLATE="${OPENSUSE_TEMPLATE}
+MODIFIED_TEMPLATE="${RUNNING_TEMPLATE}
 env:
   TEMPLATE_CHANGE_MARKER: applied"
 
@@ -426,7 +437,8 @@ assert_guest_env_var() {
     local name=$1
     local var=$2
     local expected=$3
-    run -0 ssh -F "${RDD_LIMA_HOME}/${name}/ssh.config" lima-"${name}" printenv "${var}"
+    # Use --separate-stderr to avoid Lima driver warnings leaking into output.
+    run --separate-stderr -0 rdd lima shell "${name}" printenv "${var}"
     assert_output "${expected}"
 }
 
@@ -477,7 +489,7 @@ assert_guest_env_var() {
 }
 
 # Build a second modified template with a different env value.
-MODIFIED_TEMPLATE_2="${OPENSUSE_TEMPLATE}
+MODIFIED_TEMPLATE_2="${RUNNING_TEMPLATE}
 env:
   TEMPLATE_CHANGE_MARKER: updated-while-stopped"
 
@@ -505,11 +517,21 @@ env:
 
 @test "cleanup LimaVM running test" {
     rdd ctl delete limavm "${VM_NAME}" --namespace "${NAMESPACE}"
-    rdd ctl wait --for=delete "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=60s
+    # Wrap with an outer timeout because rdd ctl wait --timeout may not be
+    # enforced when the reconciler is stalled. On WSL2, a failed
+    # wsl.exe --unregister can deadlock wslservice.exe, blocking all
+    # subsequent wsl.exe calls (including store.Inspect in the reconciler).
+    # If the wait hangs, kill wslservice.exe to recover.
+    if ! timeout 90 rdd ctl wait --for=delete "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=60s; then
+        if is_windows; then
+            MSYS_NO_PATHCONV=1 taskkill.exe /F /IM wslservice.exe || true
+        fi
+        false
+    fi
 }
 
 @test "limavm edit command updates template ConfigMap" {
-    create_limavm_running "${VM_NAME}" "opensuse-source" "false"
+    create_limavm_running "${VM_NAME}" "source-template" "false"
 
     # Wait for template ConfigMap to be created
     rdd ctl wait --for=jsonpath='{.status.templateConfigMap}' \
@@ -527,7 +549,7 @@ SCRIPT
     chmod +x "${editor_script}"
 
     # Run edit with fake editor
-    EDITOR="${editor_script}" run -0 rdd limavm edit "${VM_NAME}"
+    EDITOR="$(editor_cmd "${editor_script}")" run -0 rdd limavm edit "${VM_NAME}"
     assert_output --partial "updated successfully"
 
     # Verify ConfigMap was updated
@@ -554,7 +576,7 @@ SCRIPT
     chmod +x "${editor_script}"
 
     # Run edit aborts
-    EDITOR="${editor_script}" run -1 rdd limavm edit "${VM_NAME}"
+    EDITOR="$(editor_cmd "${editor_script}")" run -1 rdd limavm edit "${VM_NAME}"
     assert_output --partial "template data was cleared, aborting edit"
 
     # Verify ConfigMap unchanged
@@ -574,7 +596,7 @@ SCRIPT
 
     chmod +x "${editor_script}"
 
-    EDITOR="${editor_script}" run -0 rdd limavm edit "${VM_NAME}"
+    EDITOR="$(editor_cmd "${editor_script}")" run -0 rdd limavm edit "${VM_NAME}"
     assert_output --partial "No changes made to template, skipping update"
 }
 

--- a/pkg/controllers/app/app/controller.go
+++ b/pkg/controllers/app/app/controller.go
@@ -6,6 +6,7 @@ package app
 
 import (
 	_ "embed"
+	"runtime"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -15,10 +16,26 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 )
 
-// This is temporary and will be removed once the app controller is fully implemented.
+// Embedded Lima template split into platform-specific images and shared
+// configuration. The two parts are concatenated at runtime so the VM gets
+// an image type compatible with the host (qcow2 on Unix, tarball on WSL2).
 //
-//go:embed lima.yaml
-var limaTemplateData string
+//go:embed lima-images-unix.yaml
+var limaImagesUnix string
+
+//go:embed lima-images-wsl2.yaml
+var limaImagesWSL2 string
+
+//go:embed lima-template.yaml
+var limaTemplate string
+
+func limaTemplateData() string {
+	images := limaImagesUnix
+	if runtime.GOOS == "windows" {
+		images = limaImagesWSL2
+	}
+	return images + limaTemplate
+}
 
 func init() {
 	base.RegisterController(newController())
@@ -72,6 +89,6 @@ func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 	return (&controllers.AppReconciler{
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
-		LimaTemplateData: limaTemplateData,
+		LimaTemplateData: limaTemplateData(),
 	}).SetupWithManager(mgr)
 }

--- a/pkg/controllers/app/app/lima-images-unix.yaml
+++ b/pkg/controllers/app/app/lima-images-unix.yaml
@@ -1,0 +1,7 @@
+images:
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.2/distro.v0.1.2.amd64.qcow2
+  arch: x86_64
+  digest: "sha256:45de5c158399d5bc31e93f42d9c7fcfaf8dd3279ee157c702e9bd86bcaf9e088"
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.2/distro.v0.1.2.arm64.qcow2
+  arch: aarch64
+  digest: "sha256:39598a41ebe5c8da0baf428716a63c50598e8306e85bb85043877407eecc8991"

--- a/pkg/controllers/app/app/lima-images-wsl2.yaml
+++ b/pkg/controllers/app/app/lima-images-wsl2.yaml
@@ -1,0 +1,6 @@
+vmType: wsl2
+images:
+- location: https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1771357941.tar.gz
+  arch: x86_64
+  digest: sha256:423d1a0f1cabeaea6801995c90ed896dccc091180068626430f19fd87853fdf3
+mountType: wsl2

--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -1,10 +1,3 @@
-images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.2/distro.v0.1.2.amd64.qcow2
-  arch: x86_64
-  digest: "sha256:45de5c158399d5bc31e93f42d9c7fcfaf8dd3279ee157c702e9bd86bcaf9e088"
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.2/distro.v0.1.2.arm64.qcow2
-  arch: aarch64
-  digest: "sha256:39598a41ebe5c8da0baf428716a63c50598e8306e85bb85043877407eecc8991"
 cpus: 2
 memory: "6442450944"
 mounts:

--- a/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
+++ b/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
@@ -211,25 +211,6 @@ func (r *LimaVMReconciler) signalHostagent(name string) bool {
 	return process.Interrupt(state.cmd.Process.Pid) == nil
 }
 
-// killHostagent terminates the hostagent process tree. Uses KillTree instead
-// of Process.Kill so child processes (e.g. SSH port forwarders) are also
-// terminated. On Windows, Process.Kill only sends TerminateProcess to the
-// parent; children that inherited the parent's pipes would keep cmd.Wait
-// blocked indefinitely.
-func (r *LimaVMReconciler) killHostagent(name string) {
-	r.instanceStatesMu.RLock()
-	state, ok := r.instanceStates[name]
-	r.instanceStatesMu.RUnlock()
-	if !ok || state.cmd == nil || state.cmd.Process == nil {
-		return
-	}
-	// Background context: killHostagent runs during shutdown when the
-	// reconciler context may already be cancelled.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_ = process.KillTree(ctx, state.cmd.Process.Pid)
-}
-
 // enqueueReconcile sends a GenericEvent to trigger a reconcile for the named VM.
 func (r *LimaVMReconciler) enqueueReconcile(name, namespace string) {
 	vm := &v1alpha1.LimaVM{}

--- a/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
+++ b/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
@@ -75,7 +75,7 @@ func (r *LimaVMReconciler) runWatcher(ctx context.Context, name, namespace, inst
 	// Reap the hostagent process in a sub-goroutine. haCmd.Wait() blocks until
 	// the process exits and cannot be cancelled via context. This is safe because
 	// every code path that cancels the watcher also kills the hostagent process
-	// (stopInstance, shutdownAllHostagents, StopForcibly on delete), so this
+	// (stopInstance, shutdownAllHostagents, stopInstanceForcibly on delete), so this
 	// goroutine always returns promptly after cancellation.
 	// When the process exits, cancel the Watch context so events.Watch returns.
 	waitCtx, waitCancel := context.WithCancel(ctx)

--- a/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
+++ b/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
@@ -6,7 +6,6 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
@@ -19,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
 )
 
 // instancePhase represents the hostagent lifecycle as observed by the watcher.
@@ -197,16 +197,37 @@ func (r *LimaVMReconciler) waitForProcessExit(ctx context.Context, name string) 
 	}
 }
 
-// signalHostagent sends a signal to the hostagent process. Returns false if no
-// watcher exists or the process handle is unavailable.
-func (r *LimaVMReconciler) signalHostagent(name string, sig os.Signal) bool {
+// signalHostagent sends a graceful shutdown signal to the hostagent process.
+// Uses process.Interrupt which sends SIGINT on Unix and CTRL_BREAK on Windows
+// (targeted at the hostagent's process group, not the parent).
+// Returns false if no watcher exists or the signal could not be delivered.
+func (r *LimaVMReconciler) signalHostagent(name string) bool {
 	r.instanceStatesMu.RLock()
 	state, ok := r.instanceStates[name]
 	r.instanceStatesMu.RUnlock()
 	if !ok || state.cmd == nil || state.cmd.Process == nil {
 		return false
 	}
-	return state.cmd.Process.Signal(sig) == nil
+	return process.Interrupt(state.cmd.Process.Pid) == nil
+}
+
+// killHostagent terminates the hostagent process tree. Uses KillTree instead
+// of Process.Kill so child processes (e.g. SSH port forwarders) are also
+// terminated. On Windows, Process.Kill only sends TerminateProcess to the
+// parent; children that inherited the parent's pipes would keep cmd.Wait
+// blocked indefinitely.
+func (r *LimaVMReconciler) killHostagent(name string) {
+	r.instanceStatesMu.RLock()
+	state, ok := r.instanceStates[name]
+	r.instanceStatesMu.RUnlock()
+	if !ok || state.cmd == nil || state.cmd.Process == nil {
+		return
+	}
+	// Background context: killHostagent runs during shutdown when the
+	// reconciler context may already be cancelled.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = process.KillTree(ctx, state.cmd.Process.Pid)
 }
 
 // enqueueReconcile sends a GenericEvent to trigger a reconcile for the named VM.

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -522,7 +522,16 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 				stopInstanceForcibly(cleanupCtx, logger, inst)
 			}
 			cancel()
-			<-state.procExited
+			// Wait briefly for the process to exit after forced kill.
+			// Without a timeout, cmd.Wait can block indefinitely if a
+			// child process survives KillTree and holds an inherited pipe.
+			waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			select {
+			case <-state.procExited:
+			case <-waitCtx.Done():
+				logger.Info("Timed out waiting for hostagent to exit after forced kill", "instance", name)
+			}
+			waitCancel()
 		}
 		state.cancel()
 		r.instanceStatesMu.Lock()

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -512,7 +512,9 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 			// The manager context is cancelled; use background context for
 			// post-shutdown cleanup.
 			if state.cmd != nil && state.cmd.Process != nil {
-				_ = process.KillTree(context.Background(), state.cmd.Process.Pid)
+				killCtx, killCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				_ = process.KillTree(killCtx, state.cmd.Process.Pid)
+				killCancel()
 			}
 			<-state.procExited
 		}

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -503,18 +503,20 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 		case <-state.procExited:
 		case <-time.After(gracefulShutdownTimeout):
 			graceful = false
+			// The manager context is cancelled; use background context for
+			// post-shutdown cleanup.
 			if state.cmd != nil && state.cmd.Process != nil {
 				_ = process.KillTree(context.Background(), state.cmd.Process.Pid)
 			}
 			<-state.procExited
 		}
 		if !graceful {
-			// The manager context is cancelled, so use a fresh context for
-			// store.Inspect and WSL2 cleanup.
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			// Manager context is cancelled; use a fresh context for cleanup.
+			logger := ctrl.Log.WithName("shutdownAllHostagents")
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			inst, err := store.Inspect(cleanupCtx, name)
 			if err == nil && inst != nil {
-				stopInstanceForcibly(cleanupCtx, inst)
+				stopInstanceForcibly(cleanupCtx, logger, inst)
 			}
 			cancel()
 		}

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
 	limainstance "github.com/lima-vm/lima/v2/pkg/instance"
@@ -36,6 +35,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
 )
 
 const (
@@ -81,7 +81,7 @@ const (
 	preparingSentinel = ".preparing"
 
 	// gracefulShutdownTimeout is the time to wait for a hostagent to exit
-	// after sending SIGINT before falling back to SIGKILL.
+	// after requesting graceful shutdown before falling back to forced termination.
 	gracefulShutdownTimeout = 30 * time.Second
 )
 
@@ -474,8 +474,8 @@ func (r *LimaVMReconciler) waitForShutdown(ctx context.Context) error {
 }
 
 // shutdownAllHostagents terminates all running hostagents during graceful shutdown.
-// It sends SIGINT to each hostagent for graceful shutdown, waits for them to exit,
-// and falls back to SIGKILL after a timeout.
+// It sends a graceful shutdown signal to each hostagent, waits for exit, and falls
+// back to process termination after a timeout.
 func (r *LimaVMReconciler) shutdownAllHostagents() {
 	r.instanceStatesMu.RLock()
 	states := maps.Clone(r.instanceStates)
@@ -485,10 +485,10 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 		return
 	}
 
-	// Send SIGINT to all hostagents in parallel for graceful shutdown.
+	// Send graceful shutdown signal to all hostagents in parallel.
 	for _, state := range states {
 		if state.cmd != nil && state.cmd.Process != nil {
-			_ = state.cmd.Process.Signal(syscall.SIGINT)
+			_ = process.Interrupt(state.cmd.Process.Pid)
 		}
 	}
 
@@ -498,13 +498,25 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 	// TODO: Wait on all hostagents in parallel instead of sequentially; with the
 	// current loop, the total wait is N × gracefulShutdownTimeout in the worst case.
 	for name, state := range states {
+		graceful := true
 		select {
 		case <-state.procExited:
 		case <-time.After(gracefulShutdownTimeout):
+			graceful = false
 			if state.cmd != nil && state.cmd.Process != nil {
-				_ = state.cmd.Process.Kill()
+				_ = process.KillTree(context.Background(), state.cmd.Process.Pid)
 			}
 			<-state.procExited
+		}
+		if !graceful {
+			// The manager context is cancelled, so use a fresh context for
+			// store.Inspect and WSL2 cleanup.
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			inst, err := store.Inspect(cleanupCtx, name)
+			if err == nil && inst != nil {
+				stopInstanceForcibly(cleanupCtx, inst)
+			}
+			cancel()
 		}
 		state.cancel()
 		r.instanceStatesMu.Lock()

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -7,6 +7,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
@@ -448,6 +449,11 @@ func (r *LimaVMReconciler) updateCondition(ctx context.Context, limaVM *v1alpha1
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *LimaVMReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// No parent context exists yet; the manager hasn't started.
+	if err := ensureSSHKeys(context.Background()); err != nil {
+		return fmt.Errorf("failed to generate Lima SSH keys: %w", err)
+	}
+
 	r.instanceStates = make(map[string]*instanceState)
 	r.reconcileChan = make(chan event.TypedGenericEvent[*v1alpha1.LimaVM], 1)
 

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -509,17 +509,12 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 		case <-state.procExited:
 		case <-time.After(gracefulShutdownTimeout):
 			graceful = false
-			// The manager context is cancelled; use background context for
-			// post-shutdown cleanup.
-			if state.cmd != nil && state.cmd.Process != nil {
-				killCtx, killCancel := context.WithTimeout(context.Background(), 5*time.Second)
-				_ = process.KillTree(killCtx, state.cmd.Process.Pid)
-				killCancel()
-			}
-			<-state.procExited
 		}
 		if !graceful {
 			// Manager context is cancelled; use a fresh context for cleanup.
+			// Inspect before killing so PIDs are still valid (not yet recycled
+			// to unrelated processes). stopInstanceForcibly kills the process
+			// tree and cleans up PID/socket/tmp files in one pass.
 			logger := ctrl.Log.WithName("shutdownAllHostagents")
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			inst, err := store.Inspect(cleanupCtx, name)
@@ -527,6 +522,7 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 				stopInstanceForcibly(cleanupCtx, logger, inst)
 			}
 			cancel()
+			<-state.procExited
 		}
 		state.cancel()
 		r.instanceStatesMu.Lock()

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -11,8 +11,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	limainstance "github.com/lima-vm/lima/v2/pkg/instance"
 	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
@@ -42,15 +44,25 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 		logger.Error(err, "Failed to inspect Lima instance for deletion")
 	}
 	if existingInst != nil {
-		// Force-stop the instance if running. No graceful shutdown needed
-		// since the instance is being deleted; users who want a graceful
-		// shutdown can stop the instance before deleting.
-		if existingInst.Status == limatype.StatusRunning {
-			logger.Info("Force-stopping Lima instance before deletion", "instance", limaVM.Name)
-			stopInstanceForcibly(existingInst)
+		if existingInst.Status == limatype.StatusRunning || existingInst.Status == limatype.StatusBroken {
+			stopInstanceForcibly(ctx, logger, existingInst)
+		} else if existingInst.VMType == limatype.WSL2 {
+			// A "stopped" WSL2 distro can retain kernel state that deadlocks
+			// wsl.exe --unregister. Terminate it without PID-based killing,
+			// since the PIDs may have been recycled on Windows.
+			terminateWSL2Distro(ctx, logger, existingInst.Name)
 		}
+		// Clear PIDs so Lima's Delete → StopForcibly does not kill
+		// unrelated processes if the PIDs were recycled (likely on Windows).
+		existingInst.DriverPID = 0
+		existingInst.HostAgentPID = 0
 		logger.Info("Deleting Lima instance", "instance", limaVM.Name)
-		if err := limainstance.Delete(ctx, existingInst, true); err != nil {
+		// Use a timeout because Lima's WSL2 driver calls wsl.exe --unregister
+		// which can hang indefinitely if the WSL subsystem is degraded.
+		deleteCtx, deleteCancel := context.WithTimeout(ctx, 60*time.Second)
+		err = limainstance.Delete(deleteCtx, existingInst, true)
+		deleteCancel()
+		if err != nil {
 			logger.Error(err, "Failed to delete Lima instance")
 			return ctrl.Result{}, err
 		}
@@ -185,7 +197,7 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 		// the instance so the next hostagent can start with a clean slate.
 		if inst.Status == limatype.StatusRunning || inst.Status == limatype.StatusBroken {
 			logger.Info("Force-stopping orphaned VM driver", "status", inst.Status)
-			stopInstanceForcibly(inst)
+			stopInstanceForcibly(ctx, logger, inst)
 		}
 		return r.startInstance(ctx, limaVM, inst)
 
@@ -473,41 +485,100 @@ func (r *LimaVMReconciler) shutdownHostagent(ctx context.Context, name string, i
 	logger := log.FromContext(ctx)
 
 	forceStop := func() {
-		if inst == nil {
+		// Use a background context: the parent reconciler context may be
+		// nearing its deadline after the graceful shutdown wait.
+		forceCtx, forceCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer forceCancel()
+		forceInst := inst
+		if forceInst == nil {
 			var err error
-			inst, err = store.Inspect(ctx, name)
+			forceInst, err = store.Inspect(forceCtx, name)
 			if err != nil {
 				logger.Error(err, "Failed to inspect Lima instance for forceful stop")
 				return
 			}
-			if inst == nil {
+			if forceInst == nil {
 				return
 			}
 		}
-		stopInstanceForcibly(inst)
+		stopInstanceForcibly(forceCtx, logger, forceInst)
+	}
+
+	// After forced termination, wait briefly for the process to exit.
+	// Use a background context (like forceStop above) because the parent
+	// reconciler context may be exhausted or cancelled by now.
+	waitAfterKill := func() {
+		killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer killCancel()
+		r.waitForProcessExit(killCtx, name)
 	}
 
 	if r.signalHostagent(name) {
 		stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
 		defer cancel()
+		// Not tested: the forceStop fallback requires a hostagent that ignores
+		// shutdown signals. The orphaned-hostagent integration test exercises
+		// forced stop indirectly but does not isolate this timeout path.
 		if !r.waitForProcessExit(stopCtx, name) {
 			logger.Info("Hostagent did not exit gracefully, forcing stop")
 			forceStop()
-			r.waitForProcessExit(ctx, name)
+			waitAfterKill()
 		}
 	} else {
 		logger.Info("Could not signal hostagent, killing process directly")
 		r.killHostagent(name)
-		r.waitForProcessExit(ctx, name)
 		forceStop()
+		waitAfterKill()
 	}
 }
 
-// killOrphanedHostagent terminates an orphaned hostagent (one running without a
-// watcher, typically after a controller restart).
-func (r *LimaVMReconciler) killOrphanedHostagent(_ context.Context, inst *limatype.Instance) error {
-	stopInstanceForcibly(inst)
+// killOrphanedHostagent terminates an orphaned hostagent (one running without
+// a watcher, typically after a controller restart). It attempts graceful
+// shutdown first by signaling the hostagent, giving it time to stop the VM
+// driver and clean up. Falls back to forced termination after a timeout.
+func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *limatype.Instance) error {
+	logger := log.FromContext(ctx)
+
+	// Try graceful shutdown: signal the hostagent and wait for the instance
+	// to become stopped. The hostagent's own shutdown sequence handles driver
+	// termination, WSL2 distro cleanup, and tmp file removal.
+	if inst.HostAgentPID > 0 {
+		if err := process.Interrupt(inst.HostAgentPID); err != nil {
+			logger.V(1).Info("Could not signal orphaned hostagent", "pid", inst.HostAgentPID, "error", err)
+		} else {
+			stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
+			defer cancel()
+			if waitForInstanceStopped(stopCtx, inst.Name) {
+				logger.Info("Orphaned hostagent exited gracefully")
+				return nil
+			}
+			logger.Info("Orphaned hostagent did not exit gracefully, forcing stop")
+		}
+	}
+
+	stopInstanceForcibly(ctx, logger, inst)
 	return nil
+}
+
+// waitForInstanceStopped polls store.Inspect until the instance reports
+// StatusStopped or the context is cancelled.
+func waitForInstanceStopped(ctx context.Context, name string) bool {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+			inst, err := store.Inspect(ctx, name)
+			if err != nil {
+				continue // Transient error; keep polling until context expires.
+			}
+			if inst == nil || inst.Status == limatype.StatusStopped {
+				return true
+			}
+		}
+	}
 }
 
 // stopInstanceForcibly terminates the hostagent and driver processes and their
@@ -518,10 +589,74 @@ func (r *LimaVMReconciler) killOrphanedHostagent(_ context.Context, inst *limaty
 // We use process.KillTree which sends SIGKILL to the process group on Unix and
 // uses taskkill /F /T on Windows, ensuring child processes (e.g. ssh.exe port
 // forwarders) are also terminated.
-func stopInstanceForcibly(inst *limatype.Instance) {
+//
+// On WSL2, also terminates the distro because the keepAlive process
+// (nohup sleep) would keep it running after the hostagent is killed.
+func stopInstanceForcibly(ctx context.Context, logger logr.Logger, inst *limatype.Instance) {
+	allKilled := true
 	for _, pid := range []int{inst.DriverPID, inst.HostAgentPID} {
 		if pid > 0 {
-			_ = process.KillTree(context.Background(), pid)
+			if err := process.KillTree(ctx, pid); err != nil {
+				logger.V(1).Info("Failed to kill process tree", "pid", pid, "error", err)
+				allKilled = false
+			}
 		}
+	}
+	// Unlock additional disks only after confirming the instance is gone.
+	// If KillTree failed, the VM driver may still be using the disks.
+	if allKilled {
+		for _, d := range inst.AdditionalDisks {
+			disk, err := store.InspectDisk(d.Name)
+			if err != nil {
+				logger.V(1).Info("Disk does not exist", "disk", d.Name)
+				continue
+			}
+			if err := disk.Unlock(); err != nil {
+				logger.V(1).Info("Failed to unlock disk", "disk", d.Name, "error", err)
+			}
+		}
+	}
+	// On WSL2, terminate the distro so store.Inspect reports StatusStopped.
+	if inst.VMType == limatype.WSL2 {
+		terminateWSL2Distro(ctx, logger, inst.Name)
+	}
+	// Clean up PID/socket/tmp files so the next hostagent can start cleanly.
+	// Skip cleanup if any kill failed: Lima's store.Inspect derives StatusStopped
+	// from missing PID files, so removing them would mask a still-running process.
+	if !allKilled {
+		logger.Info("Skipping tmp file cleanup because process kill failed")
+		return
+	}
+	// Uses os.ReadDir (not filepath.Glob) because Glob treats brackets in the
+	// path as meta-characters, silently failing on paths like C:\Users\name[1].
+	entries, err := os.ReadDir(inst.Dir)
+	if err != nil {
+		logger.V(1).Info("Failed to read instance directory for cleanup", "dir", inst.Dir, "error", err)
+		return
+	}
+	for _, f := range entries {
+		for _, suffix := range filenames.TmpFileSuffixes {
+			if strings.HasSuffix(f.Name(), suffix) {
+				path := filepath.Join(inst.Dir, f.Name())
+				if err := os.Remove(path); err != nil {
+					logger.V(1).Info("Failed to remove tmp file", "path", path, "error", err)
+				} else {
+					logger.V(1).Info("Removed tmp file", "path", path)
+				}
+				break
+			}
+		}
+	}
+}
+
+// terminateWSL2Distro sends `wsl.exe --terminate` for the Lima distro with
+// the given instance name. Best-effort with a 10-second timeout: wsl.exe can
+// hang if the WSL subsystem is degraded.
+func terminateWSL2Distro(ctx context.Context, logger logr.Logger, instName string) {
+	distroName := "lima-" + instName
+	wslCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(wslCtx, "wsl.exe", "--terminate", distroName).Run(); err != nil {
+		logger.V(1).Info("Failed to terminate WSL2 distro", "distro", distroName, "error", err)
 	}
 }

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -555,7 +555,6 @@ func (r *LimaVMReconciler) shutdownHostagent(ctx context.Context, name string, i
 		}
 	} else {
 		logger.Info("No watcher for hostagent, forcing stop via stored PIDs")
-		r.killHostagent(name) // no-op if watcher absent; forceStop uses stored PIDs
 		forceStop()
 		waitAfterKill()
 	}

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -64,6 +64,12 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 			// PIDs aggressively, and Lima's ReadPIDFile treats any live PID
 			// as valid. On Unix, PID recycling is rare (wraps around 32768+),
 			// so we let Lima's Delete clean up any surviving driver processes.
+			//
+			// This disables Lima's internal kill retry even if stopInstanceForcibly
+			// failed above. That is intentional: a failed kill means KillTree
+			// could not reach the process (access denied, already reaped), and
+			// the PID may already be recycled. Retrying with a stale PID is
+			// worse than letting Delete proceed without a kill.
 			existingInst.DriverPID = 0
 			existingInst.HostAgentPID = 0
 		}

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -57,10 +58,15 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 			// since the PIDs may have been recycled on Windows.
 			terminateWSL2Distro(ctx, logger, existingInst.Name)
 		}
-		// Clear PIDs so Lima's Delete → StopForcibly does not kill
-		// unrelated processes if the PIDs were recycled (likely on Windows).
-		existingInst.DriverPID = 0
-		existingInst.HostAgentPID = 0
+		if runtime.GOOS == "windows" {
+			// Clear PIDs so Lima's Delete → StopForcibly does not kill
+			// unrelated processes if the PIDs were recycled. Windows recycles
+			// PIDs aggressively, and Lima's ReadPIDFile treats any live PID
+			// as valid. On Unix, PID recycling is rare (wraps around 32768+),
+			// so we let Lima's Delete clean up any surviving driver processes.
+			existingInst.DriverPID = 0
+			existingInst.HostAgentPID = 0
+		}
 		logger.Info("Deleting Lima instance", "instance", limaVM.Name)
 		// Use a timeout because Lima's WSL2 driver calls wsl.exe --unregister
 		// which can hang indefinitely if the WSL subsystem is degraded.

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -47,7 +47,7 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 		// shutdown can stop the instance before deleting.
 		if existingInst.Status == limatype.StatusRunning {
 			logger.Info("Force-stopping Lima instance before deletion", "instance", limaVM.Name)
-			limainstance.StopForcibly(existingInst)
+			stopInstanceForcibly(existingInst)
 		}
 		logger.Info("Deleting Lima instance", "instance", limaVM.Name)
 		if err := limainstance.Delete(ctx, existingInst, true); err != nil {
@@ -185,7 +185,7 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 		// the instance so the next hostagent can start with a clean slate.
 		if inst.Status == limatype.StatusRunning || inst.Status == limatype.StatusBroken {
 			logger.Info("Force-stopping orphaned VM driver", "status", inst.Status)
-			limainstance.StopForcibly(inst)
+			stopInstanceForcibly(inst)
 		}
 		return r.startInstance(ctx, limaVM, inst)
 
@@ -279,21 +279,7 @@ func (r *LimaVMReconciler) handleRestartNeeded(ctx context.Context, limaVM *v1al
 	switch phase {
 	case phaseRunning:
 		logger.Info("Restart needed: stopping running instance")
-
-		r.signalHostagent(limaVM.Name, os.Interrupt)
-		stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
-		defer cancel()
-		if !r.waitForProcessExit(stopCtx, limaVM.Name) {
-			logger.Info("Hostagent did not exit gracefully, forcing stop")
-			inst, err := store.Inspect(ctx, limaVM.Name)
-			if err != nil {
-				logger.Error(err, "Failed to inspect Lima instance for forceful stop")
-			} else if inst != nil {
-				limainstance.StopForcibly(inst)
-			}
-			r.waitForProcessExit(ctx, limaVM.Name)
-		}
-
+		r.shutdownHostagent(ctx, limaVM.Name, nil)
 		r.stopWatcher(limaVM.Name)
 
 		// Clear restartNeeded and set Stopped condition in one write.
@@ -449,15 +435,7 @@ func (r *LimaVMReconciler) stopInstance(ctx context.Context, limaVM *v1alpha1.Li
 	logger := log.FromContext(ctx)
 	logger.Info("Stopping Lima instance", "instance", limaVM.Name)
 
-	r.signalHostagent(limaVM.Name, os.Interrupt)
-	stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
-	defer cancel()
-	if !r.waitForProcessExit(stopCtx, limaVM.Name) {
-		logger.Info("Hostagent did not exit gracefully, forcing stop")
-		limainstance.StopForcibly(inst)
-		r.waitForProcessExit(ctx, limaVM.Name)
-	}
-
+	r.shutdownHostagent(ctx, limaVM.Name, inst)
 	r.stopWatcher(limaVM.Name)
 
 	// Verify the instance stopped
@@ -488,14 +466,62 @@ func (r *LimaVMReconciler) stopInstance(ctx context.Context, limaVM *v1alpha1.Li
 	return ctrl.Result{}, nil
 }
 
-// killOrphanedHostagent terminates an orphaned hostagent (one running without a
-// watcher, typically after a controller restart). Sends SIGTERM first and falls
-// back to SIGKILL after the graceful shutdown timeout.
-func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *limatype.Instance) error {
-	stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
-	defer cancel()
-	if err := limainstance.StopGracefully(stopCtx, inst, false); err != nil {
-		limainstance.StopForcibly(inst)
+// shutdownHostagent stops the hostagent for the named instance: sends a graceful
+// signal, waits for exit, and falls back to force-killing the process tree.
+// If inst is nil, it is looked up via store.Inspect when needed for forceful cleanup.
+func (r *LimaVMReconciler) shutdownHostagent(ctx context.Context, name string, inst *limatype.Instance) {
+	logger := log.FromContext(ctx)
+
+	forceStop := func() {
+		if inst == nil {
+			var err error
+			inst, err = store.Inspect(ctx, name)
+			if err != nil {
+				logger.Error(err, "Failed to inspect Lima instance for forceful stop")
+				return
+			}
+			if inst == nil {
+				return
+			}
+		}
+		stopInstanceForcibly(inst)
 	}
+
+	if r.signalHostagent(name) {
+		stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
+		defer cancel()
+		if !r.waitForProcessExit(stopCtx, name) {
+			logger.Info("Hostagent did not exit gracefully, forcing stop")
+			forceStop()
+			r.waitForProcessExit(ctx, name)
+		}
+	} else {
+		logger.Info("Could not signal hostagent, killing process directly")
+		r.killHostagent(name)
+		r.waitForProcessExit(ctx, name)
+		forceStop()
+	}
+}
+
+// killOrphanedHostagent terminates an orphaned hostagent (one running without a
+// watcher, typically after a controller restart).
+func (r *LimaVMReconciler) killOrphanedHostagent(_ context.Context, inst *limatype.Instance) error {
+	stopInstanceForcibly(inst)
 	return nil
+}
+
+// stopInstanceForcibly terminates the hostagent and driver processes and their
+// descendants. This replaces limainstance.StopForcibly because Lima's SysKill
+// on Windows uses GenerateConsoleCtrlEvent(CTRL_BREAK) which targets the entire
+// console group, killing the RDD service along with the hostagent.
+//
+// We use process.KillTree which sends SIGKILL to the process group on Unix and
+// uses taskkill /F /T on Windows, ensuring child processes (e.g. ssh.exe port
+// forwarders) are also terminated.
+func stopInstanceForcibly(inst *limatype.Instance) {
+	for _, pid := range []int{inst.DriverPID, inst.HostAgentPID} {
+		if pid > 0 {
+			_ = process.KillTree(context.Background(), pid)
+		}
+	}
 }

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -206,6 +206,16 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 		}
 		// The VM driver (e.g., QEMU) may outlive the hostagent. Force-stop
 		// the instance so the next hostagent can start with a clean slate.
+		//
+		// On Windows, StatusBroken instances may have stale PID files whose
+		// PIDs were recycled to unrelated processes. stopInstanceForcibly
+		// uses taskkill, which kills by PID without verifying the process
+		// identity. The deletion path (handleDeletion) guards against this
+		// by skipping PID-based kills for StatusBroken, but this path does
+		// not — the self-healing restart that follows limits the blast
+		// radius. The proper fix is to validate process identity (e.g.,
+		// check executable name) before killing, or use Windows Job Objects
+		// to track child processes without relying on PID files.
 		if inst.Status == limatype.StatusRunning || inst.Status == limatype.StatusBroken {
 			logger.Info("Force-stopping orphaned VM driver", "status", inst.Status)
 			stopInstanceForcibly(ctx, logger, inst)
@@ -269,6 +279,7 @@ func (r *LimaVMReconciler) handleUnwatchedState(ctx context.Context, limaVM *v1a
 	case limatype.StatusRunning, limatype.StatusBroken:
 		// Orphaned hostagent from before controller restart. Kill it so the
 		// next reconcile can start with a watcher.
+		// Same PID recycling caveat as handleWatchedState (see comment above).
 		logger.Info("Found orphaned hostagent, killing it", "status", inst.Status)
 		if err := r.killOrphanedHostagent(ctx, inst); err != nil {
 			logger.Error(err, "Failed to kill orphaned hostagent")

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -76,7 +76,7 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 		logger.Info("Deleting Lima instance", "instance", limaVM.Name)
 		// Use a timeout because Lima's WSL2 driver calls wsl.exe --unregister
 		// which can hang indefinitely if the WSL subsystem is degraded.
-		deleteCtx, deleteCancel := context.WithTimeout(ctx, 60*time.Second)
+		deleteCtx, deleteCancel := context.WithTimeout(ctx, time.Minute)
 		err = limainstance.Delete(deleteCtx, existingInst, true)
 		deleteCancel()
 		if err != nil {
@@ -634,7 +634,7 @@ func stopInstanceForcibly(ctx context.Context, logger logr.Logger, inst *limatyp
 	// If KillTree failed, the VM driver may still be using the disks.
 	if allKilled {
 		for _, d := range inst.AdditionalDisks {
-			disk, err := store.InspectDisk(d.Name)
+			disk, err := store.InspectDisk(d.Name, nil)
 			if err != nil {
 				logger.V(1).Info("Disk does not exist", "disk", d.Name)
 				continue

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -44,7 +44,12 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 		logger.Error(err, "Failed to inspect Lima instance for deletion")
 	}
 	if existingInst != nil {
-		if existingInst.Status == limatype.StatusRunning || existingInst.Status == limatype.StatusBroken {
+		// Only use PID-based force-stop for Running instances. Broken
+		// instances may have stale PID files pointing to recycled processes
+		// on Windows (Lima's ReadPIDFile treats any live PID as valid).
+		// Not tested: simulating stale PID files requires Windows-specific
+		// PID file manipulation that BATS cannot easily reproduce.
+		if existingInst.Status == limatype.StatusRunning {
 			stopInstanceForcibly(ctx, logger, existingInst)
 		} else if existingInst.VMType == limatype.WSL2 {
 			// A "stopped" WSL2 distro can retain kernel state that deadlocks
@@ -526,8 +531,8 @@ func (r *LimaVMReconciler) shutdownHostagent(ctx context.Context, name string, i
 			waitAfterKill()
 		}
 	} else {
-		logger.Info("Could not signal hostagent, killing process directly")
-		r.killHostagent(name)
+		logger.Info("No watcher for hostagent, forcing stop via stored PIDs")
+		r.killHostagent(name) // no-op if watcher absent; forceStop uses stored PIDs
 		forceStop()
 		waitAfterKill()
 	}

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -479,8 +479,9 @@ func (r *LimaVMReconciler) stopInstance(ctx context.Context, limaVM *v1alpha1.Li
 }
 
 // shutdownHostagent stops the hostagent for the named instance: sends a graceful
-// signal, waits for exit, and falls back to force-killing the process tree.
-// If inst is nil, it is looked up via store.Inspect when needed for forceful cleanup.
+// signal, waits for exit, and falls back to force-killing the process tree and
+// cleaning up WSL2 distros and tmp files. If inst is nil, it is looked up via
+// store.Inspect when needed for forceful cleanup.
 func (r *LimaVMReconciler) shutdownHostagent(ctx context.Context, name string, inst *limatype.Instance) {
 	logger := log.FromContext(ctx)
 

--- a/pkg/controllers/lima/limavm/controllers/ssh_keys.go
+++ b/pkg/controllers/lima/limavm/controllers/ssh_keys.go
@@ -16,6 +16,9 @@ import (
 // ensureSSHKeysAt generates an SSH keypair at privPath (and privPath+".pub")
 // if it doesn't already exist. Handles partial on-disk state from prior
 // crashes: missing public key, stale temp files, and corrupt private keys.
+//
+// Unlike Lima's DefaultPubKeys, this does not take an inter-process lock
+// because only one lima-controller runs per RDD instance.
 func ensureSSHKeysAt(ctx context.Context, privPath string) error {
 	// Bound ssh-keygen calls so a misconfigured system (e.g. hardware
 	// security module prompts, broken MSYS2 path conversion) cannot

--- a/pkg/controllers/lima/limavm/controllers/ssh_keys.go
+++ b/pkg/controllers/lima/limavm/controllers/ssh_keys.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// ensureSSHKeysAt generates an SSH keypair at privPath (and privPath+".pub")
+// if it doesn't already exist. Handles partial on-disk state from prior
+// crashes: missing public key, stale temp files, and corrupt private keys.
+func ensureSSHKeysAt(ctx context.Context, privPath string) error {
+	// Bound ssh-keygen calls so a misconfigured system (e.g. hardware
+	// security module prompts, broken MSYS2 path conversion) cannot
+	// block controller setup indefinitely.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	pubPath := privPath + ".pub"
+	if _, err := os.Stat(privPath); err == nil {
+		if _, err := os.Stat(pubPath); err == nil {
+			return nil
+		}
+		// Public key missing — try to derive it from the existing private key
+		// to preserve SSH access to existing VMs. Fall back to full regeneration
+		// if the private key is corrupt.
+		if pub, err := exec.CommandContext(ctx, "ssh-keygen", "-y", "-f", privPath).Output(); err == nil {
+			return os.WriteFile(pubPath, pub, 0o644)
+		}
+		_ = os.Remove(privPath)
+	}
+	// Remove orphaned public key (e.g. from a previous partial rename
+	// failure). On Windows, os.Rename fails if the destination exists.
+	_ = os.Remove(pubPath)
+	configDir := filepath.Dir(privPath)
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return fmt.Errorf("could not create %q: %w", configDir, err)
+	}
+	// Generate into a temporary path and rename on success, so an
+	// interrupted ssh-keygen does not leave a partial key that blocks
+	// future attempts.
+	tmpPath := privPath + ".tmp"
+	// Clean up stale temp files from a prior crash so ssh-keygen does not
+	// prompt "Overwrite (y/n)?" and hang waiting for a TTY that doesn't exist.
+	_ = os.Remove(tmpPath)
+	_ = os.Remove(tmpPath + ".pub")
+	cmd := exec.CommandContext(ctx, "ssh-keygen", "-t", "ed25519", "-q", "-N", "",
+		"-C", "lima", "-f", tmpPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// Clean up any partial files left by ssh-keygen.
+		_ = os.Remove(tmpPath)
+		_ = os.Remove(tmpPath + ".pub")
+		return fmt.Errorf("failed to generate SSH key: %s: %w", out, err)
+	}
+	if err := os.Rename(tmpPath+".pub", pubPath); err != nil {
+		_ = os.Remove(tmpPath)
+		_ = os.Remove(tmpPath + ".pub")
+		return fmt.Errorf("failed to rename public key: %w", err)
+	}
+	if err := os.Rename(tmpPath, privPath); err != nil {
+		_ = os.Remove(pubPath)
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename private key: %w", err)
+	}
+	return nil
+}

--- a/pkg/controllers/lima/limavm/controllers/ssh_keys_test.go
+++ b/pkg/controllers/lima/limavm/controllers/ssh_keys_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestEnsureSSHKeysAt(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("both keys exist", func(t *testing.T) {
+		dir := t.TempDir()
+		privPath := filepath.Join(dir, "user")
+		// Generate a real keypair first.
+		assert.NilError(t, ensureSSHKeysAt(ctx, privPath))
+		privBefore, err := os.ReadFile(privPath)
+		assert.NilError(t, err)
+
+		// Calling again should be a no-op.
+		assert.NilError(t, ensureSSHKeysAt(ctx, privPath))
+		privAfter, err := os.ReadFile(privPath)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, privBefore, privAfter)
+	})
+
+	t.Run("missing public key derives from private key", func(t *testing.T) {
+		dir := t.TempDir()
+		privPath := filepath.Join(dir, "user")
+		pubPath := privPath + ".pub"
+
+		// Generate a real keypair, then remove the public key.
+		assert.NilError(t, ensureSSHKeysAt(ctx, privPath))
+		privBefore, err := os.ReadFile(privPath)
+		assert.NilError(t, err)
+		assert.NilError(t, os.Remove(pubPath))
+
+		// Should derive the public key without regenerating the private key.
+		assert.NilError(t, ensureSSHKeysAt(ctx, privPath))
+		privAfter, err := os.ReadFile(privPath)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, privBefore, privAfter)
+		_, err = os.Stat(pubPath)
+		assert.NilError(t, err)
+	})
+
+	t.Run("corrupt private key triggers full regeneration", func(t *testing.T) {
+		dir := t.TempDir()
+		privPath := filepath.Join(dir, "user")
+		pubPath := privPath + ".pub"
+
+		// Write a corrupt private key (no public key).
+		assert.NilError(t, os.WriteFile(privPath, []byte("not a key"), 0o600))
+
+		// Should remove the corrupt key and generate a fresh pair.
+		assert.NilError(t, ensureSSHKeysAt(ctx, privPath))
+		priv, err := os.ReadFile(privPath)
+		assert.NilError(t, err)
+		assert.Assert(t, len(priv) > 20, "private key should be a real key, got %d bytes", len(priv))
+		_, err = os.Stat(pubPath)
+		assert.NilError(t, err)
+	})
+
+	t.Run("stale temp files from prior crash", func(t *testing.T) {
+		dir := t.TempDir()
+		privPath := filepath.Join(dir, "user")
+		tmpPath := privPath + ".tmp"
+
+		// Simulate a crash that left temp files behind.
+		assert.NilError(t, os.WriteFile(tmpPath, []byte("stale"), 0o600))
+		assert.NilError(t, os.WriteFile(tmpPath+".pub", []byte("stale"), 0o600))
+
+		// Should clean up stale temps and generate fresh keys.
+		assert.NilError(t, ensureSSHKeysAt(ctx, privPath))
+		_, err := os.Stat(privPath)
+		assert.NilError(t, err)
+		_, err = os.Stat(privPath + ".pub")
+		assert.NilError(t, err)
+		// Temp files should be gone.
+		_, err = os.Stat(tmpPath)
+		assert.Assert(t, os.IsNotExist(err))
+		_, err = os.Stat(tmpPath + ".pub")
+		assert.Assert(t, os.IsNotExist(err))
+	})
+
+	t.Run("orphaned public key without private key", func(t *testing.T) {
+		dir := t.TempDir()
+		privPath := filepath.Join(dir, "user")
+		pubPath := privPath + ".pub"
+
+		// Only the public key exists (e.g. from a partial rename failure).
+		assert.NilError(t, os.WriteFile(pubPath, []byte("orphan"), 0o644))
+
+		// Should remove the orphaned pubkey and generate a fresh pair.
+		assert.NilError(t, ensureSSHKeysAt(ctx, privPath))
+		_, err := os.Stat(privPath)
+		assert.NilError(t, err)
+		_, err = os.Stat(pubPath)
+		assert.NilError(t, err)
+	})
+
+	t.Run("no keys exist", func(t *testing.T) {
+		dir := t.TempDir()
+		privPath := filepath.Join(dir, "user")
+
+		assert.NilError(t, ensureSSHKeysAt(ctx, privPath))
+		_, err := os.Stat(privPath)
+		assert.NilError(t, err)
+		_, err = os.Stat(privPath + ".pub")
+		assert.NilError(t, err)
+	})
+}

--- a/pkg/controllers/lima/limavm/controllers/ssh_keys_unix.go
+++ b/pkg/controllers/lima/limavm/controllers/ssh_keys_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import "context"
+
+// ensureSSHKeys is a no-op on Unix. Lima's DefaultPubKeys generates the
+// SSH keypair correctly on Unix; the workaround is only needed on Windows
+// where Lima's cygpath-based path conversion breaks with Windows OpenSSH.
+func ensureSSHKeys(_ context.Context) error {
+	return nil
+}

--- a/pkg/controllers/lima/limavm/controllers/ssh_keys_windows.go
+++ b/pkg/controllers/lima/limavm/controllers/ssh_keys_windows.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype/dirnames"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+)
+
+// ensureSSHKeys generates Lima's SSH keypair if it doesn't exist.
+// Lima's DefaultPubKeys uses cygpath to convert the key path to MSYS2 format
+// (/c/...), which only works with MSYS2's ssh-keygen. Windows OpenSSH's
+// ssh-keygen doesn't understand MSYS2 paths and fails with "No such file".
+// By pre-generating the key with a native Windows path, Lima finds the
+// existing key and skips its broken keygen path.
+func ensureSSHKeys(ctx context.Context) error {
+	configDir, err := dirnames.LimaConfigDir()
+	if err != nil {
+		return err
+	}
+	return ensureSSHKeysAt(ctx, filepath.Join(configDir, filenames.UserPrivateKey))
+}

--- a/pkg/external/main.go
+++ b/pkg/external/main.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -37,6 +39,7 @@ func RunControllers(apiGroupName string) int {
 	flag.IntVar(&desiredHealthPort, "health-port", 8081+instanceOffset, "The desired port the health probe endpoint binds to.")
 
 	klog.InitFlags(nil)
+	setVerbosityFromEnv()
 	//revive:disable-next-line:deep-exit
 	flag.Parse()
 
@@ -249,4 +252,34 @@ func shouldStartController(ctx context.Context, config *rest.Config, controllerN
 		"metricsEndpoint", info.MetricsEndpoint)
 
 	return false, nil
+}
+
+// setVerbosityFromEnv sets klog verbosity from RDD_LOG_LEVEL as a default.
+// Called before flag.Parse() so that an explicit -v flag on the command line
+// takes precedence.
+//
+// The RDD service (cmd/rdd) uses logrus, where log levels map directly to
+// names (trace, debug, info, warn, error). External controllers use klog,
+// which has numeric verbosity instead of named levels. The mapping is:
+//   - trace → v=4 (very verbose, including per-reconcile details)
+//   - debug → v=2 (controller lifecycle events)
+//   - info  → v=0 (default; errors and high-level status only)
+func setVerbosityFromEnv() {
+	level := strings.TrimSpace(os.Getenv("RDD_LOG_LEVEL"))
+	switch strings.ToLower(level) {
+	case "trace":
+		if err := flag.Set("v", "4"); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to set klog verbosity: %v\n", err)
+		}
+	case "debug":
+		if err := flag.Set("v", "2"); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to set klog verbosity: %v\n", err)
+		}
+	case "", "info":
+		// info is the default klog verbosity; nothing to change.
+	default:
+		// klog has no warn/error levels; unsupported values fall through to
+		// the default verbosity (v=0), which is equivalent to info-only.
+		fmt.Fprintf(os.Stderr, "RDD_LOG_LEVEL=%q is not supported for klog; valid values are trace, debug, info\n", level)
+	}
 }

--- a/pkg/external/main.go
+++ b/pkg/external/main.go
@@ -275,11 +275,10 @@ func setVerbosityFromEnv() {
 		if err := flag.Set("v", "2"); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to set klog verbosity: %v\n", err)
 		}
-	case "", "info":
-		// info is the default klog verbosity; nothing to change.
+	case "", "info", "warn", "warning", "error", "fatal":
+		// klog cannot suppress info-level messages, so higher logrus levels
+		// map to the default verbosity (v=0).
 	default:
-		// klog has no warn/error levels; unsupported values fall through to
-		// the default verbosity (v=0), which is equivalent to info-only.
 		fmt.Fprintf(os.Stderr, "RDD_LOG_LEVEL=%q is not supported for klog; valid values are trace, debug, info\n", level)
 	}
 }

--- a/pkg/external/main.go
+++ b/pkg/external/main.go
@@ -132,9 +132,10 @@ func RunControllers(apiGroupName string) int {
 // This allows external controllers to automatically exit when `rdd svc stop` or `rdd svc delete` is called.
 func monitorControlPlane(ctx context.Context, apiGroupName string, config *rest.Config, log klog.Logger, cancel context.CancelFunc) {
 	// Use a short timeout for monitoring so we detect shutdown quickly.
-	// 1 second is sufficient for local API server connections.
+	// 2 seconds allows margin for Windows localhost TLS handshakes under load,
+	// while still detecting real shutdowns promptly (connection refused is instant).
 	monitorConfig := rest.CopyConfig(config)
-	monitorConfig.Timeout = time.Second
+	monitorConfig.Timeout = 2 * time.Second
 
 	discovery, err := controllers.NewControllerManagerDiscoveryGroup(monitorConfig, apiGroupName)
 	if err != nil {
@@ -189,7 +190,7 @@ func monitorControlPlane(ctx context.Context, apiGroupName string, config *rest.
 	defer ticker.Stop()
 
 	consecutiveFailures := 0
-	const maxFailures = 2 // 4 seconds of failures (2 * 2 seconds) - sufficient for local connections
+	const maxFailures = 3 // ~6 seconds of failures before shutdown
 
 	log.V(1).Info("Starting control plane monitoring")
 

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -365,7 +365,7 @@ func StopWithWait(wait bool) error {
 		for {
 			select {
 			case <-timeout:
-				// Graceful shutdown timed out; force-kill so we don't leave
+				// Graceful shutdown timed out; terminate so we don't leave
 				// a hung service process. Kill targets only the service; on
 				// Windows (TerminateProcess) this avoids killing hostagents
 				// that are children of the service but run in their own

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -343,11 +343,12 @@ func StopWithWait(wait bool) error {
 	// which bypasses all handlers, so we send Interrupt (CTRL_BREAK_EVENT)
 	// first to let the service run its shutdown path (shutdownAllHostagents).
 	//
-	// On Windows, Interrupt uses GenerateConsoleCtrlEvent, which only works
-	// when caller and target share a console. If invoked from a different
-	// terminal, the call fails and we fall back to Kill (TerminateProcess),
-	// bypassing graceful shutdown. Hostagents survive in their own process
-	// groups and self-heal on the next service start via killOrphanedHostagent.
+	// On Unix, Interrupt (SIGINT) always succeeds for a valid PID, so the
+	// Kill fallback never fires. On Windows, Interrupt uses
+	// GenerateConsoleCtrlEvent, which fails when caller and target lack a
+	// shared console; Kill (TerminateProcess) then bypasses graceful shutdown.
+	// Hostagents survive in their own process groups and self-heal on the
+	// next service start via killOrphanedHostagent.
 	if err := process.Interrupt(pid); err != nil {
 		if err := process.Kill(pid); err != nil {
 			return fmt.Errorf("failed to stop %q control plane with pid %d: %w", instance.Name(), pid, err)

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -338,8 +338,20 @@ func StopWithWait(wait bool) error {
 	_ = cleanupDiscoveryConfigMap() // Clean up discovery configmap to prevent stale controller info
 
 	pid := PID()
-	if err := process.Kill(pid); err != nil {
-		return fmt.Errorf("failed to stop %q control plane with pid %d: %w", instance.Name(), pid, err)
+	// Try graceful shutdown first. On Unix, Kill already sends SIGTERM which
+	// triggers the Go signal handler. On Windows, Kill uses TerminateProcess
+	// which bypasses all handlers, so we send Interrupt (CTRL_BREAK_EVENT)
+	// first to let the service run its shutdown path (shutdownAllHostagents).
+	//
+	// On Windows, Interrupt uses GenerateConsoleCtrlEvent, which only works
+	// when caller and target share a console. If invoked from a different
+	// terminal, the call fails and we fall back to Kill (TerminateProcess),
+	// bypassing graceful shutdown. Hostagents survive in their own process
+	// groups and self-heal on the next service start via killOrphanedHostagent.
+	if err := process.Interrupt(pid); err != nil {
+		if err := process.Kill(pid); err != nil {
+			return fmt.Errorf("failed to stop %q control plane with pid %d: %w", instance.Name(), pid, err)
+		}
 	}
 
 	if wait {
@@ -352,6 +364,14 @@ func StopWithWait(wait bool) error {
 		for {
 			select {
 			case <-timeout:
+				// Graceful shutdown timed out; force-kill so we don't leave
+				// a hung service process. Kill targets only the service; on
+				// Windows (TerminateProcess) this avoids killing hostagents
+				// that are children of the service but run in their own
+				// process groups. On Unix, SIGTERM suffices because the
+				// service is responsive to signals (it's just slow shutting
+				// down hostagents sequentially).
+				_ = process.Kill(pid)
 				return fmt.Errorf("timed out waiting for %q control plane with pid %d to stop", instance.Name(), pid)
 			case <-ticker.C:
 				if !Running() {

--- a/pkg/util/process/process_unix.go
+++ b/pkg/util/process/process_unix.go
@@ -39,11 +39,21 @@ func Kill(pid int) error {
 // taskkill /F /T to walk the parent-child tree. When the target is a group
 // leader whose children remain in the same group (the expected usage), both
 // platforms produce the same result.
+//
+// If the process group does not exist (the target is not a group leader),
+// falls back to killing the individual process. This handles cases like
+// a VM driver (e.g., QEMU) that inherited its parent's process group.
+//
 // Returns nil if the process (group) no longer exists.
 func KillTree(_ context.Context, pid int) error {
 	err := unix.Kill(-pid, unix.SIGKILL)
 	if errors.Is(err, unix.ESRCH) {
-		return nil
+		// Process group does not exist — the target may not be a group
+		// leader. Fall back to killing the individual process.
+		err = unix.Kill(pid, unix.SIGKILL)
+		if errors.Is(err, unix.ESRCH) {
+			return nil
+		}
 	}
 	return err
 }

--- a/pkg/util/process/process_unix.go
+++ b/pkg/util/process/process_unix.go
@@ -8,6 +8,8 @@
 package process
 
 import (
+	"context"
+	"errors"
 	"os/exec"
 
 	"golang.org/x/sys/unix"
@@ -15,10 +17,33 @@ import (
 
 // SetGroup configures the command to run in its own process group.
 func SetGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &unix.SysProcAttr{Setpgid: true}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &unix.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// Interrupt sends SIGINT to the process with the given PID.
+func Interrupt(pid int) error {
+	return unix.Kill(pid, unix.SIGINT)
 }
 
 // Kill sends SIGTERM to the process with the given PID.
 func Kill(pid int) error {
 	return unix.Kill(pid, unix.SIGTERM)
+}
+
+// KillTree terminates the process and all its descendants.
+// The target must have been started with SetGroup so it leads its own group.
+// On Unix, this sends SIGKILL to the process group. On Windows, this uses
+// taskkill /F /T to walk the parent-child tree. When the target is a group
+// leader whose children remain in the same group (the expected usage), both
+// platforms produce the same result.
+// Returns nil if the process (group) no longer exists.
+func KillTree(_ context.Context, pid int) error {
+	err := unix.Kill(-pid, unix.SIGKILL)
+	if errors.Is(err, unix.ESRCH) {
+		return nil
+	}
+	return err
 }

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -60,6 +60,10 @@ func Kill(pid int) error {
 	return nil
 }
 
+// taskkillExitNotFound is the exit code taskkill returns when the target
+// process does not exist. Not officially documented by Microsoft.
+const taskkillExitNotFound = 128
+
 // KillTree terminates the process and all its descendants.
 // The target must have been started with SetGroup so it leads its own group.
 // On Windows, this uses taskkill /F /T to walk the parent-child tree. On
@@ -78,7 +82,7 @@ func Kill(pid int) error {
 func KillTree(ctx context.Context, pid int) error {
 	err := exec.CommandContext(ctx, "taskkill", "/F", "/T", "/PID", strconv.Itoa(pid)).Run()
 	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == taskkillExitNotFound {
 		return nil
 	}
 	return err

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -6,16 +6,32 @@
 package process
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"time"
 
 	"golang.org/x/sys/windows"
 )
 
 // SetGroup configures the command to run in its own process group.
-func SetGroup(*exec.Cmd) {
-	// Not implemented on Windows.
+// On Windows, CREATE_NEW_PROCESS_GROUP allows GenerateConsoleCtrlEvent to
+// target only the child process (using its PID as the group ID) without
+// affecting the parent process.
+func SetGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &windows.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP
+}
+
+// Interrupt sends a graceful shutdown signal to the process with the given PID.
+// On Windows, this uses GenerateConsoleCtrlEvent with CTRL_BREAK_EVENT targeted
+// at the process group (requires CREATE_NEW_PROCESS_GROUP via SetGroup).
+func Interrupt(pid int) error {
+	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(pid))
 }
 
 // Kill terminates the process with the given PID.
@@ -33,10 +49,39 @@ func Kill(pid int) error {
 	if err := windows.TerminateProcess(hProcess, 1); err != nil {
 		return fmt.Errorf("failed to terminate process %d: %w", pid, err)
 	}
-	_, err = windows.WaitForSingleObject(hProcess, uint32(10*time.Second/time.Millisecond))
+	result, err := windows.WaitForSingleObject(hProcess, uint32(10*time.Second/time.Millisecond))
 	if err != nil {
-		return fmt.Errorf("timed out waiting for process %d to terminate: %w", pid, err)
+		return fmt.Errorf("failed waiting for process %d to terminate: %w", pid, err)
+	}
+	if result == uint32(windows.WAIT_TIMEOUT) {
+		return fmt.Errorf("timed out waiting for process %d to terminate", pid)
 	}
 
 	return nil
+}
+
+// KillTree terminates the process and all its descendants.
+// The target must have been started with SetGroup so it leads its own group.
+// On Windows, this uses taskkill /F /T to walk the parent-child tree. On
+// Unix, this sends SIGKILL to the process group. When the target is a group
+// leader whose children remain in the same group (the expected usage), both
+// platforms produce the same result.
+//
+// Platform asymmetry: if the target process is already dead, taskkill /T
+// returns exit code 128 (treated as success), but surviving children (e.g.,
+// SSH port forwarders) are not killed because taskkill cannot traverse the
+// tree from a dead parent. On Unix, kill(-pgid) still reaches all group
+// members. This is acceptable: orphaned port forwarders cannot rebind their
+// ports and are harmless. Windows Job Objects would fix this if needed.
+//
+// Returns nil if the process no longer exists (taskkill exit code 128).
+func KillTree(ctx context.Context, pid int) error {
+	err := exec.CommandContext(ctx, "taskkill", "/F", "/T", "/PID", strconv.Itoa(pid)).Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
+			return nil
+		}
+	}
+	return err
 }

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -77,11 +77,9 @@ func Kill(pid int) error {
 // Returns nil if the process no longer exists (taskkill exit code 128).
 func KillTree(ctx context.Context, pid int) error {
 	err := exec.CommandContext(ctx, "taskkill", "/F", "/T", "/PID", strconv.Itoa(pid)).Run()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
-			return nil
-		}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
+		return nil
 	}
 	return err
 }

--- a/scripts/collect-bats-logs.sh
+++ b/scripts/collect-bats-logs.sh
@@ -22,21 +22,23 @@ REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 
 output_dir=${1:-rdd-logs}
 
-# Use .exe extension on Windows (WSL runs Windows binaries via interop).
+# Use .exe extension on Windows (WSL or MSYS2).
 rdd="${REPO_ROOT}/bin/rdd"
-if command -v wslpath >/dev/null 2>&1; then
+if command -v wslpath >/dev/null 2>&1 || command -v cygpath >/dev/null 2>&1; then
     rdd="${REPO_ROOT}/bin/rdd.exe"
 fi
 
 # Pass RDD_INSTANCE to Windows binaries via WSL interop.
 export WSLENV="${WSLENV:+${WSLENV}:}RDD_INSTANCE"
 
-# Resolve a path from rdd, converting Windows paths to WSL paths if needed.
+# Resolve a path from rdd, converting Windows paths to POSIX paths if needed.
 resolve_path() {
     local p
     p=$("$rdd" svc paths "$1" | tr -d '\r') || return 1
     if command -v wslpath >/dev/null 2>&1; then
         p=$(wslpath -ua "$p")
+    elif command -v cygpath >/dev/null 2>&1; then
+        p=$(cygpath -u "$p")
     fi
     echo "$p"
 }


### PR DESCRIPTION
### Summary

- WSL2's `binfmt_misc` interop (which transparently executes `.exe` files from Linux) breaks mid-run on GitHub Actions runners, causing flaky test failures that are impossible to fix from our side. MSYS2 avoids this entirely because `rdd.exe` runs natively without interop translation. WSL2 is still installed for Lima (which needs it as a VM backend), but BATS itself no longer depends on a WSL distro.
- Fix Windows process signaling so stopping or restarting a VM no longer kills the RDD service (hostagents now run in their own process group)
- Fix `stopInstanceForcibly` to terminate the WSL2 distro and clean up stale PID/socket files; always terminate before unregistering to prevent `wslservice.exe` deadlocks
- Add Windows-specific Lima VM template (`finch` rootfs) and SSH key pre-generation to avoid MSYS2 path conversion issues
- Switch CI from WSL2-based BATS to MSYS2-based BATS, eliminating the dependency on a WSL distro for the test runner itself
- Honor `RDD_LOG_LEVEL` in externally spawned controllers so debug logging propagates correctly

### Key changes

Process isolation (`process_windows.go`, `limavm_lifecycle.go`): Each hostagent subprocess gets `CREATE_NEW_PROCESS_GROUP`. New `process.Interrupt()` sends `CTRL_BREAK_EVENT` targeted at the hostagent's group only. `stopInstanceForcibly` uses `TerminateProcess` instead of console-wide break events.

WSL2 deadlock prevention (`limavm_lifecycle.go`): `stopInstanceForcibly` now runs unconditionally before `wsl --unregister`, even for stopped instances. A "stopped" WSL2 distro can retain kernel-level state that deadlocks `wslservice.exe`, bricking all subsequent `wsl.exe` calls.

BATS hardening (`limavm-running.bats`): The cleanup test wraps `rdd ctl wait --for=delete` with an outer timeout and kills `wslservice.exe` if the wait hangs, recovering from WSL deadlocks instead of blocking the entire suite.

CI workflow (`bats.yaml`): Windows BATS tests run under MSYS2 (UCRT64) instead of inside a WSL2 distro. The Lima controller tests use the `finch` rootfs on Windows and the `opensuse` image on macOS.