### PR TITLE
Docker Engine: improve Docker context probe safety and isolation

### DIFF
--- a/bats/tests/32-app-controllers/engine-docker.bats
+++ b/bats/tests/32-app-controllers/engine-docker.bats
@@ -13,6 +13,14 @@ local_setup_file() {
     # The Docker socket access pattern used by these tests is not yet wired
     # up for Windows/WSL2.
     skip_on_windows
+
+    # Isolate all Docker config reads and writes from the developer's real
+    # ~/.docker directory. Set DOCKER_CONFIG before starting the service so
+    # the controller process inherits it (service.Start uses exec.Command
+    # without an explicit Env, so it inherits the caller's environment).
+    export DOCKER_CONFIG="${BATS_FILE_TMPDIR}/docker-config"
+    mkdir -p "${DOCKER_CONFIG}"
+
     # Deliberately skip setup_rdd_control_plane here: `rdd set` internally
     # calls ensureServiceRunning, which is exactly the CLI path we want to
     # exercise — the engine controller is part of the default controller
@@ -743,7 +751,7 @@ docker_context_dir() {
     else
         hash=$(printf '%s' "${name}" | shasum -a 256 | awk '{print $1}')
     fi
-    echo "${HOME}/.docker/contexts/meta/${hash}"
+    echo "${DOCKER_CONFIG}/contexts/meta/${hash}"
 }
 
 @test "moby engine creates Docker context for the instance" {
@@ -771,14 +779,22 @@ docker_context_dir() {
 @test "moby engine sets currentContext when no healthy context exists" {
     local context_name="rancher-desktop-${RDD_INSTANCE}"
 
-    # Save and clear any existing currentContext so the probe finds no
-    # healthy context and promotes ours. Restored in teardown.
-    local saved_context
-    saved_context=$(jq -r '.currentContext // empty' "${HOME}/.docker/config.json" 2>/dev/null || true)
-
-    # Clear the current context and restart the engine so the probe runs fresh.
-    jq 'del(.currentContext)' "${HOME}/.docker/config.json" >"${HOME}/.docker/config.json.tmp" &&
-        mv "${HOME}/.docker/config.json.tmp" "${HOME}/.docker/config.json"
+    # Seed a named context pointing at an unreachable socket and make it
+    # current. This forces the reconciler into the probeNamedDockerContext
+    # branch with a guaranteed-failing endpoint, independent of whether the
+    # host has a running Docker daemon at the default socket (e.g.
+    # ubuntu-latest runners ship Docker pre-installed). Using a named context
+    # also avoids the stale-env issue: the service process's DOCKER_HOST is
+    # frozen at first start, so FromEnv-based probing of "" / "default" is
+    # host-dependent and unreliable from inside a long-lived daemon.
+    probe_target="test-unreachable"
+    run_e -0 docker_context_dir "${probe_target}"
+    probe_dir="${output}"
+    mkdir -p "${probe_dir}"
+    cat >"${probe_dir}/meta.json" <<EOF
+{"Name":"${probe_target}","Endpoints":{"docker":{"Host":"unix:///nonexistent/does-not-exist.sock","SkipTLSVerify":false}}}
+EOF
+    printf '{"currentContext":"%s"}\n' "${probe_target}" >"${DOCKER_CONFIG}/config.json"
 
     rdd set running=false
     rdd set running=true containerEngine.name=moby
@@ -786,17 +802,10 @@ docker_context_dir() {
 
     # The probe goroutine runs asynchronously; give it a moment.
     try --max 6 --delay 1 -- \
-        bash -c "jq -r '.currentContext' '${HOME}/.docker/config.json' | grep -qx '${context_name}'"
+        bash -c "jq -r '.currentContext' '${DOCKER_CONFIG}/config.json' | grep -qx '${context_name}'"
 
-    run -0 jq -r '.currentContext' "${HOME}/.docker/config.json"
+    run -0 jq -r '.currentContext' "${DOCKER_CONFIG}/config.json"
     assert_output "${context_name}"
-
-    # Restore the original context if there was one.
-    if [[ -n "${saved_context}" ]]; then
-        jq --arg ctx "${saved_context}" '.currentContext = $ctx' \
-            "${HOME}/.docker/config.json" >"${HOME}/.docker/config.json.tmp" &&
-            mv "${HOME}/.docker/config.json.tmp" "${HOME}/.docker/config.json"
-    fi
 }
 
 @test "stopping moby engine removes Docker context and clears currentContext" {
@@ -812,6 +821,6 @@ docker_context_dir() {
     assert_dir_not_exists "${context_dir}"
 
     # currentContext should either be gone or point to something else.
-    run jq -r '.currentContext // empty' "${HOME}/.docker/config.json"
+    run jq -r '.currentContext // empty' "${DOCKER_CONFIG}/config.json"
     refute_output "${context_name}"
 }

--- a/pkg/controllers/app/engine/controllers/docker_context.go
+++ b/pkg/controllers/app/engine/controllers/docker_context.go
@@ -8,13 +8,16 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
-	mobyclient "github.com/moby/moby/client"
+	dockerclient "github.com/moby/moby/client"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // dockerContextProbeTimeout is the maximum time allowed to ping a Docker
@@ -46,7 +49,8 @@ func newContextStore() (store.Store, error) {
 	// Pass nil for the context-metadata TypeGetter; the store decodes a nil
 	// type into a map[string]any, which is all we need since we never inspect
 	// the Metadata field. This avoids importing cli/command, which would pull
-	// in the docker/cli metrics + telemetry chain (otel/sdk/metric, etc.).
+	// in the docker/cli metrics + telemetry chain (otel/sdk/metric, go-metrics,
+	// gorilla/mux, backoff/v5, morikuni/aec).
 	cfg := store.NewConfig(
 		nil,
 		store.EndpointTypeGetter(docker.DockerEndpoint, func() any { return &docker.EndpointMeta{} }),
@@ -74,30 +78,6 @@ func deleteDockerContext(name string) error {
 		return err
 	}
 	return s.Remove(name)
-}
-
-// getDockerContextHost returns the full Docker host URL (e.g. "unix:///path/to/docker.sock"
-// or "tcp://192.168.1.1:2376") for the named context's docker endpoint.
-// Returns an empty string if the context does not exist or has no docker endpoint.
-func getDockerContextHost(name string) (string, error) {
-	s, err := newContextStore()
-	if err != nil {
-		return "", err
-	}
-	md, err := s.GetMetadata(name)
-	if err != nil {
-		if errdefs.IsNotFound(err) {
-			return "", nil
-		}
-		return "", err
-	}
-	ep, err := docker.EndpointFromContext(md)
-	if err != nil {
-		// Missing or mistyped docker endpoint — treat as empty, not an error.
-		// The configured EndpointTypeGetter normally prevents the mistyped case.
-		return "", nil
-	}
-	return ep.Host, nil
 }
 
 // getCurrentDockerContext reads the currentContext field from ~/.docker/config.json.
@@ -149,16 +129,73 @@ func clearCurrentDockerContext(name string) error {
 	return cf.Save()
 }
 
-// probeDockerContext tries to ping the Docker daemon at the given host URL.
-// It returns true if the daemon responds within dockerContextProbeTimeout.
-func probeDockerContext(ctx context.Context, host string) bool {
-	probeCtx, cancel := context.WithTimeout(ctx, dockerContextProbeTimeout)
-	defer cancel()
-	cli, err := mobyclient.New(mobyclient.WithHost(host))
+// pingDocker creates a Docker client with opts and pings it within ctx.
+func pingDocker(ctx context.Context, opts ...dockerclient.Opt) bool {
+	cli, err := dockerclient.New(opts...)
 	if err != nil {
 		return false
 	}
 	defer cli.Close()
-	_, err = cli.Ping(probeCtx, mobyclient.PingOptions{})
+	_, err = cli.Ping(ctx, dockerclient.PingOptions{})
 	return err == nil
+}
+
+// probeDockerContext pings the implicit default Docker endpoint
+// (DOCKER_HOST or the platform default socket) within dockerContextProbeTimeout.
+// Used when currentContext is "" or "default".
+func probeDockerContext(ctx context.Context) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, dockerContextProbeTimeout)
+	defer cancel()
+	return pingDocker(probeCtx, dockerclient.FromEnv)
+}
+
+// probeNamedDockerContext pings the Docker endpoint for the named context
+// within dockerContextProbeTimeout and returns true if the endpoint is healthy.
+//
+// When we cannot determine whether the context is healthy — because the store
+// is unreadable, the endpoint metadata is missing or malformed, the scheme is
+// not tcp/unix (e.g. SSH), or the TLS config cannot be loaded — we return true
+// (assume healthy). This conservatism prevents RDD from clobbering a context
+// that is in the middle of being edited or migrated.
+func probeNamedDockerContext(ctx context.Context, name string) bool {
+	log := logf.FromContext(ctx).WithName("docker-context").WithValues("context", name)
+
+	s, err := newContextStore()
+	if err != nil {
+		log.Error(err, "Cannot open context store; assuming context healthy")
+		return true
+	}
+	md, err := s.GetMetadata(name)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return false
+		}
+		log.Error(err, "Cannot read context metadata; assuming context healthy")
+		return true
+	}
+	epMeta, err := docker.EndpointFromContext(md)
+	if err != nil {
+		log.Error(err, "Cannot decode docker endpoint; assuming context healthy")
+		return true
+	}
+	scheme, _, _ := strings.Cut(epMeta.Host, "://")
+	switch scheme {
+	case "unix", "tcp":
+	default:
+		log.Info("Non-tcp/unix endpoint scheme; assuming context healthy", "scheme", scheme)
+		return true
+	}
+	ep, err := docker.WithTLSData(s, name, epMeta)
+	if err != nil {
+		log.Error(err, "Cannot load TLS data; assuming context healthy")
+		return true
+	}
+	opts, err := ep.ClientOpts()
+	if err != nil {
+		log.Error(err, "Cannot build client options; assuming context healthy")
+		return true
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, dockerContextProbeTimeout)
+	defer cancel()
+	return pingDocker(probeCtx, opts...)
 }

--- a/pkg/controllers/app/engine/controllers/docker_context_test.go
+++ b/pkg/controllers/app/engine/controllers/docker_context_test.go
@@ -5,11 +5,15 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/errdefs"
+	"github.com/docker/cli/cli/context/docker"
+	"github.com/docker/cli/cli/context/store"
 	"gotest.tools/v3/assert"
 )
 
@@ -28,12 +32,34 @@ func newDockerTestDir(t *testing.T) string {
 	return filepath.Join(dockerDir, "config.json")
 }
 
+// testGetContextHost fetches the docker endpoint Host for name from the store.
+// Returns ("", nil) if the context does not exist or has no docker endpoint.
+func testGetContextHost(t *testing.T, name string) (string, error) {
+	t.Helper()
+	s, err := newContextStore()
+	if err != nil {
+		return "", err
+	}
+	md, err := s.GetMetadata(name)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	ep, err := docker.EndpointFromContext(md)
+	if err != nil {
+		return "", nil
+	}
+	return ep.Host, nil
+}
+
 func Test_createReplaceDockerContext(t *testing.T) {
 	newDockerTestDir(t)
 
 	assert.NilError(t, createReplaceDockerContext("rancher-desktop-2", "/tmp/docker.sock"))
 
-	host, err := getDockerContextHost("rancher-desktop-2")
+	host, err := testGetContextHost(t, "rancher-desktop-2")
 	assert.NilError(t, err)
 	assert.Equal(t, host, "unix:///tmp/docker.sock")
 
@@ -48,7 +74,7 @@ func Test_createReplaceDockerContext(t *testing.T) {
 
 	// Replacing with a new socket updates the host.
 	assert.NilError(t, createReplaceDockerContext("rancher-desktop-2", "/run/docker.sock"))
-	host, err = getDockerContextHost("rancher-desktop-2")
+	host, err = testGetContextHost(t, "rancher-desktop-2")
 	assert.NilError(t, err)
 	assert.Equal(t, host, "unix:///run/docker.sock")
 }
@@ -86,23 +112,16 @@ func Test_getCurrentDockerContext_malformedAuth(t *testing.T) {
 	assert.Assert(t, err != nil, "malformed auths entry must surface as an error")
 }
 
-func Test_getDockerContextHost_missing(t *testing.T) {
-	newDockerTestDir(t)
-	host, err := getDockerContextHost("does-not-exist")
-	assert.NilError(t, err)
-	assert.Equal(t, host, "")
-}
-
 func Test_deleteDockerContext(t *testing.T) {
 	newDockerTestDir(t)
 
 	assert.NilError(t, createReplaceDockerContext("rancher-desktop-2", "/tmp/docker.sock"))
-	host, err := getDockerContextHost("rancher-desktop-2")
+	host, err := testGetContextHost(t, "rancher-desktop-2")
 	assert.NilError(t, err)
 	assert.Equal(t, host, "unix:///tmp/docker.sock")
 
 	assert.NilError(t, deleteDockerContext("rancher-desktop-2"))
-	host, err = getDockerContextHost("rancher-desktop-2")
+	host, err = testGetContextHost(t, "rancher-desktop-2")
 	assert.NilError(t, err)
 	assert.Equal(t, host, "")
 
@@ -190,5 +209,51 @@ func Test_currentDockerContext(t *testing.T) {
 		assert.NilError(t, json.Unmarshal(data, &cfg))
 		_, hasAuths := cfg["auths"]
 		assert.Assert(t, hasAuths, "auths key must be preserved across clear")
+	})
+}
+
+func Test_probeNamedDockerContext(t *testing.T) {
+	// seedContext writes a named docker context with the given Host into the
+	// store. It uses the same store config as production code so the context
+	// is readable by probeNamedDockerContext.
+	seedContext := func(t *testing.T, name, host string) {
+		t.Helper()
+		s, err := newContextStore()
+		assert.NilError(t, err)
+		assert.NilError(t, s.CreateOrUpdate(store.Metadata{
+			Name:     name,
+			Metadata: map[string]any{},
+			Endpoints: map[string]any{
+				docker.DockerEndpoint: docker.EndpointMeta{Host: host},
+			},
+		}))
+	}
+
+	t.Run("missing context returns false", func(t *testing.T) {
+		newDockerTestDir(t)
+		result := probeNamedDockerContext(context.Background(), "does-not-exist")
+		assert.Assert(t, !result, "missing context must be treated as unhealthy")
+	})
+
+	t.Run("ssh context returns true (non-probed scheme)", func(t *testing.T) {
+		newDockerTestDir(t)
+		seedContext(t, "ssh-ctx", "ssh://user@remote-host")
+		result := probeNamedDockerContext(context.Background(), "ssh-ctx")
+		assert.Assert(t, result, "ssh context must be assumed healthy to avoid clobbering user's choice")
+	})
+
+	t.Run("unix context with unreachable socket returns false", func(t *testing.T) {
+		newDockerTestDir(t)
+		seedContext(t, "local-ctx", "unix:///nonexistent/does-not-exist.sock")
+		result := probeNamedDockerContext(context.Background(), "local-ctx")
+		assert.Assert(t, !result, "unreachable unix socket must be treated as unhealthy")
+	})
+
+	t.Run("tcp context with unreachable endpoint returns false", func(t *testing.T) {
+		newDockerTestDir(t)
+		// Port 1 is reserved and will be refused on any sane host.
+		seedContext(t, "tcp-ctx", "tcp://127.0.0.1:1")
+		result := probeNamedDockerContext(context.Background(), "tcp-ctx")
+		assert.Assert(t, !result, "unreachable tcp endpoint must be treated as unhealthy")
 	})
 }

--- a/pkg/controllers/app/engine/controllers/engine_reconciler.go
+++ b/pkg/controllers/app/engine/controllers/engine_reconciler.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"runtime"
 	"sync"
 
@@ -319,8 +320,11 @@ func (r *EngineReconciler) stopWatcher() {
 // probes the user's current context; if it is absent or unhealthy, switches
 // the default to the new context. At most one probe runs at a time.
 func (r *EngineReconciler) manageDockerContext(socketPath string) {
-	// Docker context management uses unix:// sockets; Windows requires
-	// npipe:// which is not yet implemented.
+	// TODO(windows): Docker context management uses unix:// sockets; Windows
+	// requires npipe:// in the context meta file, an npipe-aware probe client,
+	// and platform-specific path handling in getCurrentDockerContext and
+	// createReplaceDockerContext. Track in a follow-up issue before shipping
+	// Windows support.
 	if runtime.GOOS == "windows" {
 		return
 	}
@@ -358,20 +362,29 @@ func (r *EngineReconciler) manageDockerContext(socketPath string) {
 
 		current, err := getCurrentDockerContext()
 		if err != nil {
+			// An error here means the config file exists but could not be
+			// read or parsed. Do not proceed — writing currentContext now
+			// would overwrite a file we cannot safely round-trip.
 			log.Error(err, "Failed to read current Docker context")
+			return
 		}
 
-		// Probe the current context's host — not our own — to decide
-		// whether to promote ours. "default" and empty both mean no
-		// working context is set; treat them identically.
+		// DOCKER_HOST and DOCKER_CONTEXT take precedence over config.json
+		// in the Docker CLI's resolution order. Both are shell-local env
+		// vars: the daemon inherits them frozen from the shell that ran
+		// rdd svc start and they may not reflect the user's global
+		// preference. Rewriting config.json based on them could clobber a
+		// correct currentContext for sessions that don't have those vars
+		// set. Skip the probe-and-set entirely when either is present.
+		if os.Getenv("DOCKER_HOST") != "" || os.Getenv("DOCKER_CONTEXT") != "" {
+			return
+		}
+
 		var healthy bool
 		if current != "" && current != "default" {
-			currentHost, err := getDockerContextHost(current)
-			if err != nil {
-				log.Error(err, "Failed to resolve current Docker context host", "context", current)
-			} else if currentHost != "" {
-				healthy = probeDockerContext(probeCtx, currentHost)
-			}
+			healthy = probeNamedDockerContext(probeCtx, current)
+		} else {
+			healthy = probeDockerContext(probeCtx)
 		}
 		// Guard against writing currentContext after removeDockerContext has
 		// already cancelled probeCtx and deleted the context directory.
@@ -387,6 +400,7 @@ func (r *EngineReconciler) manageDockerContext(socketPath string) {
 // then resets the current context if it points at our instance and deletes
 // the instance's Docker context directory.
 func (r *EngineReconciler) removeDockerContext() {
+	// TODO(windows): see manageDockerContext — same gap applies here.
 	if runtime.GOOS == "windows" {
 		return
 	}
@@ -397,9 +411,12 @@ func (r *EngineReconciler) removeDockerContext() {
 	}
 	r.contextMu.Unlock()
 
-	// Wait for the probe goroutine to finish before deleting the context
-	// directory. The goroutine's probeCtx was just cancelled, so Ping will
-	// return within dockerContextProbeTimeout (3s) at most.
+	// Wait for any in-flight probe goroutines to finish before deleting the
+	// context directory. Each probe's context was cancelled above (or by an
+	// earlier manageDockerContext call), so each Ping returns within
+	// dockerContextProbeTimeout (3s). Multiple goroutines can be outstanding
+	// if manageDockerContext was called while a prior probe was still running;
+	// Wait blocks until all of them have exited.
 	r.contextProbeWg.Wait()
 
 	contextName := instance.Name()


### PR DESCRIPTION
This PR extends the use of docker/cli `ContextStore` to probing, replace `getDockerContextHost` + `probeDockerContext` with `probeNamedDockerContext`, leveraging `WithTLSData` and `ep.ClientOpts()` to correctly handle TCP+TLS, mTLS, and `SkipTLSVerify` contexts; treat SSH/npipe as healthy to avoid false overrides.

To elaborate further, `probeDockerContext` only calls `dockerclient.New(dockerclient.WithHost(host))`. That means:

   - TCP+TLS context: host is `tcp://192.168.1.1:2376`, no TLS certs → TLS handshake fails → probe returns false → context falsely treated as unhealthy → overridden with ours
   - mTLS context: same, no client cert → server rejects connection → false override
   - SkipTLSVerify=true: context works fine for the user, but probe fails without the right client config → false override
   - SSH context: `ssh://user@host` passed to WithHost → dial fails → false override