### PR TITLE
BATS: run bats-app on its own CI runner

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -44,6 +44,13 @@ jobs:
         - macos-15-intel
         - ubuntu-latest
         - windows-latest
+        # bats-app runs on its own runner so its WSL2 VM does not collide
+        # with bats-lima's on Windows (Lima hard-codes SSH port 22 per
+        # instance), and so bats-app can grow independently of the rest
+        # of the suite.
+        target:
+        - bats-non-app
+        - bats-app
     runs-on: ${{ matrix.runs-on }}
     steps:
     - name: "Linux: Install prerequisites"
@@ -173,7 +180,7 @@ jobs:
         output-dir: rdd-logs/_diag
       continue-on-error: true
 
-    - run: make -C bats --keep-going --jobs=$(nproc) --output-sync=target
+    - run: make -C bats ${{ matrix.target }} --keep-going --jobs=$(nproc) --output-sync=target
       shell: run-in-shell {0}
       env:
         RDD_TRACE: true
@@ -196,6 +203,6 @@ jobs:
       if: always()
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: rdd-logs-${{ matrix.runs-on }}
+        name: rdd-logs-${{ matrix.runs-on }}-${{ matrix.target }}
         path: rdd-logs/
         if-no-files-found: ignore

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -13,6 +13,7 @@ BATS_TIMEOUT ?= 1800
 BATS = $(if $(filter-out 0,$(BATS_TIMEOUT)),../scripts/bats-with-timeout.sh $(BATS_TIMEOUT)) $(BATS_CORE)
 
 default: bats-all
+.PHONY: default
 
 # Check if BATS core exists
 check-bats:
@@ -84,9 +85,21 @@ bats-containers: check-bats build-rdd build-mock-controller
 bats-controllers: bats-builtin bats-rdd bats-app bats-lima bats-containers
 .PHONY: bats-controllers
 
-# Run all BATS tests.
-bats-all: bats-helpers bats-cli bats-service bats-controllers
+# Run all BATS tests. bats-app is serialized with the rest of the suite
+# via recursive make because bats-app and bats-lima each boot a WSL2 VM
+# and Lima's WSL2 driver hard-codes SSH to guest port 22 per instance,
+# so two VMs in parallel collide on Windows localhost forwarding. CI
+# splits the two halves onto separate runners via `bats-non-app` + the
+# `bats-app` target; `-j` still parallelizes within each half.
+bats-all:
+	$(MAKE) bats-non-app
+	$(MAKE) bats-app
 .PHONY: bats-all
+
+# Everything bats-all runs except bats-app. CI runs this alongside
+# bats-app on a separate runner.
+bats-non-app: bats-helpers bats-cli bats-service bats-builtin bats-rdd bats-lima bats-containers
+.PHONY: bats-non-app
 
 # Run specific BATS test file
 # Usage: make bats-file FILE=bats/tests/31-rdd-controllers/configmapreplicaset.bats


### PR DESCRIPTION
bats-app and bats-lima each boot a WSL2 VM, and Lima's WSL2 driver hard-codes SSH to guest port 22 per instance. When `make --jobs` launches both suites concurrently on Windows, the two VMs collide on localhost:22 forwarding and one of them sees persistent "Permission denied" during SSH readiness probes until the 1800s wrapper kills the job. Run 24422550777 (PR #278 merge) is a recent instance.

Split bats-app out of the bats-all dependency chain and add a matrix dimension to the BATS workflow so bats-all and bats-app run on separate runners. Locally, the default target still runs both via recursive make so that typing `make` keeps covering the full suite without the collision. The bats-controllers grouping loses bats-app for the same reason.

As a side effect, bats-app (which is expected to grow) no longer blocks on the rest of the suite in CI.