### PR TITLE
service: keep discovery configmap through shutdown

### DIFF
--- a/docs/design/discovery.md
+++ b/docs/design/discovery.md
@@ -38,7 +38,7 @@ The ConfigMap is named `rdd-controller-manager` in the `rdd-system` namespace. E
 
 The control plane creates the ConfigMap with an empty `data` map as soon as the API server is ready, before any controller manager starts. Its `creationTimestamp` therefore marks the control plane start time, which [`rdd ctl await --since=startup`](cmd_service.md) uses to filter condition transitions.
 
-A controller manager patches the ConfigMap on startup (adding its API group key) and removes the key on shutdown. The ConfigMap itself is owned by the control plane: only the control plane creates or deletes it. The control plane recreates it on startup (dropping any stale entries from a previous crash) and deletes it on shutdown.
+A controller manager patches the ConfigMap on startup (adding its API group key) and removes the key on shutdown. The ConfigMap itself is owned by the control plane: only the control plane creates or replaces it. The control plane recreates it on startup, dropping any stale entries from a previous crash. Shutdown does not delete the ConfigMap; while the daemon is still serving, concurrent clients can continue to use the last published discovery data, and the next startup is responsible for clearing stale state.
 
 ## Ready annotation
 

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -346,9 +346,6 @@ func StopWithWait(wait bool) error {
 		return fmt.Errorf("%q control plane is not running", instance.Name())
 	}
 
-	// Clean up discovery configmap while cluster is still accessible
-	_ = cleanupDiscoveryConfigMap() // Clean up discovery configmap to prevent stale controller info
-
 	pid := PID()
 	// Try graceful shutdown first. On Unix, Kill already sends SIGTERM which
 	// triggers the Go signal handler. On Windows, Kill uses TerminateProcess
@@ -403,29 +400,6 @@ func StopWithWait(wait bool) error {
 func Stop() error {
 	// For backward compatibility, always wait
 	return StopWithWait(true)
-}
-
-// cleanupDiscoveryConfigMap removes the discovery configmap to prevent readiness check confusion.
-func cleanupDiscoveryConfigMap() error {
-	// Try to get kubeconfig, but ignore errors since control plane might be stopped
-	config, err := GetKubeRestConfig()
-	if err != nil {
-		logrus.WithError(err).Debug("Could not get kubeconfig for discovery cleanup, control plane likely stopped")
-		return nil // Not an error, just means control plane is already stopped
-	}
-
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		logrus.WithError(err).Debug("Could not create kubernetes client for discovery cleanup")
-		return nil // Not a critical error during shutdown
-	}
-
-	err = controllers.CleanupDiscovery(context.TODO(), client)
-	if err != nil {
-		logrus.WithError(err).Debug("Failed to delete discovery configmap")
-	}
-
-	return nil // Don't fail stop operation due to discovery cleanup issues
 }
 
 // Delete the service and remove all instance data.

--- a/pkg/service/controllers/discovery.go
+++ b/pkg/service/controllers/discovery.go
@@ -185,7 +185,7 @@ func (d *ControllerManagerDiscoveryGroup) registerControllerManagerImpl(ctx cont
 
 // UnregisterControllerManager removes this controller manager's data entry
 // from the discovery ConfigMap. The ConfigMap itself is owned by the control
-// plane; only [InitDiscovery] and [CleanupDiscovery] create or delete it.
+// plane and only [InitDiscovery] creates or replaces it.
 func (d *ControllerManagerDiscoveryGroup) UnregisterControllerManager(ctx context.Context) error {
 	patchData, err := json.Marshal(map[string]any{
 		"data": map[string]any{
@@ -426,22 +426,5 @@ func MarkControlPlaneReady(ctx context.Context, client kubernetes.Interface) err
 	klog.FromContext(ctx).Info("Marked control plane as ready",
 		"namespace", RDDSystemNamespace,
 		"configmap", ControllerManagerConfigMapName)
-	return nil
-}
-
-// CleanupDiscovery deletes the controller manager discovery ConfigMap.
-func CleanupDiscovery(ctx context.Context, client *kubernetes.Clientset) error {
-	err := client.CoreV1().ConfigMaps(RDDSystemNamespace).Delete(ctx, ControllerManagerConfigMapName, metav1.DeleteOptions{})
-	if errors.IsNotFound(err) {
-		return nil // Already deleted, no error
-	}
-	if err != nil {
-		return fmt.Errorf("failed to delete controller manager configmap: %w", err)
-	}
-
-	klog.FromContext(ctx).Info("Cleaned up stale controller manager discovery configmap",
-		"namespace", RDDSystemNamespace,
-		"configmap", ControllerManagerConfigMapName)
-
 	return nil
 }


### PR DESCRIPTION
The discovery ConfigMap is recreated on service startup by `InitDiscovery`, which deletes stale data before any controller managers register. Deleting the ConfigMap during shutdown creates a window where the API server can still be serving but concurrent clients lose discovery data.

Stop deleting the discovery ConfigMap from the CLI stop path. Unregister still removes each controller manager's entry, but startup remains the single place that replaces the whole ConfigMap. Update the discovery docs to match.