### PR TITLE
  Manage Docker CLI context on ContainerEngineReady transitions

### DIFF
--- a/bats/tests/32-app-controllers/engine-docker.bats
+++ b/bats/tests/32-app-controllers/engine-docker.bats
@@ -405,3 +405,89 @@ local_setup_file() {
     run -0 rdd ctl get ContainerNamespaces --namespace="${RDD_NAMESPACE}" --output=name
     refute_output
 }
+
+# --- Docker context management ---
+
+# docker_context_dir returns the ~/.docker/contexts/meta/<hash> directory for
+# the named context. Docker derives the sub-directory from sha256(name).
+docker_context_dir() {
+    local name="$1"
+    local hash
+    # sha256sum on Linux, shasum on macOS
+    if command -v sha256sum &>/dev/null; then
+        hash=$(printf '%s' "${name}" | sha256sum | awk '{print $1}')
+    else
+        hash=$(printf '%s' "${name}" | shasum -a 256 | awk '{print $1}')
+    fi
+    echo "${HOME}/.docker/contexts/meta/${hash}"
+}
+
+@test "moby engine creates Docker context for the instance" {
+    # Restart with moby (the containerd test above may have left the engine in
+    # containerd mode).
+    rdd set running=true containerEngine.name=moby
+    rdd ctl wait --for=condition=ContainerEngineReady \
+        app/app --timeout=30s
+
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    local meta_file
+    meta_file="$(docker_context_dir "${context_name}")/meta.json"
+
+    assert_file_exists "${meta_file}"
+
+    run -0 jq -r '.Name' "${meta_file}"
+    assert_output "${context_name}"
+
+    run -0 rdd service paths docker_socket
+    local socket_path=${output}
+    run -0 jq -r '.Endpoints.docker.Host' "${meta_file}"
+    assert_output "unix://${socket_path}"
+}
+
+@test "moby engine sets currentContext when no healthy context exists" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+
+    # Save and clear any existing currentContext so the probe finds no
+    # healthy context and promotes ours. Restored in teardown.
+    local saved_context
+    saved_context=$(jq -r '.currentContext // empty' "${HOME}/.docker/config.json" 2>/dev/null || true)
+
+    # Clear the current context and restart the engine so the probe runs fresh.
+    jq 'del(.currentContext)' "${HOME}/.docker/config.json" >"${HOME}/.docker/config.json.tmp" &&
+        mv "${HOME}/.docker/config.json.tmp" "${HOME}/.docker/config.json"
+
+    rdd set running=false
+    rdd set running=true containerEngine.name=moby
+    rdd ctl wait --for=condition=ContainerEngineReady app/app --timeout=30s
+
+    # The probe goroutine runs asynchronously; give it a moment.
+    try --max 6 --delay 1 -- \
+        bash -c "jq -r '.currentContext' '${HOME}/.docker/config.json' | grep -qx '${context_name}'"
+
+    run -0 jq -r '.currentContext' "${HOME}/.docker/config.json"
+    assert_output "${context_name}"
+
+    # Restore the original context if there was one.
+    if [[ -n "${saved_context}" ]]; then
+        jq --arg ctx "${saved_context}" '.currentContext = $ctx' \
+            "${HOME}/.docker/config.json" >"${HOME}/.docker/config.json.tmp" &&
+            mv "${HOME}/.docker/config.json.tmp" "${HOME}/.docker/config.json"
+    fi
+}
+
+@test "stopping moby engine removes Docker context and clears currentContext" {
+    rdd set running=false
+
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    run_e -0 docker_context_dir "${context_name}"
+    local context_dir="${output}"
+
+    # removeDockerContext runs asynchronously after the reconciler processes
+    # the Running=False transition; poll until the directory is gone.
+    try --max 10 --delay 1 -- test ! -d "${context_dir}"
+    assert_dir_not_exists "${context_dir}"
+
+    # currentContext should either be gone or point to something else.
+    run jq -r '.currentContext // empty' "${HOME}/.docker/config.json"
+    refute_output "${context_name}"
+}

