### PR TITLE
Enforce godoc comments on exported symbols

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,7 +101,6 @@ linters:
       - name: error-strings
       - name: errorf
       - name: exported
-        disabled: true
       - name: increment-decrement
       - name: indent-error-flow
       - name: package-comments
@@ -124,7 +123,6 @@ linters:
       - -QF*
       - -ST1000
       - -ST1001  # duplicates revive.dot-imports
-      - -ST1022
     usetesting:
       os-temp-dir: true
   exclusions:

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -574,7 +574,7 @@ func newLimaVMLogsCommand() *cobra.Command {
 			logPath := filepath.Join(instance.LimaHome(), args[0], name)
 			follow, _ := cmd.Flags().GetBool("follow")
 
-			return tail.TailFile(cmd.Context(), cmd.OutOrStdout(), logPath, follow)
+			return tail.File(cmd.Context(), cmd.OutOrStdout(), logPath, follow)
 		},
 	}
 	command.Flags().BoolP("stdout", "o", false, "Print stdout instead of stderr")

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -357,7 +357,7 @@ func newServiceLogCommand() *cobra.Command {
 			logPath := filepath.Join(instance.LogDir(), name)
 			follow, _ := cmd.Flags().GetBool("follow")
 
-			return tail.TailFile(cmd.Context(), cmd.OutOrStdout(), logPath, follow)
+			return tail.File(cmd.Context(), cmd.OutOrStdout(), logPath, follow)
 		},
 	}
 	command.Flags().BoolP("stdout", "o", false, "Print stdout instead of stderr")

