### PR TITLE
CI: BATS: split out lima too, drop parallel runs

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -48,9 +48,10 @@ jobs:
         # with bats-lima's on Windows (Lima hard-codes SSH port 22 per
         # instance), and so bats-app can grow independently of the rest
         # of the suite.
-        target:
-        - bats-non-app
+        suite:
         - bats-app
+        - bats-lima
+        - bats-others
     runs-on: ${{ matrix.runs-on }}
     steps:
     - name: "Linux: Install prerequisites"
@@ -180,7 +181,24 @@ jobs:
         output-dir: rdd-logs/_diag
       continue-on-error: true
 
-    - run: make -C bats ${{ matrix.target }} --keep-going --jobs=$(nproc) --output-sync=target
+    - name: Configure BATS targets
+      shell: bash
+      run: |
+        case "${{ matrix.suite }}" in
+          bats-app|bats-lima)
+            echo "BATS_TARGET=${{ matrix.suite }}" >> "$GITHUB_ENV"
+            ;;
+          bats-others)
+            echo "BATS_EXCLUDES=bats-app bats-lima" >> "$GITHUB_ENV"
+            echo "BATS_TARGET=bats-all" >> "$GITHUB_ENV"
+            ;;
+          *)
+            echo "Unknown test suite: ${{ matrix.suite }}" >&2
+            exit 1
+            ;;
+        esac
+
+    - run: make -C bats ${{ env.BATS_TARGET }} --keep-going
       shell: run-in-shell {0}
       env:
         RDD_TRACE: true
@@ -203,6 +221,6 @@ jobs:
       if: always()
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: rdd-logs-${{ matrix.runs-on }}-${{ matrix.target }}
+        name: rdd-logs-${{ matrix.runs-on }}-${{ matrix.suite }}
         path: rdd-logs/
         if-no-files-found: ignore

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -82,24 +82,13 @@ bats-containers: check-bats build-rdd build-mock-controller
 .PHONY: bats-containers
 
 # Run all controller tests.
-bats-controllers: bats-builtin bats-rdd bats-app bats-lima bats-containers
+BATS_CONTROLLERS_TARGETS := bats-builtin bats-rdd bats-app bats-lima bats-containers
+bats-controllers: $(BATS_CONTROLLERS_TARGETS)
 .PHONY: bats-controllers
 
-# Run all BATS tests. bats-app is serialized with the rest of the suite
-# via recursive make because bats-app and bats-lima each boot a WSL2 VM
-# and Lima's WSL2 driver hard-codes SSH to guest port 22 per instance,
-# so two VMs in parallel collide on Windows localhost forwarding. CI
-# splits the two halves onto separate runners via `bats-non-app` + the
-# `bats-app` target; `-j` still parallelizes within each half.
-bats-all:
-	$(MAKE) bats-non-app
-	$(MAKE) bats-app
+# Run all BATS tests.
+bats-all: $(filter-out $(BATS_EXCLUDES),bats-helpers bats-cli bats-service $(BATS_CONTROLLERS_TARGETS))
 .PHONY: bats-all
-
-# Everything bats-all runs except bats-app. CI runs this alongside
-# bats-app on a separate runner.
-bats-non-app: bats-helpers bats-cli bats-service bats-builtin bats-rdd bats-lima bats-containers
-.PHONY: bats-non-app
 
 # Run specific BATS test file
 # Usage: make bats-file FILE=bats/tests/31-rdd-controllers/configmapreplicaset.bats


### PR DESCRIPTION
Split out lima too, because that's also one of the slower suites due to having to start up the VM.  Also drop running things in parallel, since that seems to just lead to slower total run time instead due to slow CI.

While we're at it, redo the makefile so that we can just exclude specific targets (as provided in `$BATS_EXCLUDES`) rather than having a special target.  This silences some `make` warnings.