--- a/pkg/controllers/app/engine/controllers/docker_context.go
+++ b/pkg/controllers/app/engine/controllers/docker_context.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	dockerclient "github.com/moby/moby/client"
+)
+
+// dockerContextProbeTimeout is the maximum time allowed to ping a Docker
+// socket when checking the user's current context is healthy.
+const dockerContextProbeTimeout = 3 * time.Second
+
+// dockerContextMeta is the on-disk format of a Docker CLI context metadata file.
+type dockerContextMeta struct {
+	Name      string                        `json:"Name"`
+	Metadata  map[string]any                `json:"Metadata"`
+	Endpoints map[string]dockerEndpointMeta `json:"Endpoints"`
+}
+
+type dockerEndpointMeta struct {
+	Host          string `json:"Host"`
+	SkipTLSVerify bool   `json:"SkipTLSVerify"`
+}
+
+func dockerConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".docker"), nil
+}
+
+// contextMetaPath returns the path to the meta.json file for the named context.
+// Docker creates the directory name using sha256(contextName).
+func contextMetaPath(name string) (string, error) {
+	dir, err := dockerConfigDir()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(name))
+	return filepath.Join(dir, "contexts", "meta", hex.EncodeToString(sum[:]), "meta.json"), nil
+}
+
+func createReplaceDockerContext(name, socketPath string) error {
+	path, err := contextMetaPath(name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	meta := dockerContextMeta{
+		Name:     name,
+		Metadata: map[string]any{},
+		Endpoints: map[string]dockerEndpointMeta{
+			"docker": {Host: "unix://" + socketPath},
+		},
+	}
+	data, err := json.MarshalIndent(meta, "", "\t")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+func deleteDockerContext(name string) error {
+	path, err := contextMetaPath(name)
+	if err != nil {
+		return err
+	}
+	err = os.RemoveAll(filepath.Dir(path))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// getDockerContextHost returns the full Docker host URL (e.g. "unix:///path/to/docker.sock"
+// or "tcp://192.168.1.1:2376") for the named context's docker endpoint.
+// Returns an empty string if the context does not exist or has no docker endpoint.
+func getDockerContextHost(name string) (string, error) {
+	path, err := contextMetaPath(name)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	var meta dockerContextMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", err
+	}
+	return meta.Endpoints["docker"].Host, nil
+}
+
+// getCurrentDockerContext reads the currentContext field from ~/.docker/config.json.
+// Returns an empty string if the file does not exist or no context is set.
+func getCurrentDockerContext() (string, error) {
+	dir, err := dockerConfigDir()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return "", err
+	}
+	name, _ := cfg["currentContext"].(string)
+	return name, nil
+}
+
+func setCurrentDockerContext(name string) error {
+	dir, err := dockerConfigDir()
+	if err != nil {
+		return err
+	}
+	return updateDockerConfig(filepath.Join(dir, "config.json"), func(cfg map[string]any) bool {
+		if cfg["currentContext"] == name {
+			return false
+		}
+		cfg["currentContext"] = name
+		return true
+	})
+}
+
+func clearCurrentDockerContext(name string) error {
+	dir, err := dockerConfigDir()
+	if err != nil {
+		return err
+	}
+	return updateDockerConfig(filepath.Join(dir, "config.json"), func(cfg map[string]any) bool {
+		if cfg["currentContext"] != name {
+			return false
+		}
+		delete(cfg, "currentContext")
+		return true
+	})
+}
+
+// probeDockerContext tries to ping the Docker daemon at the given host URL.
+// It returns true if the daemon responds within dockerContextProbeTimeout.
+func probeDockerContext(ctx context.Context, host string) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, dockerContextProbeTimeout)
+	defer cancel()
+	cli, err := dockerclient.New(dockerclient.WithHost(host))
+	if err != nil {
+		return false
+	}
+	defer cli.Close()
+	_, err = cli.Ping(probeCtx, dockerclient.PingOptions{})
+	return err == nil
+}
+
+// updateDockerConfig reads the Docker config file at path, applies mutate,
+// and writes back atomically via a temp-file rename. All other keys are
+// preserved. mutate returns true if it changed cfg; if it returns false the
+// function is a no-op and no I/O is performed. If the file does not exist and
+// mutate returns true, the file is created.
+func updateDockerConfig(path string, mutate func(map[string]any) bool) error {
+	cfg := map[string]any{}
+	data, err := os.ReadFile(path)
+	notExist := errors.Is(err, os.ErrNotExist)
+	switch {
+	case err == nil:
+		if jsonErr := json.Unmarshal(data, &cfg); jsonErr != nil {
+			return jsonErr
+		}
+	case notExist:
+		// file will be created below if mutate signals a change
+	default:
+		return err
+	}
+
+	if changed := mutate(cfg); !changed {
+		return nil
+	}
+
+	out, err := json.MarshalIndent(cfg, "", "\t")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".config.json.*")
+	if err != nil {
+		return err
+	}
+	if _, err := tmp.Write(append(out, '\n')); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}

