### PR TITLE
Skip BATS log markers when the log directory doesn't exist

### DIFF
--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -95,11 +95,13 @@ teardown_file() {
 
 setup() {
     # Write test markers to RDD log files for easier debugging.
-    # The append may fail if the service is not running; that's fine.
-    local log
-    for log in "${RDD_LOG_DIR}"/rdd.stderr.log "${RDD_LOG_DIR}"/rdd.stdout.log; do
-        echo "=== BATS: ${BATS_TEST_DESCRIPTION} ===" >>"${log}" 2>/dev/null || true
-    done
+    # Skip if the log directory doesn't exist (test may not start a service).
+    if [[ -d "${RDD_LOG_DIR}" ]]; then
+        local log
+        for log in "${RDD_LOG_DIR}"/rdd.stderr.log "${RDD_LOG_DIR}"/rdd.stdout.log; do
+            echo "=== BATS: ${BATS_TEST_DESCRIPTION} ===" >>"${log}" 2>/dev/null || true
+        done
+    fi
 
     call_local_function
 }


### PR DESCRIPTION
Tests that don't start an rdd service have no log directory. The shell reports "No such file or directory" when it tries to open the append redirect, and 2>/dev/null doesn't suppress this because the error comes from the shell's own redirect handling, not from echo. Guard the marker writes with a directory existence check.

Example failure (on a very slow Windows runner):

```
not ok 106 try --until-fail fails when command never fails (timeout)
# tags: opensuse
# (in test file helpers/utils.bats, line 581)
#   `((SECONDS < 4))' failed
# /d/a/rancher-desktop-daemon/rancher-desktop-daemon/bats/helpers/load.bash: line 101: /c/Users/runneradmin/AppData/Local/rancher-desktop-bats-logs/rdd.stderr.log: No such file or directory
# /d/a/rancher-desktop-daemon/rancher-desktop-daemon/bats/helpers/load.bash: line 101: /c/Users/runneradmin/AppData/Local/rancher-desktop-bats-logs/rdd.stdout.log: No such file or directory
```