### PR TITLE
ci: add Windows machine-info and perf-sampler instrumentation

### DIFF
--- a/.github/actions/windows-machine-info/action.yaml
+++ b/.github/actions/windows-machine-info/action.yaml
@@ -1,0 +1,18 @@
+name: Windows Machine Info
+description: >-
+  Capture CPU, memory, disk, Defender, and WSL state into a text file.
+  Useful for diagnosing flaky timeouts that depend on runner hardware.
+
+inputs:
+  output-path:
+    description: Path for the machine-info text file.
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - if: runner.os == 'Windows'
+    shell: pwsh
+    run: >-
+      pwsh -File "${{ github.action_path }}/machine-info.ps1"
+      -OutputPath "${{ inputs.output-path }}"

--- a/.github/actions/windows-machine-info/machine-info.ps1
+++ b/.github/actions/windows-machine-info/machine-info.ps1
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# Capture Windows hardware, OS, disk, memory, Defender, and WSL state.
+# Output is plain text for human reading from a CI artifact.
+#
+# Called by the windows-machine-info composite action; not intended for
+# direct invocation.
+
+param(
+    [Parameter(Mandatory)][string]$OutputPath
+)
+
+$ErrorActionPreference = 'Continue'
+$dir = Split-Path -Parent $OutputPath
+if ($dir -and -not (Test-Path $dir)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+}
+
+# Tee everything written by Write-Output to both the console and $OutputPath.
+Start-Transcript -Path $OutputPath -Force | Out-Null
+
+try {
+    Write-Output "=== Date ==="
+    (Get-Date).ToUniversalTime().ToString('o')
+    Write-Output ''
+
+    Write-Output "=== ComputerInfo ==="
+    Get-ComputerInfo |
+        Select-Object CsName, CsManufacturer, CsModel, CsNumberOfProcessors,
+                      CsNumberOfLogicalProcessors, CsTotalPhysicalMemory,
+                      OsName, OsVersion, OsBuildNumber, OsArchitecture,
+                      OsLastBootUpTime, OsSystemDrive |
+        Format-List
+
+    Write-Output "=== CPUs ==="
+    Get-CimInstance Win32_Processor |
+        Select-Object Name, NumberOfCores, NumberOfLogicalProcessors,
+                      MaxClockSpeed, CurrentClockSpeed,
+                      L2CacheSize, L3CacheSize, ProcessorId |
+        Format-List
+
+    Write-Output "=== Memory ==="
+    $os = Get-CimInstance Win32_OperatingSystem
+    [PSCustomObject]@{
+        TotalVisibleMemoryMB = [math]::Round($os.TotalVisibleMemorySize / 1024, 1)
+        FreePhysicalMemoryMB = [math]::Round($os.FreePhysicalMemory / 1024, 1)
+        TotalVirtualMemoryMB = [math]::Round($os.TotalVirtualMemorySize / 1024, 1)
+        FreeVirtualMemoryMB  = [math]::Round($os.FreeVirtualMemory / 1024, 1)
+        FreeSpaceInPagingFilesMB = [math]::Round($os.FreeSpaceInPagingFiles / 1024, 1)
+    } | Format-List
+
+    Write-Output "=== Physical Disks ==="
+    Get-PhysicalDisk |
+        Select-Object DeviceID, FriendlyName, MediaType, BusType, Model,
+                      @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}},
+                      @{N='AllocatedGB';E={[math]::Round($_.AllocatedSize/1GB,1)}},
+                      HealthStatus, OperationalStatus, SpindleSpeed |
+        Format-Table -AutoSize
+
+    Write-Output "=== Logical Disks ==="
+    Get-CimInstance Win32_LogicalDisk |
+        Select-Object DeviceID, DriveType, FileSystem,
+                      @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}},
+                      @{N='FreeGB';E={[math]::Round($_.FreeSpace/1GB,1)}},
+                      VolumeName |
+        Format-Table -AutoSize
+
+    Write-Output "=== Disk Performance Counters (instantaneous) ==="
+    Get-Counter -Counter @(
+        '\PhysicalDisk(_Total)\Avg. Disk sec/Write',
+        '\PhysicalDisk(_Total)\Avg. Disk sec/Read',
+        '\PhysicalDisk(_Total)\Disk Write Bytes/sec',
+        '\PhysicalDisk(_Total)\Disk Read Bytes/sec',
+        '\PhysicalDisk(_Total)\Current Disk Queue Length'
+    ) -ErrorAction SilentlyContinue | Format-List
+
+    Write-Output "=== Disk Throughput Benchmark ==="
+    # Sequential write/read of a 256 MB file in TEMP. This measures the disk
+    # path the bats run actually uses (Lima's instance dirs and the lima
+    # download cache live under %USERPROFILE% / %LOCALAPPDATA%, on the same
+    # volume as %TEMP% on a default GitHub runner). FileStream with no
+    # buffering still goes through the OS file cache, so this is the
+    # cache-warm sequential rate, not raw disk speed -- but that is what
+    # gzip writes hit too.
+    $benchFile = Join-Path $env:TEMP "diag-disk-bench-$([System.Guid]::NewGuid().ToString('N')).bin"
+    try {
+        $sizeMB = 256
+        $buf = New-Object byte[] (1MB)
+        (New-Object Random).NextBytes($buf)
+
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $fs = [System.IO.File]::Create($benchFile)
+        for ($i = 0; $i -lt $sizeMB; $i++) {
+            $fs.Write($buf, 0, $buf.Length)
+        }
+        $fs.Flush($true)  # flush to disk
+        $fs.Close()
+        $sw.Stop()
+        $writeMs = $sw.Elapsed.TotalMilliseconds
+        $writeMBs = [math]::Round($sizeMB * 1000 / $writeMs, 1)
+
+        $sw.Restart()
+        $fs = [System.IO.File]::OpenRead($benchFile)
+        $total = 0
+        $readbuf = New-Object byte[] (1MB)
+        while (($n = $fs.Read($readbuf, 0, $readbuf.Length)) -gt 0) {
+            $total += $n
+        }
+        $fs.Close()
+        $sw.Stop()
+        $readMs = $sw.Elapsed.TotalMilliseconds
+        $readMBs = [math]::Round($sizeMB * 1000 / $readMs, 1)
+
+        [PSCustomObject]@{
+            File = $benchFile
+            SizeMB = $sizeMB
+            WriteMs = [math]::Round($writeMs, 1)
+            WriteMBPerSec = $writeMBs
+            ReadMs  = [math]::Round($readMs, 1)
+            ReadMBPerSec  = $readMBs
+        } | Format-List
+    } catch {
+        Write-Output "disk bench failed: $($_.Exception.Message)"
+    } finally {
+        if (Test-Path $benchFile) { Remove-Item $benchFile -Force -ErrorAction SilentlyContinue }
+    }
+
+    Write-Output "=== Defender Status ==="
+    Get-MpComputerStatus -ErrorAction SilentlyContinue |
+        Select-Object AntivirusEnabled, RealTimeProtectionEnabled,
+                      OnAccessProtectionEnabled, BehaviorMonitorEnabled,
+                      IoavProtectionEnabled, NISEnabled, IsTamperProtected,
+                      AntivirusSignatureLastUpdated, QuickScanStartTime,
+                      FullScanStartTime |
+        Format-List
+
+    Write-Output "=== Defender Preferences (subset) ==="
+    Get-MpPreference -ErrorAction SilentlyContinue |
+        Select-Object DisableRealtimeMonitoring, DisableBehaviorMonitoring,
+                      DisableScanningNetworkFiles, DisableArchiveScanning,
+                      ScanAvgCPULoadFactor, ExclusionPath, ExclusionProcess |
+        Format-List
+
+    Write-Output "=== WSL ==="
+    & wsl.exe --status
+    Write-Output ''
+    & wsl.exe --list --verbose
+    Write-Output ''
+    & wsl.exe --version 2>&1
+    Write-Output ''
+    Write-Output "--- .wslconfig (if present) ---"
+    $wslconf = Join-Path $env:USERPROFILE '.wslconfig'
+    if (Test-Path $wslconf) { Get-Content $wslconf } else { "(no .wslconfig)" }
+
+    Write-Output ''
+    Write-Output "=== Hyper-V services ==="
+    Get-Service vmms, vmcompute, hns, WslService -ErrorAction SilentlyContinue |
+        Select-Object Name, Status, StartType | Format-Table -AutoSize
+
+    Write-Output "=== Top 20 processes by working set ==="
+    Get-Process | Sort-Object -Property WS -Descending | Select-Object -First 20 |
+        Select-Object @{N='WS_MB';E={[math]::Round($_.WorkingSet64/1MB,1)}},
+                      @{N='CPU_sec';E={if ($_.CPU) { [math]::Round($_.CPU,1) } else { '' }}},
+                      Id, Handles, ProcessName |
+        Format-Table -AutoSize
+
+    Write-Output "=== Environment ==="
+    Get-ChildItem env: | Where-Object { $_.Name -match '^(LOCALAPPDATA|TEMP|TMP|USERPROFILE|HOMEDRIVE|GITHUB_|RUNNER_|RDD_|MSYS|PATH)$' } |
+        Sort-Object Name | Format-Table -AutoSize Name, Value
+}
+finally {
+    Stop-Transcript | Out-Null
+}