--- a/pkg/controllers/app/engine/controllers/docker_context_test.go
+++ b/pkg/controllers/app/engine/controllers/docker_context_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// dockerTestPaths holds the config and contexts directory for a test.
+type dockerTestPaths struct {
+	configFile  string
+	contextsDir string
+}
+
+// newDockerTestDir creates a temp ~/.docker layout and returns its paths.
+func newDockerTestDir(t *testing.T) dockerTestPaths {
+	t.Helper()
+	root := t.TempDir()
+	dockerDir := filepath.Join(root, ".docker")
+	assert.NilError(t, os.MkdirAll(dockerDir, 0o700))
+	return dockerTestPaths{
+		configFile:  filepath.Join(dockerDir, "config.json"),
+		contextsDir: filepath.Join(dockerDir, "contexts"),
+	}
+}
+
+func Test_updateDockerConfig_set(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates file when absent", func(t *testing.T) {
+		t.Parallel()
+		p := newDockerTestDir(t)
+
+		assert.NilError(t, updateDockerConfig(p.configFile, func(cfg map[string]any) bool {
+			cfg["currentContext"] = "rancher-desktop-2"
+			return true
+		}))
+
+		data, err := os.ReadFile(p.configFile)
+		assert.NilError(t, err)
+		var cfg map[string]any
+		assert.NilError(t, json.Unmarshal(data, &cfg))
+		assert.Equal(t, cfg["currentContext"], "rancher-desktop-2")
+	})
+
+	t.Run("updates existing file preserving other keys", func(t *testing.T) {
+		t.Parallel()
+		p := newDockerTestDir(t)
+		assert.NilError(t, os.WriteFile(p.configFile, []byte(`{"auths":{"example.com":{}}}`+"\n"), 0o600))
+
+		assert.NilError(t, updateDockerConfig(p.configFile, func(cfg map[string]any) bool {
+			cfg["currentContext"] = "rancher-desktop-2"
+			return true
+		}))
+
+		data, err := os.ReadFile(p.configFile)
+		assert.NilError(t, err)
+		var cfg map[string]any
+		assert.NilError(t, json.Unmarshal(data, &cfg))
+		assert.Equal(t, cfg["currentContext"], "rancher-desktop-2")
+		_, hasAuths := cfg["auths"]
+		assert.Assert(t, hasAuths, "auths key must be preserved")
+	})
+
+	t.Run("no-op when mutate returns false", func(t *testing.T) {
+		t.Parallel()
+		p := newDockerTestDir(t)
+
+		// File does not exist; mutate returns false → file must not be created.
+		assert.NilError(t, updateDockerConfig(p.configFile, func(_ map[string]any) bool {
+			return false
+		}))
+		_, err := os.Stat(p.configFile)
+		assert.Assert(t, os.IsNotExist(err), "file should not have been created")
+	})
+}
+
+func Test_updateDockerConfig_clear(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-op when file does not exist", func(t *testing.T) {
+		t.Parallel()
+		p := newDockerTestDir(t)
+
+		assert.NilError(t, updateDockerConfig(p.configFile, func(cfg map[string]any) bool {
+			if _, ok := cfg["currentContext"]; !ok {
+				return false
+			}
+			delete(cfg, "currentContext")
+			return true
+		}))
+		_, err := os.Stat(p.configFile)
+		assert.Assert(t, os.IsNotExist(err), "file should not have been created")
+	})
+
+	t.Run("removes matching currentContext preserving other keys", func(t *testing.T) {
+		t.Parallel()
+		p := newDockerTestDir(t)
+		assert.NilError(t, os.WriteFile(p.configFile,
+			[]byte(`{"currentContext":"rancher-desktop-2","auths":{"example.com":{}}}`+"\n"), 0o600))
+
+		assert.NilError(t, updateDockerConfig(p.configFile, func(cfg map[string]any) bool {
+			if cfg["currentContext"] != "rancher-desktop-2" {
+				return false
+			}
+			delete(cfg, "currentContext")
+			return true
+		}))
+
+		data, err := os.ReadFile(p.configFile)
+		assert.NilError(t, err)
+		var cfg map[string]any
+		assert.NilError(t, json.Unmarshal(data, &cfg))
+		_, hasCtx := cfg["currentContext"]
+		assert.Assert(t, !hasCtx, "currentContext should have been removed")
+		_, hasAuths := cfg["auths"]
+		assert.Assert(t, hasAuths, "auths key must be preserved")
+	})
+}
+
+func Test_createDockerContext(t *testing.T) {
+	p := newDockerTestDir(t)
+	t.Setenv("HOME", filepath.Dir(p.configFile))
+
+	assert.NilError(t, createReplaceDockerContext("rancher-desktop-2", "/tmp/docker.sock"))
+
+	metaPath, err := contextMetaPath("rancher-desktop-2")
+	assert.NilError(t, err)
+	data, err := os.ReadFile(metaPath)
+	assert.NilError(t, err)
+
+	var meta dockerContextMeta
+	assert.NilError(t, json.Unmarshal(data, &meta))
+	assert.Equal(t, meta.Name, "rancher-desktop-2")
+	assert.Equal(t, meta.Endpoints["docker"].Host, "unix:///tmp/docker.sock")
+}
+
+func Test_deleteDockerContext(t *testing.T) {
+	p := newDockerTestDir(t)
+	t.Setenv("HOME", filepath.Dir(p.configFile))
+
+	assert.NilError(t, createReplaceDockerContext("rancher-desktop-2", "/tmp/docker.sock"))
+	metaPath, err := contextMetaPath("rancher-desktop-2")
+	assert.NilError(t, err)
+	_, err = os.Stat(metaPath)
+	assert.NilError(t, err, "meta.json should exist after create")
+
+	assert.NilError(t, deleteDockerContext("rancher-desktop-2"))
+	_, err = os.Stat(filepath.Dir(metaPath))
+	assert.Assert(t, os.IsNotExist(err), "context dir should be removed")
+
+	// Second delete is a no-op.
+	assert.NilError(t, deleteDockerContext("rancher-desktop-2"))
+}
+
+func Test_currentDockerContext(t *testing.T) {
+	p := newDockerTestDir(t)
+	t.Setenv("HOME", filepath.Dir(p.configFile))
+
+	t.Run("returns empty when file absent", func(t *testing.T) {
+		name, err := getCurrentDockerContext()
+		assert.NilError(t, err)
+		assert.Equal(t, name, "")
+	})
+
+	t.Run("set then get", func(t *testing.T) {
+		assert.NilError(t, setCurrentDockerContext("rancher-desktop-2"))
+		name, err := getCurrentDockerContext()
+		assert.NilError(t, err)
+		assert.Equal(t, name, "rancher-desktop-2")
+	})
+
+	t.Run("clear only when context matches", func(t *testing.T) {
+		assert.NilError(t, setCurrentDockerContext("rancher-desktop-2"))
+		// Different name — should not clear.
+		assert.NilError(t, clearCurrentDockerContext("rancher-desktop-3"))
+		name, err := getCurrentDockerContext()
+		assert.NilError(t, err)
+		assert.Equal(t, name, "rancher-desktop-2")
+
+		// Matching name — should clear.
+		assert.NilError(t, clearCurrentDockerContext("rancher-desktop-2"))
+		name, err = getCurrentDockerContext()
+		assert.NilError(t, err)
+		assert.Equal(t, name, "")
+	})
+}

