### PR TITLE
CI: Lint: Provide token to github CLI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -101,6 +101,8 @@ jobs:
     needs: get-pr-number
     runs-on: ubuntu-latest
     if: ${{ ! needs.get-pr-number.outputs.number }}
+    permissions:
+      contents: read
     steps:
     - run: sudo apt install cpanminus
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -112,6 +114,11 @@ jobs:
         cache: false
         go-version-file: go.mod
     - run: make spelling
+      env:
+        # Pretend this is a push event; we don't need any of the extra
+        # functionality that GitHub pull request integration provides.
+        GITHUB_EVENT_NAME: push
+        GITHUB_TOKEN: ${{ github.token }}
   ltag:
     name: Check license tags
     needs: get-pr-number


### PR DESCRIPTION
This ensures that the check-spelling step can proceed.  We only provide `contents: read` because we don't care about `pull_request_target` events.

(This PR only exists to test the workflow; the relevant error message only shows up on a cross-repo PR.)