--- a/.github/actions/windows-perf-sampler/action.yaml
+++ b/.github/actions/windows-perf-sampler/action.yaml
@@ -1,0 +1,45 @@
+name: Windows Perf Sampler
+description: >-
+  Sample CPU, disk, and memory counters once per second in the background.
+  The JSONL output can be correlated against rdd.stderr timestamps to find
+  what contended for CPU/disk during slow windows.
+
+inputs:
+  command:
+    description: '"start" to launch the sampler, "stop" to terminate it.'
+    required: true
+  output-path:
+    description: Path for the JSONL output file.
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Start perf sampler
+    if: runner.os == 'Windows' && inputs.command == 'start'
+    shell: pwsh
+    run: |
+      $outputPath = "${{ inputs.output-path }}"
+      $dir = Split-Path -Parent $outputPath
+      if ($dir -and -not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+      }
+      $proc = Start-Process pwsh -PassThru -WindowStyle Hidden -ArgumentList @(
+        '-NoProfile',
+        '-File', '${{ github.action_path }}/perf-sampler.ps1',
+        '-OutputPath', $outputPath
+      )
+      $proc.Id | Set-Content -Path "$outputPath.pid"
+      Write-Output "perf-sampler started, pid=$($proc.Id)"
+
+  - name: Stop perf sampler
+    if: runner.os == 'Windows' && inputs.command == 'stop'
+    shell: pwsh
+    run: |
+      $pidFile = "${{ inputs.output-path }}.pid"
+      if (Test-Path $pidFile) {
+        $samplerPid = Get-Content $pidFile
+        Stop-Process -Id $samplerPid -Force -ErrorAction SilentlyContinue
+        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+        Write-Output "stopped perf-sampler pid=$samplerPid"
+      }

