### PR TITLE
BATS: Use *.test domains for testing

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-admission.bats
+++ b/bats/tests/33-lima-controllers/limavm-admission.bats
@@ -5,7 +5,7 @@ load '../../helpers/load'
 # because they correspond to actual VM instances on the host system.
 
 # non-functional template, but passes Lima validation
-TEMPLATE='images: [{"location":"https://foo"}]'
+TEMPLATE='images: [{"location":"https://foo.test."}]'
 
 local_setup_file() {
     setup_rdd_control_plane "lima"

--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -5,7 +5,7 @@ load '../../helpers/load'
 LIMA_TEST_NS="lima-test-ns"
 
 # non-functional template, but passes Lima validation
-TEMPLATE='images: [{"location":"https://foo"}]'
+TEMPLATE='images: [{"location":"https://foo.test."}]'
 
 local_setup_file() {
     setup_rdd_control_plane "lima"

--- a/bats/tests/33-lima-controllers/limavm-lifecycle.bats
+++ b/bats/tests/33-lima-controllers/limavm-lifecycle.bats
@@ -9,7 +9,7 @@ VM_NAME="test-vm"
 TEMPLATE_NAME="${VM_NAME}-template"
 
 # non-functional template, but passes Lima validation
-TEMPLATE='images: [{"location":"https://foo"}]'
+TEMPLATE='images: [{"location":"https://foo.test."}]'
 
 local_setup_file() {
     setup_rdd_control_plane "lima"
@@ -98,9 +98,9 @@ EOF
 
 @test "template ConfigMap modification is allowed if template key exists" {
     run -0 rdd ctl patch configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" --type='merge' \
-        --patch='{"data":{"template":"images: [{\"location\":\"https://bar\"}]"}}'
+        --patch='{"data":{"template":"images: [{\"location\":\"https://bar.test.\"}]"}}'
     run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" -o jsonpath='{.data.template}'
-    assert_output 'images: [{"location":"https://bar"}]'
+    assert_output 'images: [{"location":"https://bar.test."}]'
 }
 
 @test "template ConfigMap modification without template key is rejected" {

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -521,7 +521,7 @@ env:
     cat >"${editor_script}" <<'SCRIPT'
 #!/bin/bash
 # Replace the template content
-echo 'images: [{"location":"https://bar"}]' > "$1"
+echo 'images: [{"location":"https://bar.test."}]' > "$1"
 SCRIPT
 
     chmod +x "${editor_script}"
@@ -533,7 +533,7 @@ SCRIPT
     # Verify ConfigMap was updated
     run -0 rdd ctl get configmap "${TEMPLATE_NAME}" --namespace "${NAMESPACE}" \
         -o jsonpath='{.data.template}'
-    assert_output "images: [{\"location\":\"https://bar\"}]"
+    assert_output "images: [{\"location\":\"https://bar.test.\"}]"
 }
 
 @test "limavm edit aborts when all content is deleted" {


### PR DESCRIPTION
The `.test` TLD is reserved in RFC 2606 to never have any actual host names.  Use that instead of a plain `foo` to avoid issues with networks where attempting to resolve domains that don't exist can result in issues.