### PR TITLE
Validating admission controller app settings

### DIFF
--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -463,3 +463,18 @@ spec:
     version: "${K3S_VERSION}"
 EOF
 }
+
+@test "webhook rejects invalid update via patch dry-run" {
+    # The App may not exist here and might be deleted after kubernetes tests, so we create one.
+    create_app false
+
+    run -0 rdd ctl get app app -o jsonpath='{.spec.containerEngine.name}'
+    assert_output "moby"
+
+    run -1 rdd ctl patch app app --dry-run=server \
+        --type=merge -p '{"spec":{"kubernetes":{"enabled":true,"version":"0.0.0"}}}'
+    assert_output --partial "not supported"
+
+    run -0 rdd ctl get app app -o jsonpath='{.spec.containerEngine.name}'
+    assert_output "moby"
+}

--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -10,6 +10,8 @@ load '../../helpers/load'
 APP_NAME="app"
 VM_NAME="rd"
 INPUT_CM_NAME="rd"
+APP_VALIDATOR_CONFIG="app-validator"
+K3S_VERSION="1.32.0"
 
 delete_app() {
     # Stop the VM first so the LimaVM finalizer clears quickly.
@@ -296,6 +298,17 @@ EOF
     delete_app
 }
 
+@test "unsupported Kubernetes version is rejected by admission webhook" {
+    delete_app
+    run -1 rdd set running=false kubernetes.enabled=true kubernetes.version=1.31.99
+    assert_output --partial "not supported"
+}
+
+@test "unsupported version does not create App resource" {
+    run -1 rdd ctl get app "${APP_NAME}"
+    assert_output --partial "not found"
+}
+
 @test "valid Kubernetes version allows LimaVM creation" {
     skip_on_windows "Kubernetes tests require further setup on Windows"
     delete_app
@@ -344,4 +357,109 @@ EOF
     rdd ctl wait --for=condition=Running=False \
         limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=60s
     delete_app
+}
+
+# --- Admission webhook: --dry-run=server validation ---
+
+@test "webhook configuration is registered" {
+    rdd ctl wait --for=create ValidatingWebhookConfiguration "${APP_VALIDATOR_CONFIG}" --timeout=60s
+
+    run -0 rdd ctl get ValidatingWebhookConfiguration "${APP_VALIDATOR_CONFIG}" \
+        -o jsonpath='{.webhooks[0].name}'
+    assert_output "app-validator.app.rancherdesktop.io"
+}
+
+@test "dry-run accepts valid App settings" {
+    run -0 rdd ctl apply --dry-run=server -f - <<EOF
+apiVersion: app.rancherdesktop.io/v1alpha1
+kind: App
+metadata:
+  name: app
+spec:
+  running: false
+  containerEngine:
+    name: containerd
+  kubernetes:
+    enabled: false
+EOF
+}
+
+@test "dry-run accepts valid containerEngine moby" {
+    run -0 rdd ctl apply --dry-run=server -f - <<EOF
+apiVersion: app.rancherdesktop.io/v1alpha1
+kind: App
+metadata:
+  name: app
+spec:
+  running: false
+  containerEngine:
+    name: moby
+  kubernetes:
+    enabled: false
+EOF
+}
+
+@test "dry-run rejects invalid containerEngine name" {
+    run -1 rdd ctl apply --dry-run=server -f - <<EOF
+apiVersion: app.rancherdesktop.io/v1alpha1
+kind: App
+metadata:
+  name: app
+spec:
+  running: false
+  containerEngine:
+    name: kvm
+  kubernetes:
+    enabled: false
+EOF
+    assert_output --partial "containerEngine.name"
+}
+
+@test "dry-run rejects kubernetes.enabled=true with empty version" {
+    run -1 rdd ctl apply --dry-run=server -f - <<EOF
+apiVersion: app.rancherdesktop.io/v1alpha1
+kind: App
+metadata:
+  name: app
+spec:
+  running: false
+  containerEngine:
+    name: moby
+  kubernetes:
+    enabled: true
+EOF
+    assert_output --partial "kubernetes.version must not be empty"
+}
+
+@test "dry-run rejects unsupported kubernetes.version" {
+    run -1 rdd ctl apply --dry-run=server -f - <<EOF
+apiVersion: app.rancherdesktop.io/v1alpha1
+kind: App
+metadata:
+  name: app
+spec:
+  running: false
+  containerEngine:
+    name: moby
+  kubernetes:
+    enabled: true
+    version: "0.0.0"
+EOF
+    assert_output --partial "not supported"
+}
+
+@test "dry-run accepts supported kubernetes.version" {
+    run -0 rdd ctl apply --dry-run=server -f - <<EOF
+apiVersion: app.rancherdesktop.io/v1alpha1
+kind: App
+metadata:
+  name: app
+spec:
+  running: false
+  containerEngine:
+    name: moby
+  kubernetes:
+    enabled: true
+    version: "${K3S_VERSION}"
+EOF
 }

