### PR TITLE
Add CRD types to the "all" category

### DIFF
--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -57,6 +57,17 @@ local_setup_file() {
         --namespace "${RDD_NAMESPACE}" --timeout=60s
 }
 
+@test "verify App and LimaVM are in the 'all' category" {
+    run -0 rdd ctl api-resources --categories=all --output=name
+    assert_line apps.app.rancherdesktop.io
+    assert_line limavms.lima.rancherdesktop.io
+}
+
+@test "verify 'get all' returns the LimaVM instance" {
+    run -0 rdd ctl get all --namespace "${RDD_NAMESPACE}" --output=name
+    assert_line "limavm.lima.rancherdesktop.io/${VM_NAME}"
+}
+
 @test "verify LimaVM is named rd" {
     run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" -o name
     assert_output "limavm.lima.rancherdesktop.io/${VM_NAME}"

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -37,7 +37,7 @@ type AppStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,path=apps
+// +kubebuilder:resource:scope=Cluster,path=apps,categories="all"
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == 'app'",message="App resource must be named 'app'"
 
 // App is the Schema for the apps API.

--- a/pkg/apis/containers/v1alpha1/container_namespace_types.go
+++ b/pkg/apis/containers/v1alpha1/container_namespace_types.go
@@ -10,7 +10,7 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
-// +kubebuilder:resource:shortName=cns
+// +kubebuilder:resource:shortName=cns,categories="all"
 
 // ContainerNamespace defines a container engine namespace; note that this is distinct
 // from Kubernetes namespaces.

--- a/pkg/apis/containers/v1alpha1/container_types.go
+++ b/pkg/apis/containers/v1alpha1/container_types.go
@@ -141,6 +141,7 @@ type ContainerStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
+// +kubebuilder:resource:categories="all"
 // +kubebuilder:subresource:status
 // +kubebuilder:selectablefield:JSONPath=.status.namespace
 // +kubebuilder:printcolumn:name="Running",type=boolean,JSONPath=`.status.conditions[?(@.type=="Running")].status`

--- a/pkg/apis/containers/v1alpha1/image_types.go
+++ b/pkg/apis/containers/v1alpha1/image_types.go
@@ -61,6 +61,7 @@ type ImageStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
+// +kubebuilder:resource:categories="all"
 // +kubebuilder:subresource:status
 // +kubebuilder:selectablefield:JSONPath=.status.namespace
 // +kubebuilder:selectablefield:JSONPath=.status.id

--- a/pkg/apis/containers/v1alpha1/volume_types.go
+++ b/pkg/apis/containers/v1alpha1/volume_types.go
@@ -47,6 +47,7 @@ type VolumeStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
+// +kubebuilder:resource:categories="all"
 // +kubebuilder:subresource:status
 // +kubebuilder:selectablefield:JSONPath=.status.namespace
 // +kubebuilder:printcolumn:name="Driver",type=string,JSONPath=`.status.driver`

--- a/pkg/apis/lima/v1alpha1/limavm_types.go
+++ b/pkg/apis/lima/v1alpha1/limavm_types.go
@@ -91,6 +91,7 @@ type LimaVMStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
+// +kubebuilder:resource:categories="all"
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Running",type=boolean,JSONPath=`.spec.running`
 

--- a/pkg/controllers/app/app/crd.yaml
+++ b/pkg/controllers/app/app/crd.yaml
@@ -12,6 +12,8 @@ metadata:
 spec:
   group: app.rancherdesktop.io
   names:
+    categories:
+    - all
     kind: App
     listKind: AppList
     plural: apps

--- a/pkg/controllers/containers/container/crd.yaml
+++ b/pkg/controllers/containers/container/crd.yaml
@@ -230,6 +230,8 @@ metadata:
 spec:
   group: containers.rancherdesktop.io
   names:
+    categories:
+    - all
     kind: Container
     listKind: ContainerList
     plural: containers

--- a/pkg/controllers/containers/containernamespace/crd.yaml
+++ b/pkg/controllers/containers/containernamespace/crd.yaml
@@ -12,6 +12,8 @@ metadata:
 spec:
   group: containers.rancherdesktop.io
   names:
+    categories:
+    - all
     kind: ContainerNamespace
     listKind: ContainerNamespaceList
     plural: containernamespaces

--- a/pkg/controllers/containers/image/crd.yaml
+++ b/pkg/controllers/containers/image/crd.yaml
@@ -273,6 +273,8 @@ metadata:
 spec:
   group: containers.rancherdesktop.io
   names:
+    categories:
+    - all
     kind: Image
     listKind: ImageList
     plural: images

--- a/pkg/controllers/containers/volume/crd.yaml
+++ b/pkg/controllers/containers/volume/crd.yaml
@@ -150,6 +150,8 @@ metadata:
 spec:
   group: containers.rancherdesktop.io
   names:
+    categories:
+    - all
     kind: Volume
     listKind: VolumeList
     plural: volumes

--- a/pkg/controllers/lima/limavm/crd.yaml
+++ b/pkg/controllers/lima/limavm/crd.yaml
@@ -12,6 +12,8 @@ metadata:
 spec:
   group: lima.rancherdesktop.io
   names:
+    categories:
+    - all
     kind: LimaVM
     listKind: LimaVMList
     plural: limavms


### PR DESCRIPTION
`rdd ctl get all` now includes LimaVM, ContainerNamespace, Container, Image, and Volume resources.

Closes #201