### PR TITLE
ci: add Windows perf instrumentation and disable Compat Telemetry

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -94,6 +94,58 @@ jobs:
         Get-Service -ErrorAction Continue -Name @('W3SVC', 'docker') |
           Stop-Service
 
+        # Free CPU by disabling Microsoft Compatibility Telemetry. The
+        # windows-latest runner has only 2 vCPUs, and CompatTelRunner.exe
+        # was the single largest CPU consumer in our diagnostic runs
+        # (~340 CPU-seconds over a 24-minute BATS job, ~22% of one core).
+        # On a 2-vCPU machine that crowds out gzip/xz decompression and
+        # causes intermittent BATS timeouts when the runner happens to
+        # be saturated during a Lima cache-hit decompression.
+        #
+        # Disabling scheduled tasks doesn't work on Windows Server 2025:
+        # the legacy task names ("Microsoft Compatibility Appraiser",
+        # "ProgramDataUpdater") no longer exist, and the discovery step
+        # below confirmed there are NO scheduled tasks whose action
+        # references CompatTelRunner — so the launcher must be a service,
+        # WMI subscription, or similar that we cannot reliably enumerate
+        # across Windows versions.
+        #
+        # Use the Image File Execution Options (IFEO) "Debugger" hook
+        # instead. This is a documented Windows mechanism: when anything
+        # tries to launch CompatTelRunner.exe, Windows redirects the
+        # exec to taskkill.exe (which exits immediately on the nonsense
+        # args). It is registry-only, admin-permissions only, and works
+        # regardless of what is launching the binary. See
+        # https://github.com/adolfintel/Windows10-Privacy/issues/4
+        Write-Output "--- IFEO Debugger redirect for CompatTelRunner.exe ---"
+        $ifeo = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe'
+        New-Item -Path $ifeo -Force | Out-Null
+        New-ItemProperty -Path $ifeo -Name Debugger `
+          -Value "$env:WINDIR\System32\taskkill.exe" `
+          -PropertyType String -Force | Out-Null
+        # Kill any instance already running so we start clean.
+        Get-Process CompatTelRunner -ErrorAction SilentlyContinue |
+          Stop-Process -Force -ErrorAction SilentlyContinue
+
+        # Stop the DiagTrack service (Connected User Experiences and
+        # Telemetry) for completeness; this is one of CompatTelRunner's
+        # sibling chatty processes.
+        sc.exe stop diagtrack
+        sc.exe config diagtrack start= disabled
+
+        # Discovery: log every scheduled task whose action references
+        # CompatTel so a future debugger has data if the IFEO trick
+        # ever stops working on a new Windows image.
+        Write-Output "--- Scheduled tasks referencing CompatTel ---"
+        Get-ScheduledTask -ErrorAction SilentlyContinue | Where-Object {
+          $_.Actions | Where-Object { $_.Execute -match 'CompatTel' }
+        } | Select-Object TaskPath, TaskName, State | Format-Table -AutoSize
+
+        Write-Output "--- Verification ---"
+        Get-ItemProperty -Path $ifeo -Name Debugger | Select-Object Debugger
+        Get-Service DiagTrack -ErrorAction SilentlyContinue |
+          Format-List Name,Status,StartType
+
         # Update any pre-installed WSL
         # Sometimes this fails; retry in a loop.
         do { wsl --update } while ( -not $? )
@@ -147,11 +199,55 @@ jobs:
         wsl --status
       continue-on-error: true
 
+    # Capture machine specs once at the start of the run so artifacts
+    # carry CPU/memory/disk/Defender/WSL state alongside the logs.
+    # Useful for diagnosing flaky timeouts that depend on runner specs
+    # (the windows-latest image is currently 2 vCPUs / 8 GB RAM).
+    - name: "Windows: capture machine info"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path rdd-logs/_diag | Out-Null
+        pwsh -File scripts/windows-machine-info.ps1 -OutputPath rdd-logs/_diag/machine-info.txt
+      continue-on-error: true
+
+    # Start a background perf-counter sampler that runs for the
+    # duration of the bats job. The JSONL it produces is uploaded as
+    # part of rdd-logs and can be correlated against rdd.stderr
+    # timestamps to find what was contending for CPU/disk during a
+    # slow window.
+    - name: "Windows: start perf sampler"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path rdd-logs/_diag | Out-Null
+        $proc = Start-Process pwsh -PassThru -WindowStyle Hidden -ArgumentList @(
+          '-NoProfile',
+          '-File', 'scripts/windows-perf-sampler.ps1',
+          '-OutputPath', 'rdd-logs/_diag/perf-sampler.jsonl'
+        )
+        $proc.Id | Set-Content -Path rdd-logs/_diag/perf-sampler.pid
+        Write-Output "perf-sampler started, pid=$($proc.Id)"
+      continue-on-error: true
+
     - run: make -C bats --keep-going --jobs=$(nproc) --output-sync=target
       shell: run-in-shell {0}
       env:
         RDD_TRACE: true
         RDD_LOG_LEVEL: trace
