### PR TITLE
Windows Docker Socket Forwarding via Socket Bridge

### DIFF
--- a/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
+++ b/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
@@ -24,6 +24,8 @@ import (
 	"github.com/linuxkit/virtsock/pkg/hvsock"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/socketbridge"
 )
 
 // hostSwitchPlatform holds the host-switch state for Windows. On non-Windows
@@ -160,7 +162,7 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 		return
 	}
 
-	ln, err := vsockHandshake(ctx, logger)
+	ln, vmGUID, err := vsockHandshake(ctx, logger)
 	if err != nil {
 		logger.Error(err, "Vsock handshake failed")
 		return
@@ -189,6 +191,18 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 	mux.Handle("/services/forwarder/unexpose", vn.Mux())
 
 	g, ctx := errgroup.WithContext(ctx)
+
+	// Start the host-side socket bridge now that we have the VM GUID.
+	// It listens on the Docker named pipe and forwards each connection to
+	// rdd-guest inside the VM via vsock port 6660.  rdd-guest is baked into
+	// the VM image (via rancher-desktop-opensuse) and started by systemd.
+	g.Go(func() error {
+		bridge := socketbridge.NewDockerHostBridge(vmGUID, logger)
+		if err := bridge.Run(ctx); err != nil {
+			logger.Error(err, "Socket bridge exited with error")
+		}
+		return nil
+	})
 
 	// Accept vsock connections and feed them into the virtual network.
 	g.Go(func() error {
@@ -278,28 +292,28 @@ func newVirtualNetworkConfig(subnet hostSwitchSubnet) types.Configuration {
 
 // vsockHandshake discovers the WSL2 VM via AF_VSOCK, exchanges a signature
 // to verify identity, and returns a listener on the data port.
-func vsockHandshake(ctx context.Context, logger logr.Logger) (net.Listener, error) {
+func vsockHandshake(ctx context.Context, logger logr.Logger) (net.Listener, hvsock.GUID, error) {
 	hsCtx, hsCancel := context.WithTimeout(ctx, handshakeTimeout)
 	defer hsCancel()
 
 	vmGUID, err := getVMGUID(hsCtx, logger)
 	if err != nil {
-		return nil, fmt.Errorf("VM GUID discovery failed: %w", err)
+		return nil, hvsock.GUIDZero, fmt.Errorf("VM GUID discovery failed: %w", err)
 	}
 
 	logger.Info("Handshake succeeded", "vmGUID", vmGUID.String())
 
 	ln, err := vsockListen(vmGUID, vsockListenPort)
 	if err != nil {
-		return nil, fmt.Errorf("vsock listen on port %d failed: %w", vsockListenPort, err)
+		return nil, hvsock.GUIDZero, fmt.Errorf("vsock listen on port %d failed: %w", vsockListenPort, err)
 	}
 
 	if err := signalListenerReady(hsCtx, vmGUID); err != nil {
 		ln.Close()
-		return nil, fmt.Errorf("sending %s signal failed: %w", readySignal, err)
+		return nil, hvsock.GUIDZero, fmt.Errorf("sending %s signal failed: %w", readySignal, err)
 	}
 
-	return ln, nil
+	return ln, vmGUID, nil
 }
 
 // getVMGUID discovers the Hyper-V VM running our distro by polling the

--- a/pkg/socketbridge/host_windows.go
+++ b/pkg/socketbridge/host_windows.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build windows
+
+package socketbridge
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/go-logr/logr"
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+)
+
+const (
+	// DockerPipeName is the well-known Windows named pipe that Docker CLI
+	// and Docker Desktop use to reach dockerd.
+	DockerPipeName = `\\.\pipe\docker_engine`
+
+	// VsockForwardPort is the AF_VSOCK port that rdd-guest listens on inside
+	// the Lima VM.  Must match the constant in cmd/rdd-guest/main.go.
+	VsockForwardPort uint32 = 6660
+)
+
+// HostBridge listens on a Windows named pipe and forwards each accepted
+// connection to the guest via Hyper-V vsock.
+type HostBridge struct {
+	pipeName  string
+	vmGUID    hvsock.GUID
+	vsockPort uint32
+	log       logr.Logger
+}
+
+// NewDockerHostBridge creates a HostBridge that forwards the Docker named pipe
+// to the guest vsock agent.
+func NewDockerHostBridge(vmGUID hvsock.GUID, log logr.Logger) *HostBridge {
+	return &HostBridge{
+		pipeName:  DockerPipeName,
+		vmGUID:    vmGUID,
+		vsockPort: VsockForwardPort,
+		log:       log.WithName("socket-bridge"),
+	}
+}
+
+// Run listens for named-pipe connections and proxies them to the guest until
+// ctx is cancelled.
+func (b *HostBridge) Run(ctx context.Context) error {
+	ln, err := winio.ListenPipe(b.pipeName, nil)
+	if err != nil {
+		return fmt.Errorf("socket-bridge: listen on %s: %w", b.pipeName, err)
+	}
+	b.log.Info("Listening", "pipe", b.pipeName, "vsockPort", b.vsockPort)
+
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil // normal shutdown
+			}
+			return fmt.Errorf("socket-bridge: accept: %w", err)
+		}
+		go b.handleConn(conn)
+	}
+}
+
+// TODO: once rancher-desktop-daemon is public, consolidate with the guest-side
+// handleConn in rancher-desktop-opensuse/src/rdd-guest/main.go by importing
+// pkg/socketbridge directly instead of inlining the proxy logic.
+func (b *HostBridge) handleConn(pipeConn net.Conn) {
+	defer pipeConn.Close()
+
+	vsockConn, err := dialVsock(b.vmGUID, b.vsockPort)
+	if err != nil {
+		b.log.Error(err, "Failed to dial vsock", "port", b.vsockPort)
+		return
+	}
+
+	// Attempt half-close path first; fall back to plain bidirectional copy if
+	// either side does not implement CloseWrite (both named-pipe and vsock
+	// connections normally do, but the net.Conn interface does not guarantee it).
+	hc1, ok1 := pipeConn.(HalfCloser)
+	hc2, ok2 := vsockConn.(HalfCloser)
+	if ok1 && ok2 {
+		if err := Pipe(hc1, hc2); err != nil {
+			b.log.Error(err, "Pipe error")
+		}
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		io.Copy(pipeConn, vsockConn)
+		pipeConn.Close()
+	}()
+	io.Copy(vsockConn, pipeConn)
+	vsockConn.Close()
+	<-done
+}
+
+// dialVsock dials a Hyper-V vsock connection to the given VM and port.
+// Mirrors getVsockConnection in hostswitch_windows.go.
+func dialVsock(vmGUID hvsock.GUID, port uint32) (net.Conn, error) {
+	svcPort, err := hvsock.GUIDFromString(winio.VsockServiceID(port).String())
+	if err != nil {
+		return nil, fmt.Errorf("vsock service ID for port %d: %w", port, err)
+	}
+	return hvsock.Dial(hvsock.Addr{VMID: vmGUID, ServiceID: svcPort})
+}

--- a/pkg/socketbridge/host_windows.go
+++ b/pkg/socketbridge/host_windows.go
@@ -73,9 +73,6 @@ func (b *HostBridge) Run(ctx context.Context) error {
 	}
 }
 
