### PR TITLE
limavm: use patch to tolerate concurrent writes during Prepare

### DIFF
--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -128,9 +128,13 @@ local_setup_file() {
 }
 
 @test "wait for LimaVM Created condition to be set" {
-    # 150s allows time for the opensuse distro image download (~350MB).
+    # Download the opensuse distro image (~350MB) and decompress it. The
+    # Windows CI runner is much slower than macOS/Linux here: xz runs
+    # through Lima's stdin-wrapper pipe and is starved on every read,
+    # stretching a ~34s operation to ~3 minutes. Budget generously until
+    # that upstream slowness is addressed.
     rdd ctl wait --for=condition=Created \
-        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=150s
+        limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=5m
 }
 
 @test "verify App status mirrors LimaVM Created condition" {

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -234,11 +234,12 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		} else {
 			desired := applySpecToTemplate(r.LimaTemplateData, app.Spec)
 			if templateCM.Data[limav1alpha1.TemplateConfigMapKey] != desired {
+				patch := client.MergeFrom(templateCM.DeepCopy())
 				if templateCM.Data == nil {
 					templateCM.Data = make(map[string]string)
 				}
 				templateCM.Data[limav1alpha1.TemplateConfigMapKey] = desired
-				if err := r.Update(ctx, templateCM); err != nil {
+				if err := r.Patch(ctx, templateCM, patch); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update template ConfigMap: %w", err)
 				}
 				log.Info("Updated template ConfigMap",

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -333,9 +333,15 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	logger.Info("Created Lima instance", "instance", limaVM.Name)
+	// Patch (not Update) because Prepare() above can run for several minutes
+	// (image download + decompression), during which the app controller may
+	// propagate spec.running and bump resourceVersion. A failed Update here
+	// would leave the sentinel in place and cause the next reconcile to
+	// delete the just-prepared instance directory.
+	patch := client.MergeFrom(limaVM.DeepCopy())
 	limaVM.Status.ObservedTemplateResourceVersion = templateConfigMap.ResourceVersion
 	r.setCondition(&limaVM, ConditionCreated, metav1.ConditionTrue, ReasonCreated, "Lima instance created successfully")
-	if err := r.Status().Update(ctx, &limaVM); err != nil {
+	if err := r.Status().Patch(ctx, &limaVM, patch); err != nil {
 		logger.Error(err, "Failed to update status after instance creation")
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
**Bug.** On Windows CI, `limavm_controller.Reconcile` holds a local `LimaVM` copy for ~3 minutes while `limainstance.Prepare()` downloads and decompresses the opensuse distro image. If any write lands on the `LimaVM` during that window — for example, the app_controller propagating `spec.running=true` after a test patches the `App` — the post-Prepare `Status().Update()` fails with 409 Conflict, the reconcile aborts before removing the sentinel file, and the next reconcile interprets the sentinel as "Prepare crashed" and deletes the freshly prepared instance directory. Observed in run 24412470185 on `windows-latest`.

**Fix.** Switch the post-Prepare status write to `client.MergeFrom` + `Status().Patch()`. Without `OptimisticLock`, `MergeFrom` omits `metadata.resourceVersion` from the patch body, so concurrent writes to unrelated fields stop triggering 409s. This matches the `updateCondition` pattern already used ~12× in `limavm_lifecycle.go` for the same reason. The same cleanup lands on the app_controller's template-ConfigMap update, which had the same conflict-prone shape (not a test-breaker — controller-runtime re-queues on error — but noisy in the logs and trivially fixable).

**Test timeout.** Bump the `wait for LimaVM Created condition to be set` test from 150s to 5m. 150s was calibrated for macOS/Linux where Prepare takes ~34s; Windows consistently takes ~3 minutes because xz runs through Lima's stdin progress-reader pipe and sits idle ~90% of the time. A comment in the test points at the upstream Lima slowness, which is tracked separately for a future contribution.