### PR TITLE
bats: bound per-attempt timeouts and capture guest logs on Windows hangs

### DIFF
--- a/bats/helpers/utils.bash
+++ b/bats/helpers/utils.bash
@@ -272,6 +272,10 @@ trace() {
 # try runs the specified command until it either succeeds, or --max attempts
 # have been made (with a --delay seconds sleep in between).
 # With --until-fail, waits until the command fails instead of succeeds.
+# With --per-try-timeout DUR, each attempt is wrapped in `timeout(1)` so a
+# single hung call cannot stall the whole retry budget; DUR accepts any
+# timeout(1) suffix (s, m, h). The attempt exits non-zero (124 on SIGTERM,
+# 137 on SIGKILL) and counts like any other failure toward --max.
 #
 # Right now the command is **always** run with --separate-stderr, and stderr
 # is output after all of stdout. This is subject to change, if we can figure
@@ -279,6 +283,7 @@ trace() {
 try() {
     local max=24
     local delay=5
+    local per_try_timeout=""
     local until_fail=0
 
     while [[ $# -gt 0 ]] && [[ $1 == -* ]]; do
@@ -289,6 +294,10 @@ try() {
             ;;
         --delay)
             delay=$2
+            shift
+            ;;
+        --per-try-timeout)
+            per_try_timeout=$2
             shift
             ;;
         --until-fail)
@@ -308,7 +317,14 @@ try() {
 
     local count=0
     while true; do
-        run_e "$@"
+        if [[ -n "${per_try_timeout}" ]]; then
+            # --kill-after=5s promotes SIGTERM to SIGKILL if the command
+            # ignores the graceful signal; the grace window is short so
+            # pathological cases still cannot stall the retry loop.
+            run_e timeout --kill-after=5s "${per_try_timeout}" "$@"
+        else
+            run_e "$@"
+        fi
         local success
         if ((until_fail)); then
             success=$((status != 0))

--- a/bats/helpers/utils.bash
+++ b/bats/helpers/utils.bash
@@ -318,10 +318,12 @@ try() {
     local count=0
     while true; do
         if [[ -n "${per_try_timeout}" ]]; then
-            # --kill-after=5s promotes SIGTERM to SIGKILL if the command
-            # ignores the graceful signal; the grace window is short so
-            # pathological cases still cannot stall the retry loop.
-            run_e timeout --kill-after=5s "${per_try_timeout}" "$@"
+            # --verbose logs "sending signal TERM" to stderr so the try
+            # log distinguishes a timeout kill from a plain non-zero
+            # exit. --kill-after=5s escalates SIGTERM to SIGKILL when
+            # the command ignores the graceful signal, so a hung retry
+            # cannot stall the loop.
+            run_e timeout --verbose --kill-after=5s "${per_try_timeout}" "$@"
         else
             run_e "$@"
         fi

--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -204,7 +204,12 @@ local_setup_file() {
 }
 
 @test "wait for dockerd to be ready with moby container engine" {
-    try --max 10 --delay 3 -- rdd limavm shell "${VM_NAME}" sudo docker info
+    # Per-try timeout guards against an ssh session that connects but then
+    # blocks on an unresponsive dockerd socket inside the VM: `ssh` keeps
+    # the channel alive via keepalives, so the default retry loop would
+    # otherwise wait for the remote command forever.
+    try --max 10 --delay 3 --per-try-timeout 30s \
+        -- rdd limavm shell "${VM_NAME}" sudo docker info
 }
 
 @test "containerd is not running with moby container engine" {

--- a/scripts/bats-with-timeout.sh
+++ b/scripts/bats-with-timeout.sh
@@ -209,19 +209,17 @@ dump_memory_pressure() {
 # Every invocation is behind `timeout` so a hung guest cannot block the
 # bundle capture itself.
 dump_windows_vm_logs() {
-    case "$(uname -s)" in
-        MINGW*|MSYS*|CYGWIN*) ;;
-        *) return ;;
-    esac
-    command -v wsl.exe >/dev/null 2>&1 || return
+    command -v wsl.exe >/dev/null 2>&1 || return 0
 
-    # `--quiet --list --running` prints one distro name per line, but WSL
-    # emits UTF-16LE (with a BOM) on some Windows builds. Strip NULs and
-    # extract `lima-<name>` substrings directly so the leftover BOM bytes
-    # cannot interfere with a line-anchored match.
+    # WSL_UTF8=1 makes wsl.exe emit UTF-8 (WSL 0.64.0, 2022); without
+    # it the default is UTF-16LE with a BOM. Export so all wsl.exe
+    # calls below inherit it.
+    local -x WSL_UTF8=1
+
+    # --list --running --quiet prints one distro per line.
     local distros
     distros=$(timeout --kill-after=1 10 wsl.exe --list --running --quiet 2>/dev/null \
-        | tr -d '\0\r' | grep -Eo 'lima-[A-Za-z0-9_-]+' | sort -u || true)
+        | grep '^lima-' | sort -u || true)
     if [ -z "$distros" ]; then
         return
     fi
@@ -233,22 +231,20 @@ dump_windows_vm_logs() {
 
         echo
         echo "--- ${distro}: systemctl status rancher-desktop.target ---"
-        timeout --kill-after=1 10 \
-            wsl.exe -d "$distro" -- systemctl status rancher-desktop.target --no-pager 2>&1 || true
+        timeout --kill-after=1 10 wsl.exe -d "$distro" -- \
+            systemctl status rancher-desktop.target --no-pager 2>&1 || true
 
         echo
         echo "--- ${distro}: ps auxf ---"
-        timeout --kill-after=1 10 \
-            wsl.exe -d "$distro" -- ps auxf 2>&1 || true
+        timeout --kill-after=1 10 wsl.exe -d "$distro" -- \
+            ps auxf 2>&1 || true
 
-        # Dump the full journal for this boot. Lima VMs live only as
-        # long as the bats target, so the journal is bounded by the
-        # run's wall time; no caps to match the macOS/Linux serial.log
-        # behavior, where the full console log is preserved.
+        # Dump the full journal for this boot. The VM lives only as
+        # long as the bats target, so the journal is naturally bounded.
         echo
         echo "--- ${distro}: journalctl -b ---"
-        timeout --kill-after=1 30 \
-            wsl.exe -d "$distro" -- journalctl -b --no-pager 2>&1 || true
+        timeout --kill-after=1 30 wsl.exe -d "$distro" -- \
+            journalctl -b --no-pager 2>&1 || true
     done
 }
 

--- a/scripts/bats-with-timeout.sh
+++ b/scripts/bats-with-timeout.sh
@@ -200,6 +200,58 @@ dump_memory_pressure() {
     esac
 }
 
+# On Windows, Lima runs each VM as a WSL2 distro named `lima-<vmname>`.
+# When a bats target hangs waiting on the guest (e.g. `docker info`
+# blocked on an unresponsive dockerd socket), the host-side logs show
+# only that ssh is stuck; the actual cause lives in the VM's journal.
+# wsl.exe talks to the WSL service directly and does not depend on the
+# rdd daemon, so this dump still works after rdd is wedged or killed.
+# Every invocation is behind `timeout` so a hung guest cannot block the
+# bundle capture itself.
+dump_windows_vm_logs() {
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*) ;;
+        *) return ;;
+    esac
+    command -v wsl.exe >/dev/null 2>&1 || return
+
+    # `--quiet --list --running` prints one distro name per line, but WSL
+    # emits UTF-16LE (with a BOM) on some Windows builds. Strip NULs and
+    # extract `lima-<name>` substrings directly so the leftover BOM bytes
+    # cannot interfere with a line-anchored match.
+    local distros
+    distros=$(timeout --kill-after=1 10 wsl.exe --list --running --quiet 2>/dev/null \
+        | tr -d '\0\r' | grep -Eo 'lima-[A-Za-z0-9_-]+' | sort -u || true)
+    if [ -z "$distros" ]; then
+        return
+    fi
+
+    local distro
+    for distro in $distros; do
+        echo
+        echo "=== VM: ${distro} ==="
+
+        echo
+        echo "--- ${distro}: systemctl status rancher-desktop.target ---"
+        timeout --kill-after=1 10 \
+            wsl.exe -d "$distro" -- systemctl status rancher-desktop.target --no-pager 2>&1 || true
+
+        echo
+        echo "--- ${distro}: ps auxf ---"
+        timeout --kill-after=1 10 \
+            wsl.exe -d "$distro" -- ps auxf 2>&1 || true
+
+        # Dump the full journal for this boot. Lima VMs live only as
+        # long as the bats target, so the journal is bounded by the
+        # run's wall time; no caps to match the macOS/Linux serial.log
+        # behavior, where the full console log is preserved.
+        echo
+        echo "--- ${distro}: journalctl -b ---"
+        timeout --kill-after=1 30 \
+            wsl.exe -d "$distro" -- journalctl -b --no-pager 2>&1 || true
+    done
+}
+
 # Snapshot the current state of the rdd API server and (if wired up) the
 # forwarded Docker daemon. Wraps every probe in `timeout` so a hung or
 # dead daemon cannot block the capture — the common case for the
@@ -284,6 +336,9 @@ capture_state() {
 
         echo
         dump_api_state
+
+        echo
+        dump_windows_vm_logs
 
         echo
         echo "=== End of support bundle (${context}) ==="


### PR DESCRIPTION
Two independent diagnostics/reliability fixes, motivated by the Windows BATS hang on `fix-lima-ssh-port` (run 24707925880 / job 72265349580) where the app controllers suite wedged for 25+ minutes at the \"wait for dockerd to be ready\" test.

- **`try --per-try-timeout DUR`** wraps each attempt in `timeout(1)` with a 5s SIGTERM->SIGKILL grace window. Stops a single hung ssh session from burning the full retry budget when the remote command blocks on an unresponsive dockerd socket (ssh keepalives hide the hang from `ConnectTimeout` and `ServerAliveInterval`). Applied to the \"wait for dockerd to be ready\" test in `bats/tests/32-app-controllers/app.bats`, the first confirmed failure mode.

- **`dump_windows_vm_logs`** in `scripts/bats-with-timeout.sh` collects, for every running `lima-*` WSL distro: `systemctl status rancher-desktop.target` as a compact summary, `ps auxf` as a process snapshot, and the full boot journal via `journalctl -b --no-pager` (no line cap, matching the macOS/Linux serial.log capture). `wsl.exe` talks to the WSL service directly, so the dump survives a wedged rdd. Every invocation runs under `timeout(1)`; the function returns early on non-Windows hosts.