--- a/pkg/controllers/app/engine/controllers/engine_reconciler.go
+++ b/pkg/controllers/app/engine/controllers/engine_reconciler.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,6 +30,7 @@ import (
 
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	containersv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
 const (
@@ -89,6 +91,20 @@ type EngineReconciler struct {
 	// no longer runs, and stopWatcher is unreachable from that path.
 	watcherCtx    context.Context
 	watcherCancel context.CancelFunc
+
+	// contextMu protects contextProbeCancel and contextProbeGen.
+	contextMu sync.Mutex
+	// contextProbeCancel cancels the in-flight Docker context probe goroutine.
+	// It is nil when no probe is running.
+	contextProbeCancel context.CancelFunc
+	// contextProbeGen is incremented each time a new probe is launched; the
+	// goroutine captures its generation at launch and uses it to detect
+	// whether it has been superseded.
+	contextProbeGen int
+	// contextProbeWg is used by removeDockerContext to wait for the probe
+	// goroutine to finish before deleting the context directory, ensuring
+	// the goroutine cannot write currentContext after the directory is gone.
+	contextProbeWg sync.WaitGroup
 }
 
 // Reconcile handles App condition changes, Docker watcher lifecycle,
@@ -139,6 +155,11 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.
 			log.Info("Stopping Docker watcher",
 				"running", running, "engine", app.Spec.ContainerEngine.Name)
 			r.stopWatcher()
+		} else {
+			// The watcher was never started or died on its own (e.g. the VM
+			// socket closed). stopWatcher was not called, so clean up the
+			// Docker context directly.
+			r.removeDockerContext()
 		}
 		terminalReason := "Stopped"
 		terminalStatus := metav1.ConditionFalse
@@ -232,6 +253,7 @@ func (r *EngineReconciler) startWatcherAndSync(_ context.Context) error {
 		return err
 	}
 	r.watcher = w
+	r.manageDockerContext(instance.DockerSocket())
 	return nil
 }
 