--- a/.github/actions/windows-perf-sampler/perf-sampler.ps1
+++ b/.github/actions/windows-perf-sampler/perf-sampler.ps1
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# Sample CPU, disk, and memory counters once per second, plus the top 10
+# processes by working set. Writes one JSON object per line to $OutputPath.
+# The resulting JSONL can be correlated against rdd.stderr timestamps to
+# identify what contended for CPU/disk during slow intervals.
+#
+# Called by the windows-perf-sampler composite action; not intended for
+# direct invocation.
+
+param(
+    [Parameter(Mandatory)][string]$OutputPath,
+    [int]$IntervalSeconds = 1
+)
+
+$ErrorActionPreference = 'Continue'
+$ProgressPreference   = 'SilentlyContinue'
+
+$dir = Split-Path -Parent $OutputPath
+if ($dir -and -not (Test-Path $dir)) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+}
+
+# Truncate any previous run.
+Set-Content -Path $OutputPath -Value '' -NoNewline
+
+# Stable English counter paths. These are the same paths Get-Counter accepts
+# on US-locale runners (which is what GitHub Actions windows-latest is).
+$counters = @(
+    '\Processor(_Total)\% Processor Time'
+    '\System\Processor Queue Length'
+    '\Memory\Available MBytes'
+    '\Memory\% Committed Bytes In Use'
+    '\PhysicalDisk(_Total)\% Disk Time'
+    '\PhysicalDisk(_Total)\Disk Read Bytes/sec'
+    '\PhysicalDisk(_Total)\Disk Write Bytes/sec'
+    '\PhysicalDisk(_Total)\Avg. Disk sec/Read'
+    '\PhysicalDisk(_Total)\Avg. Disk sec/Write'
+    '\PhysicalDisk(_Total)\Current Disk Queue Length'
+)
+
+# Track previous CPU values per PID so we can emit per-second deltas
+# (Get-Process .CPU is cumulative TotalProcessorTime in seconds).
+$prevCpu = @{}
+
+while ($true) {
+    $iterStart = Get-Date
+
+    $event = [ordered]@{
+        time = $iterStart.ToUniversalTime().ToString('o')
+    }
+
+    # System counters.
+    try {
+        $sample = Get-Counter -Counter $counters -ErrorAction SilentlyContinue
+        if ($sample) {
+            $sys = [ordered]@{}
+            foreach ($s in $sample.CounterSamples) {
+                # Strip leading "\\hostname" so paths are stable across runners.
+                $key = $s.Path -replace '^\\\\[^\\]+', ''
+                $sys[$key] = [math]::Round($s.CookedValue, 4)
+            }
+            $event['sys'] = $sys
+        }
+    } catch {
+        $event['sys_error'] = $_.Exception.Message
+    }
+
+    # Per-process snapshot: top 10 by working set, plus per-second CPU delta.
+    try {
+        $allProcs = Get-Process -ErrorAction SilentlyContinue
+        $newPrev  = @{}
+        $procRows = foreach ($p in $allProcs) {
+            $cpuNow = if ($null -ne $p.CPU) { $p.CPU } else { 0 }
+            $cpuPrev = if ($prevCpu.ContainsKey($p.Id)) { $prevCpu[$p.Id] } else { $cpuNow }
+            $delta   = $cpuNow - $cpuPrev
+            $newPrev[$p.Id] = $cpuNow
+            [PSCustomObject]@{
+                name      = $p.ProcessName
+                id        = $p.Id
+                ws_mb     = [math]::Round($p.WorkingSet64 / 1MB, 1)
+                cpu_delta = [math]::Round($delta, 3)
+                handles   = $p.HandleCount
+                threads   = $p.Threads.Count
+            }
+        }
+        $prevCpu = $newPrev
+
+        # Top by working set is generally more informative for "what's
+        # consuming RAM" while top by cpu_delta is what we actually need
+        # to find a runaway process. Take the union.
+        $byWs    = $procRows | Sort-Object -Property ws_mb     -Descending | Select-Object -First 10
+        $byCpu   = $procRows | Sort-Object -Property cpu_delta -Descending | Select-Object -First 10
+        $event['top_by_ws']  = $byWs
+        $event['top_by_cpu'] = $byCpu
+    } catch {
+        $event['proc_error'] = $_.Exception.Message
+    }
+
+    # Append one compact JSON object per line.
+    try {
+        ($event | ConvertTo-Json -Compress -Depth 5) + "`n" |
+            Add-Content -Path $OutputPath -NoNewline
+    } catch {
+        # If the output path becomes unwritable, log to stderr and keep going.
+        [Console]::Error.WriteLine("perf-sampler: write failed: $($_.Exception.Message)")
+    }
+
+    # Sleep the remainder of the interval.
+    $elapsedMs = ((Get-Date) - $iterStart).TotalMilliseconds
+    $sleepMs   = ($IntervalSeconds * 1000) - $elapsedMs
+    if ($sleepMs -gt 0) {
+        Start-Sleep -Milliseconds ([int]$sleepMs)
+    }
+}

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -147,11 +147,34 @@ jobs:
         wsl --status
       continue-on-error: true
 
