### PR TITLE
Encode owner Kind in owned finalizer, document webhook requirement

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-lifecycle.bats
+++ b/bats/tests/33-lima-controllers/limavm-lifecycle.bats
@@ -74,7 +74,7 @@ EOF
 
 @test "verify template ConfigMap has owned finalizer" {
     run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.metadata.finalizers}'
-    assert_output --partial "rdd.rancherdesktop.io/owned"
+    assert_output --partial "rdd.rancherdesktop.io/owned-by-LimaVM"
 }
 
 @test "verify template ConfigMap has owner reference" {
@@ -133,12 +133,19 @@ EOF
     assert_output "${template_before}"
 }
 
+@test "template ConfigMap label removal is rejected while owned" {
+    run -1 rdd ctl patch configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --type='merge' \
+        --patch='{"metadata":{"labels":{"lima.rancherdesktop.io/template-configmap":null}}}'
+    assert_output --partial "Forbidden"
+    assert_output --partial "cannot remove"
+    assert_output --partial "resource is owned"
+}
+
 @test "template ConfigMap cannot be deleted independently" {
     run -1 rdd ctl delete configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --grace-period=0
     assert_output --partial "Forbidden"
-    assert_output --partial "cannot delete template ConfigMap"
-    assert_output --partial "protected by the LimaVM controller"
-    assert_output --partial "delete the owning LimaVM resource instead"
+    assert_output --partial "owned by LimaVM"
+    assert_output --partial "delete the LimaVM resource instead"
 
     # Verify the ConfigMap still exists
     run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}"
@@ -148,7 +155,7 @@ EOF
 @test "dry-run deletion of template ConfigMap is also rejected" {
     run -1 rdd ctl delete configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --dry-run=server
     assert_output --partial "Forbidden"
-    assert_output --partial "cannot delete template ConfigMap"
+    assert_output --partial "owned by LimaVM"
 
     # Verify the ConfigMap still exists
     run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}"

--- a/docs/design/controllers.md
+++ b/docs/design/controllers.md
@@ -32,23 +32,39 @@ A resource's own controller sets this finalizer to run cleanup before deletion. 
 
 `DeleteOwnedResources` does **not** strip this finalizer. Only the resource's own controller removes it.
 
-### `rdd.rancherdesktop.io/owned` (Cascade Blocking)
+### `rdd.rancherdesktop.io/owned-by-<Kind>` (Cascade Blocking)
 
-An owner controller sets this on child resources to block their deletion until the owner explicitly releases them via `DeleteOwnedResources`.
+An owner controller sets this on child resources to block their deletion until the owner explicitly releases them. The finalizer name encodes the owner's Kind (e.g., `rdd.rancherdesktop.io/owned-by-App`), making it self-documenting and allowing the validating webhook to tell the user which resource to delete instead.
 
 | Function | Purpose |
 |----------|---------|
+| `OwnedFinalizerFor(kind)` | Return the finalizer name for a given owner Kind |
 | `EnsureOwnedFinalizer` | Add owned finalizer to a child resource |
 | `RemoveOwnedFinalizer` | Remove owned finalizer from a child resource |
-| `HasOwnedFinalizer` | Check whether the owned finalizer is present |
+| `HasOwnedFinalizer` | Check whether any owned finalizer is present |
+| `OwnedFinalizerOwner` | Return the owner Kind from the finalizer, or "" |
+
+#### Validating Webhook Requirement
+
+Any resource type that may carry an owned finalizer **must** have a validating webhook with a `ValidateDelete` handler that rejects DELETE requests while the finalizer is present. The owned finalizer and the webhook work together as a single access-control mechanism:
+
+1. The owner creates the child with `OwnedFinalizerFor("OwnerKind")` in its finalizers.
+2. The webhook calls `OwnedFinalizerOwner` on DELETE and rejects the request with a clear error (e.g., *"cannot delete 'rd': owned by App; delete the App resource instead"*).
+3. When the owner wants to delete the child, it calls `RemoveOwnedFinalizer` first. The next DELETE passes the webhook because the finalizer is gone.
+
+Without the webhook, a DELETE request is accepted by the API server and the resource enters Terminating — but the finalizer prevents actual deletion, leaving a stuck resource with no explanation. The webhook prevents this by rejecting the DELETE outright.
+
+If the webhook uses `ObjectSelector` to match a label, the validator must also reject updates that remove the label while the owned finalizer is present. Otherwise a label removal silently deactivates the webhook, and the next DELETE bypasses the guard.
+
+For an example, see `ConfigMapValidator` in the LimaVM controller, which embeds `OwnedDeletionGuard` to protect template ConfigMaps owned by LimaVM resources.
 
 ### Why Two Finalizers?
 