+
+    - name: "Windows: stop perf sampler"
+      if: always() && runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $pidFile = 'rdd-logs/_diag/perf-sampler.pid'
+        if (Test-Path $pidFile) {
+          $samplerPid = Get-Content $pidFile
+          Stop-Process -Id $samplerPid -Force -ErrorAction SilentlyContinue
+          Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+          Write-Output "stopped perf-sampler pid=$samplerPid"
+        }
+      continue-on-error: true
 
     - name: Collect RDD logs
       if: always()

--- a/scripts/windows-machine-info.ps1
+++ b/scripts/windows-machine-info.ps1
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# One-shot Windows machine info dump for the BATS slowdown investigation.
+# Captures hardware, OS, disk, memory, Defender, and WSL state so we can
+# correlate slow gzip decompressions on the runner with environmental factors
+# the rdd.stderr logs do not record.
+#
+# Usage: pwsh -File scripts/windows-machine-info.ps1 -OutputPath <file>
+#
+# This is a temporary diagnostic. Output is plain text intended for human
+# reading from a CI artifact.
+
+param(
+    [Parameter(Mandatory)][string]$OutputPath
+)
+
+$ErrorActionPreference = 'Continue'
+$dir = Split-Path -Parent $OutputPath
+if ($dir -and -not (Test-Path $dir)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+}
+
+# Tee everything written by Write-Output to both the console and $OutputPath.
+Start-Transcript -Path $OutputPath -Force | Out-Null
+
+try {
+    Write-Output "=== Date ==="
+    (Get-Date).ToUniversalTime().ToString('o')
+    Write-Output ''
+
+    Write-Output "=== ComputerInfo ==="
+    Get-ComputerInfo |
+        Select-Object CsName, CsManufacturer, CsModel, CsNumberOfProcessors,
+                      CsNumberOfLogicalProcessors, CsTotalPhysicalMemory,
+                      OsName, OsVersion, OsBuildNumber, OsArchitecture,
+                      OsLastBootUpTime, OsSystemDrive |
+        Format-List
+
+    Write-Output "=== CPUs ==="
+    Get-CimInstance Win32_Processor |
+        Select-Object Name, NumberOfCores, NumberOfLogicalProcessors,
+                      MaxClockSpeed, CurrentClockSpeed,
+                      L2CacheSize, L3CacheSize, ProcessorId |
+        Format-List
+
+    Write-Output "=== Memory ==="
+    $os = Get-CimInstance Win32_OperatingSystem
+    [PSCustomObject]@{
+        TotalVisibleMemoryMB = [math]::Round($os.TotalVisibleMemorySize / 1024, 1)
+        FreePhysicalMemoryMB = [math]::Round($os.FreePhysicalMemory / 1024, 1)
+        TotalVirtualMemoryMB = [math]::Round($os.TotalVirtualMemorySize / 1024, 1)
+        FreeVirtualMemoryMB  = [math]::Round($os.FreeVirtualMemory / 1024, 1)
+        FreeSpaceInPagingFilesMB = [math]::Round($os.FreeSpaceInPagingFiles / 1024, 1)
+    } | Format-List
+
+    Write-Output "=== Physical Disks ==="
+    Get-PhysicalDisk |
+        Select-Object DeviceID, FriendlyName, MediaType, BusType, Model,
+                      @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}},
+                      @{N='AllocatedGB';E={[math]::Round($_.AllocatedSize/1GB,1)}},
+                      HealthStatus, OperationalStatus, SpindleSpeed |
+        Format-Table -AutoSize
+
+    Write-Output "=== Logical Disks ==="
+    Get-CimInstance Win32_LogicalDisk |
+        Select-Object DeviceID, DriveType, FileSystem,
+                      @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}},
+                      @{N='FreeGB';E={[math]::Round($_.FreeSpace/1GB,1)}},
+                      VolumeName |
+        Format-Table -AutoSize
+
+    Write-Output "=== Disk Performance Counters (instantaneous) ==="
+    Get-Counter -Counter @(
+        '\PhysicalDisk(_Total)\Avg. Disk sec/Write',
+        '\PhysicalDisk(_Total)\Avg. Disk sec/Read',
+        '\PhysicalDisk(_Total)\Disk Write Bytes/sec',
+        '\PhysicalDisk(_Total)\Disk Read Bytes/sec',
+        '\PhysicalDisk(_Total)\Current Disk Queue Length'
+    ) -ErrorAction SilentlyContinue | Format-List
+
+    Write-Output "=== Disk Throughput Benchmark ==="
+    # Sequential write/read of a 256 MB file in TEMP. This measures the disk
+    # path the bats run actually uses (Lima's instance dirs and the lima
+    # download cache live under %USERPROFILE% / %LOCALAPPDATA%, on the same
+    # volume as %TEMP% on a default GitHub runner). FileStream with no
+    # buffering still goes through the OS file cache, so this is the
+    # cache-warm sequential rate, not raw disk speed -- but that is what
+    # gzip writes hit too.
+    $benchFile = Join-Path $env:TEMP "diag-disk-bench-$([System.Guid]::NewGuid().ToString('N')).bin"
+    try {
+        $sizeMB = 256
+        $buf = New-Object byte[] (1MB)
+        (New-Object Random).NextBytes($buf)
+
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $fs = [System.IO.File]::Create($benchFile)
+        for ($i = 0; $i -lt $sizeMB; $i++) {
+            $fs.Write($buf, 0, $buf.Length)
+        }
+        $fs.Flush($true)  # flush to disk
+        $fs.Close()
+        $sw.Stop()
+        $writeMs = $sw.Elapsed.TotalMilliseconds
+        $writeMBs = [math]::Round($sizeMB * 1000 / $writeMs, 1)
+
+        $sw.Restart()
+        $fs = [System.IO.File]::OpenRead($benchFile)
+        $total = 0
+        $readbuf = New-Object byte[] (1MB)
+        while (($n = $fs.Read($readbuf, 0, $readbuf.Length)) -gt 0) {
+            $total += $n
+        }
+        $fs.Close()
+        $sw.Stop()
+        $readMs = $sw.Elapsed.TotalMilliseconds
+        $readMBs = [math]::Round($sizeMB * 1000 / $readMs, 1)
+
+        [PSCustomObject]@{
+            File = $benchFile
+            SizeMB = $sizeMB
+            WriteMs = [math]::Round($writeMs, 1)
+            WriteMBPerSec = $writeMBs
+            ReadMs  = [math]::Round($readMs, 1)
+            ReadMBPerSec  = $readMBs
+        } | Format-List
+    } catch {
+        Write-Output "disk bench failed: $($_.Exception.Message)"
+    } finally {
+        if (Test-Path $benchFile) { Remove-Item $benchFile -Force -ErrorAction SilentlyContinue }
+    }
+
+    Write-Output "=== Defender Status ==="
+    Get-MpComputerStatus -ErrorAction SilentlyContinue |
+        Select-Object AntivirusEnabled, RealTimeProtectionEnabled,
+                      OnAccessProtectionEnabled, BehaviorMonitorEnabled,
+                      IoavProtectionEnabled, NISEnabled, IsTamperProtected,
+                      AntivirusSignatureLastUpdated, QuickScanStartTime,
+                      FullScanStartTime |
+        Format-List
+
+    Write-Output "=== Defender Preferences (subset) ==="
+    Get-MpPreference -ErrorAction SilentlyContinue |
+        Select-Object DisableRealtimeMonitoring, DisableBehaviorMonitoring,
+                      DisableScanningNetworkFiles, DisableArchiveScanning,
+                      ScanAvgCPULoadFactor, ExclusionPath, ExclusionProcess |
+        Format-List
+
+    Write-Output "=== WSL ==="
+    & wsl.exe --status
+    Write-Output ''
+    & wsl.exe --list --verbose
+    Write-Output ''
+    & wsl.exe --version 2>&1
+    Write-Output ''
+    Write-Output "--- .wslconfig (if present) ---"
+    $wslconf = Join-Path $env:USERPROFILE '.wslconfig'
+    if (Test-Path $wslconf) { Get-Content $wslconf } else { "(no .wslconfig)" }
+
+    Write-Output ''
+    Write-Output "=== Hyper-V services ==="
+    Get-Service vmms, vmcompute, hns, WslService -ErrorAction SilentlyContinue |
+        Select-Object Name, Status, StartType | Format-Table -AutoSize
+
+    Write-Output "=== Top 20 processes by working set ==="
+    Get-Process | Sort-Object -Property WS -Descending | Select-Object -First 20 |
+        Select-Object @{N='WS_MB';E={[math]::Round($_.WorkingSet64/1MB,1)}},
+                      @{N='CPU_sec';E={if ($_.CPU) { [math]::Round($_.CPU,1) } else { '' }}},
+                      Id, Handles, ProcessName |
+        Format-Table -AutoSize
+
+    Write-Output "=== Environment ==="
+    Get-ChildItem env: | Where-Object { $_.Name -match '^(LOCALAPPDATA|TEMP|TMP|USERPROFILE|HOMEDRIVE|GITHUB_|RUNNER_|RDD_|MSYS|PATH)$' } |
+        Sort-Object Name | Format-Table -AutoSize Name, Value
+}
+finally {
+    Stop-Transcript | Out-Null
+}

