### PR TITLE
Add BATS for provisioning scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ endef
 endif
 
 GOLANG_SOURCES := $(shell find . -name '*.go') go.mod go.sum
+EMBEDDED_SOURCES := $(shell find ./cmd ./pkg -name '*.yaml' -o -name '*.json')
 
 # Build the Lima guest agent from our Go dependency and compress it for embedding.
 $(GUESTAGENT_BINARY): go.mod go.sum
@@ -77,7 +78,7 @@ $(GUESTAGENT_GZ): $(GUESTAGENT_BINARY)
 
 .INTERMEDIATE: $(GUESTAGENT_BINARY)
 
-bin/rdd$(EXE): $(GOLANG_SOURCES) $(GUESTAGENT_GZ)
+bin/rdd$(EXE): $(GOLANG_SOURCES) $(EMBEDDED_SOURCES) $(GUESTAGENT_GZ)
 	WSLENV=${WSLENV}:CGO_CFLAGS:CGO_ENABLED \
 	CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" CGO_ENABLED=1 \
 	go$(EXE) build -tags="$(TAGS)" -gcflags="all=${GCFLAGS}" -ldflags="$(LDFLAGS)" -o $@ ./cmd/rdd
@@ -97,7 +98,7 @@ endif
 
 # Generate build targets for API group controllers
 define CONTROLLER_TARGETS
-bin/$(1)-controller$$(EXE): $$(GOLANG_SOURCES)
+bin/$(1)-controller$$(EXE): $$(GOLANG_SOURCES) $$(EMBEDDED_SOURCES)
 	WSLENV=${WSLENV}:CGO_ENABLED CGO_ENABLED=$$(or $$(CGO_ENABLED_$(1)),0) \
 	go$$(EXE) build -tags="$(TAGS)" -gcflags="all=$${GCFLAGS}" -ldflags="$(LDFLAGS)" -o $$@ ./cmd/$(1)-controller
 	$$(call ATTACH_ENTITLEMENTS,$$@)

--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -195,15 +195,43 @@ local_setup_file() {
     assert_output "${app_gen}"
 }
 
-@test "propagating running=false updates LimaVM spec.running" {
-    rdd ctl patch app "${APP_NAME}" --type='merge' -p='{"spec":{"running":false}}'
-    rdd ctl wait --for=jsonpath='{.spec.running}'=false \
-        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=30s
+@test "wait for dockerd to be ready with moby container engine" {
+    try --max 10 --delay 3 -- rdd limavm shell "${VM_NAME}" sudo docker info
 }
 
-@test "wait for LimaVM Running condition to become false after stop" {
+@test "containerd is not running with moby container engine" {
+    run rdd limavm shell "${VM_NAME}" sudo systemctl is-active containerd
+    assert_line "inactive"
+}
+
+@test "switch container engine to containerd without stopping VM" {
+    rdd set containerEngine.name=containerd
+    # The reconciler detects the template change, stops the VM, and restarts it.
+    rdd ctl wait --for=condition=Running=False \
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=2m
+    rdd ctl wait --for=condition=Running \
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=7m
+}
+
+@test "wait for containerd to be ready with containerd engine" {
+    try --max 10 --delay 3 -- rdd limavm shell "${VM_NAME}" sudo nerdctl --address /run/k3s/containerd/containerd.sock info
+}
+
+@test "dockerd is not running with containerd engine" {
+    run rdd limavm shell "${VM_NAME}" sudo systemctl is-active docker
+    assert_line "inactive"
+}
+
+@test "stop VM and restore moby engine after containerd test" {
+    rdd set running=false containerEngine.name=moby
     rdd ctl wait --for=condition=Running=False \
         limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=60s
+}
+
+@test "propagating running=false updates LimaVM spec.running" {
+    run -0 rdd ctl get limavm "${VM_NAME}" --namespace "${RDD_NAMESPACE}" \
+        -o jsonpath='{.spec.running}'
+    assert_output "false"
 }
 
 @test "verify App mirrors LimaVM Running condition as False after stop" {


### PR DESCRIPTION
Adds the BATS test for the provisioning scripts to verify the running container engines. Also, update the makefile to trigger the build when the embedded sources (files) are changed.