### PR TITLE
Enforce godoc comments on packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,7 +104,6 @@ linters:
       - name: increment-decrement
       - name: indent-error-flow
       - name: package-comments
-        disabled: true
       - name: range
       - name: receiver-naming
       - name: redefines-builtin-id
@@ -121,7 +120,6 @@ linters:
       checks:
       - all
       - -QF*
-      - -ST1000
       - -ST1001  # duplicates revive.dot-imports
     usetesting:
       os-temp-dir: true

--- a/cmd/app-controller/main.go
+++ b/cmd/app-controller/main.go
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Command app-controller runs the app controller as a standalone process, for
+// development and testing outside the embedded control plane.
 package main
 
 import (

--- a/cmd/lima-controller/main.go
+++ b/cmd/lima-controller/main.go
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Command lima-controller runs the Lima VM controller as a standalone process,
+// for development and testing outside the embedded control plane.
 package main
 
 import (

--- a/cmd/rdd-controller/main.go
+++ b/cmd/rdd-controller/main.go
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Command rdd-controller runs the core rdd controllers as a standalone process,
+// for development and testing outside the embedded control plane.
 package main
 
 import (

--- a/cmd/rdd/main.go
+++ b/cmd/rdd/main.go
@@ -3,6 +3,9 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 // SPDX-FileCopyrightText: The KCP Authors
 
+// Command rdd is the Rancher Desktop Daemon CLI. It manages the control plane
+// lifecycle, provides kubectl access to the embedded API server, and controls
+// Lima VMs.
 package main
 
 import (

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
+
 package v1alpha1
 
 import (

--- a/pkg/apis/rdd/v1alpha1/configmapreplicaset_types.go
+++ b/pkg/apis/rdd/v1alpha1/configmapreplicaset_types.go
@@ -2,8 +2,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package v1alpha1 contains the API definitions for the configmap replicaset controller.
-// This package defines custom resources that manage ConfigMaps without any pod dependencies.
 package v1alpha1
 
 import (

--- a/pkg/apis/rdd/v1alpha1/groupversion_info.go
+++ b/pkg/apis/rdd/v1alpha1/groupversion_info.go
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package v1alpha1 contains API Schema definitions for the rdd v1alpha1 API group
+// Package v1alpha1 defines the rdd.rancherdesktop.io API group, which contains
+// system-level resources: ConfigMapReplicaSet for declarative ConfigMap
+// replication and Notary for tracking configuration changes.
 // +kubebuilder:object:generate=true
 // +kubebuilder:ac:generate=true
 // +groupName=rdd.rancherdesktop.io

--- a/pkg/cli/help/doc.go
+++ b/pkg/cli/help/doc.go
@@ -3,6 +3,9 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 // SPDX-FileCopyrightText: The KCP Authors
 
+// Package help provides CLI help text formatting for the rdd command suite,
+// including paragraph reflowing to terminal width and usage template
+// customization.
 package help
 
 import (

--- a/pkg/controllers/app/app/controller.go
+++ b/pkg/controllers/app/app/controller.go
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package app registers the App controller. The App controller manages the
+// cluster-scoped App singleton that represents the Rancher Desktop application;
+// it creates and owns a LimaVM and mirrors its conditions back to App status.
 package app
 
 import (

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package controllers implements the App reconciler, which propagates the
+// desired running state to the owned LimaVM and mirrors its conditions back to
+// App status.
 package controllers
 
 import (

--- a/pkg/controllers/app/demo/controller.go
+++ b/pkg/controllers/app/demo/controller.go
@@ -2,6 +2,10 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package demo registers the Demo controller. The Demo controller exists for
+// development and testing; it exercises the controller framework with a minimal
+// cluster-scoped singleton and passthrough HTTP endpoints. It will be removed
+// before the first release.
 package demo
 
 import (

--- a/pkg/controllers/app/demo/controllers/demo_controller.go
+++ b/pkg/controllers/app/demo/controllers/demo_controller.go
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package controllers implements the Demo reconciler, a minimal singleton
+// controller used for development and testing of the controller framework.
 package controllers
 
 import (

--- a/pkg/controllers/base/doc.go
+++ b/pkg/controllers/base/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package base provides shared controller utilities: registration, finalizers,
+// owned-resource cleanup, and webhook helpers.
+package base

--- a/pkg/controllers/base/field_indexer.go
+++ b/pkg/controllers/base/field_indexer.go
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
+
 package base
 
 import (

--- a/pkg/controllers/base/finalizer.go
+++ b/pkg/controllers/base/finalizer.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package base provides shared utilities for RDD controllers.
 package base
 
 import (

--- a/pkg/controllers/builtin/namespace/controller.go
+++ b/pkg/controllers/builtin/namespace/controller.go
@@ -2,6 +2,10 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package namespace registers the Namespace controller. This controller
+// replaces the standard Kubernetes namespace controller (which requires kubelet)
+// to handle namespace deletion by cleaning up all resources in the namespace
+// and removing the kubernetes finalizer.
 package namespace
 
 import (

--- a/pkg/controllers/builtin/namespace/controllers/namespace_controller.go
+++ b/pkg/controllers/builtin/namespace/controllers/namespace_controller.go
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package controllers implements the Namespace reconciler, which handles
+// namespace deletion by deleting all resources within the namespace and
+// removing the kubernetes finalizer.
 package controllers
 
 import (

--- a/pkg/controllers/containers/container/doc.go
+++ b/pkg/controllers/containers/container/doc.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package container registers the Container controller. Containers represent
+// running container engine objects as read-only Kubernetes resources, with
+// immutability enforced by a validating webhook.
+package container

--- a/pkg/controllers/containers/containernamespace/doc.go
+++ b/pkg/controllers/containers/containernamespace/doc.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package containernamespace registers the ContainerNamespace controller.
+// ContainerNamespaces reflect container engine namespaces (e.g. containerd
+// namespaces) as Kubernetes resources; deletion is guarded by a validating
+// webhook to prevent orphaning owned containers.
+package containernamespace

--- a/pkg/controllers/containers/controller.go
+++ b/pkg/controllers/containers/controller.go
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package containers registers all controllers related to container engines.
+// Package containers is a side-effect aggregator that blank-imports the
+// container-related controller packages (container, containernamespace, image,
+// volume) so their init functions register them with the controller framework.
 package containers
 
 import (

--- a/pkg/controllers/containers/image/image_controller.go
+++ b/pkg/controllers/containers/image/image_controller.go
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package image registers the Image controller. Images reflect container engine
+// images as Kubernetes resources, with each tag represented as a separate Image
+// object.
 package image
 
 import (

--- a/pkg/controllers/containers/volume/volume_controller.go
+++ b/pkg/controllers/containers/volume/volume_controller.go
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package volume registers the Volume controller. Volumes reflect container
+// engine volumes as Kubernetes resources.
 package volume
 
 import (

--- a/pkg/controllers/lima/limavm/controllers/doc.go
+++ b/pkg/controllers/lima/limavm/controllers/doc.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package controllers implements the LimaVM reconciler and hostagent watcher.
+// The reconciler manages VM lifecycle state transitions; the watcher monitors
+// each hostagent process and triggers reconciliation on state changes or
+// crashes.
+package controllers

--- a/pkg/controllers/lima/limavm/doc.go
+++ b/pkg/controllers/lima/limavm/doc.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package limavm registers the LimaVM controller. The LimaVM controller
+// manages the full lifecycle of Lima virtual machines: instance creation from
+// templates, hostagent process management, graceful start/stop, restart and
+// reset handling, and crash recovery.
+package limavm

--- a/pkg/controllers/mock/doc.go
+++ b/pkg/controllers/mock/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package mock provides a test controller that populates the API server with
+// mock data on startup, for integration testing without real infrastructure.
+package mock

--- a/pkg/controllers/mock/mock_controller.go
+++ b/pkg/controllers/mock/mock_controller.go
@@ -2,8 +2,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package mock contains webhooks and reconcilers to automatically generate
-// mock data on controller startup.
 package mock
 
 import (

--- a/pkg/controllers/rdd/configmapreplicaset/controller.go
+++ b/pkg/controllers/rdd/configmapreplicaset/controller.go
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package configmapreplicaset registers the ConfigMapReplicaSet controller. A
+// ConfigMapReplicaSet declaratively maintains a set of ConfigMaps with identical
+// data, operating at the API level without any pod dependencies.
 package configmapreplicaset
 
 import (

--- a/pkg/controllers/rdd/configmapreplicaset/controllers/configmapreplicaset_controller.go
+++ b/pkg/controllers/rdd/configmapreplicaset/controllers/configmapreplicaset_controller.go
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package controllers implements the reconciliation logic for custom resources.
-// This controller manages ConfigMaps declaratively without any pod dependencies.
+// Package controllers implements the ConfigMapReplicaSet reconciler, which
+// ensures the desired number of ConfigMap replicas exist with identical data.
 package controllers
 
 import (

--- a/pkg/controllers/rdd/notary/controllers/notary_controller.go
+++ b/pkg/controllers/rdd/notary/controllers/notary_controller.go
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package controllers implements the Notary reconciler, which watches a
+// ConfigMap key and records each value change into a numbered ConfigMap.
 package controllers
 
 import (

--- a/pkg/controllers/rdd/notary/doc.go
+++ b/pkg/controllers/rdd/notary/doc.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package notary registers the Notary controller. A Notary watches a ConfigMap
+// key and records each observed value change into a separate ConfigMap,
+// providing an audit trail for configuration changes.
+package notary

--- a/pkg/developer/developer.go
+++ b/pkg/developer/developer.go
@@ -2,6 +2,10 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
+// Package developer detects whether the process runs in developer mode.
+// Developer mode is enabled by the RDD_DEVELOPER_MODE environment variable or
+// by detecting the source tree relative to the executable, and exposes hidden
+// CLI flags for development.
 package developer
 
 import (

--- a/pkg/guestagent/doc.go
+++ b/pkg/guestagent/doc.go
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package guestagent provides the embedded Lima guest agent binary.
+package guestagent

--- a/pkg/guestagent/guestagent.go
+++ b/pkg/guestagent/guestagent.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package guestagent provides the embedded Lima guest agent binary.
 package guestagent
 
 import (

--- a/pkg/instance/doc.go
+++ b/pkg/instance/doc.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package instance resolves OS-specific directory paths for a named RDD
+// instance, including the service directory, Lima home, log directory, and TLS
+// certificates. Paths are derived from the RDD_INSTANCE environment variable.
+package instance

--- a/pkg/service/admission/config.go
+++ b/pkg/service/admission/config.go
@@ -3,6 +3,9 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 // SPDX-FileCopyrightText: The KCP Authors
 
+// Package admission selects and configures the Kubernetes admission plugins for
+// the embedded API server, including namespace lifecycle, service accounts,
+// webhooks, owner-reference permission enforcement, and event rate limiting.
 package admission
 
 import (

--- a/pkg/service/cmd/doc.go
+++ b/pkg/service/cmd/doc.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package service implements the rdd service serve command, which starts the
+// embedded Kubernetes API server, kine datastore, and controller managers that
+// form the RDD control plane.
+package service

--- a/pkg/service/cmd/options/doc.go
+++ b/pkg/service/cmd/options/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package options defines configuration for the embedded API server, including
+// authentication, controller selection, idle timeout, and storage paths.
+package options

--- a/pkg/service/controllers/doc.go
+++ b/pkg/service/controllers/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package controllers handles controller-manager discovery, embedded
+// controller-manager setup, readiness coordination, and passthrough proxying.
+package controllers

--- a/pkg/service/controllers/passthrough.go
+++ b/pkg/service/controllers/passthrough.go
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
+
 package controllers
 
 import (

--- a/pkg/service/datastore/doc.go
+++ b/pkg/service/datastore/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package datastore configures the kine-backed SQLite datastore that provides
+// persistent storage for the embedded API server, replacing etcd.
+package datastore

--- a/pkg/service/readiness/ready.go
+++ b/pkg/service/readiness/ready.go
@@ -3,6 +3,9 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 // SPDX-FileCopyrightText: The KCP Authors
 
+// Package readiness waits for the embedded control plane to become operational
+// by polling the API server's /readyz endpoint and checking that expected CRDs
+// are established and webhook configurations are created.
 package readiness
 
 import (

--- a/pkg/service/tokengetter/tokengetter.go
+++ b/pkg/service/tokengetter/tokengetter.go
@@ -3,6 +3,10 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 // SPDX-FileCopyrightText: The KCP Authors
 
+// Package tokengetter implements ServiceAccountTokenGetter for the embedded API
+// server's token authenticator. It reads ServiceAccount and Secret objects
+// directly from the lister cache, avoiding a circular dependency on the API
+// server during authentication.
 package tokengetter
 
 import (

--- a/pkg/util/process/doc.go
+++ b/pkg/util/process/doc.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package process provides cross-platform utilities for subprocess management,
+// including process group isolation and signal delivery (SIGINT, SIGTERM,
+// SIGKILL).
+package process

--- a/pkg/util/process/process_unix.go
+++ b/pkg/util/process/process_unix.go
@@ -4,7 +4,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package process provides cross-platform process utilities.
 package process
 
 import (

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-// Package process provides cross-platform process utilities.
 package process
 
 import (

--- a/pkg/util/tail/tail.go
+++ b/pkg/util/tail/tail.go
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package tail reads log files from the end and optionally follows new output,
+// similar to tail -f. It wraps nxadmtail with context cancellation for use in
+// CLI commands like rdd service log.
 package tail
 
 import (

--- a/pkg/version/doc.go
+++ b/pkg/version/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package version records build version information (set via linker flags) and
+// provides a --version flag for CLI commands.
+package version


### PR DESCRIPTION
Enable the revive package-comments rule and the staticcheck ST1000 check. Add doc comments to all packages that lack them.

For multi-file packages, place the doc comment in a dedicated doc.go file so it is easy to find. Single-file packages keep the comment inline. Kubebuilder API packages keep the comment in groupversion_info.go (the kubebuilder convention), and vendored nxadmtail keeps it in its main file (different license headers).

Fix four files where missing blank lines between SPDX headers and the package declaration caused the linter to misinterpret the SPDX block as a malformed doc comment.

Remove duplicate doc comments in pkg/controllers/base (finalizer.go), pkg/apis/rdd/v1alpha1 (configmapreplicaset_types.go), and pkg/util/process (platform files).

Closes #249