### PR TITLE
app: let Lima pick the SSH local port

### DIFF
--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -4,7 +4,6 @@ mounts:
 - location: "~"
   writable: true
 ssh:
-  localPort: 51422
   loadDotSSHPubKeys: false
 firmware:
   legacyBIOS: false


### PR DESCRIPTION
Hardcoding `ssh.localPort` to `51422` collides with any other Lima instance built from the same template. A second instance (e.g. the bats suite running while a dev instance is already up) fails to forward SSH, never reaches `Running`, and hangs `rdd set` on the `ContainerEngineReady` wait. Omit the field so Lima picks a free port per instance.