### PR TITLE
rdd lima shell: keep wedged SSH sessions from hanging forever

### DIFF
--- a/cmd/rdd/limavm_shell.go
+++ b/cmd/rdd/limavm_shell.go
@@ -172,8 +172,15 @@ func limaVMShellAction(cmd *cobra.Command, args []string) error {
 		logLevel = "QUIET"
 	}
 
+	// ConnectTimeout caps the TCP handshake at 30s. ServerAliveInterval=30
+	// with ServerAliveCountMax=3 closes a wedged session after ~90s of
+	// unanswered keepalives. Interactive shells and long-running commands
+	// ack the keepalives and stay connected.
 	sshArgs = append(sshArgs, []string{
 		"-o", fmt.Sprintf("LogLevel=%s", logLevel),
+		"-o", "ConnectTimeout=30",
+		"-o", "ServerAliveInterval=30",
+		"-o", "ServerAliveCountMax=3",
 		"-p", strconv.Itoa(inst.SSHLocalPort),
 		inst.SSHAddress,
 		"--",


### PR DESCRIPTION
## Summary

- Cap the SSH `ConnectTimeout` at 30s so a hung TCP handshake to the guest does not wait the full ~2 minute default.
- Add `ServerAliveInterval=30` / `ServerAliveCountMax=3` so a wedged ssh session is reaped after ~90s of unanswered keepalives instead of hanging forever.
- Interactive shells and long-running commands ack the keepalives and stay connected; only genuinely dead sessions get closed.

Split out of #309 (engine controller mirror PR) where it had snuck in unrelated to the engine work.

## Test plan

- [ ] `rdd lima shell rd echo hi` still works
- [ ] An interactive `rdd lima shell rd` session stays alive idle for >5 minutes
- [ ] A `rdd lima shell rd sleep 300` does not get killed by the keepalive