### PR TITLE
app: Create namespace as needed

### DIFF
--- a/bats/helpers/defaults.bash
+++ b/bats/helpers/defaults.bash
@@ -3,7 +3,7 @@
 export RDD_INSTANCE
 
 : "${RDD_TRACE:=false}"
-: "${RDD_NAMESPACE:=default}"
+: "${RDD_NAMESPACE:=rdd-bats}"
 : "${RDD_KEEP_LOGS:=1}"
 export RDD_KEEP_LOGS
 

--- a/bats/helpers/load.bash
+++ b/bats/helpers/load.bash
@@ -99,7 +99,10 @@ setup() {
     if [[ -d "${RDD_LOG_DIR}" ]]; then
         local log
         for log in "${RDD_LOG_DIR}"/rdd.stderr.log "${RDD_LOG_DIR}"/rdd.stdout.log; do
-            echo "=== BATS: ${BATS_TEST_DESCRIPTION} ===" >>"${log}" 2>/dev/null || true
+            printf "=== BATS: %s %s ===\n" \
+                "$(date +"%Y-%m-%dT%H:%M:%S%z")" \
+                "${BATS_TEST_DESCRIPTION}" \
+                >>"${log}" 2>/dev/null || true
         done
     fi
 

--- a/bats/tests/31-rdd-controllers/configmapreplicaset.bats
+++ b/bats/tests/31-rdd-controllers/configmapreplicaset.bats
@@ -15,7 +15,7 @@ apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: ConfigMapReplicaSet
 metadata:
   name: ${name}
-  namespace: default
+  namespace: ${RDD_NAMESPACE}
 spec:
   replicas: ${replicas}
   data:
@@ -41,11 +41,12 @@ wait_for_configmaps() {
 }
 
 @test 'create ConfigMapReplicaSet resource' {
+    rdd ctl create namespace "${RDD_NAMESPACE}" || true
     create_configmapreplicaset "basic" 3
 }
 
 @test 'verify ConfigMapReplicaSet is created in Kubernetes' {
-    rdd ctl wait --for=create ConfigMapReplicaSet basic --timeout=15s
+    rdd ctl wait --for=create ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" basic --timeout=15s
 }
 
 @test 'wait for controller to create 3 ConfigMaps' {
@@ -53,7 +54,8 @@ wait_for_configmaps() {
 }
 
 @test 'verify ConfigMaps have correct names' {
-    run -0 rdd ctl get configmaps -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=basic -o json
+    run -0 rdd ctl get configmaps --namespace "${RDD_NAMESPACE}" -o json \
+        -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=basic
     run -0 jq_output '.items[].metadata.name'
     assert_line "basic-0"
     assert_line "basic-1"
@@ -62,7 +64,7 @@ wait_for_configmaps() {
 
 @test 'verify ConfigMap content includes original data plus index' {
     # Check first ConfigMap contains original data plus index
-    run -0 rdd ctl get configmap basic-0 -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-0 -o json
     local basic0_json="${output}"
 
     run -0 jq -r '.data | keys[]' <<<"${basic0_json}"
@@ -76,16 +78,16 @@ wait_for_configmaps() {
     run -0 jq -r '.data."app.properties"' <<<"${basic0_json}"
     assert_output --partial "server.port=8080"
 
-    run -0 rdd ctl get configmap basic-0 -o jsonpath='{.data.index}'
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-0 -o jsonpath='{.data.index}'
     assert_output "0"
 
     # Check second ConfigMap has different index
-    run -0 rdd ctl get configmap basic-1 -o jsonpath='{.data.index}'
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-1 -o jsonpath='{.data.index}'
     assert_output "1"
 }
 
 @test 'verify ConfigMap owner references are set' {
-    run -0 rdd ctl get configmap basic-0 -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-0 -o json
     local configmap_json="${output}"
 
     # Verify owner reference exists and has correct kind
@@ -105,7 +107,7 @@ wait_for_configmaps() {
 
 @test 'debug owner references before deletion' {
     # Extract and validate complete owner reference structure
-    run -0 rdd ctl get ConfigMapReplicaSet basic -o json
+    run -0 rdd ctl get ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" basic -o json
     local parent_json="${output}"
 
     run -0 jq -r '.metadata.uid' <<<"${parent_json}"
@@ -115,7 +117,7 @@ wait_for_configmaps() {
     local parent_api_version=${output}
 
     # Verify owner reference structure
-    run -0 rdd ctl get configmap basic-0 -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-0 -o json
     local configmap="${output}"
 
     # Verify critical owner reference fields
@@ -136,7 +138,8 @@ wait_for_configmaps() {
 }
 
 @test 'scale ConfigMapReplicaSet up to 5 replicas' {
-    rdd ctl patch ConfigMapReplicaSet basic --type='merge' -p='{"spec":{"replicas":5}}'
+    rdd ctl patch ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" basic \
+        --type='merge' -p='{"spec":{"replicas":5}}'
 }
 
 @test 'wait for scaling up to complete (5 ConfigMaps)' {
@@ -144,7 +147,8 @@ wait_for_configmaps() {
 }
 
 @test 'verify all 5 ConfigMaps exist after scaling up' {
-    run -0 rdd ctl get configmaps -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=basic -o json
+    run -0 rdd ctl get configmaps --namespace "${RDD_NAMESPACE}" -o json \
+        -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=basic
     local configmaps="${output}"
 
     # Verify we have exactly 5 ConfigMaps
@@ -161,7 +165,8 @@ wait_for_configmaps() {
 }
 
 @test 'scale ConfigMapReplicaSet down to 2 replicas' {
-    rdd ctl patch ConfigMapReplicaSet basic --type='merge' -p='{"spec":{"replicas":2}}'
+    rdd ctl patch ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" basic \
+        --type='merge' -p='{"spec":{"replicas":2}}'
 }
 
 @test 'wait for scaling down to complete (2 ConfigMaps)' {
@@ -169,7 +174,8 @@ wait_for_configmaps() {
 }
 
 @test 'verify only 2 ConfigMaps remain after scaling down' {
-    run -0 rdd ctl get configmaps -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=basic -o json
+    run -0 rdd ctl get configmaps --namespace "${RDD_NAMESPACE}" -o json \
+        -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=basic
     local configmaps="${output}"
 
     # Verify we have exactly 2 ConfigMaps
@@ -184,16 +190,18 @@ wait_for_configmaps() {
 
 @test 'update ConfigMapReplicaSet data' {
     # Update the ConfigMapReplicaSet data
-    rdd ctl patch ConfigMapReplicaSet basic --type='merge' -p='{"spec":{"data":{"config.yaml":"updated: true\n''version: 2.0.0\n","new-file.txt":"This is a new file"}}}'
+    rdd ctl patch ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" basic \
+        --type='merge' -p='{"spec":{"data":{"config.yaml":"updated: true\n''version: 2.0.0\n","new-file.txt":"This is a new file"}}}'
 
     # Increase replica count from 2 to 4 to create new replicas with updated data
-    rdd ctl patch ConfigMapReplicaSet basic --type='merge' -p='{"spec":{"replicas":4}}'
+    rdd ctl patch ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" basic \
+        --type='merge' -p='{"spec":{"replicas":4}}'
 
     # Wait for new ConfigMaps to be created
     wait_for_configmaps "basic" 4
 
     # Verify old ConfigMaps (0,1) still have original data
-    run -0 rdd ctl get configmap basic-0 -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-0 -o json
     local basic0_json="${output}"
 
     run -0 jq -r '.data."config.yaml"' <<<"${basic0_json}"
@@ -210,7 +218,7 @@ wait_for_configmaps() {
     run -0 jq -r '.data | has("new-file.txt")' <<<"${basic0_json}"
     assert_output "false"
 
-    run -0 rdd ctl get configmap basic-1 -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-1 -o json
     local basic1_json="${output}"
 
     run -0 jq -r '.data."config.yaml"' <<<"${basic1_json}"
@@ -228,7 +236,7 @@ wait_for_configmaps() {
     assert_output "false"
 
     # Verify new ConfigMaps (2,3) have updated data
-    run -0 rdd ctl get configmap basic-2 -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-2 -o json
     local basic2_json="${output}"
 
     run -0 jq -r '.data."config.yaml"' <<<"${basic2_json}"
@@ -241,7 +249,7 @@ wait_for_configmaps() {
     run -0 jq -r '.data.index' <<<"${basic2_json}"
     assert_output "2"
 
-    run -0 rdd ctl get configmap basic-3 -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-3 -o json
     local basic3_json="${output}"
 
     run -0 jq -r '.data."config.yaml"' <<<"${basic3_json}"
@@ -258,11 +266,13 @@ wait_for_configmaps() {
 @test 'verify ConfigMapReplicaSet has finalizer for cleanup' {
     # Check that the ConfigMapReplicaSet has the cleanup finalizer
     # Check ConfigMap finalizers (should be empty)
-    run -0 rdd ctl get configmap basic-0 -o jsonpath='{.metadata.finalizers}'
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" basic-0 \
+        -o jsonpath='{.metadata.finalizers}'
     refute_output
 
     # Check parent resource finalizers (should have shared cleanup finalizer)
-    run -0 rdd ctl get ConfigMapReplicaSet basic -o jsonpath='{.metadata.finalizers}'
+    run -0 rdd ctl get ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" basic \
+        -o jsonpath='{.metadata.finalizers}'
     assert_output --partial "rdd.rancherdesktop.io/cleanup"
 }
 
@@ -273,7 +283,7 @@ wait_for_configmaps() {
 @test 'verify parent resource deletion triggers finalizer cleanup' {
     # Parent should be deleted by the finalizer after ConfigMaps are cleaned up
     # The finalizer should handle cleanup automatically
-    run -1 rdd ctl get ConfigMapReplicaSet basic
+    run -1 rdd ctl get ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" basic
 }
 
 @test 'wait for ConfigMaps to be cleaned up by finalizer' {
@@ -285,7 +295,8 @@ wait_for_configmaps() {
 }
 
 @test 'verify zero replicas ConfigMapReplicaSet is created' {
-    rdd ctl wait --for=create ConfigMapReplicaSet zero --timeout=60s
+    rdd ctl wait --for=create ConfigMapReplicaSet \
+        --namespace "${RDD_NAMESPACE}" zero --timeout=60s
 }
 
 @test 'verify no ConfigMaps are created for zero replicas' {
@@ -301,7 +312,8 @@ wait_for_configmaps() {
 }
 
 @test 'verify single ConfigMap has correct name' {
-    run -0 rdd ctl get configmaps -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=single -o json
+    run -0 rdd ctl get configmaps --namespace "${RDD_NAMESPACE}" -o json \
+        -l app.kubernetes.io/managed-by=rdd-configmapreplicaset,app.kubernetes.io/instance=single
     local configmaps="${output}"
 
     # Verify we have exactly 1 ConfigMap
@@ -314,7 +326,7 @@ wait_for_configmaps() {
 }
 
 @test 'verify single ConfigMap has correct index' {
-    run -0 rdd ctl get configmap single-0 -o jsonpath='{.data.index}'
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" single-0 -o jsonpath='{.data.index}'
     assert_output "0"
 }
 
@@ -325,7 +337,8 @@ wait_for_configmaps() {
     wait_for_configmaps "status" 3
 
     # Check the status of the ConfigMapReplicaSet
-    run -0 rdd ctl get ConfigMapReplicaSet status -o json
+    run -0 rdd ctl get ConfigMapReplicaSet --namespace "${RDD_NAMESPACE}" status \
+        -o json
     run -0 jq -r 'has("status")' <<<"${output}"
     assert_output "true"
 }

--- a/bats/tests/31-rdd-controllers/notary.bats
+++ b/bats/tests/31-rdd-controllers/notary.bats
@@ -20,7 +20,7 @@ apiVersion: rdd.rancherdesktop.io/v1alpha1
 kind: Notary
 metadata:
   name: ${name}
-  namespace: default
+  namespace: "${RDD_NAMESPACE}"
 spec:
   value: "${value}"
   configMapName: "${config_map_name}"
@@ -40,12 +40,13 @@ wait_for_notary_status() {
 }
 
 @test 'create Notary resource' {
+    rdd ctl create namespace "${RDD_NAMESPACE}" || true
     delete_resource "notary" "basic"
     create_notary "basic" "initial-value" "basic-history"
 }
 
 @test 'verify Notary is created in Kubernetes' {
-    rdd ctl wait --for=create notary basic --timeout=15s
+    rdd ctl wait --for=create notary --namespace "${RDD_NAMESPACE}" basic --timeout=15s
 }
 
 @test 'wait for controller to create ConfigMap' {
@@ -53,7 +54,7 @@ wait_for_notary_status() {
 }
 
 @test 'verify ConfigMap has correct name and content' {
-    run -0 rdd ctl get configmap "basic-history" -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" "basic-history" -o json
     local json="${output}"
 
     run -0 jq -r '.data.change_000' <<<"${json}"
@@ -67,7 +68,7 @@ wait_for_notary_status() {
 }
 
 @test 'verify ConfigMap has correct labels and owner references' {
-    run -0 rdd ctl get configmap "basic-history" -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" "basic-history" -o json
     local json="${output}"
 
     # Check labels
@@ -92,7 +93,7 @@ wait_for_notary_status() {
 }
 
 @test 'verify Notary status is updated' {
-    run -0 rdd ctl get notary basic -o json
+    run -0 rdd ctl get notary --namespace "${RDD_NAMESPACE}" basic -o json
     local json="${output}"
 
     run -0 jq -r 'has("status")' <<<"${json}"
@@ -117,7 +118,7 @@ wait_for_notary_status() {
 }
 
 @test 'verify ConfigMap records the change' {
-    run -0 rdd ctl get configmap "basic-history" -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" "basic-history" -o json
     local json="${output}"
 
     run -0 jq -r '.data.change_000' <<<"${json}"
@@ -134,7 +135,7 @@ wait_for_notary_status() {
 }
 
 @test 'verify Notary status shows updated change count' {
-    run -0 rdd ctl get notary basic -o json
+    run -0 rdd ctl get notary --namespace "${RDD_NAMESPACE}" basic -o json
     local json="${output}"
 
     run -0 jq -r '.status.lastRecordedValue' <<<"${json}"
@@ -156,7 +157,7 @@ wait_for_notary_status() {
 }
 
 @test 'verify ConfigMap records multiple changes' {
-    run -0 rdd ctl get configmap "basic-history" -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" "basic-history" -o json
     local json="${output}"
 
     # Verify all changes are recorded
@@ -188,7 +189,7 @@ wait_for_notary_status() {
     sleep 2
 
     # Check that no new change was recorded
-    run -0 rdd ctl get configmap "basic-history" -o json
+    run -0 rdd ctl get configmap --namespace "${RDD_NAMESPACE}" "basic-history" -o json
     local json="${output}"
 
     run -0 jq -r '.data.change_003' <<<"${json}"
@@ -203,7 +204,7 @@ wait_for_notary_status() {
 }
 
 @test 'verify Notary has finalizer for cleanup' {
-    run -0 rdd ctl get notary basic -o jsonpath='{.metadata.finalizers}'
+    run -0 rdd ctl get notary --namespace "${RDD_NAMESPACE}" basic -o jsonpath='{.metadata.finalizers}'
     assert_output --partial "rdd.rancherdesktop.io/cleanup"
 }
 
@@ -212,7 +213,7 @@ wait_for_notary_status() {
 }
 
 @test 'verify parent resource deletion triggers finalizer cleanup' {
-    run -1 rdd ctl get notary basic
+    run -1 rdd ctl get notary --namespace "${RDD_NAMESPACE}" basic
 }
 
 @test 'wait for ConfigMaps to be cleaned up by finalizer' {

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -21,7 +21,7 @@ These variables configure the BATS test framework. They have no effect on `rdd` 
 | Variable | Description | Default |
 | --- | --- | --- |
 | `RDD_TRACE` | Enables verbose trace output in BATS tests. | `false` |
-| `RDD_NAMESPACE` | Default Kubernetes namespace for BATS controller tests. | `default` |
+| `RDD_NAMESPACE` | Default Kubernetes namespace for BATS controller tests. | `rdd-bats` |
 | `RDD_VM_TYPE` | Lima VM type for tests that boot a VM (`qemu` or `vz`). Useful for reproducing QEMU-specific failures on macOS. | Lima's default (`vz` on macOS, `qemu` on Linux) |
 
 ## Path Variables

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -64,28 +64,16 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Handle deletion, delete the LimaVM and wait for it to finish cleaning up.
+	// Handle deletion, delete owned resources.
 	if base.IsBeingDeleted(&app) {
 		log.Info("App resource is being deleted, performing cleanup")
 
 		namespace := app.GetResourceNamespace()
+
+		// Delete the LimaVM and wait for it to finish cleaning up.
 		limaVM := &limav1alpha1.LimaVM{}
 		err := r.Get(ctx, client.ObjectKey{Name: limaVMName, Namespace: namespace}, limaVM)
-		switch {
-		case apierrors.IsNotFound(err):
-			// LimaVM is gone. Clean up any ConfigMaps that may have been left behind.
-			inputCM := &corev1.ConfigMap{}
-			if cmErr := r.Get(ctx, client.ObjectKey{Name: inputConfigMapName, Namespace: namespace}, inputCM); cmErr == nil {
-				if cmErr := r.Delete(ctx, inputCM); cmErr != nil && !apierrors.IsNotFound(cmErr) {
-					return ctrl.Result{}, fmt.Errorf("failed to delete input ConfigMap during cleanup: %w", cmErr)
-				}
-			} else if !apierrors.IsNotFound(cmErr) {
-				return ctrl.Result{}, fmt.Errorf("failed to fetch input ConfigMap during cleanup: %w", cmErr)
-			}
-			return ctrl.Result{}, base.RemoveCleanupFinalizer(ctx, r.Client, &app)
-		case err != nil:
-			return ctrl.Result{}, err
-		default:
+		if err == nil {
 			if err := base.RemoveOwnedFinalizer(ctx, r.Client, limaVM, v1alpha1.AppKind); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to remove owned finalizer from LimaVM: %w", err)
 			}
@@ -98,7 +86,34 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 				log.Info("Waiting for LimaVM deletion to complete")
 			}
 			return ctrl.Result{RequeueAfter: requeueAfterDeletion}, nil
+		} else if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch LimaVM: %w", err)
 		}
+
+		// LimaVM is gone. Clean up any ConfigMaps that may have been left behind.
+		inputCM := &corev1.ConfigMap{}
+		if cmErr := r.Get(ctx, client.ObjectKey{Name: inputConfigMapName, Namespace: namespace}, inputCM); cmErr == nil {
+			if cmErr := r.Delete(ctx, inputCM); cmErr != nil && !apierrors.IsNotFound(cmErr) {
+				return ctrl.Result{}, fmt.Errorf("failed to delete input ConfigMap during cleanup: %w", cmErr)
+			}
+		} else if !apierrors.IsNotFound(cmErr) {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch input ConfigMap during cleanup: %w", cmErr)
+		}
+
+		// Remove the namespace if it was created by this controller.
+		ns := &corev1.Namespace{}
+		if nsErr := r.Get(ctx, client.ObjectKey{Name: namespace}, ns); nsErr == nil {
+			if metav1.IsControlledBy(ns, &app) {
+				if nsErr := r.Delete(ctx, ns); nsErr != nil && !apierrors.IsNotFound(nsErr) {
+					return ctrl.Result{}, fmt.Errorf("failed to delete namespace during cleanup: %w", nsErr)
+				}
+			}
+		} else if !apierrors.IsNotFound(nsErr) {
+			return ctrl.Result{}, fmt.Errorf("failed to fetch namespace during cleanup: %w", nsErr)
+		}
+
+		// Everything has been deleted, remove the App finalizer to allow the App resource to be removed.
+		return ctrl.Result{}, base.RemoveCleanupFinalizer(ctx, r.Client, &app)
 	}
 
 	// Make sure the App is finalized so deletion goes through cleanup.
@@ -109,6 +124,25 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 	}
 
 	namespace := app.GetResourceNamespace()
+
+	// Create the namespace if it does not exist.
+	ns := &corev1.Namespace{}
+	err := r.Get(ctx, client.ObjectKey{Name: namespace}, ns)
+	if apierrors.IsNotFound(err) {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		if err := ctrl.SetControllerReference(&app, ns, r.Scheme); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to set owner reference on namespace: %w", err)
+		}
+		if err := r.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to create namespace: %w", err)
+		}
+	} else if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to fetch namespace: %w", err)
+	}
 
 	// Check whether the LimaVM already exists. If not, create the input ConfigMap and LimaVM.
 	limaVM := &limav1alpha1.LimaVM{}


### PR DESCRIPTION
This causes the app reconciler to create the namespace before trying to create LimaVM in it.  It also tries to delete the namespace (if it's owned by the app) on app delete.

To make sure this is exercised, the BATS default namespace has been changed (it was already an option).  However, this surfaced an issue where we were incorrectly assuming the default namespace in BATS.  (As noted, that was already an option that wasn't exercised very much, so it would be a bug.)