### PR TITLE
engine: fix dockerclient → mobyclient in docker_watcher

### DIFF
--- a/pkg/controllers/app/engine/controllers/docker_watcher.go
+++ b/pkg/controllers/app/engine/controllers/docker_watcher.go
@@ -461,7 +461,7 @@ func (w *dockerWatcher) dispatchContainerAction(ctx context.Context, log logr.Lo
 }
 
 func (w *dockerWatcher) hasTTY(ctx context.Context, c *containersv1alpha1.Container) (bool, error) {
-	inspect, err := w.cli.ContainerInspect(ctx, c.Name, dockerclient.ContainerInspectOptions{})
+	inspect, err := w.cli.ContainerInspect(ctx, c.Name, mobyclient.ContainerInspectOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -478,7 +478,7 @@ func (w *dockerWatcher) getLogs(ctx context.Context, c *containersv1alpha1.Conta
 		opt(options)
 	}
 
-	return w.cli.ContainerLogs(ctx, c.Name, dockerclient.ContainerLogsOptions{
+	return w.cli.ContainerLogs(ctx, c.Name, mobyclient.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     options.follow,


### PR DESCRIPTION
The merge of PR #323 left two references to a `dockerclient` import alias that does not exist in this file; the rest of the file uses `mobyclient`. Build of `pkg/controllers/app/engine/controllers` was broken on main as a result.