### PR TITLE
Requeue after template ConfigMap update

### DIFF
--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -211,7 +211,9 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 					"containerEngine", app.Spec.ContainerEngine.Name,
 					"kubernetesEnabled", app.Spec.Kubernetes.Enabled,
 					"kubernetesVersion", app.Spec.Kubernetes.Version)
-				return ctrl.Result{}, nil
+				// ConfigMaps are not watched, so requeue to let the
+				// reconciler evaluate remaining spec fields (e.g. running).
+				return ctrl.Result{Requeue: true}, nil
 			}
 		}
 	}


### PR DESCRIPTION
When the App spec changes both template fields (containerEngine, kubernetes) and the running state in one update, the reconciler updates the template ConfigMap and returns without requeueing. Because the App controller does not watch ConfigMaps, no event re-triggers reconciliation, so the running state change is never propagated to the LimaVM.

Return Requeue: true after the template update so the reconciler loops back and evaluates remaining spec fields.