--- a/pkg/apis/containers/v1alpha1/container_types.go
+++ b/pkg/apis/containers/v1alpha1/container_types.go
@@ -13,6 +13,7 @@ import (
 // ContainerStatusValue describes the status of a container.
 type ContainerStatusValue string
 
+// Possible values for ContainerStatusValue.
 const (
 	ContainerStatusCreated    ContainerStatusValue = "created"
 	ContainerStatusRunning    ContainerStatusValue = "running"

--- a/pkg/apis/containers/v1alpha1/image_types.go
+++ b/pkg/apis/containers/v1alpha1/image_types.go
@@ -94,6 +94,7 @@ type ImageList struct {
 	Items           []Image `json:"items"`
 }
 
+// ImagePullRequestSpec defines the parameters for pulling an image.
 type ImagePullRequestSpec struct {
 	// Namespace is the container namespace; refers to a `ContainerNamespace`
 	// object in the same Kubernetes namespace.  If not specified, the image
@@ -107,6 +108,7 @@ type ImagePullRequestSpec struct {
 	RepoTag string `json:"repoTag"`
 }
 
+// ImagePullRequestStatus reports the progress of an image pull request.
 type ImagePullRequestStatus struct {
 	// Conditions represent the state of the image pull request.
 	// Current known condition types include:
@@ -155,6 +157,7 @@ type ImagePullRequestList struct {
 	Items           []ImagePullRequest `json:"items"`
 }
 
+// ImagePushRequestSpec defines the parameters for pushing an image.
 type ImagePushRequestSpec struct {
 	// ImageRef is the image to push.
 	// This must be the name of an Image object in the same Kubernetes namespace.
@@ -163,6 +166,7 @@ type ImagePushRequestSpec struct {
 	ImageRef string `json:"imageRef"`
 }
 
+// ImagePushRequestStatus reports the progress of an image push request.
 type ImagePushRequestStatus struct {
 	// Conditions represent the state of the image push request.
 	// Current known condition types include:
@@ -217,6 +221,7 @@ type ImageScanRequestSpec struct {
 	ImageRef string `json:"imageRef"`
 }
 
+// ImageScanRequestStatus reports the progress and result of an image scan request.
 type ImageScanRequestStatus struct {
 	// Conditions represent the state of the image scan request.
 	// Current known condition types include:

--- a/pkg/apis/containers/v1alpha1/volume_types.go
+++ b/pkg/apis/containers/v1alpha1/volume_types.go
@@ -76,6 +76,7 @@ type VolumeList struct {
 	Items           []Volume `json:"items"`
 }
 
+// VolumeCreateSpec defines the parameters for creating a volume.
 type VolumeCreateSpec struct {
 	// Name of the volume to create; if not specified, a random name will be
 	// generated.
@@ -94,6 +95,7 @@ type VolumeCreateSpec struct {
 	Driver string `json:"driver"`
 }
 
+// VolumeCreateStatus reports the progress of a volume creation request.
 type VolumeCreateStatus struct {
 	// Conditions represent the state of the volume creation request.
 	// Current known condition types include:

--- a/pkg/cli/help/doc.go
+++ b/pkg/cli/help/doc.go
@@ -20,12 +20,14 @@ import (
 
 var reEmptyLine = regexp.MustCompile(`(?m)([\w[:punct:]]) *\n([\w[:punct:]])`)
 
+// Doc strips heredoc indentation and joins hard-wrapped lines into flowing paragraphs.
 func Doc(s string) string {
 	s = heredoc.Doc(s)
 	s = reEmptyLine.ReplaceAllString(s, "$1 $2")
 	return s
 }
 
+// FitTerminal configures Cobra's help template to word-wrap output to the terminal width.
 func FitTerminal(out io.Writer) {
 	cols, _, err := term.TerminalSize(out)
 	if err != nil {

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -32,6 +32,7 @@ const (
 	requeueAfterDeletion = 2 * time.Second
 )
 
+// AppReconciler reconciles the singleton App resource and manages its LimaVM lifecycle.
 type AppReconciler struct {
 	client.Client
 	Scheme           *runtime.Scheme

--- a/pkg/controllers/base/webhook.go
+++ b/pkg/controllers/base/webhook.go
@@ -42,14 +42,17 @@ func IsDryRun(ctx context.Context) bool {
 // validator that needs additional create/update validation.
 type OwnedDeletionGuard[T client.Object] struct{}
 
+// ValidateCreate allows all create requests.
 func (g *OwnedDeletionGuard[T]) ValidateCreate(_ context.Context, _ T) (admission.Warnings, error) {
 	return nil, nil
 }
 
+// ValidateUpdate allows all update requests.
 func (g *OwnedDeletionGuard[T]) ValidateUpdate(_ context.Context, _, _ T) (admission.Warnings, error) {
 	return nil, nil
 }
 
+// ValidateDelete rejects deletion of resources that still have an owned finalizer.
 func (g *OwnedDeletionGuard[T]) ValidateDelete(ctx context.Context, obj T) (admission.Warnings, error) {
 	if IsDryRun(ctx) {
 		klog.V(1).Infof("[DryRun] Webhook validating delete of %s/%s", obj.GetNamespace(), obj.GetName())

--- a/pkg/controllers/containers/container/container_controller.go
+++ b/pkg/controllers/containers/container/container_controller.go
@@ -68,10 +68,10 @@ func (c *controller) GetCRDData() string {
 	return controllerCRD
 }
 
-// setupReconciler sets up the ContainerReconciler with the manager.
+// setupReconciler sets up the reconciler with the manager.
 func (c *controller) setupReconciler(mgr ctrl.Manager) error {
-	mgr.GetLogger().Info("Setting up ContainerReconciler")
-	return (&ContainerReconciler{
+	mgr.GetLogger().Info("Setting up reconciler")
+	return (&reconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorder(ControllerName + "-controller"),
@@ -88,7 +88,7 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 		Operations: []admissionregistrationv1.OperationType{
 			admissionregistrationv1.Update,
 		},
-		Validator: &ContainerImmutableValidator{},
+		Validator: &immutableValidator{},
 	}
 
 	managers, err := base.SetupWebhookForResource(mgr, &v1alpha1.Container{}, mutatingConfig)

--- a/pkg/controllers/containers/container/container_reconciler.go
+++ b/pkg/controllers/containers/container/container_reconciler.go
@@ -21,8 +21,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 )
 
-// ContainerReconciler reconciles a Container object.
-type ContainerReconciler struct {
+type reconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
@@ -33,7 +32,7 @@ type ContainerReconciler struct {
 // +kubebuilder:rbac:groups=containers.rancherdesktop.io,resources=containers/finalizers,verbs=update
 
 // Reconcile implements a container reconciliation loop.
-func (r *ContainerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
 	var container containersv1alpha1.Container
@@ -79,7 +78,7 @@ func (r *ContainerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 // setCondition sets or updates a condition in the container status.
-func (r *ContainerReconciler) setCondition(container *containersv1alpha1.Container, conditionType string, status metav1.ConditionStatus, reason, message string) {
+func (r *reconciler) setCondition(container *containersv1alpha1.Container, conditionType string, status metav1.ConditionStatus, reason, message string) {
 	changed := apimeta.SetStatusCondition(&container.Status.Conditions, metav1.Condition{
 		Type:    conditionType,
 		Status:  status,
@@ -92,7 +91,7 @@ func (r *ContainerReconciler) setCondition(container *containersv1alpha1.Contain
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ContainerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&containersv1alpha1.Container{}).
 		Complete(r)

--- a/pkg/controllers/containers/container/container_webhooks.go
+++ b/pkg/controllers/containers/container/container_webhooks.go
@@ -16,22 +16,22 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
 )
 
-type ContainerImmutableValidator struct {
+type immutableValidator struct {
 	Client client.Client
 }
 
 // ValidateCreate implements [ctrlwebhookadmission.Validator].
-func (c *ContainerImmutableValidator) ValidateCreate(context.Context, *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
+func (c *immutableValidator) ValidateCreate(context.Context, *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
 	return nil, errors.New("webhook does not implement create")
 }
 
 // ValidateDelete implements [ctrlwebhookadmission.Validator].
-func (c *ContainerImmutableValidator) ValidateDelete(context.Context, *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
+func (c *immutableValidator) ValidateDelete(context.Context, *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
 	return nil, errors.New("webhook does not implement delete")
 }
 
 // ValidateUpdate implements [ctrlwebhookadmission.Validator].
-func (c *ContainerImmutableValidator) ValidateUpdate(_ context.Context, oldContainer, newContainer *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
+func (c *immutableValidator) ValidateUpdate(_ context.Context, oldContainer, newContainer *v1alpha1.Container) (warnings ctrlwebhookadmission.Warnings, err error) {
 	// Return an error if the old object does not match the new object.
 	if !equality.Semantic.DeepEqual(oldContainer.Spec, newContainer.Spec) {
 		return nil, fmt.Errorf("container objects must not be modified: old: %v, new: %v", oldContainer, newContainer)

--- a/pkg/controllers/containers/containernamespace/container_namespace_controller.go
+++ b/pkg/controllers/containers/containernamespace/container_namespace_controller.go
@@ -79,7 +79,7 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 		Operations: []admissionregistrationv1.OperationType{
 			admissionregistrationv1.Delete,
 		},
-		Validator: &ContainerNamespaceDeleteValidator{},
+		Validator: &deleteValidator{},
 	}
 
 	managers, err := base.SetupWebhookForResource(mgr, &v1alpha1.ContainerNamespace{}, mutatingConfig)

--- a/pkg/controllers/containers/containernamespace/container_namespace_webhooks.go
+++ b/pkg/controllers/containers/containernamespace/container_namespace_webhooks.go
@@ -13,15 +13,15 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
 )
 
-type ContainerNamespaceDeleteValidator struct{}
+type deleteValidator struct{}
 
 // ValidateCreate implements [ctrlwebhookadmission.Validator].
-func (c *ContainerNamespaceDeleteValidator) ValidateCreate(context.Context, *v1alpha1.ContainerNamespace) (ctrlwebhookadmission.Warnings, error) {
+func (c *deleteValidator) ValidateCreate(context.Context, *v1alpha1.ContainerNamespace) (ctrlwebhookadmission.Warnings, error) {
 	return nil, errors.New("webhook does not implement create")
 }
 
 // ValidateDelete implements [ctrlwebhookadmission.Validator].
-func (c *ContainerNamespaceDeleteValidator) ValidateDelete(context.Context, *v1alpha1.ContainerNamespace) (ctrlwebhookadmission.Warnings, error) {
+func (c *deleteValidator) ValidateDelete(context.Context, *v1alpha1.ContainerNamespace) (ctrlwebhookadmission.Warnings, error) {
 	// TODO: We should validate that:
 	// The namespace to be deleted must be empty before allowing the delete.
 	// Additionally, when using moby backend: we do not delete the `moby` namespace.
@@ -29,6 +29,6 @@ func (c *ContainerNamespaceDeleteValidator) ValidateDelete(context.Context, *v1a
 }
 
 // ValidateUpdate implements [ctrlwebhookadmission.Validator].
-func (c *ContainerNamespaceDeleteValidator) ValidateUpdate(context.Context, *v1alpha1.ContainerNamespace, *v1alpha1.ContainerNamespace) (ctrlwebhookadmission.Warnings, error) {
+func (c *deleteValidator) ValidateUpdate(context.Context, *v1alpha1.ContainerNamespace, *v1alpha1.ContainerNamespace) (ctrlwebhookadmission.Warnings, error) {
 	return nil, errors.New("webhook does not implement update")
 }

--- a/pkg/controllers/lima/limavm/controller.go
+++ b/pkg/controllers/lima/limavm/controller.go
@@ -288,10 +288,13 @@ type ConfigMapValidator struct {
 
 var _ ctrlwebhookadmission.Validator[*corev1.ConfigMap] = &ConfigMapValidator{}
 
+// ValidateCreate validates template data in newly created ConfigMaps.
 func (v *ConfigMapValidator) ValidateCreate(ctx context.Context, configMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
 	return v.validateTemplateConfigMap(ctx, configMap)
 }
 
+// ValidateUpdate rejects removing the template label while an owned finalizer is present,
+// and validates template data in updated ConfigMaps.
 func (v *ConfigMapValidator) ValidateUpdate(ctx context.Context, oldConfigMap, newConfigMap *corev1.ConfigMap) (ctrlwebhookadmission.Warnings, error) {
 	// Reject removing the template label while an owned finalizer is present.
 	// Without the label the ObjectSelector stops routing DELETEs to this webhook,

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 )
 
+// Suffix returns the instance suffix from the RDD_INSTANCE environment variable, defaulting to "2".
 var Suffix = sync.OnceValue(func() string {
 	instance := os.Getenv("RDD_INSTANCE")
 	if instance == "" {
@@ -37,10 +38,12 @@ var Index = sync.OnceValue(func() int {
 	return 100 + (sum % 100)
 })
 
+// Name returns the instance name (e.g., "rancher-desktop-2").
 var Name = sync.OnceValue(func() string {
 	return "rancher-desktop-" + Suffix()
 })
 
+// Dir returns the OS-specific data directory for this instance.
 var Dir = sync.OnceValue(func() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -78,18 +81,22 @@ var LogDir = sync.OnceValue(func() string {
 	}
 })
 
+// ArgsFile returns the path to the saved service arguments file.
 var ArgsFile = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "args.json")
 })
 
+// Config returns the path to the kubeconfig file.
 var Config = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "config.yaml")
 })
 
+// PIDFile returns the path to the service PID file.
 var PIDFile = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "rdd.pid")
 })
 
+// TLSDir returns the path to the TLS certificate directory.
 var TLSDir = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "tls")
 })

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -124,13 +124,16 @@ func init() {
 	utilruntime.Must(logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
 }
 
+// Exists reports whether a control plane instance has been created.
 func Exists() bool {
 	_, err := os.Stat(instance.ArgsFile())
 	return err == nil
 }
 
+// PIDNotFound indicates no running service process was found.
 const PIDNotFound = 0
 
+// PID returns the process ID of the running service, or PIDNotFound if it is not running.
 func PID() int {
 	pidStr, err := os.ReadFile(instance.PIDFile())
 	if err != nil {
@@ -156,10 +159,12 @@ func PID() int {
 	return pid
 }
 
+// Running reports whether the service process is alive.
 func Running() bool {
 	return PID() != PIDNotFound
 }
 
+// Create a new control plane instance with the given arguments.
 func Create(args []string) error {
 	if Exists() {
 		return fmt.Errorf("%q control plane already exists", instance.Name())
@@ -204,6 +209,7 @@ func getRuntimeControllersFromCluster(ctx context.Context) ([]string, error) {
 	return enabledControllers, nil
 }
 
+// Start the service in a background subprocess.
 func Start(ctx context.Context, args []string) error {
 	if !Exists() {
 		return fmt.Errorf("%q create control plane does not exist", instance.Name())
@@ -304,6 +310,7 @@ func checkReadiness(ctx context.Context) error {
 	return readiness.WaitForReadyWithCRDs(ctx, config, enabledControllers, false)
 }
 
+// Wait until the control plane is ready or the context is cancelled.
 func Wait(ctx context.Context) error {
 	if err := checkReadiness(ctx); err == nil {
 		return nil
@@ -324,12 +331,15 @@ func Wait(ctx context.Context) error {
 	}
 }
 
+// WaitWithTimeout calls Wait with a timeout.
 func WaitWithTimeout(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 90*time.Second) // Increased timeout for CRD establishment
 	defer cancel()
 	return Wait(ctx)
 }
 
+// StopWithWait sends a shutdown signal to the service. If wait is true, it blocks
+// until the process exits or a timeout expires.
 func StopWithWait(wait bool) error {
 	if !Running() {
 		return fmt.Errorf("%q control plane is not running", instance.Name())
@@ -388,6 +398,7 @@ func StopWithWait(wait bool) error {
 	return nil
 }
 
+// Stop the service and wait for the process to exit.
 func Stop() error {
 	// For backward compatibility, always wait
 	return StopWithWait(true)
@@ -416,6 +427,7 @@ func cleanupDiscoveryConfigMap() error {
 	return nil // Don't fail stop operation due to discovery cleanup issues
 }
 
+// Delete the service and remove all instance data.
 func Delete() error {
 	if !Exists() {
 		return fmt.Errorf("%q control plane does not exist", instance.Name())
@@ -465,6 +477,7 @@ func preserveAllInstanceLogs() {
 	}
 }
 
+// ServeArgs returns the saved command-line arguments written by Create.
 func ServeArgs() []string {
 	data, err := os.ReadFile(instance.ArgsFile())
 	if err == nil {

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -411,6 +411,7 @@ func InitDiscovery(ctx context.Context, client kubernetes.Interface) error {
 	return nil
 }
 
+// CleanupDiscovery deletes the controller manager discovery ConfigMap.
 func CleanupDiscovery(ctx context.Context, client *kubernetes.Clientset) error {
 	err := client.CoreV1().ConfigMaps(RDDSystemNamespace).Delete(ctx, ControllerManagerConfigMapName, metav1.DeleteOptions{})
 	if errors.IsNotFound(err) {

--- a/pkg/service/datastore/config.go
+++ b/pkg/service/datastore/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/k3s-io/kine/pkg/endpoint"
 )
 
+// Config holds the kine datastore configuration.
 type Config struct {
 	EndpointConfig endpoint.Config
 }
@@ -18,26 +19,31 @@ type completedConfig struct {
 	*Config
 }
 
+// CompletedConfig wraps a finalized Config for passing to NewServer.
 type CompletedConfig struct {
 	*completedConfig
 }
 
+// NewConfig creates a Config from completed options.
 func NewConfig(o CompletedOptions) (*Config, error) {
 	return &Config{
 		EndpointConfig: o.EndpointConfig,
 	}, nil
 }
 
+// Complete the configuration and return a CompletedConfig for passing to NewServer.
 func (c *Config) Complete() CompletedConfig {
 	return CompletedConfig{&completedConfig{
 		Config: c,
 	}}
 }
 
+// Server wraps the kine embedded etcd server.
 type Server struct {
 	config CompletedConfig
 }
 
+// NewServer creates a Server from a CompletedConfig. Returns nil if the config is empty.
 func NewServer(config CompletedConfig) *Server {
 	if config.Config == nil {
 		return nil

--- a/pkg/service/datastore/options.go
+++ b/pkg/service/datastore/options.go
@@ -11,6 +11,7 @@ import (
 	etcdversion "go.etcd.io/etcd/api/v3/version"
 )
 
+// Options holds user-configurable datastore settings.
 type Options struct {
 	Enabled        bool
 	EndpointConfig endpoint.Config
@@ -21,10 +22,12 @@ type completedOptions struct {
 	EndpointConfig endpoint.Config
 }
 
+// CompletedOptions wraps finalized Options for passing to NewConfig.
 type CompletedOptions struct {
 	*completedOptions
 }
 
+// NewOptions returns Options with default values.
 func NewOptions() *Options {
 	return &Options{
 		Enabled: false,
@@ -41,7 +44,7 @@ func NewOptions() *Options {
 	}
 }
 
-// Complete defaults fields that have not set by the consumer of this package.
+// Complete the options and return a CompletedOptions for passing to NewConfig.
 func (o Options) Complete() CompletedOptions {
 	ret := CompletedOptions{
 		&completedOptions{

--- a/pkg/util/nxadmtail/tail.go
+++ b/pkg/util/nxadmtail/tail.go
@@ -39,6 +39,7 @@ import (
 // ErrStop is returned when the tail of a file has been marked to be stopped.
 var ErrStop = errors.New("tail should now stop")
 
+// Line represents a single line read from a tailed file.
 type Line struct {
 	Text     string    // The contents of the file
 	Num      int       // The line number
@@ -84,6 +85,7 @@ type Config struct {
 	Logger logger
 }
 
+// Tail tracks and reads lines from a file, following appends and rotations.
 type Tail struct {
 	Filename string     // The filename
 	Lines    chan *Line // A consumable channel of *Line

--- a/pkg/util/tail/tail.go
+++ b/pkg/util/tail/tail.go
@@ -13,10 +13,9 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/nxadmtail"
 )
 
-// TailFile prints out all of the given file into the given writer.  If follow
-// is true, wait for more lines to be added to the file at end of file;
-// otherwise, just return at end of file.
-func TailFile(ctx context.Context, writer io.Writer, filePath string, follow bool) error {
+// File prints the contents of filePath to writer. If follow is true, it waits
+// for new lines at EOF; otherwise it returns at EOF.
+func File(ctx context.Context, writer io.Writer, filePath string, follow bool) error {
 	config := nxadmtail.Config{
 		ReOpen:        follow,
 		Follow:        follow,

--- a/pkg/util/tail/tail_test.go
+++ b/pkg/util/tail/tail_test.go
@@ -17,7 +17,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestTailFile(t *testing.T) {
+func TestFile(t *testing.T) {
 	const expected = "This is the last line of text"
 
 	testCases := []struct {
@@ -84,10 +84,10 @@ func TestTailFile(t *testing.T) {
 			// Across a bunch of goroutines, we need to:
 			// - Set up the scanner
 			// - Run the `prepare` function
-			// - Run TailFile until it gets stuck
+			// - Run File until it gets stuck
 			// - Run the `finish` function
-			// - Run TailFile until it gets stuck (again)
-			// - End the TailFile context (so it ends)
+			// - Run File until it gets stuck (again)
+			// - End the File context (so it ends)
 			// - Check that the last line was the expected output
 
 			lastLine := "initial value"
@@ -115,7 +115,7 @@ func TestTailFile(t *testing.T) {
 			assert.NilError(t, tc.prepare(f))
 			wg, tailCtx := errgroup.WithContext(tailCtx)
 			wg.Go(func() error {
-				return TailFile(tailCtx, w, n, tc.follow)
+				return File(tailCtx, w, n, tc.follow)
 			})
 			waitForStuck()
 			assert.NilError(t, tc.finish(f))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,9 +10,11 @@ import (
 )
 
 var (
-	// These variables are set at build time via ldflags.
-	Version   = "v0.0.0-dev"
+	// Version is the semantic version, set at build time via ldflags.
+	Version = "v0.0.0-dev"
+	// GitCommit is the git commit hash, set at build time via ldflags.
 	GitCommit = "unknown"
+	// BuildDate is the build timestamp, set at build time via ldflags.
 	BuildDate = "unknown"
 )
 


### PR DESCRIPTION
Add missing doc comments to all exported types, functions, variables, and constants. Enable the revive `exported` rule and remove the staticcheck ST1022 suppression (no violations exist).

Fix stuttering type names flagged by the exported rule:
- container.ContainerReconciler → container.Reconciler
- container.ContainerImmutableValidator → container.ImmutableValidator
- containernamespace.ContainerNamespaceDeleteValidator → containernamespace.DeleteValidator
- tail.TailFile → tail.File

Closes #249