@@ -244,6 +266,104 @@ func (r *EngineReconciler) stopWatcher() {
 
 	if w != nil {
 		w.stop()
+	}
+	r.removeDockerContext()
+}
+
+// manageDockerContext creates the instance Docker context and, in a goroutine,
+// probes the user's current context; if it is absent or unhealthy, switches
+// the default to the new context. At most one probe runs at a time.
+func (r *EngineReconciler) manageDockerContext(socketPath string) {
+	// Docker context management uses unix:// sockets; Windows requires
+	// npipe:// which is not yet implemented.
+	if runtime.GOOS == "windows" {
+		return
+	}
+	contextName := instance.Name()
+	log := logf.FromContext(r.watcherCtx).WithName("docker-context")
+
+	if err := createReplaceDockerContext(contextName, socketPath); err != nil {
+		log.Error(err, "Failed to create Docker context", "context", contextName)
+		return
+	}
+
+	r.contextMu.Lock()
+	// Cancel any in-flight probe from a previous transition.
+	if r.contextProbeCancel != nil {
+		r.contextProbeCancel()
+	}
+	probeCtx, cancel := context.WithCancel(r.watcherCtx)
+	r.contextProbeCancel = cancel
+	r.contextProbeGen++
+	myGen := r.contextProbeGen
+	r.contextMu.Unlock()
+
+	r.contextProbeWg.Add(1)
+	go func() {
+		defer r.contextProbeWg.Done()
+		defer func() {
+			r.contextMu.Lock()
+			// Clear the cancel func only if we are still the current probe.
+			if r.contextProbeGen == myGen {
+				r.contextProbeCancel = nil
+			}
+			r.contextMu.Unlock()
+			cancel()
+		}()
+
+		current, err := getCurrentDockerContext()
+		if err != nil {
+			log.Error(err, "Failed to read current Docker context")
+		}
+
+		// Probe the current context's host — not our own — to decide
+		// whether to promote ours. "default" and empty both mean no
+		// working context is set; treat them identically.
+		var healthy bool
+		if current != "" && current != "default" {
+			currentHost, err := getDockerContextHost(current)
+			if err != nil {
+				log.Error(err, "Failed to resolve current Docker context host", "context", current)
+			} else if currentHost != "" {
+				healthy = probeDockerContext(probeCtx, currentHost)
+			}
+		}
+		// Guard against writing currentContext after removeDockerContext has
+		// already cancelled probeCtx and deleted the context directory.
+		if !healthy && probeCtx.Err() == nil {
+			if err := setCurrentDockerContext(contextName); err != nil {
+				log.Error(err, "Failed to set current Docker context", "context", contextName)
+			}
+		}
+	}()
+}
+
+// removeDockerContext cancels any in-flight probe, waits for it to finish,
+// then resets the current context if it points at our instance and deletes
+// the instance's Docker context directory.
+func (r *EngineReconciler) removeDockerContext() {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	r.contextMu.Lock()
+	if r.contextProbeCancel != nil {
+		r.contextProbeCancel()
+		r.contextProbeCancel = nil
+	}
+	r.contextMu.Unlock()
+
+	// Wait for the probe goroutine to finish before deleting the context
+	// directory. The goroutine's probeCtx was just cancelled, so Ping will
+	// return within dockerContextProbeTimeout (3s) at most.
+	r.contextProbeWg.Wait()
+
+	contextName := instance.Name()
+	log := logf.FromContext(r.watcherCtx).WithName("docker-context")
+	if err := clearCurrentDockerContext(contextName); err != nil {
+		log.Error(err, "Failed to clear current Docker context", "context", contextName)
+	}
+	if err := deleteDockerContext(contextName); err != nil {
+		log.Error(err, "Failed to delete Docker context", "context", contextName)
 	}
 }
 


### PR DESCRIPTION
When `ContainerEngineReady` transitions to True for the moby engine, a Docker CLI context is created (named after the instance, e.g., `rancher-desktop-2`) pointing to `instance.DockerSocket()`.

A background probe then checks the user's current Docker context. If the current context is missing or points to an invalid socket, the newly created context is set as the default.

When `ContainerEngineReady` transitions away from True, any in-flight probe is cancelled. If the active context is ours, it is cleared, and the associated context directory is removed.

Fixes: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/318