### PR TITLE
app: Use `instance.ShortDir()` for docker socket

### DIFF
--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
 const (
@@ -50,13 +51,16 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec) (string, er
 	if err != nil {
 		return "", fmt.Errorf("failed to get host home directory: %w", err)
 	}
-	return baseTemplate + fmt.Sprintf(
-		"\nparam:\n  CONTAINER_ENGINE: %s\n  HOST_HOME: %q\n  KUBERNETES_ENABLED: %v\n  KUBERNETES_VERSION: %s\n",
-		spec.ContainerEngine.Name,
-		toLinuxPath(hostHome),
-		spec.Kubernetes.Enabled,
-		spec.Kubernetes.Version,
-	), nil
+	return strings.Join([]string{
+		baseTemplate,
+		"param:",
+		fmt.Sprintf("  CONTAINER_ENGINE: %s", spec.ContainerEngine.Name),
+		fmt.Sprintf("  HOST_HOME_GUEST: %q", toLinuxPath(hostHome)),
+		fmt.Sprintf("  HOST_SHORT_DIR: %q", instance.ShortDir()),
+		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
+		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
+		"",
+	}, "\n"), nil
 }
 
 // toLinuxPath converts a host path to a Linux-accessible path inside a Lima VM.
@@ -70,6 +74,8 @@ func toLinuxPath(hostPath string) string {
 	if len(hostPath) >= 2 && hostPath[1] == ':' {
 		drive := strings.ToLower(string(hostPath[0]))
 		rest := strings.ReplaceAll(hostPath[2:], `\`, `/`)
+		// /mnt/ is the mount point for drvfs disks in WSL2, per the default
+		// value of `[automount] root=` in `/etc/wsl.conf`.
 		return "/mnt/" + drive + rest
 	}
 	return hostPath

--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -27,14 +27,13 @@ portForwards:
   hostPortRange:
   - 0
   - 0
-  hostSocket: "{{.Home}}/.rd/docker.sock"
+  hostSocket: "{{.Param.HOST_SHORT_DIR}}/docker.sock"
 provision:
 - mode: system
   script: |
     #!/bin/bash
 
     # All param need to be mentioned for Lima validation.
-    # $PARAM_HOST_HOME - used by the kubeconfig probe
 
     set -o errexit -o nounset -o pipefail -o xtrace
 
@@ -106,7 +105,7 @@ probes:
             sudo sed 's/: default$/: rancher-desktop/g' "$K3S_YAML" >"$KUBECONFIG_LOCAL"
             # Merge into the host kubeconfig.
             KUBECONFIG_MERGED=$HOME/kubeconfig
-            KUBECONFIG_HOST="$PARAM_HOST_HOME/.kube/config"
+            KUBECONFIG_HOST="$PARAM_HOST_HOME_GUEST/.kube/config"
             export KUBECONFIG="$KUBECONFIG_HOST:$KUBECONFIG_LOCAL"
             kubectl config view --merge --flatten >"$KUBECONFIG_MERGED" || break
             # Only overwrite if the merged config has at least as many contexts.


### PR DESCRIPTION
This mounts the docker socket at `instance.ShortDir()`, instead of hard- coding at `~/.rd/docker.sock`.  This matches the original design (see `docs/design/cmd_app.md`).

Fixes #294