-A resource can need both finalizers. Consider a LimaVM owned by the App controller. The App controller sets `/owned` on the LimaVM so `DeleteOwnedResources` can release it during App deletion. The LimaVM controller sets `/cleanup` on itself to stop the VM and delete disk files before the resource disappears. With a single finalizer, `DeleteOwnedResources` would strip it, and the LimaVM would be deleted without ever running its cleanup — leaking the VM on disk.
+A resource can need both finalizers. Consider a LimaVM owned by the App controller. The App controller sets `/owned-by-App` on the LimaVM so `DeleteOwnedResources` can release it during App deletion. The LimaVM controller sets `/cleanup` on itself to stop the VM and delete disk files before the resource disappears. With a single finalizer, `DeleteOwnedResources` would strip it, and the LimaVM would be deleted without ever running its cleanup — leaking the VM on disk.
 
 ## DeleteOwnedResources
 
-`DeleteOwnedResources` finds all resources owned by a given object (via owner references), strips their `/owned` finalizer, and deletes them. It uses dynamic resource discovery to find all namespaced resource types without a hardcoded list.
+`DeleteOwnedResources` finds all resources owned by a given object (via owner references), strips their `owned-by-*` finalizers, and deletes them. It uses dynamic resource discovery to find all namespaced resource types without a hardcoded list.
 
 For cluster-scoped owners, the resource must implement `ResourceNamespace` to specify which namespace contains its children.
 

--- a/pkg/apis/lima/v1alpha1/limavm_types.go
+++ b/pkg/apis/lima/v1alpha1/limavm_types.go
@@ -8,6 +8,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// LimaVMKind is the Kind string for LimaVM resources.
+const LimaVMKind = "LimaVM"
+
 // TemplateConfigMapKey is the key used to store the template text in the templateConfigMap.
 const TemplateConfigMapKey = "template"
 

