### PR TITLE
Add host-switch virtual network for WSL2 instances

### DIFF
--- a/.github/workflows/go-mod-k8s-sync.yaml
+++ b/.github/workflows/go-mod-k8s-sync.yaml
@@ -23,7 +23,6 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-        ref: ${{ github.head_ref || github.ref }}
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         cache: false
@@ -54,7 +53,11 @@ jobs:
         fi
   commit-changes:
     needs: update-go-mod
-    if: needs.update-go-mod.outputs.changed
+    # Skip cross-repository PRs: GITHUB_TOKEN can't push to forks, and
+    # update-go-mod already shows the required diff in the step summary.
+    if: >-
+      needs.update-go-mod.outputs.changed
+      && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
       id-token: write # Required for ./.github/actions/get-token

--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -128,8 +128,9 @@ local_setup_file() {
 }
 
 @test "wait for LimaVM Created condition to be set" {
+    # 150s allows time for the opensuse distro image download (~350MB).
     rdd ctl wait --for=condition=Created \
-        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=60s
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=150s
 }
 
 @test "verify App status mirrors LimaVM Created condition" {

--- a/docs/design/api_lima.md
+++ b/docs/design/api_lima.md
@@ -323,3 +323,5 @@ While a `LimaVM` object is specific to an OS, a `LimaDisk` object is just an `ex
 ## LimaNetwork
 
 TBD
+
+See [WSL2 Networking](networking.md) for how the opensuse distro gets network connectivity on Windows via a virtual L2 network over AF_VSOCK.

--- a/docs/design/networking.md
+++ b/docs/design/networking.md
@@ -1,0 +1,184 @@
+# WSL2 Networking
+
+WSL2 VMs run inside a Hyper-V lightweight utility VM that lacks a direct network bridge to the Windows host. The opensuse distro uses a virtual L2 network over AF_VSOCK to provide DNS, DHCP, and NAT between the guest and the host.
+
+## Architecture
+
+The LimaVM controller runs a host-switch goroutine for each WSL2 instance. The guest-side binaries (`network-setup`, `vm-switch`) are baked into the opensuse distro image.
+
+```
+Windows Host (RDD process)                    WSL2 VM (opensuse distro)
+────────────────────────                      ────────────────────────
+host-switch goroutine                         Default namespace
+├─ vsock handshake (port 6669) ◄────────────► ├─ network-setup
+├─ vsock listener (port 6656)  ◄────────────► │  └─ vsock dial (port 6656)
+├─ gvisor-tap-vsock virtual network           │
+│  ├─ DNS (*.rancher-desktop.internal)        Isolated network namespace
+│  ├─ DHCP (192.168.127.2)                    ├─ vm-switch
+│  ├─ NAT (.254 → 127.0.0.1)                 │  ├─ TAP eth0 (192.168.127.2)
+│  └─ HTTP API (:80)                          │  └─ udhcpc → DHCP from host
+└─ OS syscalls (egress)                       ├─ veth-rd-ns (192.168.143.1)
+                                              └─ containers, k3s, etc.
+```
+
+### Virtual Network Topology
+
+The virtual network uses the `192.168.127.0/24` subnet:
+
+| Address | Role |
+|---------|------|
+| `192.168.127.1` | Gateway (host-switch) |
+| `192.168.127.2` | TAP device (guest, assigned via DHCP static lease) |
+| `192.168.127.254` | Static DNS host (NAT to `127.0.0.1` on host) |
+
+The guest resolves `gateway.rancher-desktop.internal` and `host.rancher-desktop.internal` via DNS zones served by gvisor-tap-vsock.
+
+A veth pair bridges the default WSL namespace (`veth-rd-wsl`, `192.168.143.2`) and the isolated network namespace (`veth-rd-ns`, `192.168.143.1`). All container services run inside the isolated namespace.
+
+## Vsock Handshake Protocol
+
+The host and guest discover each other through a two-phase handshake over AF_VSOCK.
+
+### Phase 1: VM Discovery (port 6669)
+
+Multiple Hyper-V VMs may be running. The host-switch identifies the correct one by exchanging a signature phrase.
+
+```mermaid
+sequenceDiagram
+    participant HS as Host-Switch
+    participant Reg as Windows Registry
+    participant NS as network-setup (guest)
+
+    HS->>Reg: Enumerate running VM GUIDs
+    Reg-->>HS: [GUID-A, GUID-B, ...]
+
+    par For each GUID
+        HS->>NS: Dial vsock port 6669
+        NS-->>HS: Send signature phrase
+        HS->>HS: Compare signature
+    end
+
+    Note over HS: Match found for GUID-A
+```
+
+The signature phrase is `"github.com/rancher-sandbox/rancher-desktop/src/go/networking"`. This is a fixed protocol constant shared between host-switch and the guest's `network-setup` binary. Because the signature is product-wide rather than per-instance, this discovery assumes only one opensuse WSL2 instance runs at a time.
+
+### Phase 2: Data Channel (port 6656)
+
+After identifying the VM, the host-switch creates a listener and signals readiness.
+
+```mermaid
+sequenceDiagram
+    participant HS as Host-Switch
+    participant NS as network-setup (guest)
+    participant VS as vm-switch (guest)
+
+    HS->>HS: Listen on vsock port 6656
+    HS->>NS: Dial port 6669, send "READY"
+    NS->>NS: Connect to vsock port 6656
+    NS->>VS: Spawn vm-switch (pass vsock FD)
+    VS->>VS: Create TAP device (eth0)
+    VS->>HS: Ethernet frames over vsock
+    HS->>VS: Ethernet frames over vsock
+```
+
+Ethernet frames use a simple framing protocol: a 2-byte little-endian size prefix followed by the raw frame payload.
+
+## Virtual Network Services
+
+The host-switch creates a [gvisor-tap-vsock](https://github.com/containers/gvisor-tap-vsock) virtual network that provides:
+
+- **DNS**: Resolves `*.rancher-desktop.internal` and `*.docker.internal` zones. Forwards all other queries to the host's DNS resolver.
+- **DHCP**: Assigns `192.168.127.2` to the guest's TAP device via a static lease keyed on MAC address `5a:94:ef:e4:0c:ee`.
+- **NAT**: Maps `192.168.127.254` to `127.0.0.1`, allowing the guest to reach services bound to localhost on the Windows host.
+- **HTTP API**: Listens on `192.168.127.1:80` with endpoints for dynamic port forwarding (`/services/forwarder/expose`, `/services/forwarder/unexpose`, `/services/forwarder/all`).
+
+## Lifecycle Integration
+
+The host-switch goroutine ties into the `LimaVM` controller lifecycle. It starts before the hostagent (because the guest blocks on the vsock handshake during boot) and stops after the hostagent and watcher.
+
+### Normal Start
+
+```mermaid
+sequenceDiagram
+    participant R as Reconciler
+    participant HS as Host-Switch
+    participant HA as Hostagent
+    participant G as Guest (opensuse)
+
+    R->>HS: startHostSwitch()
+    Note over HS: Begin vsock handshake loop
+    R->>HA: Start hostagent process
+    HA->>G: Boot WSL2 distro
+    G->>G: network-setup.service starts
+    G->>HS: Vsock handshake (port 6669)
+    HS->>G: "READY" signal
+    G->>HS: Data connection (port 6656)
+    G->>G: DHCP → 192.168.127.2
+    G->>G: Container services start
+```
+
+### Normal Stop
+
+```mermaid
+sequenceDiagram
+    participant R as Reconciler
+    participant HA as Hostagent
+    participant W as Watcher
+    participant HS as Host-Switch
+
+    R->>HA: Graceful shutdown (SIGINT)
+    HA->>HA: Exit
+    R->>W: stopWatcher()
+    R->>HS: stopHostSwitch()
+    HS->>HS: Context cancelled, goroutine exits
+```
+
+### Crash Recovery
+
+If the hostagent crashes, the watcher detects the exit and triggers a reconcile. The reconciler stops the old host-switch and starts fresh.
+
+```mermaid
+sequenceDiagram
+    participant R as Reconciler
+    participant W as Watcher
+    participant HS as Host-Switch (old)
+    participant HS2 as Host-Switch (new)
+    participant HA as Hostagent
+
+    HA->>HA: Crash
+    W->>R: Enqueue reconcile (phase=Stopped)
+    R->>W: stopWatcher()
+    R->>HS: stopHostSwitch()
+    R->>HS2: startHostSwitch()
+    R->>HA: Start new hostagent
+    Note over HS2,HA: Fresh handshake cycle
+```
+
+### Control Plane Restart
+
+When the control plane restarts, the host-switch goroutine is gone. The reconciler detects the orphaned hostagent, kills it, and restarts both the host-switch and the hostagent.
+
+### Graceful Shutdown
+
+The `shutdownAllHostagents` runnable stops each host-switch after its hostagent exits.
+
+## Implementation
+
+### Guest-side binaries (in opensuse distro image)
+
+| Binary | Systemd unit | Purpose |
+|--------|-------------|---------|
+| `network-setup` | `network-setup.service` | Vsock handshake, namespace setup, spawns vm-switch |
+| `vm-switch` | (child of network-setup) | TAP device, Ethernet frame relay, DHCP client |
+| `wsl-proxy` | (future) | Dynamic port forwarding from guest agent |
+
+### Dependencies
+
+The host-switch uses [gvisor-tap-vsock](https://github.com/containers/gvisor-tap-vsock) for the virtual network stack and [go-winio](https://github.com/microsoft/go-winio) / [virtsock](https://github.com/linuxkit/virtsock) for AF_VSOCK on Windows. All three are already transitive dependencies via Lima.
+
+## Future Work
+
+- **Kubernetes port forwarding**: Pre-forward `127.0.0.1:6443` to `192.168.127.2:6443` so `kubectl` on the host reaches the K8s API inside the VM.
+- **Dynamic port forwarding**: Run `wsl-proxy` in the guest to relay container port mappings from the guest agent to the host-switch's HTTP API.
+- **DNS search domains**: Read Windows DNS search domains and pass them to gvisor-tap-vsock's DHCP configuration.

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,15 @@ go 1.25.0
 require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/Microsoft/go-winio v0.6.2
+	github.com/containers/gvisor-tap-vsock v0.8.8
 	github.com/coreos/go-semver v0.3.1
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/k3s-io/kine v1.14.2
 	github.com/lima-vm/lima/v2 v2.1.0
+	github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mikefarah/yq/v4 v4.52.5
 	github.com/moby/moby/api v1.54.0
@@ -64,7 +67,6 @@ require (
 	github.com/Code-Hex/vz/v3 v3.7.1 // indirect
 	github.com/Djarvur/go-err113 v0.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
-	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/MirrexOne/unqueryvet v1.3.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.1 // indirect
@@ -115,7 +117,6 @@ require (
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/ltag v0.3.0 // indirect
-	github.com/containers/gvisor-tap-vsock v0.8.8 // indirect
 	github.com/coreos/go-oidc v2.3.0+incompatible // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
@@ -249,7 +250,6 @@ require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lima-vm/go-qcow2reader v0.7.1 // indirect
 	github.com/lima-vm/sshocker v0.3.9 // indirect
-	github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2 // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/macabu/inamedparam v0.2.0 // indirect

--- a/pkg/controllers/app/app/lima-images-wsl2.yaml
+++ b/pkg/controllers/app/app/lima-images-wsl2.yaml
@@ -1,6 +1,6 @@
 vmType: wsl2
 images:
-- location: https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1771357941.tar.gz
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.1.2/distro.v0.1.2.amd64.tar.xz
   arch: x86_64
-  digest: sha256:423d1a0f1cabeaea6801995c90ed896dccc091180068626430f19fd87853fdf3
+  digest: sha256:dab70ce152f163ad5c7ce45accb314b91a68f43efd9a153415eaab3e22b8cdf8
 mountType: wsl2

--- a/pkg/controllers/lima/limavm/controllers/hostswitch_other.go
+++ b/pkg/controllers/lima/limavm/controllers/hostswitch_other.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build !windows
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+)
+
+// hostSwitchPlatform is empty on non-Windows platforms. On Windows, it holds
+// the mutex and state map for host-switch goroutines (see hostswitch_windows.go).
+type hostSwitchPlatform struct{}
+
+// initHostSwitch is a no-op on non-Windows platforms.
+func (hostSwitchPlatform) initHostSwitch() {}
+
+// startHostSwitch is a no-op on non-Windows platforms. The host-switch virtual
+// network is only needed for WSL2 instances, which require AF_VSOCK to bridge
+// networking between the Hyper-V VM and the Windows host.
+func (r *LimaVMReconciler) startHostSwitch(_ context.Context, _ string, _ *limatype.Instance) {}
+
+// stopHostSwitch is a no-op on non-Windows platforms.
+func (r *LimaVMReconciler) stopHostSwitch(_ string) {}

--- a/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
+++ b/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build windows
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
+	"github.com/containers/gvisor-tap-vsock/pkg/virtualnetwork"
+	"github.com/go-logr/logr"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/windows/registry"
+)
+
+// hostSwitchPlatform holds the host-switch state for Windows. On non-Windows
+// platforms, this is an empty struct (see hostswitch_other.go).
+type hostSwitchPlatform struct {
+	// hostSwitchMu protects hostSwitchStates. A separate mutex (not
+	// instanceStatesMu) because the host-switch goroutine starts before
+	// the watcher creates its instanceState entry.
+	hostSwitchMu     sync.Mutex
+	hostSwitchStates map[string]*hostSwitchState
+}
+
+// initHostSwitch initializes the host-switch state map.
+func (p *hostSwitchPlatform) initHostSwitch() {
+	p.hostSwitchStates = make(map[string]*hostSwitchState)
+}
+
+// hostSwitchState tracks a running host-switch goroutine for one VM instance.
+type hostSwitchState struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// Virtual network configuration for the host-switch. These values are a
+// protocol contract with the guest-side binaries (network-setup, vm-switch)
+// baked into the opensuse distro image.
+const (
+	defaultSubnet    = "192.168.127.0/24"
+	tapDeviceMacAddr = "5a:94:ef:e4:0c:ee"
+)
+
+// hostSwitchSubnet holds the derived network addresses for the virtual network.
+type hostSwitchSubnet struct {
+	GatewayIP       string
+	StaticDHCPLease map[string]string
+	StaticDNSHost   string
+	SubnetCIDR      string
+}
+
+// validateSubnet parses a CIDR subnet and derives the gateway, DHCP lease,
+// and static DNS host addresses used by the virtual network.
+func validateSubnet(subnet string) (*hostSwitchSubnet, error) {
+	ip, _, err := net.ParseCIDR(subnet)
+	if err != nil {
+		return nil, fmt.Errorf("invalid subnet %q: %w", subnet, err)
+	}
+	ipv4 := ip.To4()
+	if ipv4 == nil {
+		return nil, fmt.Errorf("subnet %q is not IPv4", subnet)
+	}
+	tapIP := net.IPv4(ipv4[0], ipv4[1], ipv4[2], 2).String()
+	return &hostSwitchSubnet{
+		GatewayIP: net.IPv4(ipv4[0], ipv4[1], ipv4[2], 1).String(),
+		StaticDHCPLease: map[string]string{
+			tapIP: tapDeviceMacAddr,
+		},
+		StaticDNSHost: net.IPv4(ipv4[0], ipv4[1], ipv4[2], 254).String(),
+		SubnetCIDR:    subnet,
+	}, nil
+}
+
+// Vsock port assignments. These are protocol constants shared with the
+// guest-side network-setup binary.
+const (
+	vsockHandshakePort = 6669
+	vsockListenPort    = 6656
+	handshakeTimeout   = 5 * time.Minute
+
+	// signaturePhrase identifies our distro among all running Hyper-V VMs.
+	// This value is a protocol contract with the guest-side network-setup
+	// binary and must not be changed independently.
+	signaturePhrase = "github.com/rancher-sandbox/rancher-desktop/src/go/networking"
+	readySignal     = "READY"
+
+	gatewayMacAddr = "5a:94:ef:e4:0c:dd"
+	defaultMTU     = 1500
+)
+
+// startHostSwitch launches the host-switch goroutine for a WSL2 instance.
+// It must be called before the hostagent starts, because the guest's
+// network-setup.service performs a vsock handshake during early boot.
+func (r *LimaVMReconciler) startHostSwitch(ctx context.Context, name string, inst *limatype.Instance) {
+	if inst.VMType != limatype.WSL2 {
+		return
+	}
+
+	r.stopHostSwitch(name)
+
+	hsCtx, hsCancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+
+	r.hostSwitchMu.Lock()
+	r.hostSwitchStates[name] = &hostSwitchState{
+		cancel: hsCancel,
+		done:   done,
+	}
+	r.hostSwitchMu.Unlock()
+
+	logger := logr.FromContextOrDiscard(ctx).WithValues("instance", name, "component", "host-switch")
+	go r.runHostSwitch(hsCtx, logger, done)
+}
+
+// stopHostSwitch cancels the host-switch goroutine and waits for it to exit.
+func (r *LimaVMReconciler) stopHostSwitch(name string) {
+	r.hostSwitchMu.Lock()
+	state, ok := r.hostSwitchStates[name]
+	if ok {
+		delete(r.hostSwitchStates, name)
+	}
+	r.hostSwitchMu.Unlock()
+	if !ok {
+		return
+	}
+
+	state.cancel()
+	<-state.done
+}
+
+// runHostSwitch is the host-switch goroutine. It performs the vsock handshake,
+// creates a gvisor-tap-vsock virtual network, and relays Ethernet frames
+// between the host and the WSL2 VM until the context is cancelled.
+//
+// If the goroutine exits due to an error (not context cancellation), the
+// controller is not notified: the guest loses DHCP/DNS/NAT and must be
+// restarted manually. Integrating host-switch health into the controller's
+// state machine (enqueue a reconcile on unexpected exit) would allow
+// automatic recovery but requires non-trivial plumbing.
+func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger, done chan struct{}) {
+	defer close(done)
+
+	subnet, err := validateSubnet(defaultSubnet)
+	if err != nil {
+		logger.Error(err, "Invalid subnet configuration")
+		return
+	}
+
+	ln, err := vsockHandshake(ctx, logger)
+	if err != nil {
+		logger.Error(err, "Vsock handshake failed")
+		return
+	}
+
+	cfg := newVirtualNetworkConfig(*subnet)
+	vn, err := virtualnetwork.New(&cfg)
+	if err != nil {
+		ln.Close()
+		logger.Error(err, "Failed to create virtual network")
+		return
+	}
+
+	// Set up the API listener before starting errgroup goroutines so a
+	// failure here does not leak goroutines.
+	apiAddr := fmt.Sprintf("%s:80", cfg.GatewayIP)
+	vnLn, err := vn.Listen("tcp", apiAddr)
+	if err != nil {
+		ln.Close()
+		logger.Error(err, "Failed to listen on API address", "addr", apiAddr)
+		return
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/services/forwarder/all", vn.Mux())
+	mux.Handle("/services/forwarder/expose", vn.Mux())
+	mux.Handle("/services/forwarder/unexpose", vn.Mux())
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Accept vsock connections and feed them into the virtual network.
+	g.Go(func() error {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					return nil // Listener closed during shutdown.
+				}
+				return fmt.Errorf("vsock accept failed: %w", err)
+			}
+			// AcceptStdio blocks until the connection closes. This is
+			// intentional: each VM runs a single vm-switch process, so
+			// reconnections are serial (old connection EOF, then new accept).
+			if err := vn.AcceptStdio(ctx, conn); err != nil {
+				logger.Error(err, "Failed to accept connection into virtual network")
+			} else {
+				logger.Info("Accepted vsock connection")
+			}
+		}
+	})
+
+	// Close the vsock listener when the context is cancelled.
+	g.Go(func() error {
+		<-ctx.Done()
+		return ln.Close()
+	})
+
+	g.Go(func() error {
+		<-ctx.Done()
+		return vnLn.Close()
+	})
+	g.Go(func() error {
+		s := &http.Server{
+			Handler:      mux,
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+		err := s.Serve(vnLn)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
+			return err
+		}
+		return nil
+	})
+
+	logger.Info("Host-switch running", "subnet", subnet.SubnetCIDR, "gateway", subnet.GatewayIP)
+
+	if err := g.Wait(); err != nil {
+		logger.Error(err, "Host-switch exited with error")
+	} else {
+		logger.Info("Host-switch stopped")
+	}
+}
+
+// newVirtualNetworkConfig builds the gvisor-tap-vsock configuration.
+func newVirtualNetworkConfig(subnet hostSwitchSubnet) types.Configuration {
+	return types.Configuration{
+		MTU:               defaultMTU,
+		Subnet:            subnet.SubnetCIDR,
+		GatewayIP:         subnet.GatewayIP,
+		GatewayMacAddress: gatewayMacAddr,
+		DHCPStaticLeases:  subnet.StaticDHCPLease,
+		DNS: []types.Zone{
+			{
+				Name: "rancher-desktop.internal.",
+				Records: []types.Record{
+					{Name: "gateway", IP: net.ParseIP(subnet.GatewayIP)},
+					{Name: "host", IP: net.ParseIP(subnet.StaticDNSHost)},
+				},
+			},
+			{
+				Name: "docker.internal.",
+				Records: []types.Record{
+					{Name: "gateway", IP: net.ParseIP(subnet.GatewayIP)},
+					{Name: "host", IP: net.ParseIP(subnet.StaticDNSHost)},
+				},
+			},
+		},
+		NAT: map[string]string{
+			subnet.StaticDNSHost: "127.0.0.1",
+		},
+		GatewayVirtualIPs: []string{subnet.StaticDNSHost},
+	}
+}
+
+// --- Vsock handshake ---
+
+// vsockHandshake discovers the WSL2 VM via AF_VSOCK, exchanges a signature
+// to verify identity, and returns a listener on the data port.
+func vsockHandshake(ctx context.Context, logger logr.Logger) (net.Listener, error) {
+	hsCtx, hsCancel := context.WithTimeout(ctx, handshakeTimeout)
+	defer hsCancel()
+
+	vmGUID, err := getVMGUID(hsCtx, logger)
+	if err != nil {
+		return nil, fmt.Errorf("VM GUID discovery failed: %w", err)
+	}
+
+	logger.Info("Handshake succeeded", "vmGUID", vmGUID.String())
+
+	ln, err := vsockListen(vmGUID, vsockListenPort)
+	if err != nil {
+		return nil, fmt.Errorf("vsock listen on port %d failed: %w", vsockListenPort, err)
+	}
+
+	if err := signalListenerReady(hsCtx, vmGUID); err != nil {
+		ln.Close()
+		return nil, fmt.Errorf("sending %s signal failed: %w", readySignal, err)
+	}
+
+	return ln, nil
+}
+
+// getVMGUID discovers the Hyper-V VM running our distro by polling the
+// registry for VM GUIDs and handshaking with each in parallel. The registry
+// is rescanned every second so that VMs starting after the initial scan
+// (e.g., the WSL2 utility VM on a fresh system) are discovered.
+//
+// The signature-based discovery assumes only one opensuse WSL2 instance
+// runs at a time. With multiple instances, the first match wins and the
+// others get no host-switch networking.
+func getVMGUID(ctx context.Context, logger logr.Logger) (hvsock.GUID, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	found := make(chan hvsock.GUID, 1)
+	seen := make(map[hvsock.GUID]bool)
+
+	scanRegistry := func() {
+		key, err := registry.OpenKey(
+			registry.LOCAL_MACHINE,
+			`SOFTWARE\Microsoft\Windows NT\CurrentVersion\HostComputeService\VolatileStore\ComputeSystem`,
+			registry.ENUMERATE_SUB_KEYS)
+		if err != nil {
+			return // Registry key not present yet; retry on next tick.
+		}
+		names, err := key.ReadSubKeyNames(0)
+		key.Close()
+		if err != nil {
+			return
+		}
+		for _, name := range names {
+			vmGUID, err := hvsock.GUIDFromString(name)
+			if err != nil {
+				logger.V(1).Info("Skipping invalid VM GUID", "name", name, "error", err)
+				continue
+			}
+			if !seen[vmGUID] {
+				seen[vmGUID] = true
+				go attemptHandshake(ctx, logger, vmGUID, found)
+			}
+		}
+	}
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	// Immediate first scan, then rescan on each tick.
+	scanRegistry()
+	for {
+		select {
+		case vmGUID := <-found:
+			return vmGUID, nil
+		case <-ctx.Done():
+			return hvsock.GUIDZero, fmt.Errorf("VM GUID discovery timed out: %w", ctx.Err())
+		case <-ticker.C:
+			scanRegistry()
+		}
+	}
+}
+
+// attemptHandshake polls a single VM GUID once per second, trying to match
+// the signature phrase. Each probe runs synchronously to avoid goroutine
+// leaks and panics from sending on a closed channel.
+func attemptHandshake(ctx context.Context, logger logr.Logger, vmGUID hvsock.GUID, found chan<- hvsock.GUID) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		conn, err := getVsockConnection(vmGUID, vsockHandshakePort)
+		if ctx.Err() != nil {
+			if conn != nil {
+				conn.Close()
+			}
+			return
+		}
+		if err != nil {
+			logger.V(1).Info("Handshake dial failed", "vmGUID", vmGUID.String(), "error", err)
+		} else {
+			sig, err := readSignature(conn)
+			conn.Close()
+			if err != nil {
+				logger.V(1).Info("Handshake read failed", "vmGUID", vmGUID.String(), "error", err)
+			} else if sig == signaturePhrase {
+				logger.V(1).Info("Signature matched", "vmGUID", vmGUID.String())
+				select {
+				case found <- vmGUID:
+				default:
+				}
+				return
+			} else {
+				// Valid signature from a different distro; no point retrying.
+				logger.V(1).Info("Signature mismatch", "vmGUID", vmGUID.String())
+				return
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// readSignature reads the signature phrase from the peer.
+func readSignature(conn net.Conn) (string, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return "", err
+	}
+	buf := make([]byte, len(signaturePhrase))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// signalListenerReady tells the guest that the data listener is ready.
+// The dial is wrapped in a goroutine because hvsock.Dial does not accept
+// a context. The select on ctx.Done prevents the caller from hanging, but
+// the dial goroutine itself may leak if the VM becomes unresponsive.
+func signalListenerReady(ctx context.Context, vmGUID hvsock.GUID) error {
+	type result struct{ err error }
+	ch := make(chan result, 1)
+	go func() {
+		conn, err := getVsockConnection(vmGUID, vsockHandshakePort)
+		if err != nil {
+			ch <- result{err}
+			return
+		}
+		defer conn.Close()
+		_, err = conn.Write([]byte(readySignal))
+		ch <- result{err}
+	}()
+	select {
+	case r := <-ch:
+		return r.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// --- Vsock connection helpers ---
+
+// vsockListen creates an AF_VSOCK listener bound to a specific VM and port.
+func vsockListen(vmGUID hvsock.GUID, port uint32) (net.Listener, error) {
+	svcPort, err := hvsock.GUIDFromString(winio.VsockServiceID(port).String())
+	if err != nil {
+		return nil, fmt.Errorf("invalid vsock service GUID for port %d: %w", port, err)
+	}
+	return hvsock.Listen(hvsock.Addr{VMID: vmGUID, ServiceID: svcPort})
+}
+
+// getVsockConnection dials a vsock connection to the given VM and port.
+func getVsockConnection(vmGUID hvsock.GUID, port uint32) (net.Conn, error) {
+	svcPort, err := hvsock.GUIDFromString(winio.VsockServiceID(port).String())
+	if err != nil {
+		return nil, err
+	}
+	return hvsock.Dial(hvsock.Addr{VMID: vmGUID, ServiceID: svcPort})
+}

--- a/pkg/controllers/lima/limavm/controllers/hostswitch_windows_test.go
+++ b/pkg/controllers/lima/limavm/controllers/hostswitch_windows_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"net"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateSubnet(t *testing.T) {
+	t.Run("default subnet", func(t *testing.T) {
+		s, err := validateSubnet("192.168.127.0/24")
+		assert.NilError(t, err)
+		assert.Equal(t, s.GatewayIP, "192.168.127.1")
+		assert.Equal(t, s.StaticDNSHost, "192.168.127.254")
+		assert.Equal(t, s.SubnetCIDR, "192.168.127.0/24")
+		assert.Equal(t, len(s.StaticDHCPLease), 1)
+		assert.Equal(t, s.StaticDHCPLease["192.168.127.2"], tapDeviceMacAddr)
+	})
+
+	t.Run("custom subnet", func(t *testing.T) {
+		s, err := validateSubnet("10.0.0.0/24")
+		assert.NilError(t, err)
+		assert.Equal(t, s.GatewayIP, "10.0.0.1")
+		assert.Equal(t, s.StaticDNSHost, "10.0.0.254")
+		assert.Equal(t, s.SubnetCIDR, "10.0.0.0/24")
+		assert.Equal(t, s.StaticDHCPLease["10.0.0.2"], tapDeviceMacAddr)
+	})
+
+	t.Run("invalid CIDR", func(t *testing.T) {
+		_, err := validateSubnet("not-a-cidr")
+		assert.ErrorContains(t, err, "invalid subnet")
+	})
+
+	t.Run("IPv6 rejected", func(t *testing.T) {
+		_, err := validateSubnet("fd00::/64")
+		assert.ErrorContains(t, err, "not IPv4")
+	})
+}
+
+func TestNewVirtualNetworkConfig(t *testing.T) {
+	subnet := hostSwitchSubnet{
+		GatewayIP:       "192.168.127.1",
+		StaticDHCPLease: map[string]string{"192.168.127.2": tapDeviceMacAddr},
+		StaticDNSHost:   "192.168.127.254",
+		SubnetCIDR:      "192.168.127.0/24",
+	}
+	cfg := newVirtualNetworkConfig(subnet)
+
+	assert.Equal(t, cfg.MTU, defaultMTU)
+	assert.Equal(t, cfg.Subnet, "192.168.127.0/24")
+	assert.Equal(t, cfg.GatewayIP, "192.168.127.1")
+	assert.Equal(t, cfg.GatewayMacAddress, gatewayMacAddr)
+	assert.DeepEqual(t, cfg.DHCPStaticLeases, map[string]string{"192.168.127.2": tapDeviceMacAddr})
+
+	// DNS zones
+	assert.Equal(t, len(cfg.DNS), 2)
+	assert.Equal(t, cfg.DNS[0].Name, "rancher-desktop.internal.")
+	assert.Equal(t, cfg.DNS[1].Name, "docker.internal.")
+	for _, zone := range cfg.DNS {
+		assert.Equal(t, len(zone.Records), 2)
+		assert.Equal(t, zone.Records[0].Name, "gateway")
+		assert.Assert(t, zone.Records[0].IP.Equal(net.ParseIP("192.168.127.1")))
+		assert.Equal(t, zone.Records[1].Name, "host")
+		assert.Assert(t, zone.Records[1].IP.Equal(net.ParseIP("192.168.127.254")))
+	}
+
+	// NAT and virtual IPs
+	assert.DeepEqual(t, cfg.NAT, map[string]string{"192.168.127.254": "127.0.0.1"})
+	assert.DeepEqual(t, cfg.GatewayVirtualIPs, []string{"192.168.127.254"})
+}

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -136,6 +136,8 @@ type LimaVMReconciler struct {
 	instanceStatesMu sync.RWMutex
 	instanceStates   map[string]*instanceState
 	reconcileChan    chan event.TypedGenericEvent[*v1alpha1.LimaVM]
+
+	hostSwitchPlatform
 }
 
 // +kubebuilder:rbac:groups=lima.rancherdesktop.io,resources=limavms,verbs=get;list;watch;create;update;patch;delete
@@ -455,6 +457,7 @@ func (r *LimaVMReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	r.instanceStates = make(map[string]*instanceState)
+	r.initHostSwitch()
 	r.reconcileChan = make(chan event.TypedGenericEvent[*v1alpha1.LimaVM], 1)
 
 	if err := mgr.Add(manager.RunnableFunc(r.waitForShutdown)); err != nil {
@@ -537,5 +540,6 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 		r.instanceStatesMu.Lock()
 		delete(r.instanceStates, name)
 		r.instanceStatesMu.Unlock()
+		r.stopHostSwitch(name)
 	}
 }

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -37,6 +37,7 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 	logger := log.FromContext(ctx)
 
 	r.stopWatcher(limaVM.Name)
+	r.stopHostSwitch(limaVM.Name)
 
 	// Stop and delete the Lima instance.
 	// Inspect may fail if the instance doesn't exist, which is fine during
@@ -209,6 +210,7 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 		// Hostagent exited while it should be running (crash or failed start).
 		// Clean up the dead watcher and start fresh.
 		r.stopWatcher(limaVM.Name)
+		r.stopHostSwitch(limaVM.Name)
 		inst, err := store.Inspect(ctx, limaVM.Name)
 		if err != nil {
 			logger.Error(err, "Failed to inspect Lima instance")
@@ -263,6 +265,7 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 	default:
 		// phase == phaseStopped && !shouldRun
 		r.stopWatcher(limaVM.Name)
+		r.stopHostSwitch(limaVM.Name)
 		if !base.HasConditionWithReason(limaVM.Status.Conditions, ConditionRunning, metav1.ConditionFalse, ReasonStopped) {
 			if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStopped, "Lima instance is stopped"); err != nil {
 				logger.Error(err, "Failed to update stopped condition")
@@ -328,6 +331,7 @@ func (r *LimaVMReconciler) handleRestartNeeded(ctx context.Context, limaVM *v1al
 		logger.Info("Restart needed: stopping running instance")
 		r.shutdownHostagent(ctx, limaVM.Name, nil)
 		r.stopWatcher(limaVM.Name)
+		r.stopHostSwitch(limaVM.Name)
 
 		// Clear restartNeeded and set Stopped condition in one write.
 		// This is inlined (rather than calling stopInstance) so both changes
@@ -438,6 +442,11 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 
 	begin := time.Now()
 
+	// Start the host-switch virtual network for WSL2 instances. This must
+	// happen before the hostagent starts, because the guest's
+	// network-setup.service performs a vsock handshake during early boot.
+	r.startHostSwitch(ctx, limaVM.Name, inst)
+
 	// Start hostagent in background.
 	haCmd := exec.CommandContext(ctx, rddPath, args...)
 	process.SetGroup(haCmd)
@@ -446,6 +455,7 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 
 	if err := haCmd.Start(); err != nil {
 		logger.Error(err, "Failed to start hostagent")
+		r.stopHostSwitch(limaVM.Name)
 		if updateErr := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStartFailed, err.Error()); updateErr != nil {
 			logger.Error(updateErr, "Failed to update status after hostagent start failure")
 		}
@@ -455,6 +465,7 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	// Wait for PID file to be created (indicates hostagent has started)
 	if err := r.waitForPIDFile(haPIDPath, haStderrPath); err != nil {
 		logger.Error(err, "Hostagent did not start")
+		r.stopHostSwitch(limaVM.Name)
 		if updateErr := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStartFailed, err.Error()); updateErr != nil {
 			logger.Error(updateErr, "Failed to update status after hostagent startup failure")
 		}
@@ -492,6 +503,7 @@ func (r *LimaVMReconciler) stopInstance(ctx context.Context, limaVM *v1alpha1.Li
 
 	r.shutdownHostagent(ctx, limaVM.Name, inst)
 	r.stopWatcher(limaVM.Name)
+	r.stopHostSwitch(limaVM.Name)
 
 	// Verify the instance stopped
 	inst, err := store.Inspect(ctx, limaVM.Name)


### PR DESCRIPTION
The opensuse distro expects a host-switch process on the Windows host to provide networking via a virtual L2 network over AF_VSOCK. Without it, the distro's network-setup.service blocks on a vsock handshake during boot and never gets an IP address.

Port the host-switch logic from rancher-desktop's networking module into the LimaVM controller as an in-process goroutine. The goroutine performs the vsock handshake with the guest, then runs a gvisor-tap-vsock virtual network providing DNS, DHCP, and NAT.

The host-switch starts before the hostagent (the guest blocks on the handshake during early boot) and stops after the hostagent and watcher.

Also switch the WSL2 App image from Finch rootfs to the opensuse distro.

---

Also: Fix go-mod-k8s-sync checkout for cross-repository PRs

The checkout steps hardcoded the base repository, so fetching the head branch failed for cross-repository pull requests.  Specify the head repository explicitly so the fetch targets the fork where the branch exists.