### PR TITLE
api: containers: make ContainerPort.Bindings optional

### DIFF
--- a/bats/tests/32-app-controllers/engine-docker.bats
+++ b/bats/tests/32-app-controllers/engine-docker.bats
@@ -170,6 +170,44 @@ do_websocket() { # endpoint
         container/"${cid}" --timeout=30s
 }
 
+@test "ports mirror with and without host bindings" {
+    # nginx has EXPOSE 80 in its Dockerfile. Running it without -p
+    # yields NetworkSettings.Ports={"80/tcp":null} — an exposed but
+    # unpublished port. Running it with -p 80 adds IPv4 and IPv6 host
+    # bindings. The mirror must surface both cases: the port name
+    # always appears, and bindings appear only when the port is
+    # published.
+    run_e -0 docker run -d --name test-exposed nginx
+    exposed_cid=${output}
+    run_e -0 docker run -d --name test-published -p 80 nginx
+    published_cid=${output}
+
+    rdd ctl wait --for=jsonpath='{.status.status}'=running \
+        --namespace="${RDD_NAMESPACE}" container/"${exposed_cid}" --timeout=30s
+    rdd ctl wait --for=jsonpath='{.status.status}'=running \
+        --namespace="${RDD_NAMESPACE}" container/"${published_cid}" --timeout=30s
+
+    # Both mirrors list the exposed port by name.
+    run -0 rdd ctl get container "${exposed_cid}" --namespace="${RDD_NAMESPACE}" \
+        -o jsonpath='{.status.ports[*].name}'
+    assert_output "80/tcp"
+    run -0 rdd ctl get container "${published_cid}" --namespace="${RDD_NAMESPACE}" \
+        -o jsonpath='{.status.ports[*].name}'
+    assert_output "80/tcp"
+
+    # Unpublished: no bindings.
+    run -0 rdd ctl get container "${exposed_cid}" --namespace="${RDD_NAMESPACE}" \
+        -o jsonpath='{.status.ports[?(@.name=="80/tcp")].bindings[*].hostPort}'
+    refute_output
+
+    # Published: at least one binding.
+    run -0 rdd ctl get container "${published_cid}" --namespace="${RDD_NAMESPACE}" \
+        -o jsonpath='{.status.ports[?(@.name=="80/tcp")].bindings[*].hostPort}'
+    assert_output
+
+    docker rm --force test-exposed test-published
+}
+
 # --- Container logs ---
 
 @test "docker logs for container with tty" {

--- a/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/containerport.go
+++ b/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/containerport.go
@@ -9,8 +9,8 @@ package v1alpha1
 type ContainerPortApplyConfiguration struct {
 	// Name of the port; in the form [port]/[protocol], e.g. "80/tcp".
 	Name *string `json:"name,omitempty"`
-	// Bindings to the host port; can contain multiple entries to e.g. express
-	// IPv4 and IPv6 bindings.
+	// Bindings to the host port; empty for an exposed but unpublished port,
+	// otherwise one entry per binding (e.g. IPv4 and IPv6).
 	Bindings []ContainerPortBindingApplyConfiguration `json:"bindings,omitempty"`
 }
 

--- a/pkg/apis/containers/v1alpha1/container_types.go
+++ b/pkg/apis/containers/v1alpha1/container_types.go
@@ -115,11 +115,11 @@ type ContainerPort struct {
 	//
 	// +required
 	Name string `json:"name"`
-	// Bindings to the host port; can contain multiple entries to e.g. express
-	// IPv4 and IPv6 bindings.
+	// Bindings to the host port; empty for an exposed but unpublished port,
+	// otherwise one entry per binding (e.g. IPv4 and IPv6).
 	//
-	// +required
-	Bindings []ContainerPortBinding `json:"bindings"`
+	// +optional
+	Bindings []ContainerPortBinding `json:"bindings,omitempty"`
 }
 
 // ContainerSpec is currently empty. Actions are requested via the AnnotationAction

--- a/pkg/controllers/containers/container/crd.yaml
+++ b/pkg/controllers/containers/container/crd.yaml
@@ -86,8 +86,8 @@ spec:
                   properties:
                     bindings:
                       description: |-
-                        Bindings to the host port; can contain multiple entries to e.g. express
-                        IPv4 and IPv6 bindings.
+                        Bindings to the host port; empty for an exposed but unpublished port,
+                        otherwise one entry per binding (e.g. IPv4 and IPv6).
                       items:
                         description: ContainerPortBinding describes one host port
                           for the container to bind to.
@@ -110,7 +110,6 @@ spec:
                         e.g. "80/tcp".
                       type: string
                   required:
-                  - bindings
                   - name
                   type: object
                 type: array
@@ -442,8 +441,8 @@ spec:
                   properties:
                     bindings:
                       description: |-
-                        Bindings to the host port; can contain multiple entries to e.g. express
-                        IPv4 and IPv6 bindings.
+                        Bindings to the host port; empty for an exposed but unpublished port,
+                        otherwise one entry per binding (e.g. IPv4 and IPv6).
                       items:
                         description: ContainerPortBinding describes one host port
                           for the container to bind to.
@@ -466,7 +465,6 @@ spec:
                         e.g. "80/tcp".
                       type: string
                   required:
-                  - bindings
                   - name
                   type: object
                 type: array


### PR DESCRIPTION
- Flip `ContainerPort.Bindings` from `+required` to `+optional` so the Container mirror can surface exposed but unpublished ports (e.g. nginx's `EXPOSE 80` without `-p` at runtime). Docker returns these as `NetworkSettings.Ports={"80/tcp":null}`; the engine emits a `ContainerPort` with an empty `bindings` slice, which the prior schema rejected under SSA, leaving the mirror frozen at `status=created`.

- The `Ports` field already documents itself as "exposed ports of the container", so requiring bindings on each entry contradicted the documented intent. Clients wanting only published ports can filter by `len(bindings) > 0`.

- Regenerate CRD yaml + apply configuration.