+    - name: "Windows: capture machine info"
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/windows-machine-info
+      with:
+        output-path: rdd-logs/_diag/machine-info.txt
+      continue-on-error: true
+
+    - name: "Windows: start perf sampler"
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/windows-perf-sampler
+      with:
+        command: start
+        output-path: rdd-logs/_diag/perf-sampler.jsonl
+      continue-on-error: true
+
     - run: make -C bats --keep-going --jobs=$(nproc) --output-sync=target
       shell: run-in-shell {0}
       env:
         RDD_TRACE: true
         RDD_LOG_LEVEL: trace
+
+    - name: "Windows: stop perf sampler"
+      if: always() && runner.os == 'Windows'
+      uses: ./.github/actions/windows-perf-sampler
+      with:
+        command: stop
+        output-path: rdd-logs/_diag/perf-sampler.jsonl
+      continue-on-error: true
 
     - name: Collect RDD logs
       if: always()


### PR DESCRIPTION
Capture runner specs (CPU, memory, disk, Defender, WSL) at the start of the BATS job and sample perf counters once per second throughout. Both produce files under rdd-logs/_diag/ that upload with the existing artifact step, enabling correlation with rdd.stderr timestamps when diagnosing flaky timeouts.

Each is a reusable composite action:
- .github/actions/windows-machine-info (one-shot snapshot)
- .github/actions/windows-perf-sampler (start/stop background sampler)