### PR TITLE
Add provisioning scripts to bundled Lima template

### DIFF
--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -44,7 +44,7 @@ type AppReconciler struct {
 
 func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec) string {
 	return baseTemplate + fmt.Sprintf(
-		"\nparam:\n  CONTAINER_ENGINE: %s\n  KUBERNETES_ENABLED: %v\n  KUBERNETES_VERSION: %s\n",
+		"\nparam:\n  CONTAINER_ENGINE: %s\n  HOST_HOME: \"{{.Home}}\"\n  KUBERNETES_ENABLED: %v\n  KUBERNETES_VERSION: %s\n",
 		spec.ContainerEngine.Name,
 		spec.Kubernetes.Enabled,
 		spec.Kubernetes.Version,

--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -40,6 +40,10 @@ provision:
 
     systemctl stop rancher-desktop.target
 
+    # Write the selected container engine; docker.service and containerd.service
+    mkdir -p /etc/sysconfig
+    echo "CONTAINER_ENGINE=${PARAM_CONTAINER_ENGINE}" >/etc/sysconfig/rancher-desktop
+
     # Enable the requested container engine and disable the other.
     # containerd.service has a Conflicts=docker, so we must not start both.
     CONTAINERD_ACTION=$([[ $PARAM_CONTAINER_ENGINE = containerd ]] && echo enable || echo disable)

--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -32,13 +32,85 @@ provision:
 - mode: system
   script: |
     #!/bin/bash
-    set -e -u -x
-    mkdir -p /etc/rancher-desktop
-    printf 'CONTAINER_ENGINE=%s\nKUBERNETES_ENABLED=%s\nKUBERNETES_VERSION=%s\n' \
-      '{{.Param.CONTAINER_ENGINE}}' \
-      '{{.Param.KUBERNETES_ENABLED}}' \
-      '{{.Param.KUBERNETES_VERSION}}' \
-      > /etc/rancher-desktop/params.env
+
+    # All param need to be mentioned for Lima validation.
+    # $PARAM_HOST_HOME - used by the kubeconfig probe
+
+    set -o errexit -o nounset -o pipefail -o xtrace
+
+    systemctl stop rancher-desktop.target
+
+    # Enable the requested container engine and disable the other.
+    # containerd.service has a Conflicts=docker, so we must not start both.
+    CONTAINERD_ACTION=$([[ $PARAM_CONTAINER_ENGINE = containerd ]] && echo enable || echo disable)
+    DOCKER_ACTION=$([[ $PARAM_CONTAINER_ENGINE = moby ]] && echo enable || echo disable)
+    systemctl "$CONTAINERD_ACTION" containerd.service buildkitd.service
+    systemctl "$DOCKER_ACTION" docker.service docker.socket
+
+    if [[ $PARAM_KUBERNETES_ENABLED == "true" ]]; then
+        export INSTALL_K3S_VERSION="v${PARAM_KUBERNETES_VERSION}+k3s1"
+        INSTALLED_VERSION=""
+        [[ -x /usr/local/bin/k3s ]] && INSTALLED_VERSION=$(/usr/local/bin/k3s --version | awk '{print $3; exit}')
+        if [[ $INSTALL_K3S_VERSION != "${INSTALLED_VERSION}" ]]; then
+            # Don't enable k3s at install time; add it as a want of rancher-desktop.target instead.
+            export INSTALL_K3S_SKIP_ENABLE=true
+            (
+                export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/sbin:/bin
+                curl -sfL https://get.k3s.io | sh -
+            )
+            systemctl add-wants rancher-desktop.target k3s.service
+        fi
+
+        if [[ $PARAM_CONTAINER_ENGINE == "containerd" ]]; then
+            echo "K3S_CONTAINER_ENGINE_OPTIONS=--container-runtime-endpoint /run/k3s/containerd/containerd.sock" \
+                >/etc/systemd/system/k3s.service.env
+        else
+            echo "K3S_CONTAINER_ENGINE_OPTIONS=--docker" >/etc/systemd/system/k3s.service.env
+        fi
+
+        # Remove stale kubeconfig so k3s regenerates it on start.
+        rm -f /etc/rancher/k3s/k3s.yaml
+    fi
+
+    systemctl start rancher-desktop.target
+
+probes:
+- description: Update kube config on the host
+  script: |
+    #!/bin/bash
+
+    # This script runs in USER mode.
+
+    set -o errexit -o nounset -o pipefail -o xtrace
+
+    if [[ $PARAM_KUBERNETES_ENABLED != "true" ]]; then
+        exit 0
+    fi
+
+    K3S_YAML=/etc/rancher/k3s/k3s.yaml
+    for _ in $(seq 90); do
+        if [[ -e $K3S_YAML ]]; then
+            sleep 1
+            # Rename the default context/user/cluster to "rancher-desktop".
+            KUBECONFIG_LOCAL="$HOME/.kube/config"
+            mkdir -p "$(dirname "$KUBECONFIG_LOCAL")"
+            sudo sed 's/: default$/: rancher-desktop/g' "$K3S_YAML" >"$KUBECONFIG_LOCAL"
+            # Merge into the host kubeconfig.
+            KUBECONFIG_MERGED=$HOME/kubeconfig
+            KUBECONFIG_HOST="$PARAM_HOST_HOME/.kube/config"
+            export KUBECONFIG="$KUBECONFIG_HOST:$KUBECONFIG_LOCAL"
+            kubectl config view --merge --flatten >"$KUBECONFIG_MERGED" || break
+            # Only overwrite if the merged config has at least as many contexts.
+            HOST_CONFIGS=$(KUBECONFIG=$KUBECONFIG_HOST kubectl config get-contexts -o name | wc -l)
+            MERGED_CONFIGS=$(KUBECONFIG=$KUBECONFIG_MERGED kubectl config get-contexts -o name | wc -l)
+            if [[ "$HOST_CONFIGS" -le "$MERGED_CONFIGS" ]]; then
+                cp "$KUBECONFIG_MERGED" "$KUBECONFIG_HOST"
+            fi
+            exit 0
+        fi
+        sleep 1
+    done
+    exit 1
 hostResolver:
   hosts:
     host.docker.internal: host.lima.internal


### PR DESCRIPTION
Extract provisioning logic from TwoCows and include it in the bundled Lima template. The provision script enables the configured container engine (moby/containerd) and installs k3s when Kubernetes is enabled.

A script merges the k3s kubeconfig into the host's `~/.kube/config` under the "rancher-desktop" context.

All configurable values are exposed via the `PARAM` mechanism. `HOST_HOME` is added to the appended param block using Lima's `{{.Home}}` template variable.

Fixes: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/263