--- a/bats/tests/32-app-controllers/set.bats
+++ b/bats/tests/32-app-controllers/set.bats
@@ -125,7 +125,8 @@ local_setup_file() {
     run -0 get_app_field '.spec.kubernetes.version'
     assert_output "1.32.2"
 
-    rdd set kubernetes.version=
+    # Clear both together: webhook rejects an empty version when enabled=true.
+    rdd set kubernetes.enabled=false kubernetes.version=
 
     run -0 get_app_field '.spec.kubernetes.version'
     assert_output ""

--- a/pkg/controllers/app/app/controller.go
+++ b/pkg/controllers/app/app/controller.go
@@ -11,6 +11,7 @@ import (
 	_ "embed"
 	"runtime"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
@@ -31,6 +32,9 @@ var limaImagesWSL2 string
 
 //go:embed lima-template.yaml
 var limaTemplate string
+
+//go:embed k3s-versions.json
+var k3sVersionsData string
 
 func limaTemplateData() string {
 	images := limaImagesUnix
@@ -53,8 +57,21 @@ const APIGroup = "app"
 //go:embed crd.yaml
 var appCRD string
 
+const (
+	// appValidatorWebhookName is the name used for the App validating webhook.
+	appValidatorWebhookName = "app-validator.app.rancherdesktop.io"
+	// appValidatorConfigName is the name of the App ValidatingWebhookConfiguration.
+	appValidatorConfigName = "app-validator"
+)
+
 // controller implements the base.Controller interface for app.
-type controller struct{}
+type controller struct {
+	webhookPort     int
+	webhookManagers []base.WebhookManager
+}
+
+// Verify that controller implements base.WebhookController interface.
+var _ base.WebhookController = &controller{}
 
 func newController() base.Controller {
 	return &controller{}
@@ -78,6 +95,42 @@ func (c *controller) GetCRDData() string {
 	return appCRD
 }
 
+// SetWebhookPort sets the webhook port allocated by SharedControllerManager.
+func (c *controller) SetWebhookPort(port int) {
+	c.webhookPort = port
+}
+
+// GetWebhookServiceName returns the DNS service name for webhook certificates.
+func (c *controller) GetWebhookServiceName() string {
+	return ControllerName + "-webhook"
+}
+
+// GetWebhookManagers returns all WebhookManagers for parallel setup.
+func (c *controller) GetWebhookManagers() []base.WebhookManager {
+	return c.webhookManagers
+}
+
+// setupWebhook sets up the App validating webhook.
+func (c *controller) setupWebhook(mgr ctrl.Manager) error {
+	validatingConfig := base.WebhookConfig[*v1alpha1.App]{
+		Name:        appValidatorConfigName,
+		WebhookName: appValidatorWebhookName,
+		WebhookPort: c.webhookPort,
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
+			admissionregistrationv1.Update,
+		},
+		Validator: &controllers.AppValidator{K3sVersionsData: k3sVersionsData},
+	}
+
+	managers, err := base.SetupWebhookForResource(mgr, &v1alpha1.App{}, validatingConfig)
+	if err != nil {
+		return err
+	}
+	c.webhookManagers = append(c.webhookManagers, managers...)
+	return nil
+}
+
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
 // It registers the CRD types with the scheme and sets up the controller with the manager.
 // It also registers Lima types, which allows App controller to create and watch LimaVM resources.
@@ -89,9 +142,13 @@ func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return (&controllers.AppReconciler{
+	if err := (&controllers.AppReconciler{
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
 		LimaTemplateData: limaTemplateData(),
-	}).SetupWithManager(mgr)
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	return c.setupWebhook(mgr)
 }

--- a/pkg/controllers/app/app/controller.go
+++ b/pkg/controllers/app/app/controller.go
@@ -112,6 +112,10 @@ func (c *controller) GetWebhookManagers() []base.WebhookManager {
 
 // setupWebhook sets up the App validating webhook.
 func (c *controller) setupWebhook(mgr ctrl.Manager) error {
+	validator, err := controllers.NewAppValidator(k3sVersionsData)
+	if err != nil {
+		return err
+	}
 	validatingConfig := base.WebhookConfig[*v1alpha1.App]{
 		Name:        appValidatorConfigName,
 		WebhookName: appValidatorWebhookName,
@@ -120,7 +124,7 @@ func (c *controller) setupWebhook(mgr ctrl.Manager) error {
 			admissionregistrationv1.Create,
 			admissionregistrationv1.Update,
 		},
-		Validator: &controllers.AppValidator{K3sVersionsData: k3sVersionsData},
+		Validator: validator,
 	}
 
 	managers, err := base.SetupWebhookForResource(mgr, &v1alpha1.App{}, validatingConfig)

--- a/pkg/controllers/app/app/controllers/app_webhook.go
+++ b/pkg/controllers/app/app/controllers/app_webhook.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	ctrlwebhookadmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+// AppValidator validates App resources via admission webhook.
+type AppValidator struct {
+	K3sVersionsData string
+}
+
+// ValidateCreate validates a new App resource.
+func (v *AppValidator) ValidateCreate(_ context.Context, obj *v1alpha1.App) (ctrlwebhookadmission.Warnings, error) {
+	return v.validate(obj)
+}
+
+// ValidateUpdate validates an updated App resource.
+func (v *AppValidator) ValidateUpdate(_ context.Context, _, newObj *v1alpha1.App) (ctrlwebhookadmission.Warnings, error) {
+	return v.validate(newObj)
+}
+
+// ValidateDelete is a no-op; App deletion is governed by the cleanup finalizer.
+func (v *AppValidator) ValidateDelete(_ context.Context, _ *v1alpha1.App) (ctrlwebhookadmission.Warnings, error) {
+	return nil, nil
+}
+
+func (v *AppValidator) validate(app *v1alpha1.App) (ctrlwebhookadmission.Warnings, error) {
+	engine := app.Spec.ContainerEngine.Name
+	if engine != "moby" && engine != "containerd" {
+		return nil, fmt.Errorf("spec.containerEngine.name %q is invalid; must be \"moby\" or \"containerd\"", engine)
+	}
+
+	k8s := app.Spec.Kubernetes
+	if k8s.Enabled && k8s.Version == "" {
+		return nil, errors.New("spec.kubernetes.version must not be empty when spec.kubernetes.enabled is true")
+	}
+
+	if k8s.Version != "" {
+		supported, err := parseK3sVersions(v.K3sVersionsData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load supported Kubernetes versions: %w", err)
+		}
+		if _, ok := supported[k8s.Version]; !ok {
+			return nil, fmt.Errorf("spec.kubernetes.version %q is not supported; see the bundled k3s-versions.json for valid versions", k8s.Version)
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/controllers/app/app/controllers/app_webhook.go
+++ b/pkg/controllers/app/app/controllers/app_webhook.go
@@ -16,7 +16,18 @@ import (
 
 // AppValidator validates App resources via admission webhook.
 type AppValidator struct {
-	K3sVersionsData string
+	supportedK8sVersions map[string]struct{}
+}
+
+// NewAppValidator parses k3sVersionsData once at construction time so that a
+// malformed JSON fixture causes controller startup to fail rather than the
+// first admission request.
+func NewAppValidator(k3sVersionsData string) (*AppValidator, error) {
+	supported, err := parseK3sVersions(k3sVersionsData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load supported Kubernetes versions: %w", err)
+	}
+	return &AppValidator{supportedK8sVersions: supported}, nil
 }
 
 // ValidateCreate validates a new App resource.
@@ -35,22 +46,13 @@ func (v *AppValidator) ValidateDelete(_ context.Context, _ *v1alpha1.App) (ctrlw
 }
 
 func (v *AppValidator) validate(app *v1alpha1.App) (ctrlwebhookadmission.Warnings, error) {
-	engine := app.Spec.ContainerEngine.Name
-	if engine != "moby" && engine != "containerd" {
-		return nil, fmt.Errorf("spec.containerEngine.name %q is invalid; must be \"moby\" or \"containerd\"", engine)
-	}
-
 	k8s := app.Spec.Kubernetes
 	if k8s.Enabled && k8s.Version == "" {
 		return nil, errors.New("spec.kubernetes.version must not be empty when spec.kubernetes.enabled is true")
 	}
 
 	if k8s.Version != "" {
-		supported, err := parseK3sVersions(v.K3sVersionsData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load supported Kubernetes versions: %w", err)
-		}
-		if _, ok := supported[k8s.Version]; !ok {
+		if _, ok := v.supportedK8sVersions[k8s.Version]; !ok {
 			return nil, fmt.Errorf("spec.kubernetes.version %q is not supported; see the bundled k3s-versions.json for valid versions", k8s.Version)
 		}
 	}

--- a/pkg/controllers/app/app/controllers/k3s_versions.go
+++ b/pkg/controllers/app/app/controllers/k3s_versions.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// k3sVersionsJSON mirrors the k3s-versions.json versions.
+type k3sVersionsJSON struct {
+	Versions []string `json:"versions"`
+}
+
+// parseK3sVersions returns the supported Kubernetes versions from the
+// embedded k3s-versions.json. The versions are stripped and stored as bare semver strings
+// (e.g. "1.32.0") so they can be compared directly against App spec values.
+func parseK3sVersions(data string) (map[string]struct{}, error) {
+	var parsed k3sVersionsJSON
+	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse k3s versions: %w", err)
+	}
+	set := make(map[string]struct{}, len(parsed.Versions))
+	for _, v := range parsed.Versions {
+		// Strip leading "v" and "+k3s*" suffix: "v1.32.0+k3s1" → "1.32.0"
+		bare := strings.TrimPrefix(v, "v")
+		if idx := strings.Index(bare, "+"); idx >= 0 {
+			bare = bare[:idx]
+		}
+		set[bare] = struct{}{}
+	}
+	return set, nil
+}

--- a/pkg/controllers/app/app/controllers/k3s_versions.go
+++ b/pkg/controllers/app/app/controllers/k3s_versions.go
@@ -27,9 +27,7 @@ func parseK3sVersions(data string) (map[string]struct{}, error) {
 	for _, v := range parsed.Versions {
 		// Strip leading "v" and "+k3s*" suffix: "v1.32.0+k3s1" → "1.32.0"
 		bare := strings.TrimPrefix(v, "v")
-		if idx := strings.Index(bare, "+"); idx >= 0 {
-			bare = bare[:idx]
-		}
+		bare, _, _ = strings.Cut(bare, "+")
 		set[bare] = struct{}{}
 	}
 	return set, nil

--- a/pkg/controllers/app/app/controllers/k3s_versions_test.go
+++ b/pkg/controllers/app/app/controllers/k3s_versions_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_parseK3sVersions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantKeys []string
+		wantErr  bool
+	}{
+		{
+			name:     "typical bundled format",
+			input:    `{"versions":["v1.32.0+k3s1","v1.31.5+k3s1"]}`,
+			wantKeys: []string{"1.32.0", "1.31.5"},
+		},
+		{
+			name:  "two k3s builds of same version normalize to one key",
+			input: `{"versions":["v1.32.0+k3s1","v1.32.0+k3s2"]}`,
+			// Both strip to "1.32.0"; the set must contain exactly that key.
+			wantKeys: []string{"1.32.0"},
+		},
+		{
+			name:     "entry without v prefix",
+			input:    `{"versions":["1.30.0+k3s1"]}`,
+			wantKeys: []string{"1.30.0"},
+		},
+		{
+			name:     "entry without + suffix",
+			input:    `{"versions":["v1.29.0"]}`,
+			wantKeys: []string{"1.29.0"},
+		},
+		{
+			name:     "entry without v prefix or + suffix",
+			input:    `{"versions":["1.28.0"]}`,
+			wantKeys: []string{"1.28.0"},
+		},
+		{
+			name:     "empty versions array",
+			input:    `{"versions":[]}`,
+			wantKeys: []string{},
+		},
+		{
+			name:    "malformed JSON",
+			input:   `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseK3sVersions(tt.input)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected an error but got nil")
+				return
+			}
+			assert.NilError(t, err)
+
+			for _, key := range tt.wantKeys {
+				_, ok := got[key]
+				assert.Assert(t, ok, "expected key %q not found in result %v", key, got)
+			}
+			assert.Equal(t, len(got), len(tt.wantKeys), "result has wrong number of keys: %v", got)
+		})
+	}
+}


### PR DESCRIPTION
This PR creates a validating admission webhook for App settings. It validates `containerEngine.name` (moby|containerd), `kubernetes.version` against bundled k3s-versions.json, and requires a non-empty version when `kubernetes.enabled` is true. Move validation out of the reconciler into the webhook so invalid specs are rejected at admission time.

Fixes: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/262