### PR TITLE
Engine docker context improvements

### DIFF
--- a/bats/tests/32-app-controllers/engine-docker.bats
+++ b/bats/tests/32-app-controllers/engine-docker.bats
@@ -13,6 +13,14 @@ local_setup_file() {
     # The Docker socket access pattern used by these tests is not yet wired
     # up for Windows/WSL2.
     skip_on_windows
+
+    # Isolate all Docker config reads and writes from the developer's real
+    # ~/.docker directory. Set DOCKER_CONFIG before starting the service so
+    # the controller process inherits it (service.Start uses exec.Command
+    # without an explicit Env, so it inherits the caller's environment).
+    export DOCKER_CONFIG="${BATS_SUITE_TMPDIR}/docker-config"
+    mkdir -p "${DOCKER_CONFIG}"
+
     # Deliberately skip setup_rdd_control_plane here: `rdd set` internally
     # calls ensureServiceRunning, which is exactly the CLI path we want to
     # exercise — the engine controller is part of the default controller
@@ -570,7 +578,7 @@ docker_context_dir() {
     else
         hash=$(printf '%s' "${name}" | shasum -a 256 | awk '{print $1}')
     fi
-    echo "${HOME}/.docker/contexts/meta/${hash}"
+    echo "${DOCKER_CONFIG}/contexts/meta/${hash}"
 }
 
 @test "moby engine creates Docker context for the instance" {
@@ -598,32 +606,16 @@ docker_context_dir() {
 @test "moby engine sets currentContext when no healthy context exists" {
     local context_name="rancher-desktop-${RDD_INSTANCE}"
 
-    # Save and clear any existing currentContext so the probe finds no
-    # healthy context and promotes ours. Restored in teardown.
-    local saved_context
-    saved_context=$(jq -r '.currentContext // empty' "${HOME}/.docker/config.json" 2>/dev/null || true)
-
-    # Clear the current context and restart the engine so the probe runs fresh.
-    jq 'del(.currentContext)' "${HOME}/.docker/config.json" >"${HOME}/.docker/config.json.tmp" &&
-        mv "${HOME}/.docker/config.json.tmp" "${HOME}/.docker/config.json"
-
     rdd set running=false
     rdd set running=true containerEngine.name=moby
     rdd ctl wait --for=condition=ContainerEngineReady app/app --timeout=30s
 
     # The probe goroutine runs asynchronously; give it a moment.
     try --max 6 --delay 1 -- \
-        bash -c "jq -r '.currentContext' '${HOME}/.docker/config.json' | grep -qx '${context_name}'"
+        bash -c "jq -r '.currentContext' '${DOCKER_CONFIG}/config.json' | grep -qx '${context_name}'"
 
-    run -0 jq -r '.currentContext' "${HOME}/.docker/config.json"
+    run -0 jq -r '.currentContext' "${DOCKER_CONFIG}/config.json"
     assert_output "${context_name}"
-
-    # Restore the original context if there was one.
-    if [[ -n "${saved_context}" ]]; then
-        jq --arg ctx "${saved_context}" '.currentContext = $ctx' \
-            "${HOME}/.docker/config.json" >"${HOME}/.docker/config.json.tmp" &&
-            mv "${HOME}/.docker/config.json.tmp" "${HOME}/.docker/config.json"
-    fi
 }
 
 @test "stopping moby engine removes Docker context and clears currentContext" {
@@ -639,6 +631,6 @@ docker_context_dir() {
     assert_dir_not_exists "${context_dir}"
 
     # currentContext should either be gone or point to something else.
-    run jq -r '.currentContext // empty' "${HOME}/.docker/config.json"
+    run jq -r '.currentContext // empty' "${DOCKER_CONFIG}/config.json"
     refute_output "${context_name}"
 }

--- a/pkg/controllers/app/engine/controllers/docker_context.go
+++ b/pkg/controllers/app/engine/controllers/docker_context.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -150,16 +151,92 @@ func clearCurrentDockerContext(name string) error {
 	return cf.Save()
 }
 
-// probeDockerContext tries to ping the Docker daemon at the given host URL.
-// It returns true if the daemon responds within dockerContextProbeTimeout.
-func probeDockerContext(ctx context.Context, host string) bool {
-	probeCtx, cancel := context.WithTimeout(ctx, dockerContextProbeTimeout)
-	defer cancel()
-	cli, err := dockerclient.New(dockerclient.WithHost(host))
+// pingDocker creates a Docker client with opts and pings it within ctx.
+func pingDocker(ctx context.Context, opts ...dockerclient.Opt) bool {
+	cli, err := dockerclient.New(opts...)
 	if err != nil {
 		return false
 	}
 	defer cli.Close()
-	_, err = cli.Ping(probeCtx, dockerclient.PingOptions{})
+	_, err = cli.Ping(ctx, dockerclient.PingOptions{})
 	return err == nil
+}
+
+// probeDockerContext pings the Docker endpoint at host within dockerContextProbeTimeout.
+// If host is empty, dockerclient.FromEnv is used so the implicit default socket
+// (DOCKER_HOST or the platform default, e.g. /var/run/docker.sock) is contacted —
+// matching what Docker CLI does for the "default" context.
+func probeDockerContext(ctx context.Context, host string) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, dockerContextProbeTimeout)
+	defer cancel()
+	if host != "" {
+		return pingDocker(probeCtx, dockerclient.WithHost(host))
+	}
+	return pingDocker(probeCtx, dockerclient.FromEnv)
+}
+
+// probeNamedDockerContext probes the named Docker context by reconstructing its
+// full transport state from the context store:
+//   - unix://  – probed directly.
+//   - tcp://   – TLS certificates are loaded from the context store's TLS
+//     directory when present; plain TCP is used otherwise.
+//   - ssh://, npipe://, or any other scheme – health cannot be determined without
+//     additional implementation, so the function returns true (assume healthy) to
+//     avoid incorrectly overriding the user's working context.
+//   - context not found – returns false (treat as unhealthy).
+//   - metadata unreadable – returns true (assume healthy to avoid overriding).
+func probeNamedDockerContext(ctx context.Context, name string) bool {
+	s, err := newContextStore()
+	if err != nil {
+		return true
+	}
+	md, err := s.GetMetadata(name)
+	if err != nil {
+		return !errdefs.IsNotFound(err)
+	}
+	ep, err := docker.EndpointFromContext(md)
+	if err != nil {
+		return true
+	}
+	host := ep.Host
+	if host == "" {
+		return false
+	}
+	scheme, _, _ := strings.Cut(host, "://")
+	switch scheme {
+	case "unix":
+		return probeDockerContext(ctx, host)
+	case "tcp":
+		probeCtx, cancel := context.WithTimeout(ctx, dockerContextProbeTimeout)
+		defer cancel()
+		opts := []dockerclient.Opt{dockerclient.WithHost(host)}
+		// Load TLS certs from the context store's TLS directory.
+		// Note: ep.SkipTLSVerify=true without cert files is not handled here;
+		// probing such a context with plain TCP will fail if the server requires
+		// a TLS handshake, causing a false-negative treated as unhealthy.
+		// This edge case requires a custom http.Transport and we can do this later.
+		tlsDir := filepath.Join(s.GetStorageInfo(name).TLSPath, docker.DockerEndpoint)
+		caPath := filepath.Join(tlsDir, "ca.pem")
+		certPath := filepath.Join(tlsDir, "cert.pem")
+		keyPath := filepath.Join(tlsDir, "key.pem")
+		_, hasCA := os.Stat(caPath)
+		_, hasCert := os.Stat(certPath)
+		_, hasKey := os.Stat(keyPath)
+		useCA := ""
+		if hasCA == nil {
+			useCA = caPath
+		}
+		useCert, useKey := "", ""
+		if hasCert == nil && hasKey == nil {
+			useCert, useKey = certPath, keyPath
+		}
+		if useCA != "" || useCert != "" {
+			opts = append(opts, dockerclient.WithTLSClientConfig(useCA, useCert, useKey))
+		}
+		return pingDocker(probeCtx, opts...)
+	default:
+		// ssh://, npipe://, or unknown: we cannot reconstruct the full transport
+		// state, so assume healthy to avoid overriding the user's working context.
+		return true
+	}
 }

--- a/pkg/controllers/app/engine/controllers/engine_reconciler.go
+++ b/pkg/controllers/app/engine/controllers/engine_reconciler.go
@@ -267,8 +267,11 @@ func (r *EngineReconciler) stopWatcher() {
 // probes the user's current context; if it is absent or unhealthy, switches
 // the default to the new context. At most one probe runs at a time.
 func (r *EngineReconciler) manageDockerContext(socketPath string) {
-	// Docker context management uses unix:// sockets; Windows requires
-	// npipe:// which is not yet implemented.
+	// TODO(windows): Docker context management uses unix:// sockets; Windows
+	// requires npipe:// in the context meta file, an npipe-aware probe client,
+	// and platform-specific path handling in getCurrentDockerContext and
+	// createReplaceDockerContext. Track in a follow-up issue before shipping
+	// Windows support.
 	if runtime.GOOS == "windows" {
 		return
 	}
@@ -306,20 +309,18 @@ func (r *EngineReconciler) manageDockerContext(socketPath string) {
 
 		current, err := getCurrentDockerContext()
 		if err != nil {
+			// An error here means the config file exists but could not be
+			// read or parsed. Do not proceed — writing currentContext now
+			// would overwrite a file we cannot safely round-trip.
 			log.Error(err, "Failed to read current Docker context")
+			return
 		}
 
-		// Probe the current context's host — not our own — to decide
-		// whether to promote ours. "default" and empty both mean no
-		// working context is set; treat them identically.
 		var healthy bool
 		if current != "" && current != "default" {
-			currentHost, err := getDockerContextHost(current)
-			if err != nil {
-				log.Error(err, "Failed to resolve current Docker context host", "context", current)
-			} else if currentHost != "" {
-				healthy = probeDockerContext(probeCtx, currentHost)
-			}
+			healthy = probeNamedDockerContext(probeCtx, current)
+		} else {
+			healthy = probeDockerContext(probeCtx, "")
 		}
 		// Guard against writing currentContext after removeDockerContext has
 		// already cancelled probeCtx and deleted the context directory.
@@ -335,6 +336,7 @@ func (r *EngineReconciler) manageDockerContext(socketPath string) {
 // then resets the current context if it points at our instance and deletes
 // the instance's Docker context directory.
 func (r *EngineReconciler) removeDockerContext() {
+	// TODO(windows): see manageDockerContext — same gap applies here.
 	if runtime.GOOS == "windows" {
 		return
 	}
@@ -345,9 +347,12 @@ func (r *EngineReconciler) removeDockerContext() {
 	}
 	r.contextMu.Unlock()
 
-	// Wait for the probe goroutine to finish before deleting the context
-	// directory. The goroutine's probeCtx was just cancelled, so Ping will
-	// return within dockerContextProbeTimeout (3s) at most.
+	// Wait for any in-flight probe goroutines to finish before deleting the
+	// context directory. Each probe's context was cancelled above (or by an
+	// earlier manageDockerContext call), so each Ping returns within
+	// dockerContextProbeTimeout (3s). Multiple goroutines can be outstanding
+	// if manageDockerContext was called while a prior probe was still running;
+	// Wait blocks until all of them have exited.
 	r.contextProbeWg.Wait()
 
 	contextName := instance.Name()


### PR DESCRIPTION
- respect `DOCKER_CONFIG` for better test isolation for BATS
- probe default context via FromEnv, add probeNamedDockerContext with TLS support
- avoid overriding `ssh/npipe/unknown` contexts
- remove `getDockerContextHost`
- ensure atomic docker config writes
- update WaitGroup comment for multiple goroutines