### PR TITLE
rdd kubectl: embed kuberlr-style version resolver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,9 @@ updates:
   cooldown:
     default-days: 7
 - package-ecosystem: gomod
-  directory: /
+  directories:
+  - /
+  - /bats/tests/10-cli/fake-kube
   schedule:
     interval: daily
   cooldown:

--- a/bats/helpers/os.bash
+++ b/bats/helpers/os.bash
@@ -96,11 +96,26 @@ sudo_needs_password() {
 # Cross-platform process management.
 # MSYS2's kill cannot reach Win32 processes, so use taskkill.exe on Windows.
 
+# Translate an MSYS PID to its Win32 PID. taskkill and tasklist filter
+# on the Win32 PID, but $! in MSYS bash returns the MSYS PID, and the
+# two differ for native Win32 children. /proc/<pid>/winpid holds the
+# mapping; outside MSYS the PID is already a Win32 PID.
+winpid() {
+    local pid=$1
+    if is_msys && [[ -r /proc/${pid}/winpid ]]; then
+        cat "/proc/${pid}/winpid"
+    else
+        printf '%s' "${pid}"
+    fi
+}
+
 # Check if a process is alive. Returns 0 if alive, non-zero otherwise.
 assert_process_alive() {
-    local pid=$1
+    local pid wpid
+    pid=$1
     if is_windows; then
-        MSYS_NO_PATHCONV=1 tasklist.exe /FI "PID eq ${pid}" /NH 2>/dev/null | grep -qw "${pid}"
+        wpid=$(winpid "${pid}")
+        MSYS_NO_PATHCONV=1 tasklist.exe /FI "PID eq ${wpid}" /NH 2>/dev/null | grep -qw "${wpid}"
     else
         kill -0 "${pid}" 2>/dev/null
     fi
@@ -108,9 +123,11 @@ assert_process_alive() {
 
 # Send SIGKILL (or TerminateProcess on Windows) to a process.
 process_kill() {
-    local pid=$1
+    local pid wpid
+    pid=$1
     if is_windows; then
-        MSYS_NO_PATHCONV=1 taskkill.exe /PID "${pid}" /F >/dev/null 2>&1
+        wpid=$(winpid "${pid}")
+        MSYS_NO_PATHCONV=1 taskkill.exe /PID "${wpid}" /F >/dev/null 2>&1
     else
         kill -9 "${pid}"
     fi

--- a/bats/helpers/paths.bash
+++ b/bats/helpers/paths.bash
@@ -6,6 +6,21 @@ inside_repo_clone() {
     [[ -d "${PATH_REPO_ROOT}/pkg/rancher-desktop-daemon" ]]
 }
 
+# winpath converts a POSIX path to its Windows-native equivalent
+# (/tmp/x -> C:\msys64\tmp\x on MSYS, /mnt/c/tmp/x -> C:\tmp\x on WSL).
+# Use it for env vars and args that reach a native Windows binary
+# without traversing the rdd() function's conversions. Returns its
+# input unchanged on Linux and macOS.
+winpath() {
+    if is_msys; then
+        cygpath -w "$1"
+    elif is_windows && using_windows_exe; then
+        wslpath -w "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
+
 # Convert 'export KEY="C:\win\path"' to POSIX paths (WSL or MSYS2).
 win_to_posix_exports() {
     tr -d "\r" | while IFS= read -r line; do

--- a/bats/tests/10-cli/5-paths.bats
+++ b/bats/tests/10-cli/5-paths.bats
@@ -1,6 +1,6 @@
 load '../../helpers/load'
 
-ALL_KEYS="args_file config dir lima_home log_dir pid_file short_dir tls_dir"
+ALL_KEYS="args_file cache_dir config dir docker_socket kubectl_cache lima_home log_dir pid_file short_dir tls_dir"
 
 @test 'rdd svc paths prints all keys in table format' {
     run -0 rdd svc paths
@@ -37,4 +37,15 @@ ALL_KEYS="args_file config dir lima_home log_dir pid_file short_dir tls_dir"
     assert_output --partial 'unknown key'
     assert_output --partial 'no_such_key'
     assert_output --partial 'valid keys'
+}
+
+@test 'rdd svc paths honors RDD_CACHE_DIR override' {
+    cache_override=$(winpath "${BATS_TEST_TMPDIR}/cache-override")
+
+    RDD_CACHE_DIR="${cache_override}" run -0 rdd svc paths cache_dir
+    assert_output "${cache_override}"
+
+    RDD_CACHE_DIR="${cache_override}" run -0 rdd svc paths kubectl_cache
+    assert_output --partial "${cache_override}"
+    assert_output --regexp 'kubectl[/\\][a-z0-9]+-[a-z0-9]+$'
 }

--- a/bats/tests/10-cli/7-kubectl-cache.bats
+++ b/bats/tests/10-cli/7-kubectl-cache.bats
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# End-to-end test of the rdd kubectl version resolver's download / cache
+# lifecycle. A fake apiserver advertises an out-of-skew version (v1.99.0),
+# and a fake mirror serves a matching fake kubectl. The Go server under
+# the sibling fake-kube/server directory plays both roles. The fake
+# kubectl prints "fake-kubectl: <args>"; a passing test proves the
+# resolver downloaded, sha-verified, and exec'd it.
+
+load '../../helpers/load'
+
+local_setup_file() {
+    GOOS=$(go env GOOS)
+    export GOOS
+    GOARCH=$(go env GOARCH)
+    export GOARCH
+    # EXE is set in commands.bash (".exe" on Windows, empty elsewhere)
+    # and re-exported below for the rdd subprocess. Don't shadow it
+    # locally.
+    export EXE
+
+    # Stage the fake kubectl into the mirror tree at the path the
+    # resolver will GET when it sees serverVersion=v1.99.0.
+    export MIRROR_ROOT=${BATS_FILE_TMPDIR}/mirror
+    export MIRROR_BIN_DIR=${MIRROR_ROOT}/release/v1.99.0/bin/${GOOS}/${GOARCH}
+    mkdir -p "${MIRROR_BIN_DIR}"
+    # Build inside the helper module so go.mod resolution picks up the
+    # sibling fake-kube/go.mod, not the parent rancher-desktop-daemon one.
+    # The -o paths feed go.exe directly on Windows, so they need
+    # winpath conversion for the same reason the server's path args do.
+    (
+        cd "${BATS_TEST_DIRNAME}/fake-kube" || exit
+        go build -ldflags='-s -w' \
+            -o "$(winpath "${MIRROR_BIN_DIR}/kubectl${EXE}")" \
+            ./kubectl
+        go build -ldflags='-s -w' \
+            -o "$(winpath "${BATS_FILE_TMPDIR}/fake-kube-server${EXE}")" \
+            ./server
+    )
+    SERVER_BIN=${BATS_FILE_TMPDIR}/fake-kube-server${EXE}
+
+    PORT_FILE=${BATS_FILE_TMPDIR}/port
+    export LOG_FILE=${BATS_FILE_TMPDIR}/server.log
+    export GIT_VERSION_FILE=${BATS_FILE_TMPDIR}/git-version
+    export VERSION_STATUS_FILE=${BATS_FILE_TMPDIR}/version-status
+    # On MSYS, the server is a native Windows .exe that cannot read
+    # MSYS-namespace paths (/tmp/..., /c/...). Convert each path arg
+    # with cygpath. Production rdd never crosses this boundary;
+    # MSYS_NO_PATHCONV=1 in load.bash leaves URL-like paths alone.
+    "${SERVER_BIN}" \
+        --root "$(winpath "${MIRROR_ROOT}")" \
+        --major 1 --minor 99 --git-version v1.99.0 \
+        --git-version-file "$(winpath "${GIT_VERSION_FILE}")" \
+        --version-status-file "$(winpath "${VERSION_STATUS_FILE}")" \
+        --port-file "$(winpath "${PORT_FILE}")" \
+        --log-file "$(winpath "${LOG_FILE}")" &
+    SERVER_PID=$!
+    # setup_file and teardown_file run in separate subshells, so the env
+    # var alone would vanish; save_var persists it via BATS_RUN_TMPDIR.
+    save_var SERVER_PID
+    # Wait for the port file. Server picks an ephemeral port, so we read it back.
+    local i
+    for i in {1..50}; do
+        [[ -s ${PORT_FILE} ]] && break
+        sleep 0.1
+    done
+    [[ -s ${PORT_FILE} ]] || fail "fake-kube-server did not write a port file"
+    PORT=$(<"${PORT_FILE}")
+    export PORT
+
+    KUBECONFIG_PATH=${BATS_FILE_TMPDIR}/kubeconfig
+    cat >"${KUBECONFIG_PATH}" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: fake
+  cluster:
+    server: http://127.0.0.1:${PORT}
+    insecure-skip-tls-verify: true
+contexts:
+- name: fake
+  context:
+    cluster: fake
+    user: ""
+current-context: fake
+EOF
+
+    export CACHE_DIR=${BATS_FILE_TMPDIR}/cache
+
+    # Env vars every test passes to rdd. winpath converts paths to Windows
+    # form on MSYS / WSL (no-op on macOS/Linux).
+    RDD_CACHE_DIR=$(winpath "${CACHE_DIR}")
+    export RDD_CACHE_DIR
+    export RDD_KUBECTL_MIRROR=http://127.0.0.1:${PORT}
+    KUBECONFIG=$(winpath "${KUBECONFIG_PATH}")
+    export KUBECONFIG
+}
+
+local_teardown_file() {
+    # Deviates from the "no teardown_file" rule. The rule's intent is to
+    # preserve rdd state for post-mortem inspection; an HTTP server bound
+    # to an ephemeral port is the opposite — leaving it running just leaks
+    # ports between sessions.
+    if load_var SERVER_PID; then
+        process_kill "${SERVER_PID}" 2>/dev/null || true
+    fi
+}
+
+local_setup() {
+    rm -rf "${CACHE_DIR}"
+    : >"${LOG_FILE}"
+    # Reset both /version override files so each test starts with the
+    # default v1.99.0 / 200 behavior.
+    rm -f "${GIT_VERSION_FILE}" "${VERSION_STATUS_FILE}"
+    # Republish the kubectl checksum every test so the sha-mismatch test
+    # cannot leak its zeroed fixture into a later run.
+    write_kubectl_sha512
+}
+
+write_kubectl_sha512() {
+    if is_macos; then
+        shasum -a 512 "${MIRROR_BIN_DIR}/kubectl${EXE}" | awk '{print $1}' >"${MIRROR_BIN_DIR}/kubectl${EXE}.sha512"
+    else
+        sha512sum "${MIRROR_BIN_DIR}/kubectl${EXE}" | awk '{print $1}' >"${MIRROR_BIN_DIR}/kubectl${EXE}.sha512"
+    fi
+}
+
+@test 'rdd kubectl downloads a version-matched kubectl on cache miss' {
+    cached=${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-v1.99.0${EXE}
+    assert_file_not_exists "${cached}"
+
+    run -0 rdd kubectl get pods
+
+    assert_output --partial 'fake-kubectl: get pods'
+    assert_file_executable "${cached}"
+    assert_file_contains "${LOG_FILE}" '^GET /version'
+    assert_file_contains "${LOG_FILE}" "^GET /release/v1.99.0/bin/${GOOS}/${GOARCH}/kubectl${EXE}.sha512$"
+    assert_file_contains "${LOG_FILE}" "^GET /release/v1.99.0/bin/${GOOS}/${GOARCH}/kubectl${EXE}$"
+}
+
+@test 'rdd kubectl skips the download when the cache already has a match' {
+    cache_subdir=${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}
+    mkdir -p "${cache_subdir}"
+    cp "${MIRROR_BIN_DIR}/kubectl${EXE}" "${cache_subdir}/kubectl-v1.99.0${EXE}"
+    chmod 0755 "${cache_subdir}/kubectl-v1.99.0${EXE}"
+
+    run -0 rdd kubectl get pods
+
+    assert_output --partial 'fake-kubectl: get pods'
+    assert_file_contains "${LOG_FILE}" '^GET /version'
+    refute_file_contains "${LOG_FILE}" '/release/'
+}
+
+@test 'rdd kubectl errors when the mirror has no kubectl for the server version' {
+    # Point the apiserver at v1.99.1, for which the mirror tree is empty.
+    # The resolver's first GET (.sha512) hits a 404 and surfaces the error.
+    echo v1.99.1 >"${GIT_VERSION_FILE}"
+
+    run rdd kubectl get pods
+
+    assert_failure
+    assert_output --partial 'resolving kubectl version'
+    assert_output --partial '404'
+    refute_output --partial 'fake-kubectl:'
+    assert_file_not_exists "${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-v1.99.1${EXE}"
+}
+
+@test 'rdd kubectl errors on sha512 mismatch' {
+    # Replace the published checksum with a wrong one. The download
+    # succeeds, the sha verification fails, and no cache file lands.
+    echo "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" \
+        >"${MIRROR_BIN_DIR}/kubectl${EXE}.sha512"
+
+    run rdd kubectl get pods
+
+    assert_failure
+    assert_output --partial 'resolving kubectl version'
+    assert_output --partial 'checksum mismatch'
+    refute_output --partial 'fake-kubectl:'
+    assert_file_not_exists "${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-v1.99.0${EXE}"
+}
+
+@test 'rdd kubectl falls through to embedded when the apiserver returns 500 on /version' {
+    echo 500 >"${VERSION_STATUS_FILE}"
+
+    # `kubectl version` (no --client) makes the resolver probe; --client
+    # would short-circuit isClientOnly before the probe and never reach
+    # the 500. Exit code is unasserted because modern kubectl's behavior
+    # on a 500 from /version varies across versions; the test verifies
+    # probe-then-fall-through, not embedded kubectl's exit code.
+    run rdd kubectl version
+
+    # Embedded kubectl runs and prints something; the resolver neither
+    # downloaded nor errored.
+    assert_output
+    refute_output --partial 'fake-kubectl:'
+    refute_output --partial 'resolving kubectl version'
+    refute_file_contains "${LOG_FILE}" '/release/'
+
+    # Count /version requests to prove the resolver probed: the resolver
+    # sends one, then the embedded kubectl's `version` subcommand sends
+    # one of its own. A regression that short-circuits the resolver
+    # would drop the count to 1 — assert_file_contains alone cannot
+    # tell that case from this one.
+    run -0 awk '/^GET \/version$/ {n++} END {print n+0}' "${LOG_FILE}"
+    version_requests=${output}
+    if [[ ${version_requests} -lt 2 ]]; then
+        run -0 cat "${LOG_FILE}"
+        fail "expected >= 2 GET /version (resolver + embedded kubectl), got ${version_requests}: ${output}"
+    fi
+}

--- a/bats/tests/10-cli/7-kubectl-cache.bats
+++ b/bats/tests/10-cli/7-kubectl-cache.bats
@@ -47,7 +47,7 @@ local_setup_file() {
     export VERSION_STATUS_FILE=${BATS_FILE_TMPDIR}/version-status
     # On MSYS, the server is a native Windows .exe that cannot read
     # MSYS-namespace paths (/tmp/..., /c/...). Convert each path arg
-    # with cygpath. Production rdd never crosses this boundary;
+    # with winpath. Production rdd never crosses this boundary;
     # MSYS_NO_PATHCONV=1 in load.bash leaves URL-like paths alone.
     "${SERVER_BIN}" \
         --root "$(winpath "${MIRROR_ROOT}")" \
@@ -71,6 +71,7 @@ local_setup_file() {
     export PORT
 
     KUBECONFIG_PATH=${BATS_FILE_TMPDIR}/kubeconfig
+    export KUBECONFIG_PATH
     cat >"${KUBECONFIG_PATH}" <<EOF
 apiVersion: v1
 kind: Config
@@ -88,14 +89,20 @@ current-context: fake
 EOF
 
     export CACHE_DIR=${BATS_FILE_TMPDIR}/cache
+}
 
-    # Env vars every test passes to rdd. winpath converts paths to Windows
-    # form on MSYS / WSL (no-op on macOS/Linux).
-    RDD_CACHE_DIR=$(winpath "${CACHE_DIR}")
-    export RDD_CACHE_DIR
-    export RDD_KUBECTL_MIRROR=http://127.0.0.1:${PORT}
-    KUBECONFIG=$(winpath "${KUBECONFIG_PATH}")
-    export KUBECONFIG
+# rdd_env runs rdd with RDD_CACHE_DIR, RDD_KUBECTL_MIRROR, and
+# KUBECONFIG set via env(1) instead of exported by bash. On Git Bash
+# for Windows, bash strips MSYS-root prefixes from exported env values
+# before exec'ing native children, landing the resolver's cache writes
+# on a different drive than the shell reads back from. env(1) sets the
+# vars in its own process, so the values reach rdd.exe verbatim.
+rdd_env() {
+    env \
+        "RDD_CACHE_DIR=$(winpath "${CACHE_DIR}")" \
+        "RDD_KUBECTL_MIRROR=http://127.0.0.1:${PORT}" \
+        "KUBECONFIG=$(winpath "${KUBECONFIG_PATH}")" \
+        rdd "$@"
 }
 
 local_teardown_file() {
@@ -131,7 +138,7 @@ write_kubectl_sha512() {
     cached=${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-v1.99.0${EXE}
     assert_file_not_exists "${cached}"
 
-    run -0 rdd kubectl get pods
+    run -0 rdd_env kubectl get pods
 
     assert_output --partial 'fake-kubectl: get pods'
     assert_file_executable "${cached}"
@@ -146,7 +153,7 @@ write_kubectl_sha512() {
     cp "${MIRROR_BIN_DIR}/kubectl${EXE}" "${cache_subdir}/kubectl-v1.99.0${EXE}"
     chmod 0755 "${cache_subdir}/kubectl-v1.99.0${EXE}"
 
-    run -0 rdd kubectl get pods
+    run -0 rdd_env kubectl get pods
 
     assert_output --partial 'fake-kubectl: get pods'
     assert_file_contains "${LOG_FILE}" '^GET /version'
@@ -158,7 +165,7 @@ write_kubectl_sha512() {
     # The resolver's first GET (.sha512) hits a 404 and surfaces the error.
     echo v1.99.1 >"${GIT_VERSION_FILE}"
 
-    run rdd kubectl get pods
+    run rdd_env kubectl get pods
 
     assert_failure
     assert_output --partial 'resolving kubectl version'
@@ -173,7 +180,7 @@ write_kubectl_sha512() {
     echo "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" \
         >"${MIRROR_BIN_DIR}/kubectl${EXE}.sha512"
 
-    run rdd kubectl get pods
+    run rdd_env kubectl get pods
 
     assert_failure
     assert_output --partial 'resolving kubectl version'
@@ -190,7 +197,7 @@ write_kubectl_sha512() {
     # the 500. Exit code is unasserted because modern kubectl's behavior
     # on a 500 from /version varies across versions; the test verifies
     # probe-then-fall-through, not embedded kubectl's exit code.
-    run rdd kubectl version
+    run rdd_env kubectl version
 
     # Embedded kubectl runs and prints something; the resolver neither
     # downloaded nor errored.

--- a/bats/tests/10-cli/fake-kube/README.md
+++ b/bats/tests/10-cli/fake-kube/README.md
@@ -1,0 +1,29 @@
+# fake-kube
+
+Test fixtures for `7-kubectl-cache.bats`, sitting next to the test that uses them.
+
+## Programs
+
+- **`kubectl/`** — a stand-in `kubectl` binary. Prints `fake-kubectl: <args>`
+  and exits 0. The BATS test serves it from the fake mirror and asserts
+  the output to confirm the resolver downloaded, sha-verified, and exec'd
+  it. Compiles to a real PE on Windows so `CreateProcess` accepts it.
+
+- **`server/`** — a single HTTP server playing two roles:
+  1. The Kubernetes apiserver: `GET /version` returns a configurable
+     `version.Info` JSON. The resolver hits this first to decide whether
+     to download.
+  2. The Kubernetes release mirror: `GET /release/...` serves files from
+     a configurable directory tree. `RDD_KUBECTL_MIRROR` points at this
+     URL during the test.
+
+## Why a separate Go module
+
+Keeps this directory off the main `./...` build path so the fixtures
+never enter the rdd binary, and so the parent `go.mod` stays free of
+test-only dependencies.
+
+## Build
+
+`local_setup_file()` in `7-kubectl-cache.bats` builds both binaries
+into `$BATS_FILE_TMPDIR` on each test run.

--- a/bats/tests/10-cli/fake-kube/go.mod
+++ b/bats/tests/10-cli/fake-kube/go.mod
@@ -1,0 +1,6 @@
+// Test fixture: see the sibling README.md for the role this module plays.
+// Stays a separate module so its programs neither inflate the rdd binary
+// nor pull test-only dependencies into the main go.mod.
+module fake-kube
+
+go 1.25.0

--- a/bats/tests/10-cli/fake-kube/kubectl/main.go
+++ b/bats/tests/10-cli/fake-kube/kubectl/main.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Command fake-kubectl stands in for the real kubectl binary in BATS
+// tests of the rdd kubectl version resolver. It prints its arguments
+// with a fixed marker prefix and exits 0, so a passing test proves the
+// resolver downloaded, sha-verified, and exec'd this file.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	fmt.Println("fake-kubectl:", strings.Join(os.Args[1:], " "))
+}

--- a/bats/tests/10-cli/fake-kube/server/main.go
+++ b/bats/tests/10-cli/fake-kube/server/main.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Command fake-kube-server fakes both endpoints the kuberlr resolver
+// touches: the kubernetes apiserver's /version (which decides whether to
+// download) and the release mirror's /release/* tree (which serves the
+// fake kubectl). One server handles both roles so a single port covers
+// both KUBECONFIG and RDD_KUBECTL_MIRROR.
+//
+// The server picks an ephemeral port, writes it to the file named by
+// --port-file, and logs every request to the file named by --log-file
+// (one "METHOD path" per line). The BATS test reads the port back to
+// build the kubeconfig, then greps the log to assert which downloads
+// happened on each test run.
+//
+// Two override files let individual tests change /version's behavior
+// without restarting the server. Each request reads the file fresh, so
+// a test can drop the file in setup() and let the next request pick it
+// up. A missing or empty file falls back to the --git-version flag and
+// HTTP 200.
+//
+//	--git-version-file:    one-line gitVersion string (e.g. "v1.99.1")
+//	--version-status-file: one-line HTTP status code (e.g. "500")
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+func main() {
+	root := flag.String("root", "", "directory served under /release/")
+	major := flag.String("major", "1", "kubernetes server Major version")
+	minor := flag.String("minor", "99", "kubernetes server Minor version")
+	gitVersion := flag.String("git-version", "v1.99.0", "default kubernetes server gitVersion")
+	gitVersionFile := flag.String("git-version-file", "", "optional file overriding gitVersion at request time")
+	versionStatusFile := flag.String("version-status-file", "", "optional file overriding /version HTTP status at request time")
+	portFile := flag.String("port-file", "", "file to receive the assigned port")
+	logFile := flag.String("log-file", "", "file to receive one request line per request")
+	flag.Parse()
+	if *root == "" || *portFile == "" || *logFile == "" {
+		log.Fatal("--root, --port-file, and --log-file are required")
+	}
+
+	// O_APPEND so per-test truncation (`: > log`) by BATS is honored:
+	// without it, the server's fd position drifts past the new EOF and
+	// writes land in a sparse hole that grep treats as binary noise.
+	logFD, err := os.OpenFile(*logFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		log.Fatalf("opening log file: %v", err)
+	}
+	defer logFD.Close()
+	var logMu sync.Mutex
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+		recordRequest(logFD, &logMu, r)
+		status := readIntFile(*versionStatusFile, http.StatusOK)
+		gv := readStringFile(*gitVersionFile, *gitVersion)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_, _ = fmt.Fprintf(w,
+				`{"major":%q,"minor":%q,"gitVersion":%q,"gitCommit":"fake","gitTreeState":"clean","buildDate":"2026-01-01T00:00:00Z","goVersion":"go1.21","compiler":"gc","platform":"%s/%s"}`,
+				*major, *minor, gv, runtime.GOOS, runtime.GOARCH,
+			)
+		}
+	})
+	mux.Handle("/release/", logging(logFD, &logMu, http.StripPrefix("/release/", http.FileServer(http.Dir(filepath.Join(*root, "release"))))))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := os.WriteFile(*portFile, []byte(strconv.Itoa(port)), 0o644); err != nil {
+		log.Fatalf("writing port file: %v", err)
+	}
+
+	server := &http.Server{Handler: mux}
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("serve: %v", err)
+	}
+}
+
+// logging wraps h so every request lands in the request log before h sees
+// it. The release file server does not get to bypass logging just because
+// it sits behind a StripPrefix.
+func logging(fd *os.File, mu *sync.Mutex, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recordRequest(fd, mu, r)
+		h.ServeHTTP(w, r)
+	})
+}
+
+func recordRequest(fd *os.File, mu *sync.Mutex, r *http.Request) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(fd, "%s %s\n", r.Method, r.URL.Path)
+}
+
+// readStringFile returns the trimmed contents of path, or fallback when
+// path is empty, missing, or unreadable.
+func readStringFile(path, fallback string) string {
+	if path == "" {
+		return fallback
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fallback
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+// readIntFile returns the parsed integer in path, or fallback when path
+// is empty, missing, unreadable, or unparseable.
+func readIntFile(path string, fallback int) int {
+	s := readStringFile(path, "")
+	if s == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fallback
+	}
+	return n
+}

--- a/cmd/rdd/kubectl.go
+++ b/cmd/rdd/kubectl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	// Import to initialize client auth plugins.
@@ -17,6 +18,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/kuberlr"
 )
 
 func newCtlCommand() *cobra.Command {
@@ -40,6 +42,10 @@ func ctlAction(cmd *cobra.Command, args []string) error {
 	if err := os.Setenv("KUBECONFIG", instance.Config()); err != nil {
 		return fmt.Errorf("failed to set KUBECONFIG: %w", err)
 	}
+	// rdd ctl always targets the embedded apiserver. Embedded apiserver
+	// and embedded kubectl share a k8s.io/kubernetes module entry, so
+	// the version probe would always fall through. Skip it.
+	kuberlr.SkipResolver()
 	return kubectlAction(cmd, args)
 }
 
@@ -54,7 +60,23 @@ func newKubectlCommand() *cobra.Command {
 	return command
 }
 
-func kubectlAction(*cobra.Command, []string) error {
+func kubectlAction(cmd *cobra.Command, args []string) error {
+	path, err := kuberlr.Resolve(cmd.Context(), args)
+	if err != nil {
+		// A download or sha-mismatch failure surfaces here. We refuse
+		// to silently fall back to the embedded kubectl — running a
+		// version-mismatched binary against the user's cluster would
+		// hide the failure behind weird kubectl errors. Apiserver-probe
+		// failures (unreachable cluster, missing kubeconfig) do not
+		// reach this branch: serverVersion converts them to ok=false
+		// with a nil error, so Resolve returns "" and the embedded
+		// kubectl handles client-only commands.
+		return fmt.Errorf("resolving kubectl version: %w", err)
+	}
+	if path != "" {
+		logrus.WithField("path", path).Debug("using cached kubectl")
+		return kuberlr.Exec(cmd.Context(), path, args)
+	}
 	os.Args = os.Args[1:]
 	command := kubectlcmd.NewDefaultKubectlCommand()
 	if err := cli.RunNoErrOutput(command); err != nil {

--- a/cmd/rdd/main.go
+++ b/cmd/rdd/main.go
@@ -167,9 +167,13 @@ func main() {
 	)
 	if err := cli.RunNoErrOutput(cmd); err != nil {
 		// *cliexit.Error lets a subcommand opt into a specific exit code; everything else gets exit 1.
+		// A nil inner Err means the subcommand has already written its own output (e.g. kuberlr.Exec
+		// propagating a kubectl child's exit code), so skip the redundant log line.
 		var exitErr *cliexit.Error
 		if errors.As(err, &exitErr) {
-			logrus.Error(err)
+			if exitErr.Err != nil {
+				logrus.Error(err)
+			}
 			os.Exit(exitErr.Code)
 		}
 		logrus.Fatal(err)

--- a/cmd/rdd/service_paths.go
+++ b/cmd/rdd/service_paths.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/kuberlr"
 )
 
 func instancePaths() map[string]string {
@@ -28,6 +29,8 @@ func instancePaths() map[string]string {
 		"pid_file":      instance.PIDFile(),
 		"args_file":     instance.ArgsFile(),
 		"docker_socket": instance.DockerSocket(),
+		"cache_dir":     kuberlr.CacheRoot(),
+		"kubectl_cache": kuberlr.CacheDir(),
 	}
 }
 

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -12,7 +12,7 @@ This service directory contains the following files:
 
 | File | Description |
 | --- | --- |
-| `config.json` | service config settings (written by `rdd service create` or `rdd service start`)
+| `config.yaml` | service config settings (written by `rdd service create` or `rdd service start`)
 | `rdd.pid`     | pid of the control plane process (normally a background daemon) |
 | `rdd.sqlite3` | control plane data store |
 
@@ -38,7 +38,7 @@ It runs in a background process, which is started on demand by `rdd service serv
 
 Creates the service without starting it. This will rarely be used; the `rdd service start` command will call it automatically when the service does not yet exist.
 
-Creates the service directory with the `rdd.sqlite3` data store. Stores the configuration settings in the `config.json` file.
+Creates the service directory with the `rdd.sqlite3` data store. Stores the configuration settings in the `config.yaml` file.
 
 Configuration options (incomplete):
 
@@ -75,16 +75,16 @@ Additional configuration for individual controllers:
 
 Backgrounds itself (fork && exec) unless invoked with `--background=false` for easier debugging.
 
-Saves its own PID into `rdd.pid` and then starts the apiserver and the controller-manager using the configuration found in `config.json`.
+Saves its own PID into `rdd.pid` and then starts the apiserver and the controller-manager using the configuration found in `config.yaml`.
 
-Once the apiserver is running the config data will be copied into the `config` map in the `rdd-system` namespace. No controller should access `config.json` directly.
+Once the apiserver is running the config data will be copied into the `config` map in the `rdd-system` namespace. No controller should access `config.yaml` directly.
 
 
 ### `rdd service start`
 
 Starts the service. Calls `rdd service create` if the service does not yet exist.
 
-Takes all the same options as `rdd service create` and updates `config.json` with latest settings.
+Takes all the same options as `rdd service create` and updates `config.yaml` with latest settings.
 
 Runs `rdd service serve` to actually start the control plane in the background
 
@@ -134,6 +134,9 @@ Prints instance directory and file paths. Accepts an optional key argument to pr
 | `config` | RDD control plane config file path |
 | `pid_file` | PID file path |
 | `args_file` | Saved arguments file path |
+| `docker_socket` | Host-side Docker socket |
+| `cache_dir` | rdd-wide cache root (shared across instances) |
+| `kubectl_cache` | Cache directory for downloaded kubectl binaries (shared across instances) |
 
 Output formats (`--output`, `-o`):
 
@@ -149,14 +152,17 @@ Examples:
 
 ```console
 $ rdd svc paths
-args_file  /path/to/rancher-desktop-default/rdd.args
-config     /path/to/rancher-desktop-default/config.json
-dir        /path/to/rancher-desktop-default
-lima_home  /path/to/.rd2/lima
-log_dir    /path/to/rancher-desktop-default/log
-pid_file   /path/to/rancher-desktop-default/rdd.pid
-short_dir  /path/to/.rd2
-tls_dir    /path/to/rancher-desktop-default/tls
+args_file      /path/to/rancher-desktop-default/args.json
+cache_dir      /path/to/Caches/rancher-desktop
+config         /path/to/rancher-desktop-default/config.yaml
+dir            /path/to/rancher-desktop-default
+docker_socket  /path/to/.rd2/docker.sock
+kubectl_cache  /path/to/Caches/rancher-desktop/kubectl/darwin-arm64
+lima_home      /path/to/.rd2/lima
+log_dir        /path/to/rancher-desktop-default/log
+pid_file       /path/to/rancher-desktop-default/rdd.pid
+short_dir      /path/to/.rd2
+tls_dir        /path/to/rancher-desktop-default/tls
 
 $ rdd svc paths log_dir
 /path/to/rancher-desktop-default/log

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -13,6 +13,8 @@ These variables control RDD behavior. Set them before running `rdd` commands.
 | `RDD_KEEP_LOGS` | Preserves logs for post-mortem debugging. See [Log Preservation](#log-preservation) for details. | unset |
 | `RDD_LOG_LEVEL` | Sets the log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`). Overridden by `--log-level` flag. When unset, defaults to `debug` in developer mode, `warn` otherwise. | unset |
 | `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
+| `RDD_CACHE_DIR` | Overrides the rdd-wide cache root. The kubectl resolver appends `kubectl/<os>-<arch>/` inside it. | `os.UserCacheDir()`/`rancher-desktop` (e.g. `~/Library/Caches/rancher-desktop` on macOS) |
+| `RDD_KUBECTL_MIRROR` | Overrides the Kubernetes release mirror used to download version-matched kubectl binaries. | `https://dl.k8s.io` |
 
 ### BATS Test Variables
 
@@ -24,9 +26,17 @@ These variables configure the BATS test framework. They have no effect on `rdd` 
 | `RDD_NAMESPACE` | Default Kubernetes namespace for BATS controller tests. | `rdd-bats` |
 | `RDD_VM_TYPE` | Lima VM type for tests that boot a VM (`qemu` or `vz`). Useful for reproducing QEMU-specific failures on macOS. | Lima's default (`vz` on macOS, `qemu` on Linux) |
 
+### Internal Variables
+
+`rdd` sets these variables itself; users should leave them alone. They appear here so a developer reading a process tree or strace output can identify them.
+
+| Variable | Description |
+| --- | --- |
+| `RDD_KUBECTL_RESOLVED` | Recursion guard for the kubectl version resolver. `kuberlr.Exec` sets it on the kubectl child process so a downloaded kubectl that re-execs `rdd` through a shim cannot recurse back into version resolution. `rdd ctl` achieves the same skip via the in-process `kuberlr.SkipResolver()` helper, not this env var. |
+
 ## Path Variables
 
-`rdd svc paths --output=shell` exports these variables. They reflect the paths RDD uses for the current instance; setting them has no effect on RDD's behavior.
+`rdd svc paths --output=shell` exports these variables. Most are informational; `RDD_CACHE_DIR` is also honored as the cache-root override (see Configuration Variables above).
 
 ```shell
 source <(rdd svc paths --output=shell)
@@ -35,8 +45,11 @@ source <(rdd svc paths --output=shell)
 | Variable | Description | Example (macOS, instance `2`) |
 | --- | --- | --- |
 | `RDD_ARGS_FILE` | Saved startup arguments | `~/Library/Application Support/rancher-desktop-2/args.json` |
+| `RDD_CACHE_DIR` | rdd-wide cache root (shared across instances) | `~/Library/Caches/rancher-desktop` |
 | `RDD_DIR` | Service instance directory | `~/Library/Application Support/rancher-desktop-2` |
 | `RDD_CONFIG` | RDD control plane config file | `~/Library/Application Support/rancher-desktop-2/config.yaml` |
+| `RDD_DOCKER_SOCKET` | Host-side Docker socket | `~/.rd2/docker.sock` |
+| `RDD_KUBECTL_CACHE` | Cache directory for downloaded kubectl binaries (shared across instances) | `~/Library/Caches/rancher-desktop/kubectl/darwin-arm64` |
 | `RDD_LIMA_HOME` | Lima home directory | `~/.rd2/lima` |
 | `RDD_LOG_DIR` | Log directory | `~/Library/Logs/rancher-desktop-2` |
 | `RDD_PID_FILE` | Service PID file | `~/Library/Application Support/rancher-desktop-2/rdd.pid` |

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Microsoft/go-winio v0.6.2
+	github.com/blang/semver/v4 v4.0.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/containers/gvisor-tap-vsock v0.8.8
 	github.com/coreos/go-semver v0.3.1
@@ -35,6 +36,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/apiserver v0.35.4
+	k8s.io/cli-runtime v0.35.4
 	k8s.io/client-go v0.35.4
 	k8s.io/component-base v0.35.4
 	k8s.io/klog/v2 v2.140.0
@@ -94,7 +96,6 @@ require (
 	github.com/balajiv113/fd v0.0.0-20230330094840-143eec500f3e // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
@@ -430,7 +431,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gvisor.dev/gvisor v0.0.0-20240916094835-a174eb65023f // indirect
 	honnef.co/go/tools v0.6.1 // indirect
-	k8s.io/cli-runtime v0.35.4 // indirect
 	k8s.io/cloud-provider v0.35.4 // indirect
 	k8s.io/cluster-bootstrap v0.35.4 // indirect
 	k8s.io/code-generator v0.35.4 // indirect

--- a/pkg/kuberlr/cache.go
+++ b/pkg/kuberlr/cache.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package kuberlr resolves a kubectl binary compatible with the cluster
+// targeted by the user's kubeconfig. When the kubectl embedded in rdd falls
+// within the supported version skew, rdd execs the embedded binary;
+// otherwise rdd fetches a matching kubectl from dl.k8s.io into a shared
+// cache and execs it in place. Modeled on github.com/flavio/kuberlr.
+package kuberlr
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// envCacheDir lets tests (and operators) override the rdd-wide cache root.
+// Anticipates a shared rdd cache that future consumers (k3s images, lima
+// templates) can join — kuberlr appends its own subdirectory.
+const envCacheDir = "RDD_CACHE_DIR"
+
+// CacheDir returns the directory holding downloaded kubectl binaries. All
+// rdd instances share this cache; kubectl does not vary per instance.
+// Setting RDD_CACHE_DIR overrides the rdd-wide root; kuberlr always
+// appends kubectl/<os>-<arch>/ inside that root.
+//
+//	macOS:   ~/Library/Caches/rancher-desktop/kubectl/<os>-<arch>/
+//	Linux:   ~/.cache/rancher-desktop/kubectl/<os>-<arch>/  ($XDG_CACHE_HOME)
+//	Windows: %LocalAppData%\rancher-desktop\kubectl\<os>-<arch>\
+//
+// TODO(eviction): the cache only grows; a user switching across many
+// remote clusters accumulates ~50 MB per minor version indefinitely.
+// SIGKILL or power loss during a download also leaks the .kubectl-*
+// temp file that defer os.Remove normally cleans up. A per-version
+// TTL or LRU sweep should clear both stale binaries and stale
+// .kubectl-* leftovers before the directory becomes a noticeable
+// footprint.
+func CacheDir() string {
+	return filepath.Join(CacheRoot(), "kubectl", runtime.GOOS+"-"+runtime.GOARCH)
+}
+
+// CacheRoot returns the rdd-wide cache root. RDD_CACHE_DIR overrides the
+// OS default. Future cache consumers (k3s images, Lima templates) should
+// append their own subdirectory inside this root.
+func CacheRoot() string {
+	if root := os.Getenv(envCacheDir); root != "" {
+		return root
+	}
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		panic(fmt.Errorf("could not determine user cache directory: %w", err))
+	}
+	return filepath.Join(cache, "rancher-desktop")
+}

--- a/pkg/kuberlr/downloader.go
+++ b/pkg/kuberlr/downloader.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package kuberlr
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/sirupsen/logrus"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/version"
+)
+
+// defaultKubeMirror is the upstream Kubernetes release mirror. SIG Release
+// publishes dl.k8s.io as the canonical CDN endpoint.
+const defaultKubeMirror = "https://dl.k8s.io"
+
+// envKubeMirror lets tests (and operators) point the resolver at an
+// alternate mirror. Useful for offline mirrors and for the BATS cache
+// lifecycle test, which serves a fake binary from a local HTTP server.
+const envKubeMirror = "RDD_KUBECTL_MIRROR"
+
+// downloadTimeout caps each mirror request. Five minutes turns a hung
+// mirror into a bounded failure and still covers a ~50 MB kubectl
+// binary on slow links (~170 kB/s).
+const downloadTimeout = 5 * time.Minute
+
+// httpClient enforces downloadTimeout on every kuberlr request.
+// http.DefaultClient sets no Timeout, and the inherited cobra context
+// carries no deadline. If the request context later carries a shorter
+// deadline, that deadline wins.
+var httpClient = &http.Client{Timeout: downloadTimeout}
+
+// userAgent identifies rdd-kuberlr traffic to mirrors and proxies.
+// Corporate proxies and air-gapped mirrors regularly rate-limit or
+// denylist the default Go client UA (`Go-http-client/1.1`); naming
+// the client also helps SIG Release correlate kuberlr-style traffic
+// against dl.k8s.io.
+var userAgent = "rdd-kuberlr/" + version.Version
+
+// mirrorURL returns the mirror base URL the resolver downloads from.
+//
+// TODO(offline): pair this with a "may we download?" toggle so air-gapped
+// users can pre-populate CacheDir() and forbid network fetches.
+func mirrorURL() string {
+	if v := os.Getenv(envKubeMirror); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return defaultKubeMirror
+}
+
+// ensureCached returns the path to a cached kubectl matching want. If no
+// matching binary exists on disk, ensureCached downloads one from the
+// upstream mirror and verifies its sha512 before publishing it atomically.
+func ensureCached(ctx context.Context, want semver.Version) (string, error) {
+	path := cachedPath(want)
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	logrus.Infof("downloading kubectl v%d.%d.%d from %s", want.Major, want.Minor, want.Patch, mirrorURL())
+	if err := download(ctx, want, path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// cachedPath returns the absolute path of the cached kubectl for v.
+func cachedPath(v semver.Version) string {
+	name := fmt.Sprintf("kubectl-v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(CacheDir(), name)
+}
+
+// download fetches kubectl v from the upstream mirror, verifies its sha512
+// against the mirror's published checksum, and renames the verified file to
+// dst. A failure leaves no partial file behind for the next call to mistake
+// for a valid binary.
+func download(ctx context.Context, v semver.Version, dst string) error {
+	base := fmt.Sprintf("%s/release/v%d.%d.%d/bin/%s/%s/kubectl", mirrorURL(), v.Major, v.Minor, v.Patch, runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		base += ".exe"
+	}
+	want, err := fetchSha512(ctx, base+".sha512")
+	if err != nil {
+		return fmt.Errorf("fetching checksum: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".kubectl-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	h := sha512.New()
+	if err := streamGet(ctx, base, io.MultiWriter(tmp, h), maxKubectlBytes); err != nil {
+		tmp.Close()
+		return fmt.Errorf("downloading %s: %w", base, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != want {
+		return fmt.Errorf("checksum mismatch for %s: want %s, got %s", base, want, got)
+	}
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, dst)
+}
+
+// Body-size caps for streamGet. maxSha512Bytes covers the longest
+// `sha512sum`-format line (128 hex chars + two spaces + a generous
+// filename); maxKubectlBytes covers the kubectl binary with headroom
+// (current kubectl is ~50 MB). A misconfigured mirror serving the
+// binary at the .sha512 URL hits the small cap first and fails with
+// a clear error instead of streaming megabytes into a strings.Builder.
+//
+// If kubectl ever exceeds maxKubectlBytes, io.LimitReader truncates
+// silently and the digest covers a partial body, so the caller sees a
+// "checksum mismatch" error rather than a size-cap message. Bump the
+// cap when kubectl outgrows it.
+const (
+	maxSha512Bytes  = 4 << 10   // 4 KiB
+	maxKubectlBytes = 256 << 20 // 256 MiB
+)
+
+// fetchSha512 downloads the sha512 hex digest at url. dl.k8s.io serves
+// the bare digest, but a mirror populated with `sha512sum` writes the
+// digest, two spaces, and the filename — fields() takes the digest and
+// drops the trailing filename so both formats verify. fetchSha512
+// rejects non-128-hex tokens so a misconfigured mirror surfaces a
+// "malformed checksum" error instead of the misleading "checksum
+// mismatch" download's digest comparison would produce.
+func fetchSha512(ctx context.Context, url string) (string, error) {
+	var sb strings.Builder
+	if err := streamGet(ctx, url, &sb, maxSha512Bytes); err != nil {
+		return "", err
+	}
+	fields := strings.Fields(sb.String())
+	if len(fields) == 0 {
+		return "", fmt.Errorf("empty checksum response from %s", url)
+	}
+	// Normalize to lowercase to match download's hex.EncodeToString
+	// output. PowerShell Get-FileHash emits uppercase hex; without
+	// this, the comparison rejects valid digests as mismatched.
+	digest := strings.ToLower(fields[0])
+	if len(digest) != sha512.Size*2 {
+		return "", fmt.Errorf("malformed checksum from %s: %d chars, want %d", url, len(digest), sha512.Size*2)
+	}
+	for _, c := range digest {
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+			return "", fmt.Errorf("malformed checksum from %s: non-hex character %q", url, c)
+		}
+	}
+	return digest, nil
+}
+
+// streamGet performs a GET on url and copies the response body into w,
+// capped at maxBytes. The cap turns a malicious or misconfigured mirror
+// into a bounded failure: the underlying io.LimitReader stops reading
+// after maxBytes regardless of the server's intent. streamGet returns
+// an error on any non-200 status.
+func streamGet(ctx context.Context, url string, w io.Writer, maxBytes int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	_, err = io.Copy(w, io.LimitReader(resp.Body, maxBytes))
+	return err
+}

--- a/pkg/kuberlr/exec_unix.go
+++ b/pkg/kuberlr/exec_unix.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build !windows
+
+package kuberlr
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Exec replaces the current process with kubectl at path, passing args and
+// the current environment plus a recursion guard. The kubectl process
+// inherits our PID, so the shell sees its exit status directly. ctx is
+// accepted for signature parity with the Windows variant; syscall.Exec
+// replaces the process so cancellation no longer applies.
+func Exec(_ context.Context, path string, args []string) error {
+	env := append(os.Environ(), envSkipResolver+"=1")
+	if err := syscall.Exec(path, append([]string{path}, args...), env); err != nil {
+		return fmt.Errorf("exec %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/kuberlr/exec_windows.go
+++ b/pkg/kuberlr/exec_windows.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build windows
+
+package kuberlr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	cliexit "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/exit"
+)
+
+// Exec runs kubectl at path as a child process and propagates its exit
+// status. Windows lacks an equivalent of the unix exec() syscall, so rdd
+// spawns kubectl, waits for it, and returns a *cliexit.Error so main can
+// re-issue the kubectl exit code. Both processes share the console, so
+// Ctrl+C and Ctrl+Break reach kubectl directly without explicit signal
+// forwarding. The recursion guard prevents kubectl from looping through
+// Resolve if it ever re-execs us.
+func Exec(ctx context.Context, path string, args []string) error {
+	// CommandContext hard-kills on ctx cancellation. The cobra context
+	// is never canceled today; wiring signal-driven cancellation must
+	// revisit this site, or rdd's hard-kill races kubectl's graceful
+	// shutdown of the console-delivered Ctrl+C.
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Env = append(os.Environ(), envSkipResolver+"=1")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return &cliexit.Error{Code: exitErr.ExitCode()}
+	}
+	if err != nil {
+		return fmt.Errorf("running %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/kuberlr/resolver.go
+++ b/pkg/kuberlr/resolver.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package kuberlr
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	componentbasever "k8s.io/component-base/version"
+)
+
+// envSkipResolver tells Resolve to short-circuit. Exec sets it on the
+// kubectl child process so a downloaded kubectl that re-execs us through
+// a shim cannot recurse back into version resolution.
+const envSkipResolver = "RDD_KUBECTL_RESOLVED"
+
+// skipResolver short-circuits Resolve for the rest of this process.
+// Same-process toggle; envSkipResolver covers the cross-process recursion
+// guard that Exec sets on the kubectl child.
+var skipResolver bool
+
+// SkipResolver short-circuits Resolve for the rest of this process.
+// rdd ctl calls this before kubectlAction because it always targets
+// the embedded apiserver, whose version matches the embedded kubectl
+// by construction — the probe would always fall through anyway.
+func SkipResolver() {
+	skipResolver = true
+}
+
+// serverProbeTimeout caps the discovery call. A reachable cluster answers
+// in under 100 ms; an unreachable one would otherwise stall every kubectl
+// invocation.
+const serverProbeTimeout = 2 * time.Second
+
+// Resolve returns the path to a kubectl binary compatible with the cluster
+// the user's kubeconfig points at. An empty path means "use the embedded
+// kubectl"; a non-empty path means "exec this binary instead". args holds
+// the kubectl-style arguments the caller will pass through; Resolve binds
+// kubectl's connection-override flags (via genericclioptions.ConfigFlags)
+// so the version probe targets the same cluster the kubectl child will
+// contact. The deprecated --username and --password basic-auth flags
+// stay unbound on the resolver side; see parseKubeConfigFlags for the
+// rationale and the rest of the flag surface.
+//
+// When the cluster probe fails for any reason — unreachable, missing or
+// malformed kubeconfig, unparseable server version — or when the embedded
+// kubectl is within ±1 minor of the server, Resolve returns "". Resolve
+// also returns "" without probing for invocations the embedded kubectl
+// can answer on its own (config, completion, options, help, --help, -h,
+// version --client) so client-only commands skip the network round trip
+// when the cluster is unreachable.
+//
+// TODO(offline): when no cached kubectl matches and the network is down,
+// Resolve currently fails with the download error. Add an opt-out for
+// download attempts (config flag or RDD_KUBECTL_OFFLINE) and fall back to
+// the cached binary closest to the server's minor.
+func Resolve(ctx context.Context, args []string) (string, error) {
+	if skipResolver || os.Getenv(envSkipResolver) != "" {
+		return "", nil
+	}
+	if isClientOnly(args) {
+		return "", nil
+	}
+	embedded, err := embeddedVersion()
+	if err != nil {
+		// `go run ./cmd/rdd kubectl ...` and IDE debug builds skip the
+		// Makefile's -ldflags -X, so componentbasever returns the
+		// in-tree default `v0.0.0-master+$Format:%H$`, which fails
+		// semver parsing. Fall through to the embedded kubectl rather
+		// than break every dev invocation.
+		logrus.WithError(err).Debug("kubectl resolver: embedded version not parseable; using embedded kubectl")
+		return "", nil
+	}
+	server, ok := serverVersion(args)
+	if !ok {
+		return "", nil
+	}
+	if compatible(embedded, server) {
+		return "", nil
+	}
+	return ensureCached(ctx, server)
+}
+
+// compatible reports whether a kubectl of client.Minor can drive a server
+// of server.Minor under the standard Kubernetes skew of ±1 minor. A
+// different Major rules out compatibility outright.
+func compatible(client, server semver.Version) bool {
+	if client.Major != server.Major {
+		return false
+	}
+	diff := int64(client.Minor) - int64(server.Minor)
+	return diff >= -1 && diff <= 1
+}
+
+// embeddedVersion reads the kubectl version baked into the rdd binary
+// from k8s.io/component-base/version, populated by -X linker flags in
+// the Makefile. Declared as a var so unit tests can swap it in to
+// exercise the parse-failure fall-through that `go run` and IDE debug
+// builds hit at runtime.
+var embeddedVersion = func() (semver.Version, error) {
+	return semver.ParseTolerant(componentbasever.Get().GitVersion)
+}
+
+// serverVersion contacts the cluster named by args (and the user's
+// kubeconfig) and parses its reported version. ok is false on every
+// failure path — missing kubeconfig, malformed config, unreachable
+// cluster, unparseable version — because each is a legitimate reason
+// to skip the resolver and fall through to the embedded kubectl. The
+// three routine paths log at debug; the unparseable-version path logs
+// at warn because an apiserver answering /version with garbage is the
+// kind of surprise an operator wants to see at the default log level.
+func serverVersion(args []string) (semver.Version, bool) {
+	cfg, err := loadClientConfig(args)
+	if err != nil {
+		logrus.WithError(err).Debug("kubectl resolver: cannot load kubeconfig; using embedded kubectl")
+		return semver.Version{}, false
+	}
+	cfg.Timeout = serverProbeTimeout
+	client, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		logrus.WithError(err).Debug("kubectl resolver: cannot build discovery client; using embedded kubectl")
+		return semver.Version{}, false
+	}
+	info, err := client.ServerVersion()
+	if err != nil {
+		logrus.WithError(err).Debug("kubectl resolver: cluster probe failed; using embedded kubectl")
+		return semver.Version{}, false
+	}
+	v, err := semver.ParseTolerant(info.GitVersion)
+	if err != nil {
+		logrus.WithError(err).Warnf("kubectl resolver: cannot parse server version %q; using embedded kubectl", info.GitVersion)
+		return semver.Version{}, false
+	}
+	return v, true
+}
+
+// loadClientConfig builds a rest.Config from KUBECONFIG plus the kubectl
+// connection-override flags in args. The resolver and the kubectl child
+// must aim at the same cluster so the version skew check matches the
+// cluster kubectl actually contacts; reusing kubectl's own flag binding
+// (genericclioptions.ConfigFlags) keeps them aligned by construction.
+func loadClientConfig(args []string) (*rest.Config, error) {
+	return parseKubeConfigFlags(args).ToRawKubeConfigLoader().ClientConfig()
+}
+
+// parseKubeConfigFlags binds genericclioptions.NewConfigFlags(true) to
+// a pflag FlagSet, parses args, and returns the populated flags. The
+// bound surface is whatever NewConfigFlags(true).AddFlags exposes —
+// the kubectl connection-override flags (--kubeconfig, --context,
+// --server/-s, --cluster, --user, --token, --certificate-authority,
+// --client-certificate, --client-key, --tls-server-name,
+// --insecure-skip-tls-verify, --request-timeout, --as, --as-group,
+// --as-uid, --as-user-extra, --cache-dir, --disable-compression,
+// --namespace/-n). Unknown flags (kubectl subcommands and their own
+// flags) and positional arguments pass through silently.
+//
+// The deprecated --username and --password flags stay unbound. Binding
+// them via WithDeprecatedPasswordFlag would make ToRawKubeConfigLoader
+// return the interactive variant that prompts on stdin when the
+// kubeconfig context lacks credentials — the wrong behavior for a
+// background version probe. The kubectl child still receives those
+// flags and processes them per its own binding; the asymmetry only
+// affects the resolver's probe, which falls through silently to the
+// embedded kubectl on probe failure either way.
+//
+// parseKubeConfigFlags exists as a separate helper so unit tests can
+// verify the binding without reaching for a real cluster.
+func parseKubeConfigFlags(args []string) *genericclioptions.ConfigFlags {
+	fs := pflag.NewFlagSet("rdd-kubectl", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+	cf := genericclioptions.NewConfigFlags(true)
+	cf.AddFlags(fs)
+	_ = fs.Parse(args)
+	return cf
+}
+
+// clientOnlySubcommands lists kubectl subcommands that never contact
+// a cluster. config and completion manipulate local state only;
+// kustomize renders local manifests; plugin lists local plugins on
+// PATH; options prints kubectl's global flags; help prints help text.
+var clientOnlySubcommands = map[string]bool{
+	"completion": true,
+	"config":     true,
+	"kustomize":  true,
+	"plugin":     true,
+	"options":    true,
+	"help":       true,
+}
+
+// isClientOnly reports whether args describe a kubectl invocation
+// the resolver can skip without losing correctness. Empty args, the
+// help flags, "version --client", and the subcommands in
+// clientOnlySubcommands all qualify; everything else falls through
+// to the probe so the version skew check still runs.
+//
+// The walk binds genericclioptions.ConfigFlags (kubectl's connection
+// overrides) and the bare-bool kubectl globals (--help/-h, --client,
+// --warnings-as-errors) into a per-call pflag FlagSet. Klog flags
+// (--v, --vmodule, --log_dir, …) intentionally stay unbound so their
+// values do not leak into klog's process-global state; pflag's
+// UnknownFlags handling consumes the assumed value of any spaced
+// unknown flag, so `--v 4 config view` correctly leaves [config,
+// view] as positionals.
+//
+// Bool-parse errors short-circuit pflag's parser: a malformed value
+// like `--client=garbage version` halts parse mid-args, leaves no
+// positionals, and lands in the empty-positionals branch below
+// (return true). This deviates from a strict conservative bias, but
+// kubectl rejects the same malformed flag in the embedded path
+// before contacting any cluster, so no silent mismatched execution
+// follows.
+//
+// Conservative bias: when isClientOnly cannot identify the
+// invocation, prefer to probe; misclassifying as client-only would
+// skip the version skew check and silently use a mismatched embedded
+// kubectl.
+func isClientOnly(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	fs := pflag.NewFlagSet("rdd-kubectl", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+
+	cf := genericclioptions.NewConfigFlags(true)
+	cf.AddFlags(fs)
+
+	var help, client, warningsAsErrors, matchServerVersion bool
+	fs.BoolVarP(&help, "help", "h", false, "")
+	fs.BoolVar(&client, "client", false, "")
+	fs.BoolVar(&warningsAsErrors, "warnings-as-errors", false, "")
+	fs.BoolVar(&matchServerVersion, "match-server-version", false, "")
+
+	_ = fs.Parse(args)
+
+	if help {
+		return true
+	}
+	positionals := fs.Args()
+	if len(positionals) == 0 {
+		return true
+	}
+	subcommand := positionals[0]
+	if subcommand == "version" {
+		// `kubectl version` (no --client) probes the server for its
+		// version. Treat that as cluster-bound so the resolver picks
+		// a version-matched binary to do the probe.
+		return client
+	}
+	return clientOnlySubcommands[subcommand]
+}

--- a/pkg/kuberlr/resolver_test.go
+++ b/pkg/kuberlr/resolver_test.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package kuberlr
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"gotest.tools/v3/assert"
+)
+
+func TestCompatible(t *testing.T) {
+	v := func(major, minor uint64) semver.Version {
+		return semver.Version{Major: major, Minor: minor}
+	}
+	// Vendor clusters annotate gitVersion with build suffixes (EKS, GKE,
+	// AKS); the EKS/GKE/AKS rows verify that ParseTolerant accepts the
+	// common forms and that compatible reads only the leading semver
+	// fields.
+	mustParse := func(s string) semver.Version {
+		ver, err := semver.ParseTolerant(s)
+		assert.NilError(t, err, "ParseTolerant(%q)", s)
+		return ver
+	}
+	type testCase struct {
+		name   string
+		client semver.Version
+		server semver.Version
+		want   bool
+	}
+	cases := []testCase{
+		{"same minor", v(1, 30), v(1, 30), true},
+		{"client one ahead", v(1, 31), v(1, 30), true},
+		{"client one behind", v(1, 29), v(1, 30), true},
+		{"client two ahead", v(1, 32), v(1, 30), false},
+		{"client two behind", v(1, 28), v(1, 30), false},
+		{"server at zero, client at zero", v(1, 0), v(1, 0), true},
+		{"server at zero, client at one", v(1, 1), v(1, 0), true},
+		{"patch differences ignored", semver.Version{Major: 1, Minor: 30, Patch: 99}, semver.Version{Major: 1, Minor: 30, Patch: 0}, true},
+		{"different major rules out", v(1, 30), semver.Version{Major: 2, Minor: 30}, false},
+		{"EKS suffix server within skew", v(1, 30), mustParse("v1.30.0-eks-1234"), true},
+		{"GKE suffix server within skew", v(1, 30), mustParse("v1.30.7-gke.500"), true},
+		{"AKS suffix server out of skew", v(1, 30), mustParse("v1.32.0-aks.1"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, compatible(tc.client, tc.server), tc.want)
+		})
+	}
+}
+
+func TestCachedPath(t *testing.T) {
+	v := semver.Version{Major: 1, Minor: 30, Patch: 5}
+	got := cachedPath(v)
+	wantSuffix := "kubectl-v1.30.5"
+	if runtime.GOOS == "windows" {
+		wantSuffix += ".exe"
+	}
+	assert.Assert(t, strings.HasSuffix(got, wantSuffix), "cachedPath = %q, want suffix %q", got, wantSuffix)
+	assert.Assert(t, strings.HasPrefix(got, CacheDir()), "cachedPath = %q, want prefix %q", got, CacheDir())
+}
+
+func TestParseKubeConfigFlags(t *testing.T) {
+	deref := func(p *string) string {
+		if p == nil {
+			return ""
+		}
+		return *p
+	}
+	derefBool := func(p *bool) bool {
+		if p == nil {
+			return false
+		}
+		return *p
+	}
+
+	type want struct {
+		kubeconfig string
+		context    string
+		server     string
+		cluster    string
+		user       string
+		token      string
+		caFile     string
+		certFile   string
+		keyFile    string
+		tlsName    string
+		insecure   bool
+		username   string
+		password   string
+		namespace  string
+	}
+	cases := []struct {
+		name string
+		args []string
+		want want
+	}{
+		{"empty", nil, want{}},
+		{"unrelated args", []string{"get", "pods"}, want{}},
+		{"--kubeconfig spaced", []string{"--kubeconfig", "/k", "get", "pods"}, want{kubeconfig: "/k"}},
+		{"--kubeconfig equals", []string{"--kubeconfig=/k", "get", "pods"}, want{kubeconfig: "/k"}},
+		{"--context spaced", []string{"--context", "c", "get", "pods"}, want{context: "c"}},
+		{"--context equals", []string{"--context=c", "get", "pods"}, want{context: "c"}},
+		{"--server spaced", []string{"--server", "https://x:6443", "get"}, want{server: "https://x:6443"}},
+		{"--server equals", []string{"--server=https://x:6443", "get"}, want{server: "https://x:6443"}},
+		{"-s alias spaced", []string{"-s", "https://x:6443", "get"}, want{server: "https://x:6443"}},
+		{"-s alias equals", []string{"-s=https://x:6443", "get"}, want{server: "https://x:6443"}},
+		{"--cluster", []string{"--cluster=prod", "get"}, want{cluster: "prod"}},
+		{"--user", []string{"--user=alice", "get"}, want{user: "alice"}},
+		{"--token", []string{"--token=eyJabc", "get"}, want{token: "eyJabc"}},
+		{"--certificate-authority", []string{"--certificate-authority=/ca.crt", "get"}, want{caFile: "/ca.crt"}},
+		{"--client-certificate", []string{"--client-certificate=/c.crt", "get"}, want{certFile: "/c.crt"}},
+		{"--client-key", []string{"--client-key=/c.key", "get"}, want{keyFile: "/c.key"}},
+		{"--tls-server-name", []string{"--tls-server-name=api.example", "get"}, want{tlsName: "api.example"}},
+		{"--insecure-skip-tls-verify bare", []string{"--insecure-skip-tls-verify", "get"}, want{insecure: true}},
+		{"--insecure-skip-tls-verify=true", []string{"--insecure-skip-tls-verify=true", "get"}, want{insecure: true}},
+		{"--namespace spaced", []string{"--namespace", "kube-system", "get"}, want{namespace: "kube-system"}},
+		{"-n alias", []string{"-n", "kube-system", "get"}, want{namespace: "kube-system"}},
+		{"all auth/tls together", []string{"--server=https://x", "--token=tk", "--certificate-authority=/ca", "--insecure-skip-tls-verify", "get"}, want{server: "https://x", token: "tk", caFile: "/ca", insecure: true}},
+		{"flag at end without value is ignored", []string{"get", "--server"}, want{}},
+		{"later flag wins", []string{"--context=a", "--context=b"}, want{context: "b"}},
+		{"stops at --", []string{"exec", "pod", "--", "tool", "--kubeconfig=/other", "--server=https://other"}, want{}},
+		{"flags before -- still parse", []string{"--kubeconfig=/k", "--server=https://x", "exec", "pod", "--", "tool", "--context=other"}, want{kubeconfig: "/k", server: "https://x"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cf := parseKubeConfigFlags(tc.args)
+			actual := want{
+				kubeconfig: deref(cf.KubeConfig),
+				context:    deref(cf.Context),
+				server:     deref(cf.APIServer),
+				cluster:    deref(cf.ClusterName),
+				user:       deref(cf.AuthInfoName),
+				token:      deref(cf.BearerToken),
+				caFile:     deref(cf.CAFile),
+				certFile:   deref(cf.CertFile),
+				keyFile:    deref(cf.KeyFile),
+				tlsName:    deref(cf.TLSServerName),
+				insecure:   derefBool(cf.Insecure),
+				username:   deref(cf.Username),
+				password:   deref(cf.Password),
+				namespace:  deref(cf.Namespace),
+			}
+			assert.Equal(t, actual, tc.want)
+		})
+	}
+}
+
+func TestIsClientOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"empty", nil, true},
+		{"--help alone", []string{"--help"}, true},
+		{"-h alone", []string{"-h"}, true},
+		{"--help after subcommand", []string{"get", "pods", "--help"}, true},
+		{"--help=true alone", []string{"--help=true"}, true},
+		{"--help=1 after subcommand", []string{"get", "pods", "--help=1"}, true},
+		{"-h=true alone", []string{"-h=true"}, true},
+		{"--help=false probes", []string{"--help=false", "get", "pods"}, false},
+		{"-h=0 probes", []string{"-h=0", "get", "pods"}, false},
+		{"--help=garbage stops parse, no positionals", []string{"--help=garbage", "get", "pods"}, true},
+		{"version --client", []string{"version", "--client"}, true},
+		{"version --client with --output", []string{"version", "--client", "--output=json"}, true},
+		{"version --client=true", []string{"version", "--client=true"}, true},
+		{"version --client=false", []string{"version", "--client=false"}, false},
+		{"version --client=1", []string{"version", "--client=1"}, true},
+		{"version --client then --client=false (last wins)", []string{"version", "--client", "--client=false"}, false},
+		{"version --client=false then --client (last wins)", []string{"version", "--client=false", "--client"}, true},
+		{"version --client=garbage stays false", []string{"version", "--client=garbage"}, false},
+		{"version without --client", []string{"version"}, false},
+		{"completion bash", []string{"completion", "bash"}, true},
+		{"config view", []string{"config", "view"}, true},
+		{"config get-contexts", []string{"config", "get-contexts"}, true},
+		{"kustomize bare", []string{"kustomize"}, true},
+		{"kustomize with dir", []string{"kustomize", "./manifests"}, true},
+		{"kustomize with --enable-helm", []string{"kustomize", "./m", "--enable-helm"}, true},
+		{"plugin bare", []string{"plugin"}, true},
+		{"plugin list", []string{"plugin", "list"}, true},
+		{"options", []string{"options"}, true},
+		{"help subcommand", []string{"help", "get"}, true},
+		{"get pods", []string{"get", "pods"}, false},
+		{"apply -f", []string{"apply", "-f", "manifest.yaml"}, false},
+		{"with kubeconfig flag spaced", []string{"--kubeconfig", "/k", "completion", "bash"}, true},
+		{"with kubeconfig flag equals", []string{"--kubeconfig=/k", "completion", "bash"}, true},
+		{"with --server before subcommand", []string{"--server", "https://x", "config", "view"}, true},
+		{"--server URL must not be read as subcommand", []string{"--server", "completion", "get", "pods"}, false},
+		{"-n namespace before subcommand", []string{"-n", "kube-system", "get", "pods"}, false},
+		{"-n with config", []string{"-n", "ns", "config", "view"}, true},
+		{"--as-user-extra spaced before subcommand", []string{"--as-user-extra", "k=v", "config", "view"}, true},
+		{"--as-user-extra equals before subcommand", []string{"--as-user-extra=k=v", "config", "view"}, true},
+		{"unknown long flag swallows next non-flag arg as assumed value", []string{"--unknown", "config", "view"}, false},
+		{"stops at --", []string{"exec", "pod", "--", "completion"}, false},
+		{"-- before subcommand still finds the subcommand", []string{"--", "get", "pods"}, false},
+		{"unknown --v spaced rides UnknownFlags path", []string{"--v", "4", "config", "view"}, true},
+		{"unknown --v=N equals form rides UnknownFlags path", []string{"--v=4", "config", "view"}, true},
+		{"unknown --vmodule spaced rides UnknownFlags path", []string{"--vmodule", "foo=2", "config", "view"}, true},
+		{"--warnings-as-errors bare bool", []string{"--warnings-as-errors", "config", "view"}, true},
+		{"--warnings-as-errors=true", []string{"--warnings-as-errors=true", "config", "view"}, true},
+		{"--match-server-version bare bool", []string{"--match-server-version", "config", "view"}, true},
+		{"--match-server-version=true", []string{"--match-server-version=true", "config", "view"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, isClientOnly(tc.args), tc.want)
+		})
+	}
+}
+
+// TestResolveEmbeddedVersionUnparseable locks in the dev-build fall-through:
+// `go run ./cmd/rdd kubectl ...` and IDE debug builds skip the Makefile's
+// -ldflags -X, so componentbasever returns the in-tree default
+// `v0.0.0-master+$Format:%H$`, which fails semver parsing. Resolve must
+// return ("", nil) so the embedded kubectl handles the invocation rather
+// than aborting every dev kubectl call.
+func TestResolveEmbeddedVersionUnparseable(t *testing.T) {
+	orig := embeddedVersion
+	t.Cleanup(func() { embeddedVersion = orig })
+	embeddedVersion = func() (semver.Version, error) {
+		return semver.Version{}, errors.New("test: unparseable embedded version")
+	}
+
+	// Args that would otherwise reach the cluster probe (not client-only).
+	path, err := Resolve(context.Background(), []string{"get", "pods"})
+	assert.NilError(t, err)
+	assert.Equal(t, path, "")
+}
+
+// TestResolveSkipsWhenRecursionGuardSet locks in the cross-process recursion
+// guard: Exec sets RDD_KUBECTL_RESOLVED on the kubectl child so a downloaded
+// kubectl that re-execs us through a shim short-circuits Resolve at the top
+// instead of recursing into another probe + download cycle. The mocked
+// embeddedVersion fails the test if the guard fails to short-circuit before
+// the version probe.
+func TestResolveSkipsWhenRecursionGuardSet(t *testing.T) {
+	t.Setenv(envSkipResolver, "1")
+	orig := embeddedVersion
+	t.Cleanup(func() { embeddedVersion = orig })
+	embeddedVersionCalled := false
+	embeddedVersion = func() (semver.Version, error) {
+		embeddedVersionCalled = true
+		return semver.Version{}, nil
+	}
+
+	// Args that would otherwise reach the cluster probe.
+	path, err := Resolve(context.Background(), []string{"get", "pods"})
+	assert.NilError(t, err)
+	assert.Equal(t, path, "")
+	assert.Assert(t, !embeddedVersionCalled, "Resolve reached embeddedVersion despite envSkipResolver")
+}


### PR DESCRIPTION
When `rdd kubectl` runs against an external cluster more than +/-1 minor out of skew with the embedded kubectl, the resolver fetches a version-matched kubectl from dl.k8s.io into a shared cache, sha512-verifies it, and execs it in place. Within skew, or when the cluster is unreachable, control falls through to the embedded kubectl. Modeled on github.com/flavio/kuberlr; everything functional there sits under internal/ (only build-time version constants are exported), so Go forbids importing it and this commit reimplements the resolver inline in pkg/kuberlr/.

`rdd ctl` always targets the embedded apiserver. The embedded apiserver and the embedded kubectl come from the same k8s.io/kubernetes module entry, so they cannot drift. `ctlAction` calls `kuberlr.SkipResolver()` before `kubectlAction` so the probe never runs.

The cache lives under os.UserCacheDir() and is shared across instances:

```
  macOS:   ~/Library/Caches/rancher-desktop/kubectl/<os>-<arch>/
  Linux:   ~/.cache/rancher-desktop/kubectl/<os>-<arch>/
  Windows: %LocalAppData%\rancher-desktop\kubectl\<os>-<arch>\
```

`rdd svc paths kubectl_cache` reports the path. Two env vars override the resolver's I/O for tests and offline operation:

```
  RDD_CACHE_DIR        rdd-wide cache root; kuberlr appends
                       kubectl/<os>-<arch>/ inside it. Anticipates a
                       shared rdd cache that future consumers (k3s
                       images, lima templates) can join.
  RDD_KUBECTL_MIRROR   alternate release mirror (default
                       https://dl.k8s.io). Used by the BATS tests below.
```

Error policy: download failures (mirror 404, sha512 mismatch, network) surface loudly with non-zero exit and a "resolving kubectl version: ..." message. Falling back to a version-mismatched embedded kubectl would hide the failure behind weird kubectl errors. Apiserver-probe failures (unreachable cluster, missing or malformed kubeconfig, unparseable server version) fall through silently: serverVersion returns ok=false with nil error, Resolve returns "", and the embedded kubectl handles client-only commands. The three routine paths log at debug; the unparseable-version path logs at warn because an apiserver answering /version with garbage is a surprise worth surfacing.

Binary delta: +16 KB stripped. The only new direct dep is github.com/blang/semver/v4, already a transitive dep.

A TODO marks an offline mode (suppress downloads, fall back to closest cached binary) layered on top of the same env vars.

Coverage:
- pkg/kuberlr/resolver_test.go: skew rule (TestCompatible, with EKS/GKE/AKS gitVersion suffixes), kubectl connection-override flag binding (TestParseKubeConfigFlags, full genericclioptions.ConfigFlags surface), client-only detection (TestIsClientOnly), and cache-path layout (TestCachedPath).
- bats/tests/10-cli/7-kubectl-cache.bats with sibling fake-kube/: a standalone Go module providing a fake kubectl (prints args) and a fake server playing both apiserver /version and release mirror /release/* roles. Five tests cover download-on-miss, skip-on-hit, mirror-404, sha-mismatch, and apiserver-500 silent fall-through. The server reads /version overrides from per-test files so tests steer behavior without restarting it.
- bats/tests/10-cli/5-paths.bats: kubectl_cache added to ALL_KEYS.