### PR TITLE
Increase app.bats VM boot timeout to 300s

### DIFF
--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -150,7 +150,7 @@ local_setup_file() {
 
 @test "wait for LimaVM Running condition to become true after start" {
     rdd ctl wait --for=condition=Running \
-        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=120s
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=300s
 }
 
 @test "wait for App Running condition to become True" {


### PR DESCRIPTION
First VM boots on Intel CI runners take over 2 minutes (SSH port alone takes ~1m46s). The 120s timeout fails intermittently. The lima controller tests already use 300s for the same wait.