### PR TITLE
rdd ctl: rename await to wait-condition

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -109,8 +109,8 @@ editor_cmd() {
 }
 
 @test "verify initial Running condition is False/Stopped" {
-    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
-        --for=condition=Running=False --reason=Stopped --timeout=120s
+    rdd ctl wait-condition "limavm/${VM_NAME}" Running=False --namespace "${NAMESPACE}" \
+        --reason=Stopped --timeout=120s
 }
 
 @test "start the VM by setting running=true" {
@@ -123,8 +123,8 @@ editor_cmd() {
 }
 
 @test "wait for Running condition to become True/Started" {
-    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
-        --for=condition=Running --reason=Started --timeout=300s
+    rdd ctl wait-condition "limavm/${VM_NAME}" Running --namespace "${NAMESPACE}" \
+        --reason=Started --timeout=300s
 }
 
 @test "verify hostagent PID file exists" {
@@ -182,8 +182,8 @@ EOF
 }
 
 @test "wait for Running condition to become False/Stopped" {
-    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
-        --for=condition=Running=False --reason=Stopped --timeout=300s
+    rdd ctl wait-condition "limavm/${VM_NAME}" Running=False --namespace "${NAMESPACE}" \
+        --reason=Stopped --timeout=300s
 }
 
 @test "verify hostagent PID file is removed" {
@@ -345,8 +345,8 @@ EOF
 
     # shutdownAllHostagents runs during graceful shutdown, so the hostagent
     # is already dead by the time the service exits.
-    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
-        --for=condition=Running --reason=Started --since=startup --timeout=300s
+    rdd ctl wait-condition "limavm/${VM_NAME}" Running --namespace "${NAMESPACE}" \
+        --reason=Started --since=startup --timeout=300s
 }
 
 # Restart tests
@@ -401,8 +401,8 @@ assert_restart_annotation_absent() {
     refute_output # restartNeeded has omitempty; false means absent
 
     # VM should stay stopped because spec.running=false
-    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
-        --for=condition=Running=False --reason=Stopped --timeout=30s
+    rdd ctl wait-condition "limavm/${VM_NAME}" Running=False --namespace "${NAMESPACE}" \
+        --reason=Stopped --timeout=30s
 }
 
 @test "restart command on stopped VM starts it" {
@@ -511,8 +511,8 @@ env:
     rdd ctl wait --for=jsonpath='{.status.observedTemplateResourceVersion}'="${PATCHED_TEMPLATE_RV_2}" \
         "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=30s
     assert_instance_template_contains "${VM_NAME}" "updated-while-stopped"
-    rdd ctl await "limavm/${VM_NAME}" --namespace "${NAMESPACE}" \
-        --for=condition=Running=False --reason=Stopped --timeout=30s
+    rdd ctl wait-condition "limavm/${VM_NAME}" Running=False --namespace "${NAMESPACE}" \
+        --reason=Stopped --timeout=30s
 }
 
 @test "cleanup LimaVM running test" {

--- a/cmd/rdd/ctl_wait_condition.go
+++ b/cmd/rdd/ctl_wait_condition.go
@@ -32,11 +32,10 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
 )
 
-// ctlAwaitAction waits for a resource condition to reach a specific state,
+// ctlWaitConditionAction waits for a resource condition to reach a specific state,
 // optionally requiring the transition to have occurred after a given timestamp.
-func ctlAwaitAction(cmd *cobra.Command, rawArgs []string) error {
-	flags := pflag.NewFlagSet("await", pflag.ContinueOnError)
-	forFlag := flags.String("for", "", "Condition to wait for: condition=TYPE[=STATUS] (STATUS defaults to True)")
+func ctlWaitConditionAction(cmd *cobra.Command, rawArgs []string) error {
+	flags := pflag.NewFlagSet("wait-condition", pflag.ContinueOnError)
 	reason := flags.String("reason", "", "Required condition reason")
 	since := flags.String("since", "", "Require lastTransitionTime after this value (ISO 8601 timestamp or \"startup\")")
 	timeout := flags.Duration("timeout", 30*time.Second, "How long to wait")
@@ -46,18 +45,15 @@ func ctlAwaitAction(cmd *cobra.Command, rawArgs []string) error {
 		return err
 	}
 	positional := flags.Args()
-	if len(positional) != 1 {
-		return fmt.Errorf("expected TYPE/NAME argument, got %d arguments", len(positional))
-	}
-	if *forFlag == "" {
-		return errors.New("--for is required (e.g. --for=condition=Running)")
+	if len(positional) != 2 {
+		return fmt.Errorf("expected TYPE/NAME and CONDITION[=STATUS] arguments, got %d arguments", len(positional))
 	}
 
-	condType, condStatus, err := parseConditionFlag(*forFlag)
+	resourceType, resourceName, err := parseResourceArg(positional[0])
 	if err != nil {
 		return err
 	}
-	resourceType, resourceName, err := parseResourceArg(positional[0])
+	condType, condStatus, err := parseConditionArg(positional[1])
 	if err != nil {
 		return err
 	}
@@ -138,18 +134,15 @@ func ctlAwaitAction(cmd *cobra.Command, rawArgs []string) error {
 	return err
 }
 
-// parseConditionFlag parses "condition=TYPE[=STATUS]" from the --for flag.
-func parseConditionFlag(flag string) (condType, condStatus string, err error) {
-	value, found := strings.CutPrefix(flag, "condition=")
-	if !found {
-		return "", "", fmt.Errorf("--for must start with \"condition=\", got %q", flag)
-	}
-	condType, condStatus, _ = strings.Cut(value, "=")
+// parseConditionArg parses "TYPE[=STATUS]" into condition type and status.
+// STATUS defaults to "True" when omitted.
+func parseConditionArg(arg string) (condType, condStatus string, err error) {
+	condType, condStatus, _ = strings.Cut(arg, "=")
 	if condStatus == "" {
 		condStatus = "True"
 	}
 	if condType == "" {
-		return "", "", fmt.Errorf("condition type must not be empty in --for=%q", flag)
+		return "", "", fmt.Errorf("condition type must not be empty in %q", arg)
 	}
 	return condType, condStatus, nil
 }

--- a/cmd/rdd/kubectl.go
+++ b/cmd/rdd/kubectl.go
@@ -34,8 +34,8 @@ func ctlAction(cmd *cobra.Command, args []string) error {
 	if err := ensureServiceRunning(cmd.Context()); err != nil {
 		return err
 	}
-	if len(args) > 0 && args[0] == "await" {
-		return ctlAwaitAction(cmd, args[1:])
+	if len(args) > 0 && args[0] == "wait-condition" {
+		return ctlWaitConditionAction(cmd, args[1:])
 	}
 	if err := os.Setenv("KUBECONFIG", instance.Config()); err != nil {
 		return fmt.Errorf("failed to set KUBECONFIG: %w", err)

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -188,17 +188,18 @@ Example to list all `vms` in all namespaces:
 rdd ctl get vm -A
 ```
 
-### `rdd ctl await`
+### `rdd ctl wait-condition`
 
 Waits for a resource condition to reach a specific state. Unlike `kubectl wait`, this command can filter by `lastTransitionTime` and condition `reason`.
 
 ```shell
-rdd ctl await TYPE[.GROUP]/NAME --for=condition=TYPE[=STATUS] [flags]
+rdd ctl wait-condition TYPE[.GROUP]/NAME CONDITION[=STATUS] [flags]
 ```
+
+The `CONDITION[=STATUS]` positional argument names the condition type to match; `STATUS` defaults to `True`.
 
 Flags:
 
-- `--for=condition=TYPE[=STATUS]` (required): condition to match; STATUS defaults to `True`
 - `--reason=REASON`: require the condition's `.reason` field to match
 - `--since=TIMESTAMP|startup`: require `lastTransitionTime` after this value; `startup` reads the controller manager's start time from the discovery ConfigMap
 - `--timeout=DURATION`: how long to wait (default `30s`)
@@ -208,13 +209,13 @@ Examples:
 
 ```shell
 # Wait for Running=True with reason Started, transitioned since controller startup
-rdd ctl await limavm/default --for=condition=Running --reason=Started --since=startup --timeout=60s
+rdd ctl wait-condition limavm/default Running --reason=Started --since=startup --timeout=60s
 
 # Wait for a condition after a specific timestamp
-rdd ctl await limavm/default --for=condition=Running --since=2024-01-15T10:30:00Z
+rdd ctl wait-condition limavm/default Running --since=2024-01-15T10:30:00Z
 
 # Wait for Running=False
-rdd ctl await limavm/default --for=condition=Running=False --timeout=60s
+rdd ctl wait-condition limavm/default Running=False --timeout=60s
 ```
 
 ### `rdd ctl logs`


### PR DESCRIPTION
## Summary

- Rename `rdd ctl await` to `rdd ctl wait-condition`. The previous name was easy to confuse with the kubectl-wait passthrough `rdd ctl wait`.
- Drop the `--for=condition=` ceremony. Since the command only ever matches `.status.conditions` entries (the `--for` flag required a `condition=` prefix), accept `CONDITION[=STATUS]` as a positional argument instead.
- `--reason`, `--since`, `--timeout`, `--namespace` are unchanged.

Before:
```
rdd ctl await foo/bar --for=condition=Running=True --reason=Started --since=startup
```
After:
```
rdd ctl wait-condition foo/bar Running=True --reason=Started --since=startup
```

`rdd ctl wait` (kubectl passthrough) is untouched and remains the right tool for condition waits that don't need `--reason` or `--since=startup`.

Fixes #311