--- a/scripts/windows-perf-sampler.ps1
+++ b/scripts/windows-perf-sampler.ps1
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# Continuous Windows perf sampler for the BATS slowdown investigation.
+#
+# Samples CPU, disk, and memory counters once per second, plus a snapshot
+# of the top 10 processes by working set, and writes one JSON object per
+# line to $OutputPath. Designed to run in the background while `make -C bats`
+# executes; the resulting JSONL is uploaded as a CI artifact and correlated
+# against rdd.stderr timestamps to figure out what was contending for the
+# disk during the slow gzip windows.
+#
+# Usage:
+#   pwsh -File scripts/windows-perf-sampler.ps1 -OutputPath <file> [-IntervalSeconds 1]
+#
+# This is a temporary diagnostic. To remove, delete this script and the
+# workflow steps that start/stop it.
+
+param(
+    [Parameter(Mandatory)][string]$OutputPath,
+    [int]$IntervalSeconds = 1
+)
+
+$ErrorActionPreference = 'Continue'
+$ProgressPreference   = 'SilentlyContinue'
+
+$dir = Split-Path -Parent $OutputPath
+if ($dir -and -not (Test-Path $dir)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+}
+
+# Truncate any previous run.
+Set-Content -Path $OutputPath -Value '' -NoNewline
+
+# Stable English counter paths. These are the same paths Get-Counter accepts
+# on US-locale runners (which is what GitHub Actions windows-latest is).
+$counters = @(
+    '\Processor(_Total)\% Processor Time'
+    '\System\Processor Queue Length'
+    '\Memory\Available MBytes'
+    '\Memory\% Committed Bytes In Use'
+    '\PhysicalDisk(_Total)\% Disk Time'
+    '\PhysicalDisk(_Total)\Disk Read Bytes/sec'
+    '\PhysicalDisk(_Total)\Disk Write Bytes/sec'
+    '\PhysicalDisk(_Total)\Avg. Disk sec/Read'
+    '\PhysicalDisk(_Total)\Avg. Disk sec/Write'
+    '\PhysicalDisk(_Total)\Current Disk Queue Length'
+)
+
+# Track previous CPU values per PID so we can emit per-second deltas
+# (Get-Process .CPU is cumulative TotalProcessorTime in seconds).
+$prevCpu = @{}
+
+while ($true) {
+    $iterStart = Get-Date
+
+    $event = [ordered]@{
+        time = $iterStart.ToUniversalTime().ToString('o')
+    }
+
+    # System counters.
+    try {
+        $sample = Get-Counter -Counter $counters -ErrorAction SilentlyContinue
+        if ($sample) {
+            $sys = [ordered]@{}
+            foreach ($s in $sample.CounterSamples) {
+                # Strip leading "\\hostname" so paths are stable across runners.
+                $key = $s.Path -replace '^\\\\[^\\]+', ''
+                $sys[$key] = [math]::Round($s.CookedValue, 4)
+            }
+            $event['sys'] = $sys
+        }
+    } catch {
+        $event['sys_error'] = $_.Exception.Message
+    }
+
+    # Per-process snapshot: top 10 by working set, plus per-second CPU delta.
+    try {
+        $allProcs = Get-Process -ErrorAction SilentlyContinue
+        $newPrev  = @{}
+        $procRows = foreach ($p in $allProcs) {
+            $cpuNow = if ($null -ne $p.CPU) { $p.CPU } else { 0 }
+            $cpuPrev = if ($prevCpu.ContainsKey($p.Id)) { $prevCpu[$p.Id] } else { $cpuNow }
+            $delta   = $cpuNow - $cpuPrev
+            $newPrev[$p.Id] = $cpuNow
+            [PSCustomObject]@{
+                name      = $p.ProcessName
+                id        = $p.Id
+                ws_mb     = [math]::Round($p.WorkingSet64 / 1MB, 1)
+                cpu_delta = [math]::Round($delta, 3)
+                handles   = $p.HandleCount
+                threads   = $p.Threads.Count
+            }
+        }
+        $prevCpu = $newPrev
+
+        # Top by working set is generally more informative for "what's
+        # consuming RAM" while top by cpu_delta is what we actually need
+        # to find a runaway process. Take the union.
+        $byWs    = $procRows | Sort-Object -Property ws_mb     -Descending | Select-Object -First 10
+        $byCpu   = $procRows | Sort-Object -Property cpu_delta -Descending | Select-Object -First 10
+        $event['top_by_ws']  = $byWs
+        $event['top_by_cpu'] = $byCpu
+    } catch {
+        $event['proc_error'] = $_.Exception.Message
+    }
+
+    # Append one compact JSON object per line.
+    try {
+        ($event | ConvertTo-Json -Compress -Depth 5) + "`n" |
+            Add-Content -Path $OutputPath -NoNewline
+    } catch {
+        # If the output path becomes unwritable, log to stderr and keep going.
+        [Console]::Error.WriteLine("perf-sampler: write failed: $($_.Exception.Message)")
+    }
+
+    # Sleep the remainder of the interval.
+    $elapsedMs = ((Get-Date) - $iterStart).TotalMilliseconds
+    $sleepMs   = ($IntervalSeconds * 1000) - $elapsedMs
+    if ($sleepMs -gt 0) {
+        Start-Sleep -Milliseconds ([int]$sleepMs)
+    }
+}