-// TODO: once rancher-desktop-daemon is public, consolidate with the guest-side
-// handleConn in rancher-desktop-opensuse/src/rdd-guest/main.go by importing
-// pkg/socketbridge directly instead of inlining the proxy logic.
 func (b *HostBridge) handleConn(pipeConn net.Conn) {
 	defer pipeConn.Close()
 
@@ -100,10 +97,14 @@ func (b *HostBridge) handleConn(pipeConn net.Conn) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		io.Copy(pipeConn, vsockConn)
+		if _, err := io.Copy(pipeConn, vsockConn); err != nil {
+			b.log.Error(err, "Copy vsock→pipe error")
+		}
 		pipeConn.Close()
 	}()
-	io.Copy(vsockConn, pipeConn)
+	if _, err := io.Copy(vsockConn, pipeConn); err != nil {
+		b.log.Error(err, "Copy pipe→vsock error")
+	}
 	vsockConn.Close()
 	<-done
 }

--- a/pkg/socketbridge/proxy.go
+++ b/pkg/socketbridge/proxy.go
@@ -8,6 +8,7 @@
 package socketbridge
 
 import (
+	"errors"
 	"io"
 	"sync"
 )
@@ -34,7 +35,7 @@ func Pipe(c1, c2 HalfCloser) error {
 	var mu sync.Mutex
 
 	record := func(err error) {
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			mu.Lock()
 			if firstErr == nil {
 				firstErr = err
@@ -43,7 +44,7 @@ func Pipe(c1, c2 HalfCloser) error {
 		}
 	}
 
-	copy := func(dst, src HalfCloser) {
+	forward := func(dst, src HalfCloser) {
 		defer wg.Done()
 		_, err := io.Copy(dst, src)
 		record(err)
@@ -52,8 +53,8 @@ func Pipe(c1, c2 HalfCloser) error {
 	}
 
 	wg.Add(2)
-	go copy(c1, c2)
-	go copy(c2, c1)
+	go forward(c1, c2)
+	go forward(c2, c1)
 	wg.Wait()
 
 	c1.Close()

--- a/pkg/socketbridge/proxy.go
+++ b/pkg/socketbridge/proxy.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package socketbridge provides a raw bidirectional byte proxy used to forward
+// a host-side socket to a guest-side socket across a transport boundary (e.g.
+// AF_VSOCK on Windows/Hyper-V).
+package socketbridge
+
+import (
+	"io"
+	"sync"
+)
+
+// HalfCloser is implemented by connections that support half-close semantics
+// (e.g. net.TCPConn, named-pipe connections, vsock connections).  When one
+// direction reaches EOF the write side of the peer connection is closed so the
+// remote end receives a clean EOF rather than waiting forever.
+type HalfCloser interface {
+	io.ReadWriteCloser
+	// CloseWrite shuts down the write side of the connection without closing
+	// the read side.
+	CloseWrite() error
+}
+
+// Pipe copies data bidirectionally between c1 and c2 until both directions are
+// done.  When a read from one side returns io.EOF (or any error), the write
+// side of the other connection is half-closed so the remote peer gets a clean
+// EOF.  Pipe blocks until both copy goroutines have exited and then closes
+// both connections.
+func Pipe(c1, c2 HalfCloser) error {
+	var wg sync.WaitGroup
+	var firstErr error
+	var mu sync.Mutex
+
+	record := func(err error) {
+		if err != nil && err != io.EOF {
+			mu.Lock()
+			if firstErr == nil {
+				firstErr = err
+			}
+			mu.Unlock()
+		}
+	}
+
+	copy := func(dst, src HalfCloser) {
+		defer wg.Done()
+		_, err := io.Copy(dst, src)
+		record(err)
+		// Half-close the write side of dst so the remote peer sees EOF.
+		record(dst.CloseWrite())
+	}
+
+	wg.Add(2)
+	go copy(c1, c2)
+	go copy(c2, c1)
+	wg.Wait()
+
+	c1.Close()
+	c2.Close()
+	return firstErr
+}

--- a/pkg/socketbridge/proxy_test.go
+++ b/pkg/socketbridge/proxy_test.go
@@ -8,31 +8,48 @@ import (
 	"io"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/socketbridge"
 )
 
 // splitConn wraps separate read/write ends so the external test code and the
-// Pipe function each own one side of the IO.  It is meant to satisfy HalfCloser functionality.
+// Pipe function each own one side of the IO.  It satisfies HalfCloser.
 //
-// How the test is layed out (a and b are two individual and unrelated connections):
+// How the test is laid out (a and b are two separate, unrelated connections):
 //
-//	external→aIn_w  [pipe1]  aIn_r→a.Read   Pipe copies→  b.Write→bOut_w  [pipe3]  bOut_r→external
-//	external→bIn_w  [pipe2]  bIn_r→b.Read   Pipe copies→  a.Write→aOut_w  [pipe4]  aOut_r→external
+//	external→aIn  [pipe1]  a.Read   Pipe copies→  b.Write→bOut  [pipe3]  bOut→external
+//	external→bIn  [pipe2]  b.Read   Pipe copies→  a.Write→aOut  [pipe4]  aOut→external
 type splitConn struct {
-	r          *io.PipeReader
-	w          *io.PipeWriter
-	writeDone  bool
+	r         *io.PipeReader
+	w         *io.PipeWriter
+	writeDone bool
 }
 
-func newSplitConnPair() (a, b *splitConn, aIn, bIn *io.PipeWriter, aOut, bOut *io.PipeReader) {
-	aIn_r, aIn_w := io.Pipe()
-	bIn_r, bIn_w := io.Pipe()
-	aOut_r, aOut_w := io.Pipe()
-	bOut_r, bOut_w := io.Pipe()
+// splitConnPair bundles the two splitConns and their exposed pipe ends so
+// callers avoid functions with more than five return values.
+type splitConnPair struct {
+	A, B *splitConn
+	AIn  *io.PipeWriter
+	BIn  *io.PipeWriter
+	AOut *io.PipeReader
+	BOut *io.PipeReader
+}
 
-	a = &splitConn{r: aIn_r, w: aOut_w}
-	b = &splitConn{r: bIn_r, w: bOut_w}
-	return a, b, aIn_w, bIn_w, aOut_r, bOut_r
+func newSplitConnPair() splitConnPair {
+	aInR, aInW := io.Pipe()
+	bInR, bInW := io.Pipe()
+	aOutR, aOutW := io.Pipe()
+	bOutR, bOutW := io.Pipe()
+
+	return splitConnPair{
+		A:    &splitConn{r: aInR, w: aOutW},
+		B:    &splitConn{r: bInR, w: bOutW},
+		AIn:  aInW,
+		BIn:  bInW,
+		AOut: aOutR,
+		BOut: bOutR,
+	}
 }
 
 func (c *splitConn) Read(p []byte) (int, error)  { return c.r.Read(p) }
@@ -45,6 +62,7 @@ func (c *splitConn) Close() error {
 	}
 	return werr
 }
+
 func (c *splitConn) CloseWrite() error {
 	if c.writeDone {
 		return nil
@@ -54,64 +72,53 @@ func (c *splitConn) CloseWrite() error {
 }
 
 func TestPipe_BidirectionalData(t *testing.T) {
-	a, b, aIn, bIn, aOut, bOut := newSplitConnPair()
+	p := newSplitConnPair()
 
 	pipeDone := make(chan error, 1)
-	go func() { pipeDone <- socketbridge.Pipe(a, b) }()
+	go func() { pipeDone <- socketbridge.Pipe(p.A, p.B) }()
 
 	const fromA = "hello from A side"
 	const fromB = "reply from B side"
 
-	// Write to a's input should emerge from b's output.
+	// Write to A's input; should emerge from B's output.
 	go func() {
-		if _, err := aIn.Write([]byte(fromA)); err != nil {
-			t.Errorf("writing to aIn: %v", err)
+		if _, err := p.AIn.Write([]byte(fromA)); err != nil {
+			t.Errorf("writing to AIn: %v", err)
 		}
-		aIn.Close()
+		p.AIn.Close()
 	}()
 
 	got := make([]byte, len(fromA))
-	if _, err := io.ReadFull(bOut, got); err != nil {
-		t.Fatalf("reading from bOut: %v", err)
-	}
-	if string(got) != fromA {
-		t.Errorf("bOut got %q, want %q", got, fromA)
-	}
+	_, err := io.ReadFull(p.BOut, got)
+	assert.NilError(t, err)
+	assert.Equal(t, string(got), fromA)
 
-	// Write to b's input should emerge from a's output.
+	// Write to B's input; should emerge from A's output.
 	go func() {
-		if _, err := bIn.Write([]byte(fromB)); err != nil {
-			t.Errorf("writing to bIn: %v", err)
+		if _, err := p.BIn.Write([]byte(fromB)); err != nil {
+			t.Errorf("writing to BIn: %v", err)
 		}
-		bIn.Close()
+		p.BIn.Close()
 	}()
 
 	got2 := make([]byte, len(fromB))
-	if _, err := io.ReadFull(aOut, got2); err != nil {
-		t.Fatalf("reading from aOut: %v", err)
-	}
-	if string(got2) != fromB {
-		t.Errorf("aOut got %q, want %q", got2, fromB)
-	}
+	_, err = io.ReadFull(p.AOut, got2)
+	assert.NilError(t, err)
+	assert.Equal(t, string(got2), fromB)
 
-	if err := <-pipeDone; err != nil {
-		t.Errorf("Pipe returned unexpected error: %v", err)
-	}
+	assert.NilError(t, <-pipeDone)
 }
 
 func TestPipe_HalfClose(t *testing.T) {
-	// Verify Pipe completes cleanly with no errors when both input sides are closed without
-	// writing any data, EOF should propagate via CloseWrite to the other side.
-	a, b, aIn, bIn, _, _ := newSplitConnPair()
+	// Verify Pipe completes cleanly when both input sides are closed without
+	// writing any data; EOF propagates via CloseWrite to the other side.
+	p := newSplitConnPair()
 
 	pipeDone := make(chan error, 1)
-	go func() { pipeDone <- socketbridge.Pipe(a, b) }()
+	go func() { pipeDone <- socketbridge.Pipe(p.A, p.B) }()
 
-	aIn.Close()
-	bIn.Close()
+	p.AIn.Close()
+	p.BIn.Close()
 
-	if err := <-pipeDone; err != nil {
-		t.Errorf("Pipe returned unexpected error: %v", err)
-	}
+	assert.NilError(t, <-pipeDone)
 }
-

--- a/pkg/socketbridge/proxy_test.go
+++ b/pkg/socketbridge/proxy_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package socketbridge_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/socketbridge"
+)
+
+// splitConn wraps separate read/write ends so the external test code and the
+// Pipe function each own one side of the IO.  It is meant to satisfy HalfCloser functionality.
+//
+// How the test is layed out (a and b are two individual and unrelated connections):
+//
+//	external→aIn_w  [pipe1]  aIn_r→a.Read   Pipe copies→  b.Write→bOut_w  [pipe3]  bOut_r→external
+//	external→bIn_w  [pipe2]  bIn_r→b.Read   Pipe copies→  a.Write→aOut_w  [pipe4]  aOut_r→external
+type splitConn struct {
+	r          *io.PipeReader
+	w          *io.PipeWriter
+	writeDone  bool
+}
+
+func newSplitConnPair() (a, b *splitConn, aIn, bIn *io.PipeWriter, aOut, bOut *io.PipeReader) {
+	aIn_r, aIn_w := io.Pipe()
+	bIn_r, bIn_w := io.Pipe()
+	aOut_r, aOut_w := io.Pipe()
+	bOut_r, bOut_w := io.Pipe()
+
+	a = &splitConn{r: aIn_r, w: aOut_w}
+	b = &splitConn{r: bIn_r, w: bOut_w}
+	return a, b, aIn_w, bIn_w, aOut_r, bOut_r
+}
+
+func (c *splitConn) Read(p []byte) (int, error)  { return c.r.Read(p) }
+func (c *splitConn) Write(p []byte) (int, error) { return c.w.Write(p) }
+func (c *splitConn) Close() error {
+	rerr := c.r.Close()
+	werr := c.w.Close()
+	if rerr != nil {
+		return rerr
+	}
+	return werr
+}
+func (c *splitConn) CloseWrite() error {
+	if c.writeDone {
+		return nil
+	}
+	c.writeDone = true
+	return c.w.Close()
+}
+
+func TestPipe_BidirectionalData(t *testing.T) {
+	a, b, aIn, bIn, aOut, bOut := newSplitConnPair()
+
+	pipeDone := make(chan error, 1)
+	go func() { pipeDone <- socketbridge.Pipe(a, b) }()
+
+	const fromA = "hello from A side"
+	const fromB = "reply from B side"
+
+	// Write to a's input should emerge from b's output.
+	go func() {
+		if _, err := aIn.Write([]byte(fromA)); err != nil {
+			t.Errorf("writing to aIn: %v", err)
+		}
+		aIn.Close()
+	}()
+
+	got := make([]byte, len(fromA))
+	if _, err := io.ReadFull(bOut, got); err != nil {
+		t.Fatalf("reading from bOut: %v", err)
+	}
+	if string(got) != fromA {
+		t.Errorf("bOut got %q, want %q", got, fromA)
+	}
+
+	// Write to b's input should emerge from a's output.
+	go func() {
+		if _, err := bIn.Write([]byte(fromB)); err != nil {
+			t.Errorf("writing to bIn: %v", err)
+		}
+		bIn.Close()
+	}()
+
+	got2 := make([]byte, len(fromB))
+	if _, err := io.ReadFull(aOut, got2); err != nil {
+		t.Fatalf("reading from aOut: %v", err)
+	}
+	if string(got2) != fromB {
+		t.Errorf("aOut got %q, want %q", got2, fromB)
+	}
+
+	if err := <-pipeDone; err != nil {
+		t.Errorf("Pipe returned unexpected error: %v", err)
+	}
+}
+
+func TestPipe_HalfClose(t *testing.T) {
+	// Verify Pipe completes cleanly with no errors when both input sides are closed without
+	// writing any data, EOF should propagate via CloseWrite to the other side.
+	a, b, aIn, bIn, _, _ := newSplitConnPair()
+
+	pipeDone := make(chan error, 1)
+	go func() { pipeDone <- socketbridge.Pipe(a, b) }()
+
+	aIn.Close()
+	bIn.Close()
+
+	if err := <-pipeDone; err != nil {
+		t.Errorf("Pipe returned unexpected error: %v", err)
+	}
+}
+


### PR DESCRIPTION
On Windows (WSL2/Hyper-V), there was no path for the Docker CLI to reach dockerd inside the Lima VM. The Docker CLI on Windows expects `npipe://./pipe/docker_engine`, but nothing was listening on that pipe, and no forwarding existed between the host and the VM. macOS/Linux already works via Lima's built-in SSH portForwards.

To tackle this, the following solution is done as part of this PR:

A thin, raw TCP socket bridge composed of two parts:

  Host side (this PR) — a new HostBridge that runs inside the host-switch goroutine (which already has the Hyper-V VM GUID from the vsock handshake):

   - Listens on `\\.\pipe\docker_engine`
   - For each connection, dials vsock port 6660 to the VM
   - Proxies raw bytes bidirectionally with half-close semantics

  Guest side — a new rdd-guest binary (built and deployed via rancher-desktop-opensuse):

   - Listens on `AF_VSOCK` port 6660 inside the VM
   - Forwards each connection to `/var/run/docker.sock`
   - Started by systemd as part of rancher-desktop.target

Because the bridge operates at the raw byte level (not HTTP), `docker exec -it` and `docker logs -f` work correctly without any HTTP 101 upgrade handling, the stream is transparent.

Fixes: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/157