--- a/pkg/controllers/base/finalizer.go
+++ b/pkg/controllers/base/finalizer.go
@@ -27,9 +27,15 @@ import (
 // DeleteOwnedResources does NOT strip this finalizer.
 const CleanupFinalizerName = "rdd.rancherdesktop.io/cleanup"
 
-// OwnedFinalizerName is the cascade-blocking finalizer. An owner controller sets it on
-// child resources so that DeleteOwnedResources can strip it to unblock deletion.
-const OwnedFinalizerName = "rdd.rancherdesktop.io/owned"
+// ownedFinalizerPrefix is the prefix for cascade-blocking finalizers. The full finalizer
+// name includes the owner's Kind so that the validating webhook can tell the user
+// which resource to delete instead (e.g., "rdd.rancherdesktop.io/owned-by-App").
+const ownedFinalizerPrefix = "rdd.rancherdesktop.io/owned-by-"
+
+// OwnedFinalizerFor returns the owned finalizer name for a given owner Kind.
+func OwnedFinalizerFor(ownerKind string) string {
+	return ownedFinalizerPrefix + ownerKind
+}
 
 // EnsureCleanupFinalizer adds the cleanup finalizer to the object if not already present.
 // Returns true if the finalizer was added and the object has been updated.
@@ -55,10 +61,16 @@ func RemoveCleanupFinalizer(ctx context.Context, c client.Client, obj client.Obj
 	return nil
 }
 
-// EnsureOwnedFinalizer adds the owned finalizer to a child object if not already present.
-// Returns true if the finalizer was added and the object has been updated.
-func EnsureOwnedFinalizer(ctx context.Context, c client.Client, obj client.Object) (bool, error) {
-	if !controllerutil.AddFinalizer(obj, OwnedFinalizerName) {
+// EnsureOwnedFinalizer adds the owned finalizer for ownerKind to a child object if not
+// already present. Returns true if the finalizer was added and the object has been updated.
+// A resource may have at most one owned finalizer; adding a second is a programming error.
+func EnsureOwnedFinalizer(ctx context.Context, c client.Client, obj client.Object, ownerKind string) (bool, error) {
+	// Belt-and-suspenders: controllerutil.SetControllerReference already rejects a second
+	// controller owner, so this should never trigger. Guard anyway for a clear error message.
+	if existing := OwnedFinalizerOwner(obj); existing != "" && existing != ownerKind {
+		return false, fmt.Errorf("cannot add owned-by-%s finalizer: already owned by %s (multi-owner not supported)", ownerKind, existing)
+	}
+	if !controllerutil.AddFinalizer(obj, OwnedFinalizerFor(ownerKind)) {
 		return false, nil
 	}
 	if err := c.Update(ctx, obj); err != nil {
@@ -67,9 +79,9 @@ func EnsureOwnedFinalizer(ctx context.Context, c client.Client, obj client.Objec
 	return true, nil
 }
 
-// RemoveOwnedFinalizer removes the owned finalizer from the object and updates it.
-func RemoveOwnedFinalizer(ctx context.Context, c client.Client, obj client.Object) error {
-	if controllerutil.RemoveFinalizer(obj, OwnedFinalizerName) {
+// RemoveOwnedFinalizer removes the owned finalizer for ownerKind from the object and updates it.
+func RemoveOwnedFinalizer(ctx context.Context, c client.Client, obj client.Object, ownerKind string) error {
+	if controllerutil.RemoveFinalizer(obj, OwnedFinalizerFor(ownerKind)) {
 		if err := c.Update(ctx, obj); err != nil {
 			return fmt.Errorf("failed to remove owned finalizer: %w", err)
 		}
@@ -156,10 +168,10 @@ func DeleteOwnedResources(ctx context.Context, c client.Client, owner client.Obj
 				continue
 			}
 
-			// Strip the owned finalizer to unblock deletion. The cleanup finalizer (if any)
+			// Strip owned finalizers to unblock deletion. The cleanup finalizer (if any)
 			// remains so the child's own controller can still run its cleanup logic.
 			patch := client.MergeFrom(item.DeepCopy())
-			if controllerutil.RemoveFinalizer(&item, OwnedFinalizerName) {
+			if removeOwnedFinalizers(&item) {
 				// Use Patch instead of Update for PartialObjectMetadata
 				if err := c.Patch(ctx, &item, patch); err != nil {
 					itemLogger := logger.V(1).WithValues("namespace", item.GetNamespace(), "name", item.GetName(), "gvk", gvk.String())
@@ -242,9 +254,38 @@ func HasCleanupFinalizer(obj client.Object) bool {
 	return controllerutil.ContainsFinalizer(obj, CleanupFinalizerName)
 }
 
-// HasOwnedFinalizer checks if a resource has the owned finalizer.
+// HasOwnedFinalizer checks if a resource has any owned finalizer.
 func HasOwnedFinalizer(obj client.Object) bool {
-	return controllerutil.ContainsFinalizer(obj, OwnedFinalizerName)
+	return OwnedFinalizerOwner(obj) != ""
+}
+
+// OwnedFinalizerOwner returns the owner Kind encoded in the owned finalizer,
+// or "" if no owned finalizer is present.
+func OwnedFinalizerOwner(obj client.Object) string {
+	for _, f := range obj.GetFinalizers() {
+		if strings.HasPrefix(f, ownedFinalizerPrefix) {
+			return strings.TrimPrefix(f, ownedFinalizerPrefix)
+		}
+	}
+	return ""
+}
+
+// removeOwnedFinalizers strips all owned-by-* finalizers from obj.
+// Returns true if any were removed. Multi-owner is not supported
+// (EnsureOwnedFinalizer rejects it), so at most one will be present.
+func removeOwnedFinalizers(obj client.Object) bool {
+	finalizers := obj.GetFinalizers()
+	filtered := make([]string, 0, len(finalizers))
+	for _, f := range finalizers {
+		if !strings.HasPrefix(f, ownedFinalizerPrefix) {
+			filtered = append(filtered, f)
+		}
+	}
+	if len(filtered) == len(finalizers) {
+		return false
+	}
+	obj.SetFinalizers(filtered)
+	return true
 }
 
 // IsOwnedByUID checks if a resource is owned by an owner with the given UID.

--- a/pkg/controllers/base/finalizer_test.go
+++ b/pkg/controllers/base/finalizer_test.go
@@ -69,12 +69,12 @@ func TestDeleteOwnedResources(t *testing.T) {
 		},
 		{
 			name:          "config map with owned finalizer only",
-			finalizers:    []string{OwnedFinalizerName},
+			finalizers:    []string{OwnedFinalizerFor("ConfigMap")},
 			expectDeleted: true,
 		},
 		{
 			name:          "config map with both finalizers strips only owned",
-			finalizers:    []string{CleanupFinalizerName, OwnedFinalizerName},
+			finalizers:    []string{CleanupFinalizerName, OwnedFinalizerFor("ConfigMap")},
 			expectDeleted: false,
 		},
 	}
@@ -151,4 +151,83 @@ func TestDeleteOwnedResources(t *testing.T) {
 			assert.Check(t, cmp.ErrorIs(err, nil), "failed to get unrelated object")
 		})
 	}
+}
+
+func TestOwnedFinalizerOwner(t *testing.T) {
+	testCases := []struct {
+		name       string
+		finalizers []string
+		wantOwner  string
+	}{
+		{
+			name:      "no finalizers",
+			wantOwner: "",
+		},
+		{
+			name:       "unrelated finalizer only",
+			finalizers: []string{CleanupFinalizerName},
+			wantOwner:  "",
+		},
+		{
+			name:       "single owned finalizer",
+			finalizers: []string{OwnedFinalizerFor("App")},
+			wantOwner:  "App",
+		},
+		{
+			name:       "owned finalizer among others",
+			finalizers: []string{CleanupFinalizerName, OwnedFinalizerFor("LimaVM"), "some.other/finalizer"},
+			wantOwner:  "LimaVM",
+		},
+		{
+			name:       "multiple owned finalizers returns first",
+			finalizers: []string{OwnedFinalizerFor("App"), OwnedFinalizerFor("LimaVM")},
+			wantOwner:  "App",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+			obj.SetFinalizers(tc.finalizers)
+			got := OwnedFinalizerOwner(obj)
+			assert.Equal(t, got, tc.wantOwner)
+		})
+	}
+}
+
+func TestOwnedDeletionGuardValidateDelete(t *testing.T) {
+	guard := &OwnedDeletionGuard[*corev1.ConfigMap]{}
+
+	t.Run("allows delete without owned finalizer", func(t *testing.T) {
+		obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+		warnings, err := guard.ValidateDelete(t.Context(), obj)
+		assert.NilError(t, err)
+		assert.Assert(t, warnings == nil)
+	})
+
+	t.Run("rejects delete with owned finalizer", func(t *testing.T) {
+		obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:       "my-config",
+			Finalizers: []string{OwnedFinalizerFor("App")},
+		}}
+		warnings, err := guard.ValidateDelete(t.Context(), obj)
+		assert.Assert(t, warnings == nil)
+		assert.ErrorContains(t, err, `cannot delete "my-config"`)
+		assert.ErrorContains(t, err, "owned by App")
+		assert.ErrorContains(t, err, "delete the App resource instead")
+	})
+
+	t.Run("no-ops for create and update", func(t *testing.T) {
+		obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Finalizers: []string{OwnedFinalizerFor("App")},
+		}}
+		warnings, err := guard.ValidateCreate(t.Context(), obj)
+		assert.NilError(t, err)
+		assert.Assert(t, warnings == nil)
+
+		warnings, err = guard.ValidateUpdate(t.Context(), obj, obj)
+		assert.NilError(t, err)
+		assert.Assert(t, warnings == nil)
+	})
 }

--- a/pkg/controllers/base/webhook.go
+++ b/pkg/controllers/base/webhook.go
@@ -36,6 +36,30 @@ func IsDryRun(ctx context.Context) bool {
 	return req.DryRun != nil && *req.DryRun
 }
 
+// OwnedDeletionGuard is a generic validating webhook that rejects DELETE requests
+// on resources with an owned finalizer. It implements admission.Validator[T] so it
+// can be used directly as the Validator in a WebhookConfig, or embedded in a
+// validator that needs additional create/update validation.
+type OwnedDeletionGuard[T client.Object] struct{}
+
+func (g *OwnedDeletionGuard[T]) ValidateCreate(_ context.Context, _ T) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (g *OwnedDeletionGuard[T]) ValidateUpdate(_ context.Context, _, _ T) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (g *OwnedDeletionGuard[T]) ValidateDelete(ctx context.Context, obj T) (admission.Warnings, error) {
+	if IsDryRun(ctx) {
+		klog.V(1).Infof("[DryRun] Webhook validating delete of %s/%s", obj.GetNamespace(), obj.GetName())
+	}
+	if owner := OwnedFinalizerOwner(obj); owner != "" {
+		return nil, fmt.Errorf("cannot delete %q: owned by %s; delete the %s resource instead", obj.GetName(), owner, owner)
+	}
+	return nil, nil
+}
+
 // GenerateWebhookPath generates the webhook path that controller-runtime uses
 // when registering a webhook for a given GroupVersionKind and webhook type.
 // This follows controller-runtime's conventions:

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -208,7 +208,7 @@ func (d *defaulter) Default(ctx context.Context, limavm *v1alpha1.LimaVM) error 
 				controllers.TemplateConfigMapLabel: "true",
 			},
 			Finalizers: []string{
-				base.OwnedFinalizerName,
+				base.OwnedFinalizerFor(v1alpha1.LimaVMKind),
 			},
 		},
 		Data: map[string]string{
@@ -255,8 +255,10 @@ func (d *defaulter) fetchTemplateRefData(ctx context.Context, limavm *v1alpha1.L
 
 // ConfigMapValidator validates ConfigMap resources that are template ConfigMaps for LimaVM resources.
 // It is only invoked for ConfigMaps that have the TemplateConfigMapLabel set to "true".
+// ValidateDelete is inherited from the embedded OwnedDeletionGuard.
 type ConfigMapValidator struct {
 	Client client.Client
+	base.OwnedDeletionGuard[*corev1.ConfigMap]
 }
 
 var _ ctrlwebhookadmission.Validator[*corev1.ConfigMap] = &ConfigMapValidator{}
@@ -265,18 +267,16 @@ func (v *ConfigMapValidator) ValidateCreate(ctx context.Context, configMap *core
 	return v.validateTemplateConfigMap(ctx, configMap)
 }
 
-func (v *ConfigMapValidator) ValidateUpdate(ctx context.Context, _, newConfigMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
+func (v *ConfigMapValidator) ValidateUpdate(ctx context.Context, oldConfigMap, newConfigMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
+	// Reject removing the template label while an owned finalizer is present.
+	// Without the label the ObjectSelector stops routing DELETEs to this webhook,
+	// which would leave the finalizer stuck with no user-facing explanation.
+	if base.HasOwnedFinalizer(oldConfigMap) {
+		if newConfigMap.Labels[controllers.TemplateConfigMapLabel] != "true" {
+			return nil, fmt.Errorf("cannot remove %s label: resource is owned", controllers.TemplateConfigMapLabel)
+		}
+	}
 	return v.validateTemplateConfigMap(ctx, newConfigMap)
-}
-
-func (v *ConfigMapValidator) ValidateDelete(ctx context.Context, configMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
-	if base.IsDryRun(ctx) {
-		klog.V(1).Infof("[DryRun] Webhook validating ConfigMap deletion %s/%s\n", configMap.Namespace, configMap.Name)
-	}
-	if base.HasOwnedFinalizer(configMap) {
-		return nil, fmt.Errorf("cannot delete template ConfigMap %q: it is protected by the LimaVM controller; delete the owning LimaVM resource instead", configMap.Name)
-	}
-	return nil, nil
 }
 
 // validateTemplateConfigMap validates the template data in a ConfigMap.


### PR DESCRIPTION
- Encode the owner's `Kind` in the owned finalizer name (`rdd.rancherdesktop.io/owned-by-App` instead of `rdd.rancherdesktop.io/owned`)
- Document that any resource type carrying an owned finalizer must have a validating webhook that rejects `DELETE` while the finalizer is present
- Add generic `OwnedDeletionGuard[T]` webhook in the base package
- Refactor `ConfigMapValidator` to embed `OwnedDeletionGuard` instead of hand-rolling `ValidateDelete`

### Motivation

The owned finalizer and a validating webhook work together as a single access-control gate: the webhook rejects `DELETE` requests while the finalizer is present, and the owner removes the finalizer when it wants to allow deletion. Without the webhook, a user who deletes an owned resource gets a stuck `Terminating` object with no explanation.

Encoding the owner `Kind` in the finalizer name (`owned-by-App`, `owned-by-LimaVM`) makes the finalizer self-documenting and lets the generic `OwnedDeletionGuard` construct clear rejection messages without per-resource configuration.