### PR DESCRIPTION
The `bats-lima-controller` suite has been intermittently timing out on `windows-latest` because gzip decompression of the cached Lima rootfs occasionally takes 100+ seconds against a 120s test deadline. The `windows-latest` runner has only 1 physical core / 2 logical processors and 8 GB RAM, so any background CPU consumer can starve gzip badly.

Investigation showed that `CompatTelRunner.exe` (Microsoft Compatibility Telemetry) was the single largest CPU consumer over a 24-minute BATS job — ~340 CPU-seconds, roughly 22% of one core averaged across the run. Disabling it freed enough headroom that the worst-case `gzip` in limavm-running.bats` dropped from 181s to 5-12s, and the overall runner saturation dropped meaningfully (samples at queue=0 went from 16.5% to 26.8%, samples at CPU>=99% from 24% to 16%).

This commit adds two pieces:

1. Disable `CompatTelRunner` via the Image File Execution Options "Debugger" hook -- a documented Windows mechanism that redirects any attempt to launch `CompatTelRunner.exe` through `taskkill.exe`, which exits immediately. Tried first via `Disable-ScheduledTask` (silently fails on SYSTEM-owned tasks), then via `schtasks.exe` (legacy task names no longer exist on Server 2025), then via binary rename (works but heavy-handed). The IFEO hook is the community-recommended approach, registry-only, launcher-agnostic, and additionally avoids ~80 CPU-seconds of `svchost` retry overhead that the rename approach generated.

2. Two PowerShell diagnostic scripts plus workflow steps to run them:

   - `windows-machine-info.ps1`: one-shot dump of CPU/memory/disk/Defender /WSL state plus a 256 MB sequential write+read benchmark, written to `rdd-logs/_diag/machine-info.txt` at the start of the BATS job.

   - `windows-perf-sampler.ps1`: continuous JSONL sampler that runs in the background for the duration of the bats job. Per-second samples include system CPU/memory/disk counters and the top 10 processes by working set + per-second CPU delta. Written to `rdd-logs/_diag/perf-sampler.jsonl`, uploaded as part of the existing `rdd-logs` artifact.

The instrumentation is generally useful for any Windows GHA runner where intermittent CPU contention may be at play, not just this PR.