### PR TITLE
ci: disable Compatibility Telemetry on Windows runners

### DIFF
--- a/.github/actions/disable-compat-telemetry/action.yaml
+++ b/.github/actions/disable-compat-telemetry/action.yaml
@@ -1,0 +1,56 @@
+name: Disable Compatibility Telemetry
+description: >-
+  Block CompatTelRunner.exe via IFEO debugger redirect and disable the
+  DiagTrack service. Runs only on Windows; harmless no-op otherwise.
+
+runs:
+  using: composite
+  steps:
+  - name: Block CompatTelRunner via IFEO redirect
+    if: runner.os == 'Windows'
+    shell: pwsh
+    run: |
+      # Use Image File Execution Options to redirect CompatTelRunner.exe
+      # to where.exe (which just looks up args on PATH and exits).
+      # This is a documented Windows mechanism that works regardless of
+      # what launches the binary (scheduled task, service, WMI, etc.).
+      # See https://github.com/adolfintel/Windows10-Privacy/issues/4
+      #
+      # On a 2-vCPU GitHub runner, CompatTelRunner consumed ~340 CPU-seconds
+      # over a 24-minute BATS job (~22% of one core), crowding out gzip/xz
+      # decompression and causing intermittent timeouts.
+      $ifeo = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe'
+      New-Item -Path $ifeo -Force | Out-Null
+      New-ItemProperty -Path $ifeo -Name Debugger `
+        -Value "$env:WINDIR\System32\where.exe" `
+        -PropertyType String -Force | Out-Null
+
+      # Kill any instance already running.
+      Get-Process CompatTelRunner -ErrorAction SilentlyContinue |
+        Stop-Process -Force -ErrorAction SilentlyContinue
+
+  - name: Disable DiagTrack service
+    if: runner.os == 'Windows'
+    shell: pwsh
+    run: |
+      # DiagTrack (Connected User Experiences and Telemetry) is
+      # CompatTelRunner's sibling chatty process.
+      Set-Service DiagTrack -StartupType Disabled -Status Stopped
+
+  - name: Log telemetry state for debugging
+    if: runner.os == 'Windows'
+    shell: pwsh
+    run: |
+      $ifeo = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe'
+
+      # Log scheduled tasks referencing CompatTel so we have data
+      # if the IFEO trick stops working on a future Windows image.
+      Write-Output "--- Scheduled tasks referencing CompatTel ---"
+      Get-ScheduledTask -ErrorAction SilentlyContinue | Where-Object {
+        $_.Actions | Where-Object { $_.Execute -match 'CompatTel' }
+      } | Select-Object TaskPath, TaskName, State | Format-Table -AutoSize
+
+      Write-Output "--- Verification ---"
+      Get-ItemProperty -Path $ifeo -Name Debugger | Select-Object Debugger
+      Get-Service DiagTrack -ErrorAction SilentlyContinue |
+        Format-List Name, Status, StartType

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -139,6 +139,10 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: "Windows: disable Compatibility Telemetry"
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/disable-compat-telemetry
+
     - name: "Windows: WSL debugging"
       if: runner.os == 'Windows'
       shell: pwsh


### PR DESCRIPTION
Block CompatTelRunner.exe via an IFEO debugger redirect and disable the DiagTrack service before the BATS job starts. On a 2-vCPU runner, CompatTelRunner consumed ~22% of one core over a 24-minute job, crowding out gzip/xz decompression and causing intermittent timeouts.

Extract the logic into a reusable composite action at .github/actions/disable-compat-telemetry.