### PR TITLE
Bats runtime fixes

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -77,6 +77,13 @@ jobs:
       run: |
         brew install bash coreutils make
 
+        # Disable Spotlight indexing on all volumes. On macos-15-intel CI
+        # runners, mds/mds_stores/mdworker_shared collectively consumed
+        # ~230% CPU during BATS runs — more than two of the runner's four
+        # logical cores — starving Lima's VM of the cycles it needs to
+        # boot within the test timeout.
+        sudo mdutil -a -i off
+
         # Set up run-in-shell helper script (as a symlink to bash)
         mkdir -p bin
         ln -s $(brew --prefix bash)/bin/bash bin/run-in-shell

--- a/bats/helpers/commands.bash
+++ b/bats/helpers/commands.bash
@@ -82,5 +82,8 @@ rdd() {
             export WSLENV
         fi
     fi
-    "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${args[@]}"
+    # Close BATS's internal fds 3 and 4 so any daemon rdd spawns (hostagent,
+    # qemu) cannot inherit them. A grandchild that keeps fd 3 open will hang
+    # bats when it next tries to capture output via run/$(...).
+    "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${args[@]}" 3>&- 4>&-
 }


### PR DESCRIPTION
* Disable spotlight metadata collection on macOS runners.
* Prevent inheritance of &3 and &4 by daemon processes, which block BATS from terminating.