### PR TITLE
Check-spelling: Update to v0.0.26

### DIFF
--- a/.github/actions/disable-compat-telemetry/action.yaml
+++ b/.github/actions/disable-compat-telemetry/action.yaml
@@ -1,12 +1,13 @@
 name: Disable Compatibility Telemetry
 description: >-
-  Block CompatTelRunner.exe via IFEO debugger redirect and disable the
-  DiagTrack service. Runs only on Windows; harmless no-op otherwise.
+  Block CompatTelRunner.exe via Image File Execution Options debugger redirect
+  and disable the DiagTrack service. Runs only on Windows; harmless no-op
+  otherwise.
 
 runs:
   using: composite
   steps:
-  - name: Block CompatTelRunner via IFEO redirect
+  - name: Block CompatTelRunner via Image File Execution Options redirect
     if: runner.os == 'Windows'
     shell: pwsh
     run: |
@@ -19,9 +20,9 @@ runs:
       # On a 2-vCPU GitHub runner, CompatTelRunner consumed ~340 CPU-seconds
       # over a 24-minute BATS job (~22% of one core), crowding out gzip/xz
       # decompression and causing intermittent timeouts.
-      $ifeo = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe'
-      New-Item -Path $ifeo -Force | Out-Null
-      New-ItemProperty -Path $ifeo -Name Debugger `
+      $key = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe'
+      New-Item -Path $key -Force | Out-Null
+      New-ItemProperty -Path $key -Name Debugger `
         -Value "$env:WINDIR\System32\where.exe" `
         -PropertyType String -Force | Out-Null
 
@@ -41,7 +42,7 @@ runs:
     if: runner.os == 'Windows'
     shell: pwsh
     run: |
-      $ifeo = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe'
+      $key = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe'
 
       # Log scheduled tasks referencing CompatTel so we have data
       # if the IFEO trick stops working on a future Windows image.
@@ -51,6 +52,6 @@ runs:
       } | Select-Object TaskPath, TaskName, State | Format-Table -AutoSize
 
       Write-Output "--- Verification ---"
-      Get-ItemProperty -Path $ifeo -Name Debugger | Select-Object Debugger
+      Get-ItemProperty -Path $key -Name Debugger | Select-Object Debugger
       Get-Service DiagTrack -ErrorAction SilentlyContinue |
         Format-List Name, Status, StartType

--- a/.github/actions/spelling/expect/rd.txt
+++ b/.github/actions/spelling/expect/rd.txt
@@ -6,12 +6,14 @@ devmode
 eio
 genericfeatures
 goruntime
+hostswitch
 mountpoint
 nerdctl
 nochange
 rancherdesktop
 rdctl
 rdd
+unexpose
 
 # container namespace (resource short name)
 cns

--- a/.github/actions/spelling/expect/tech.txt
+++ b/.github/actions/spelling/expect/tech.txt
@@ -3,21 +3,21 @@ backgrounding
 backquotes
 cooloff
 crt
+Dilithium
 filewatcher
 FQDNs
 gui
 hyperlinks
 keypair
 lte
+MBytes
 NONINFRINGEMENT
 OIDC
 remoting
 seek'ed
+tsv
 vendored
 vms
-
-# Architectures
-aarch
 
 # Kubernetes and KubeBuilder
 applyconfiguration
@@ -27,6 +27,8 @@ printcolumn
 
 # Linux
 binfmt
+# as in /proc/*/cmdline
+cmdline
 COLORTERM
 distros
 kvm
@@ -37,15 +39,25 @@ pgid
 pids
 qcow
 rootfs
+# as in /etc/sysconfig
+sysconfig
 tarball
 veth
 zst
 zypper
 
+# macOS
+# metadata server, see mds_store
+mds
+
 # Windows
-APPDATA
+# typeperf binary logs
+blg
+Cim
 cygwin
 ERRORLEVEL
+HKLM
+LASTEXITCODE
 LOCALAPPDATA
 mnt
 msys
@@ -53,12 +65,15 @@ MSYSTEM
 netsh
 PROGRAMFILES
 pwsh
+relog
 SYSTEMROOT
 taskkill
+typeperf
 UCRT
 usebackq
+WINDIR
 winver
 wsl
-WSLENV
+wslconfig
 wslpath
 wslservice

--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -67,14 +67,11 @@ PATHCONV
 batslib
 
 # C & compilers
-ALLOCA
 ftell
 ldflags
 sprintf
 
 # make
-addprefix
-addsuffix
 DBSTAT
 DSQLITE
 endef

--- a/.github/actions/windows-machine-info/machine-info.ps1
+++ b/.github/actions/windows-machine-info/machine-info.ps1
@@ -102,14 +102,13 @@ try {
         }
         $sw.Stop()
         $writeMs = $sw.Elapsed.TotalMilliseconds
-        $writeMBs = [math]::Round($sizeMB * 1000 / $writeMs, 1)
 
         $sw.Restart()
         $fs = [System.IO.File]::OpenRead($benchFile)
         try {
             $total = 0
-            $readbuf = New-Object byte[] (1MB)
-            while (($n = $fs.Read($readbuf, 0, $readbuf.Length)) -gt 0) {
+            $readBuf = New-Object byte[] (1MB)
+            while (($n = $fs.Read($readBuf, 0, $readBuf.Length)) -gt 0) {
                 $total += $n
             }
         } finally {
@@ -117,15 +116,14 @@ try {
         }
         $sw.Stop()
         $readMs = $sw.Elapsed.TotalMilliseconds
-        $readMBs = [math]::Round($sizeMB * 1000 / $readMs, 1)
 
         [PSCustomObject]@{
             File = $benchFile
             SizeMB = $sizeMB
             WriteMs = [math]::Round($writeMs, 1)
-            WriteMBPerSec = $writeMBs
+            WriteMBPerSec = [math]::Round($sizeMB * 1000 / $writeMs, 1)
             ReadMs  = [math]::Round($readMs, 1)
-            ReadMBPerSec  = $readMBs
+            ReadMBPerSec  = [math]::Round($sizeMB * 1000 / $readMs, 1)
         } | Format-List
     } catch {
         Write-Output "disk bench failed: $($_.Exception.Message)"
@@ -157,8 +155,8 @@ try {
     & wsl.exe --version 2>&1
     Write-Output ''
     Write-Output "--- .wslconfig (if present) ---"
-    $wslconf = Join-Path $env:USERPROFILE '.wslconfig'
-    if (Test-Path $wslconf) { Get-Content $wslconf } else { "(no .wslconfig)" }
+    $wslconfig = Join-Path $env:USERPROFILE '.wslconfig'
+    if (Test-Path $wslconfig) { Get-Content $wslconfig } else { "(no .wslconfig)" }
 
     Write-Output ''
     Write-Output "=== Hyper-V services ==="

--- a/.github/actions/windows-typeperf-sampler/action.yaml
+++ b/.github/actions/windows-typeperf-sampler/action.yaml
@@ -1,4 +1,4 @@
-name: Windows Typeperf Sampler
+name: Windows typeperf Sampler
 description: >-
   Low-overhead perf counter collection using typeperf. Collects into a
   BLG (binary log) which captures processes that start mid-run. On stop,

--- a/.github/actions/windows-typeperf-sampler/summarize-typeperf.go
+++ b/.github/actions/windows-typeperf-sampler/summarize-typeperf.go
@@ -8,7 +8,7 @@
 //
 // Usage:
 //
-//	go run .github/actions/windows-typeperf-sampler/summarize-typeperf.go <perfdata.tsv> [topN]
+//	go run .github/actions/windows-typeperf-sampler/summarize-typeperf.go <perf-data.tsv> [topN]
 package main
 
 import (
@@ -46,7 +46,7 @@ var headerRe = regexp.MustCompile(`\\Process\(([^)]+)\)\\(.+)$`)
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "usage: summarize-typeperf <perfdata.tsv> [topN]\n")
+		fmt.Fprintf(os.Stderr, "usage: summarize-typeperf <perf-data.tsv> [topN]\n")
 		os.Exit(1)
 	}
 	topN := 10
@@ -78,7 +78,7 @@ func main() {
 	// Build indices during single header pass.
 	var sysColIdx []int
 	sysNames := map[int]string{}
-	procs := map[string]*procIndex{}
+	processes := map[string]*procIndex{}
 	instances := make([]string, 0, 256)
 
 	for i, h := range headers {
@@ -95,10 +95,10 @@ func main() {
 		if inst == "_Total" || inst == "Idle" {
 			continue
 		}
-		pi, ok := procs[inst]
+		pi, ok := processes[inst]
 		if !ok {
 			pi = &procIndex{-1, -1, -1, -1, -1}
-			procs[inst] = pi
+			processes[inst] = pi
 			instances = append(instances, inst)
 		}
 		switch counter {
@@ -115,7 +115,7 @@ func main() {
 		}
 	}
 
-	fmt.Printf("Processes tracked: %d\n", len(procs))
+	fmt.Printf("Processes tracked: %d\n", len(processes))
 
 	rowNum := 0
 	for {
@@ -157,7 +157,7 @@ func main() {
 		// Per-process snapshots via precomputed indices
 		snaps := make([]procSnap, 0, len(instances))
 		for _, inst := range instances {
-			pi := procs[inst]
+			pi := processes[inst]
 			cpu, cpuOK := colFloat(record, pi.cpu)
 			ws, wsOK := colFloat(record, pi.ws)
 			if !cpuOK && !wsOK {

--- a/bats/tests/32-app-controllers/engine-docker.bats
+++ b/bats/tests/32-app-controllers/engine-docker.bats
@@ -43,7 +43,7 @@ local_setup_file() {
         --field-selector "status.repoTag=busybox:latest" --timeout=30s
 }
 
-@test "docker rmi of one tag removes only the tag mirror" {
+@test "docker image rm of one tag removes only the tag mirror" {
     # Docker's untag event carries the image ID hash, not the tag
     # name, so the engine cannot match the event payload against
     # status.repoTag directly. reconcileImageByID re-inspects the
@@ -58,7 +58,7 @@ local_setup_file() {
         --field-selector "status.repoTag=busybox:latest" -o name
     assert_output
 
-    docker rmi busybox:alias
+    docker image rm busybox:alias
     rdd ctl wait --for=delete --namespace="${RDD_NAMESPACE}" image \
         --field-selector "status.repoTag=busybox:alias" --timeout=30s
 
@@ -81,13 +81,13 @@ local_setup_file() {
     alpine_id=${output}
 
     # The pin must be a running container: in this VM's Docker,
-    # rmi --force will fully remove an image whose only references are
+    # image rm --force will fully remove an image whose only references are
     # stopped containers, leaving nothing for the dangling-mirror path
     # to observe.
     docker run -d --name dangling-pin alpine:latest sleep inf
 
     # Remove the only tag; the running container keeps the image alive.
-    docker rmi --force alpine:latest
+    docker image rm --force alpine:latest
 
     # The dangling mirror has no RepoTag — query by status.id instead.
     rdd ctl wait --for=create --namespace="${RDD_NAMESPACE}" image \
@@ -116,7 +116,7 @@ local_setup_file() {
 
     # Cleanup.
     docker rm --force dangling-pin
-    docker rmi dangling-tag-test:v1
+    docker image rm dangling-tag-test:v1
 }
 
 # --- Container lifecycle mirroring ---

--- a/cmd/rdd/limavm_shell.go
+++ b/cmd/rdd/limavm_shell.go
@@ -174,8 +174,8 @@ func limaVMShellAction(cmd *cobra.Command, args []string) error {
 
 	// ConnectTimeout caps the TCP handshake at 30s. ServerAliveInterval=30
 	// with ServerAliveCountMax=3 closes a wedged session after ~90s of
-	// unanswered keepalives. Interactive shells and long-running commands
-	// ack the keepalives and stay connected.
+	// unanswered keep-alives. Interactive shells and long-running commands
+	// ack the keep-alives and stay connected.
 	sshArgs = append(sshArgs, []string{
 		"-o", fmt.Sprintf("LogLevel=%s", logLevel),
 		"-o", "ConnectTimeout=30",

--- a/cmd/rdd/set.go
+++ b/cmd/rdd/set.go
@@ -236,15 +236,15 @@ func collectEntries(schema *apiextensionsv1.JSONSchemaProps, prefix string, out 
 
 		info := "(" + prop.Type + ")"
 		if len(prop.Enum) > 0 {
-			var vals []string
+			var values []string
 			for _, e := range prop.Enum {
 				var s string
 				if json.Unmarshal(e.Raw, &s) == nil {
-					vals = append(vals, s)
+					values = append(values, s)
 				}
 			}
-			if len(vals) > 0 {
-				info = "(" + strings.Join(vals, "|") + ")"
+			if len(values) > 0 {
+				info = "(" + strings.Join(values, "|") + ")"
 			}
 		}
 
@@ -584,12 +584,12 @@ func getAppKubeClient(ctx context.Context) (client.Client, *rest.Config, error) 
 // fetchSpecSchema retrieves the App CRD from the API server and returns the
 // OpenAPI v3 schema for the spec field.
 func fetchSpecSchema(ctx context.Context, config *rest.Config) (*apiextensionsv1.JSONSchemaProps, error) {
-	apiextClient, err := apiextensionsclientset.NewForConfig(config)
+	client, err := apiextensionsclientset.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create apiextensions client: %w", err)
 	}
 
-	crd, err := apiextClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, appCRDName, metav1.GetOptions{})
+	crd, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, appCRDName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, errors.New("app CRD is not installed; make sure the control plane is running with the app controller enabled")

--- a/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -32,12 +32,12 @@ func Test_computeSettledCondition(t *testing.T) {
 	// makeApp builds an App at the given generation, running spec, and
 	// conditions. Callers pass generation=2 so stale ObservedGeneration
 	// values have room below.
-	makeApp := func(generation int64, running bool, conds ...metav1.Condition) *v1alpha1.App {
+	makeApp := func(generation int64, running bool, conditions ...metav1.Condition) *v1alpha1.App {
 		return &v1alpha1.App{
 			ObjectMeta: metav1.ObjectMeta{Generation: generation},
 			Spec:       v1alpha1.AppSpec{Running: running},
 			Status: v1alpha1.AppStatus{
-				Conditions: conds,
+				Conditions: conditions,
 			},
 		}
 	}

--- a/pkg/controllers/app/engine/controllers/docker_context.go
+++ b/pkg/controllers/app/engine/controllers/docker_context.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
-	dockerclient "github.com/moby/moby/client"
+	mobyclient "github.com/moby/moby/client"
 )
 
 // dockerContextProbeTimeout is the maximum time allowed to ping a Docker
@@ -46,8 +46,7 @@ func newContextStore() (store.Store, error) {
 	// Pass nil for the context-metadata TypeGetter; the store decodes a nil
 	// type into a map[string]any, which is all we need since we never inspect
 	// the Metadata field. This avoids importing cli/command, which would pull
-	// in the docker/cli metrics + telemetry chain (otel/sdk/metric, go-metrics,
-	// gorilla/mux, backoff/v5, morikuni/aec).
+	// in the docker/cli metrics + telemetry chain (otel/sdk/metric, etc.).
 	cfg := store.NewConfig(
 		nil,
 		store.EndpointTypeGetter(docker.DockerEndpoint, func() any { return &docker.EndpointMeta{} }),
@@ -155,11 +154,11 @@ func clearCurrentDockerContext(name string) error {
 func probeDockerContext(ctx context.Context, host string) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, dockerContextProbeTimeout)
 	defer cancel()
-	cli, err := dockerclient.New(dockerclient.WithHost(host))
+	cli, err := mobyclient.New(mobyclient.WithHost(host))
 	if err != nil {
 		return false
 	}
 	defer cli.Close()
-	_, err = cli.Ping(probeCtx, dockerclient.PingOptions{})
+	_, err = cli.Ping(probeCtx, mobyclient.PingOptions{})
 	return err == nil
 }

--- a/pkg/controllers/app/engine/controllers/docker_watcher.go
+++ b/pkg/controllers/app/engine/controllers/docker_watcher.go
@@ -12,10 +12,10 @@ import (
 	"strconv"
 	"time"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/go-logr/logr"
 	"github.com/moby/moby/api/types/events"
-	dockerclient "github.com/moby/moby/client"
+	mobyclient "github.com/moby/moby/client"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +34,7 @@ var _ engine = (*dockerWatcher)(nil)
 // dockerWatcher manages a Docker client connection and event stream. It
 // performs a full sync on connect and then watches for incremental changes.
 type dockerWatcher struct {
-	cli *dockerclient.Client
+	cli *mobyclient.Client
 	k8s client.Client
 
 	// apiNamespace is the Kubernetes namespace where mirror resources live.
@@ -51,8 +51,8 @@ type dockerWatcher struct {
 // the event stream watcher goroutine.
 func newDockerWatcher(ctx context.Context, k8s client.Client, apiNamespace string, reconcileChan chan<- event.GenericEvent) (*dockerWatcher, error) {
 	socketPath := instance.DockerSocket()
-	cli, err := dockerclient.New(
-		dockerclient.WithHost("unix://" + socketPath),
+	cli, err := mobyclient.New(
+		mobyclient.WithHost("unix://" + socketPath),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Docker client: %w", err)
@@ -61,7 +61,7 @@ func newDockerWatcher(ctx context.Context, k8s client.Client, apiNamespace strin
 	// Verify the connection by pinging Docker.
 	pingCtx, pingCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer pingCancel()
-	if _, err := cli.Ping(pingCtx, dockerclient.PingOptions{}); err != nil {
+	if _, err := cli.Ping(pingCtx, mobyclient.PingOptions{}); err != nil {
 		cli.Close()
 		return nil, fmt.Errorf("failed to ping Docker: %w", err)
 	}
@@ -104,10 +104,10 @@ func newDockerWatcher(ctx context.Context, k8s client.Client, apiNamespace strin
 
 // dockerEventsSince returns a Docker events "Since" timestamp anchored
 // on the daemon's own clock, avoiding host/guest clock skew.
-func dockerEventsSince(ctx context.Context, cli *dockerclient.Client) (string, error) {
+func dockerEventsSince(ctx context.Context, cli *mobyclient.Client) (string, error) {
 	infoCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	result, err := cli.Info(infoCtx, dockerclient.InfoOptions{})
+	result, err := cli.Info(infoCtx, mobyclient.InfoOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to query Docker info: %w", err)
 	}
@@ -169,12 +169,12 @@ func (w *dockerWatcher) run(ctx context.Context, since string) {
 		}
 	}()
 
-	eventFilter := dockerclient.Filters{}.
+	eventFilter := mobyclient.Filters{}.
 		Add("type", string(events.ContainerEventType)).
 		Add("type", string(events.ImageEventType)).
 		Add("type", string(events.VolumeEventType))
 
-	result := w.cli.Events(ctx, dockerclient.EventsListOptions{
+	result := w.cli.Events(ctx, mobyclient.EventsListOptions{
 		Since:   since,
 		Filters: eventFilter,
 	})
@@ -420,11 +420,11 @@ func (w *dockerWatcher) dispatchContainerAction(ctx context.Context, log logr.Lo
 	switch action {
 	case containersv1alpha1.ContainerActionStart:
 		log.Info("Starting container", "id", id)
-		_, err := w.cli.ContainerStart(ctx, id, dockerclient.ContainerStartOptions{})
+		_, err := w.cli.ContainerStart(ctx, id, mobyclient.ContainerStartOptions{})
 		return err
 	case containersv1alpha1.ContainerActionStop:
 		log.Info("Stopping container", "id", id)
-		_, err := w.cli.ContainerStop(ctx, id, dockerclient.ContainerStopOptions{})
+		_, err := w.cli.ContainerStop(ctx, id, mobyclient.ContainerStopOptions{})
 		return err
 	case containersv1alpha1.ContainerActionPause:
 		_, paused, err := w.containerRunState(ctx, id)
@@ -435,7 +435,7 @@ func (w *dockerWatcher) dispatchContainerAction(ctx context.Context, log logr.Lo
 			return nil
 		}
 		log.Info("Pausing container", "id", id)
-		_, err = w.cli.ContainerPause(ctx, id, dockerclient.ContainerPauseOptions{})
+		_, err = w.cli.ContainerPause(ctx, id, mobyclient.ContainerPauseOptions{})
 		return err
 	case containersv1alpha1.ContainerActionUnpause:
 		running, paused, err := w.containerRunState(ctx, id)
@@ -449,11 +449,11 @@ func (w *dockerWatcher) dispatchContainerAction(ctx context.Context, log logr.Lo
 			return nil
 		}
 		log.Info("Unpausing container", "id", id)
-		_, err = w.cli.ContainerUnpause(ctx, id, dockerclient.ContainerUnpauseOptions{})
+		_, err = w.cli.ContainerUnpause(ctx, id, mobyclient.ContainerUnpauseOptions{})
 		return err
 	case containersv1alpha1.ContainerActionRestart:
 		log.Info("Restarting container", "id", id)
-		_, err := w.cli.ContainerRestart(ctx, id, dockerclient.ContainerRestartOptions{})
+		_, err := w.cli.ContainerRestart(ctx, id, mobyclient.ContainerRestartOptions{})
 		return err
 	}
 	return fmt.Errorf("unknown container action %q", action)
@@ -464,7 +464,7 @@ func (w *dockerWatcher) dispatchContainerAction(ctx context.Context, log logr.Lo
 // also checks running so that unpause on a stopped container reports a
 // failure instead of a silent success.
 func (w *dockerWatcher) containerRunState(ctx context.Context, id string) (running, paused bool, err error) {
-	inspect, err := w.cli.ContainerInspect(ctx, id, dockerclient.ContainerInspectOptions{})
+	inspect, err := w.cli.ContainerInspect(ctx, id, mobyclient.ContainerInspectOptions{})
 	if err != nil {
 		return false, false, err
 	}
@@ -546,8 +546,8 @@ func (w *dockerWatcher) removeActionAnnotation(ctx context.Context, latest *cont
 // running. Images use Force: false so in-use images are kept and the
 // finalizer retries until the last consumer goes away.
 func (w *dockerWatcher) deleteContainer(ctx context.Context, c *containersv1alpha1.Container) error {
-	_, err := w.cli.ContainerRemove(ctx, c.Name, dockerclient.ContainerRemoveOptions{Force: true})
-	if cerrdefs.IsNotFound(err) {
+	_, err := w.cli.ContainerRemove(ctx, c.Name, mobyclient.ContainerRemoveOptions{Force: true})
+	if errdefs.IsNotFound(err) {
 		return nil
 	}
 	return err
@@ -560,8 +560,8 @@ func (w *dockerWatcher) deleteImage(ctx context.Context, img *containersv1alpha1
 	if img.Status.RepoTag != "" {
 		ref = img.Status.RepoTag
 	}
-	_, err := w.cli.ImageRemove(ctx, ref, dockerclient.ImageRemoveOptions{})
-	if cerrdefs.IsNotFound(err) {
+	_, err := w.cli.ImageRemove(ctx, ref, mobyclient.ImageRemoveOptions{})
+	if errdefs.IsNotFound(err) {
 		return nil
 	}
 	return err
@@ -570,8 +570,8 @@ func (w *dockerWatcher) deleteImage(ctx context.Context, img *containersv1alpha1
 // deleteVolume removes a volume from Docker. See deleteContainer for the
 // error-handling contract.
 func (w *dockerWatcher) deleteVolume(ctx context.Context, v *containersv1alpha1.Volume) error {
-	_, err := w.cli.VolumeRemove(ctx, v.Status.Name, dockerclient.VolumeRemoveOptions{Force: true})
-	if cerrdefs.IsNotFound(err) {
+	_, err := w.cli.VolumeRemove(ctx, v.Status.Name, mobyclient.VolumeRemoveOptions{Force: true})
+	if errdefs.IsNotFound(err) {
 		return nil
 	}
 	return err

--- a/pkg/controllers/app/engine/controllers/engine_reconciler.go
+++ b/pkg/controllers/app/engine/controllers/engine_reconciler.go
@@ -496,7 +496,7 @@ func (r *EngineReconciler) deleteAllOfType(ctx context.Context, list client.Obje
 
 // reconcileContainerActions processes the AnnotationAction annotation on
 // every container that carries one. Per-container errors are joined and
-// returned; a patch failure requeues the reconcile so the caller retries.
+// returned; a patch failure re-queues the reconcile so the caller retries.
 // Containers without the annotation are skipped.
 func (r *EngineReconciler) reconcileContainerActions(ctx context.Context) error {
 	r.watcherMu.Lock()

--- a/pkg/controllers/app/engine/controllers/sync_containers.go
+++ b/pkg/controllers/app/engine/controllers/sync_containers.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"time"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	mobycontainer "github.com/moby/moby/api/types/container"
 	mobynetwork "github.com/moby/moby/api/types/network"
-	dockerclient "github.com/moby/moby/client"
+	mobyclient "github.com/moby/moby/client"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +38,7 @@ import (
 func (w *dockerWatcher) syncAllContainers(ctx context.Context) error {
 	log := logf.FromContext(ctx).WithName("docker-watcher")
 
-	listResult, err := w.cli.ContainerList(ctx, dockerclient.ContainerListOptions{All: true})
+	listResult, err := w.cli.ContainerList(ctx, mobyclient.ContainerListOptions{All: true})
 	if err != nil {
 		return fmt.Errorf("failed to list containers: %w", err)
 	}
@@ -82,8 +82,8 @@ func (w *dockerWatcher) syncAllContainers(ctx context.Context) error {
 // raced a concurrent delete between List and Inspect, and the stale
 // mirror is pruned later in syncAllContainers.
 func (w *dockerWatcher) syncContainer(ctx context.Context, id string) error {
-	result, err := w.cli.ContainerInspect(ctx, id, dockerclient.ContainerInspectOptions{})
-	if cerrdefs.IsNotFound(err) {
+	result, err := w.cli.ContainerInspect(ctx, id, mobyclient.ContainerInspectOptions{})
+	if errdefs.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {

--- a/pkg/controllers/app/engine/controllers/sync_images.go
+++ b/pkg/controllers/app/engine/controllers/sync_images.go
@@ -13,9 +13,9 @@ import (
 	"sort"
 	"time"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	mobyimage "github.com/moby/moby/api/types/image"
-	dockerclient "github.com/moby/moby/client"
+	mobyclient "github.com/moby/moby/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,7 +54,7 @@ func imageMirrorNames(id string, repoTags []string) []string {
 func (w *dockerWatcher) syncAllImages(ctx context.Context) error {
 	log := logf.FromContext(ctx).WithName("docker-watcher")
 
-	listResult, err := w.cli.ImageList(ctx, dockerclient.ImageListOptions{All: true})
+	listResult, err := w.cli.ImageList(ctx, mobyclient.ImageListOptions{All: true})
 	if err != nil {
 		return fmt.Errorf("failed to list images: %w", err)
 	}
@@ -99,7 +99,7 @@ func (w *dockerWatcher) syncAllImages(ctx context.Context) error {
 // pruned later by syncAllImages.
 func (w *dockerWatcher) syncImageFromSummary(ctx context.Context, summary mobyimage.Summary) error {
 	result, err := w.cli.ImageInspect(ctx, summary.ID)
-	if cerrdefs.IsNotFound(err) {
+	if errdefs.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {
@@ -206,7 +206,7 @@ func (w *dockerWatcher) applyImage(
 // name — notably Docker's untag events (see handleImageEvent).
 func (w *dockerWatcher) reconcileImageByID(ctx context.Context, id string) error {
 	result, err := w.cli.ImageInspect(ctx, id)
-	if cerrdefs.IsNotFound(err) {
+	if errdefs.IsNotFound(err) {
 		return w.removeImagesByID(ctx, id)
 	}
 	if err != nil {

--- a/pkg/controllers/app/engine/controllers/sync_volumes.go
+++ b/pkg/controllers/app/engine/controllers/sync_volumes.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"time"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	mobyvolume "github.com/moby/moby/api/types/volume"
-	dockerclient "github.com/moby/moby/client"
+	mobyclient "github.com/moby/moby/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +38,7 @@ func volumeMirrorName(dockerName string) string {
 func (w *dockerWatcher) syncAllVolumes(ctx context.Context) error {
 	log := logf.FromContext(ctx).WithName("docker-watcher")
 
-	volumeList, err := w.cli.VolumeList(ctx, dockerclient.VolumeListOptions{})
+	volumeList, err := w.cli.VolumeList(ctx, mobyclient.VolumeListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list volumes: %w", err)
 	}
@@ -82,8 +82,8 @@ func (w *dockerWatcher) syncAllVolumes(ctx context.Context) error {
 // a concurrent delete between List and Inspect, and the stale mirror
 // is pruned later in syncAllVolumes.
 func (w *dockerWatcher) syncVolume(ctx context.Context, name string) error {
-	result, err := w.cli.VolumeInspect(ctx, name, dockerclient.VolumeInspectOptions{})
-	if cerrdefs.IsNotFound(err) {
+	result, err := w.cli.VolumeInspect(ctx, name, mobyclient.VolumeInspectOptions{})
+	if errdefs.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {

--- a/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
+++ b/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
@@ -304,7 +304,7 @@ func vsockHandshake(ctx context.Context, logger logr.Logger) (net.Listener, erro
 
 // getVMGUID discovers the Hyper-V VM running our distro by polling the
 // registry for VM GUIDs and handshaking with each in parallel. The registry
-// is rescanned every second so that VMs starting after the initial scan
+// is re-scanned every second so that VMs starting after the initial scan
 // (e.g., the WSL2 utility VM on a fresh system) are discovered.
 //
 // The signature-based discovery assumes only one opensuse WSL2 instance

--- a/scripts/bats-with-timeout.sh
+++ b/scripts/bats-with-timeout.sh
@@ -5,8 +5,8 @@
 # SPDX-FileCopyrightText: The Rancher Desktop Authors
 
 # Run a bats target with a timeout. Always writes a support bundle
-# (process tree, pgid, wchan, open fds) at the end so CI artifacts carry
-# the evidence needed to diagnose hangs and leaked processes. On timeout,
+# (process tree, pgid, wchan, open file descriptors) at the end so CI artifacts
+# carry the evidence needed to diagnose hangs and leaked processes. On timeout,
 # additionally kills the target with SIGTERM then SIGKILL.
 #
 # Non-destructive state capture is unfiltered so the bundle shows sibling
@@ -100,7 +100,7 @@ dump_linux_proc() {
         echo "state: $(grep -m1 ^State "$pid_dir/status" 2>/dev/null || echo ?)"
         echo "wchan: $(cat "$pid_dir/wchan" 2>/dev/null || echo ?)"
         echo "cmdline: $(tr '\0' ' ' <"$pid_dir/cmdline" 2>/dev/null || echo ?)"
-        echo "fds:"
+        echo "file descriptors:"
         ls -l "$pid_dir/fd/" 2>/dev/null | sed 's/^/  /' || true
     done
 }
@@ -114,14 +114,14 @@ dump_macos_ps() {
         if is_interesting_process "$comm"; then
             pids+=("$pid")
         fi
-    done < <(ps -axo pid=,ucomm= 2>/dev/null || true)
+    done < <(ps -a -x -o pid=,ucomm= 2>/dev/null || true)
 
     for pid in "${pids[@]}"; do
         echo
         echo "--- pid=${pid} ---"
         ps -p "$pid" -o pid,pgid,stat,wchan,command 2>/dev/null | sed 's/^/  /' || true
         if command -v lsof >/dev/null 2>&1; then
-            echo "fds (lsof):"
+            echo "file descriptors (lsof):"
             lsof -p "$pid" 2>/dev/null | sed 's/^/  /' || true
         fi
         # `sample` captures user-space call stacks on macOS without attaching.
@@ -133,16 +133,18 @@ dump_macos_ps() {
 }
 
 dump_sockets() {
+    local -a cmd
     if command -v ss >/dev/null 2>&1; then
-        echo "=== Open sockets (ss -tupn) ==="
-        ss -tupn 2>&1 || true
+        cmd=(ss --tcp --udp --processes --numeric)
     elif command -v lsof >/dev/null 2>&1; then
-        echo "=== Open sockets (lsof -iP) ==="
-        lsof -iP 2>&1 || true
+        cmd=(lsof -i -P)
     elif command -v netstat >/dev/null 2>&1; then
-        echo "=== Open sockets (netstat -an) ==="
-        netstat -an 2>&1 || true
+        cmd=(netstat -a -n)
+    else
+        return
     fi
+    echo "=== Open sockets (${cmd[*]}) ==="
+    "${cmd[@]}" 2>&1 || true
 }
 
 # Capture evidence of memory pressure or external process kills.
@@ -158,6 +160,7 @@ dump_memory_pressure() {
         Darwin)
             vm_stat 2>&1 || true
             echo
+            # no-spell-check-next-line
             sysctl vm.swapusage 2>&1 || true
             ;;
         Linux)
@@ -185,8 +188,19 @@ dump_memory_pressure() {
             # bats target (30-min timeout + slack). --style compact keeps
             # output small.
             if command -v log >/dev/null 2>&1; then
+                local predicate=(
+                    '(sender == "kernel") AND'
+                    '('
+                    '(eventMessage CONTAINS[c] "jetsam") OR '
+                    # no-spell-check-next-line
+                    '(eventMessage CONTAINS[c] "memorystatus") OR '
+                    '(eventMessage CONTAINS[c] "low swap") OR '
+                    # no-spell-check-next-line
+                    '(eventMessage CONTAINS[c] "lowmem")'
+                    ')'
+                )
                 log show --style compact --last 1h \
-                    --predicate '(sender == "kernel") AND ((eventMessage CONTAINS[c] "jetsam") OR (eventMessage CONTAINS[c] "memorystatus") OR (eventMessage CONTAINS[c] "low swap") OR (eventMessage CONTAINS[c] "lowmem"))' \
+                    --predicate "${predicate[*]}" \
                     2>&1 | tail -100 || true
             fi
             ;;
@@ -194,7 +208,7 @@ dump_memory_pressure() {
             # OOM killer activations appear in dmesg. The ring buffer is
             # capped, so tail is sufficient.
             if command -v dmesg >/dev/null 2>&1; then
-                dmesg 2>/dev/null | grep -iE 'oom|killed process|out of memory' | tail -50 || true
+                dmesg 2>/dev/null | grep -iE 'OOM|killed process|out of memory' | tail -50 || true
             fi
             ;;
     esac
@@ -260,13 +274,13 @@ dump_api_state() {
 capture_state() {
     local context=$1
     {
-        echo "=== Support bundle for RDD_INSTANCE=${instance} (${context}) at $(date -Iseconds 2>/dev/null || date) ==="
+        echo "=== Support bundle for RDD_INSTANCE=${instance} (${context}) at $(date --iso-8601=seconds 2>/dev/null || date) ==="
         echo "uname: $(uname -a)"
 
         echo
         echo "=== ps ==="
-        # ps auxf is Linux-only; fall back to plain aux on macOS/BSD.
-        ps auxf 2>/dev/null || ps aux 2>&1 || true
+        # `ps --forest` is Linux-only; fall back to without on macOS/BSD.
+        ps aux --forest 2>/dev/null || ps aux 2>&1 || true
 
         echo
         echo "=== Per-process state ==="
@@ -311,12 +325,12 @@ our_leaked_pids() {
         if matches_our_instance "$(cmdline_of "$pid")"; then
             echo "$pid"
         fi
-    done < <(ps -axo pid=,ucomm= 2>/dev/null || ps -eo pid=,ucomm= 2>/dev/null || true)
+    done < <(ps -a -x -o pid=,ucomm= 2>/dev/null || ps -e -o pid=,ucomm= 2>/dev/null || true)
 }
 
 # SIGQUIT Go processes belonging to our RDD_INSTANCE so their goroutine
 # stacks land in the preserved stderr logs. No-op if nothing is leaked.
-sigquit_our_go_leaks() {
+sig_quit_our_go_leaks() {
     local pid
     local leaked
     leaked=$(our_leaked_pids 1)
@@ -338,7 +352,7 @@ sigquit_our_go_leaks() {
 
 # SIGKILL any process still running under our RDD_INSTANCE so the CI
 # runner is clean for later steps. No-op if nothing is leaked.
-sigkill_our_leaks() {
+sig_kill_our_leaks() {
     local pid
     local leaked
     leaked=$(our_leaked_pids 0)
@@ -360,14 +374,14 @@ cmd_pid=$!
 
 # Poll for the deadline or command completion. Must run in the main shell
 # so we can reliably wait for both the dump and the command to finish
-# before exiting (a backgrounded watchdog would be killed mid-dump when
+# before exiting (a background watchdog would be killed mid-dump when
 # the main shell exits).
 deadline=$(($(date +%s) + timeout_seconds))
 while kill -0 "${cmd_pid}" 2>/dev/null; do
     if [ "$(date +%s)" -ge "${deadline}" ]; then
         echo "bats-with-timeout: RDD_INSTANCE=${instance} exceeded ${timeout_seconds}s, capturing support bundle" >&2
         capture_state "timeout"
-        sigquit_our_go_leaks
+        sig_quit_our_go_leaks
         echo "bats-with-timeout: sending SIGTERM to ${cmd_pid}" >&2
         kill -TERM "${cmd_pid}" 2>/dev/null || true
         # Give it 30s to shut down gracefully, then SIGKILL.
@@ -389,10 +403,10 @@ exit_code=0
 wait "${cmd_pid}" || exit_code=$?
 
 # Always capture a post-run bundle so leaked grandchildren get recorded
-# even when the bats target itself succeeded. sigkill_our_leaks cleans up
+# even when the bats target itself succeeded. sig_kill_our_leaks cleans up
 # anything still matching our RDD_INSTANCE so sibling targets aren't
 # confused and the CI runner exits clean.
 capture_state "post-run"
-sigkill_our_leaks
+sig_kill_our_leaks
 
 exit "${exit_code}"

--- a/scripts/check-spelling.sh
+++ b/scripts/check-spelling.sh
@@ -86,6 +86,8 @@ INPUTS=$(yq --output-format=json <<EOF
     use_magic_file: 1
     report-timing: 1
     warnings: $(IFS=,; echo "${warnings[*]}")
+    ignore-next-line: |
+        no-spell-check-next-line
     use_sarif: ${CI:-0}
     extra_dictionary_limit: 20
     extra_dictionaries:


### PR DESCRIPTION
This fixes CI to actually fail on spelling errors; the second commit then fixes all of the cases we have.