### PR TITLE
K3s: Use a dynamic port

### DIFF
--- a/docs/design/api_app.md
+++ b/docs/design/api_app.md
@@ -64,6 +64,7 @@ spec:
   namespace: rancher-desktop
 
 status:
+  kubernetesPort: 7443
   conditions:
   - type: Created
     status: "True"
@@ -93,6 +94,8 @@ status:
 - **spec.kubernetes.enabled**: Whether Kubernetes should be enabled in the VM. Defaults to `false`. Propagated to the `KUBERNETES_ENABLED` Lima template param.
 
 - **spec.kubernetes.version**: The Kubernetes version to use (e.g. `"1.30.2"`). Defaults to `"1.30.2"`. Propagated to the `KUBERNETES_VERSION` Lima template param.
+
+- **status.kubernetesPort**: The host TCP port allocated for the k3s API server (`7441 + instance.Index()` by default). Set by the App reconciler on the first reconcile after `spec.kubernetes.enabled` becomes `true`, and cleared when `spec.kubernetes.enabled` is set back to `false` so that a fresh port is resolved on the next enable. The `KUBERNETES_PORT` Lima template param is set to this value; Lima's identity port-forward rule binds the same port on the host and forwards it to the guest.
 
 - **status.conditions**: Multiple controllers write here. The App controller mirrors `Created` and `Running` from the owned `LimaVM`, computes `Settled`, and the engine controller writes `ContainerEngineReady`. All writers use `retry.RetryOnConflict` with a re-Get so concurrent status updates do not 409.
 

--- a/docs/design/networking.md
+++ b/docs/design/networking.md
@@ -182,6 +182,6 @@ The host-switch uses [gvisor-tap-vsock](https://github.com/containers/gvisor-tap
 
 ## Future Work
 
-- **Kubernetes port forwarding**: Pre-forward `127.0.0.1:6443` to `192.168.127.2:6443` so `kubectl` on the host reaches the K8s API inside the VM.
+- **Kubernetes port forwarding**: Pre-forward `127.0.0.1:<App.Status.KubernetesPort>` to the VM's k3s API server so `kubectl` on the host reaches the K8s API inside the VM. The port is allocated dynamically at `7441 + instance.Index()` and stored in `App.Status.KubernetesPort`.
 - **Dynamic port forwarding**: Run `wsl-proxy` in the guest to relay container port mappings from the guest agent to the host-switch's HTTP API.
 - **DNS search domains**: Read Windows DNS search domains and pass them to gvisor-tap-vsock's DHCP configuration.

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -109,13 +109,14 @@ type AppStatus struct {
 	// (guestPortRange:[1,65535] → hostPortRange:[0,0]) later binds the same
 	// port on the host.
 	//
-	// There is a TOCTOU window between ResolvePort releasing the port and
-	// Lima binding it (typically seconds to minutes). If another process
-	// claims the port in that window, Lima's forwarding silently fails,
-	// probeK3sAPI returns false, and KubernetesReady stays False until the
-	// App is recreated with a freshly resolved port. A future improvement
-	// would keep the listener open until Lima is ready to bind, or observe
-	// the actual host port from Lima state rather than storing an intent.
+	// The window between ResolvePort releasing the port and Lima binding it
+	// spans VM boot, provisioning, and k3s install — minutes on a cold
+	// start. If another process claims the port during that window, Lima
+	// logs "failed to set up forwarding tcp port" and kubectl gets
+	// connection refused; the LimaVM still reports Running. A future
+	// improvement would keep the listener open until Lima is ready to bind,
+	// or read the bound host port from Lima state instead of storing an
+	// intent.
 	// +optional
 	KubernetesPort int `json:"kubernetesPort,omitempty"`
 	// conditions represent the current state of the App resource.

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -103,8 +103,19 @@ type AppSpec struct {
 
 // AppStatus defines the observed state of App.
 type AppStatus struct {
-	// kubernetesPort is the port that Kubernetes API server listens on.
-	// This is only set if Kubernetes is enabled.
+	// kubernetesPort is the intended port for the Kubernetes API server.
+	// AppReconciler calls ResolvePort to find a free port, closes the
+	// listener, then persists this value. Lima's identity port-forward rule
+	// (guestPortRange:[1,65535] → hostPortRange:[0,0]) later binds the same
+	// port on the host.
+	//
+	// There is a TOCTOU window between ResolvePort releasing the port and
+	// Lima binding it (typically seconds to minutes). If another process
+	// claims the port in that window, Lima's forwarding silently fails,
+	// probeK3sAPI returns false, and KubernetesReady stays False until the
+	// App is recreated with a freshly resolved port. A future improvement
+	// would keep the listener open until Lima is ready to bind, or observe
+	// the actual host port from Lima state rather than storing an intent.
 	// +optional
 	KubernetesPort int `json:"kubernetesPort,omitempty"`
 	// conditions represent the current state of the App resource.

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -103,6 +103,10 @@ type AppSpec struct {
 
 // AppStatus defines the observed state of App.
 type AppStatus struct {
+	// kubernetesPort is the port that Kubernetes API server listens on.
+	// This is only set if Kubernetes is enabled.
+	// +optional
+	KubernetesPort int `json:"kubernetesPort,omitempty"`
 	// conditions represent the current state of the App resource.
 	// +listType=map
 	// +listMapKey=type

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -227,12 +227,11 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		return ctrl.Result{}, limaVMErr
 	}
 
-	// If the Kubernetes port is not set, resolve and persist it now.
-	// ResolvePort closes the listener immediately after probing, so there is
-	// a TOCTOU window before Lima binds the same port via its identity
-	// port-forward rule. In the unlikely event the port is stolen, Lima's
-	// forwarding fails and KubernetesReady stays False — a visible failure
-	// rather than a silent wrong connection. See AppStatus.KubernetesPort.
+	// Resolve the host port for the k3s API and persist it. ResolvePort
+	// closes the listener immediately after probing, leaving a TOCTOU
+	// window before Lima's identity port-forward rule binds the same port
+	// (see AppStatus.KubernetesPort). If the port is stolen during that
+	// window, Lima logs a warning and kubectl gets connection refused.
 	if app.Spec.Kubernetes.Enabled && app.Status.KubernetesPort == 0 {
 		port, err := controllers.ResolvePort(ctx, 7441+instance.Index())
 		if err != nil {

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -30,6 +30,7 @@ import (
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
 )
 
 // ControllerDiscovery enumerates controllers enabled across all controller
@@ -90,7 +91,7 @@ func (r *AppReconciler) engineEnabled(ctx context.Context) bool {
 	return slices.Contains(enabled, v1alpha1.EngineControllerName)
 }
 
-func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec) (string, error) {
+func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, status v1alpha1.AppStatus) (string, error) {
 	hostHome, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get host home directory: %w", err)
@@ -103,6 +104,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec) (string, er
 		fmt.Sprintf("  HOST_HOME_GUEST: %q", toLinuxPath(hostHome)),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
+		fmt.Sprintf("  KUBERNETES_PORT: %d", status.KubernetesPort),
 		"",
 	}, "\n"), nil
 }
@@ -225,8 +227,21 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		return ctrl.Result{}, limaVMErr
 	}
 
+	// If the Kubernetes port is not set, set it first.
+	if app.Spec.Kubernetes.Enabled && app.Status.KubernetesPort == 0 {
+		app.Status.KubernetesPort, err = controllers.ResolvePort(ctx, 7441+instance.Index())
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to resolve Kubernetes port: %w", err)
+		}
+		if err := r.Status().Update(ctx, &app); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update App status: %w", err)
+		}
+		// The status update causes a requeue.
+		return ctrl.Result{}, nil
+	}
+
 	if apierrors.IsNotFound(limaVMErr) {
-		template, err := applySpecToTemplate(r.LimaTemplateData, app.Spec)
+		template, err := applySpecToTemplate(r.LimaTemplateData, app.Spec, app.Status)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to apply spec to template: %w", err)
 		}
@@ -310,7 +325,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 				return ctrl.Result{}, fmt.Errorf("failed to fetch LimaVM template ConfigMap: %w", err)
 			}
 		} else {
-			desired, err := applySpecToTemplate(r.LimaTemplateData, app.Spec)
+			desired, err := applySpecToTemplate(r.LimaTemplateData, app.Spec, app.Status)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to apply spec to template: %w", err)
 			}

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -91,7 +91,7 @@ func (r *AppReconciler) engineEnabled(ctx context.Context) bool {
 	return slices.Contains(enabled, v1alpha1.EngineControllerName)
 }
 
-func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, status v1alpha1.AppStatus) (string, error) {
+func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesPort int) (string, error) {
 	hostHome, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get host home directory: %w", err)
@@ -104,7 +104,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, status v1al
 		fmt.Sprintf("  HOST_HOME_GUEST: %q", toLinuxPath(hostHome)),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
-		fmt.Sprintf("  KUBERNETES_PORT: %d", status.KubernetesPort),
+		fmt.Sprintf("  KUBERNETES_PORT: %d", kubernetesPort),
 		"",
 	}, "\n"), nil
 }
@@ -227,21 +227,56 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		return ctrl.Result{}, limaVMErr
 	}
 
-	// If the Kubernetes port is not set, set it first.
+	// If the Kubernetes port is not set, resolve and persist it now.
+	// ResolvePort closes the listener immediately after probing, so there is
+	// a TOCTOU window before Lima binds the same port via its identity
+	// port-forward rule. In the unlikely event the port is stolen, Lima's
+	// forwarding fails and KubernetesReady stays False — a visible failure
+	// rather than a silent wrong connection. See AppStatus.KubernetesPort.
 	if app.Spec.Kubernetes.Enabled && app.Status.KubernetesPort == 0 {
-		app.Status.KubernetesPort, err = controllers.ResolvePort(ctx, 7441+instance.Index())
+		port, err := controllers.ResolvePort(ctx, 7441+instance.Index())
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to resolve Kubernetes port: %w", err)
 		}
-		if err := r.Status().Update(ctx, &app); err != nil {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest := &v1alpha1.App{}
+			if err := r.Get(ctx, client.ObjectKey{Name: appName}, latest); err != nil {
+				return err
+			}
+			if latest.Status.KubernetesPort != 0 {
+				return nil
+			}
+			latest.Status.KubernetesPort = port
+			return r.Status().Update(ctx, latest)
+		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update App status: %w", err)
 		}
 		// The status update causes a requeue.
 		return ctrl.Result{}, nil
 	}
 
+	// Clear a stale port when Kubernetes is disabled so the next enable
+	// resolves a fresh port rather than reusing one that may have been
+	// claimed by another process during the intervening idle window.
+	if !app.Spec.Kubernetes.Enabled && app.Status.KubernetesPort != 0 {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest := &v1alpha1.App{}
+			if err := r.Get(ctx, client.ObjectKey{Name: appName}, latest); err != nil {
+				return err
+			}
+			if latest.Status.KubernetesPort == 0 {
+				return nil
+			}
+			latest.Status.KubernetesPort = 0
+			return r.Status().Update(ctx, latest)
+		}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to clear Kubernetes port: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	if apierrors.IsNotFound(limaVMErr) {
-		template, err := applySpecToTemplate(r.LimaTemplateData, app.Spec, app.Status)
+		template, err := applySpecToTemplate(r.LimaTemplateData, app.Spec, app.Status.KubernetesPort)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to apply spec to template: %w", err)
 		}
@@ -325,7 +360,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 				return ctrl.Result{}, fmt.Errorf("failed to fetch LimaVM template ConfigMap: %w", err)
 			}
 		} else {
-			desired, err := applySpecToTemplate(r.LimaTemplateData, app.Spec, app.Status)
+			desired, err := applySpecToTemplate(r.LimaTemplateData, app.Spec, app.Status.KubernetesPort)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to apply spec to template: %w", err)
 			}

--- a/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -7,13 +7,20 @@ package controllers
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
 )
 
 // fakeDiscovery satisfies ControllerDiscovery for unit tests.
@@ -241,4 +248,155 @@ func Test_engineEnabled(t *testing.T) {
 			assert.Equal(t, r.engineEnabled(t.Context()), tt.want)
 		})
 	}
+}
+
+func Test_applySpecToTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		spec            v1alpha1.AppSpec
+		status          v1alpha1.AppStatus
+		wantPortLine    string
+		wantEnabledLine string
+	}{
+		{
+			name: "kubernetes enabled with port set emits the port",
+			spec: v1alpha1.AppSpec{
+				Kubernetes: v1alpha1.KubernetesSpec{Enabled: true, Version: "1.32.0"},
+			},
+			status:          v1alpha1.AppStatus{KubernetesPort: 7443},
+			wantPortLine:    "  KUBERNETES_PORT: 7443",
+			wantEnabledLine: "  KUBERNETES_ENABLED: true",
+		},
+		{
+			name: "kubernetes disabled with port zero emits zero",
+			spec: v1alpha1.AppSpec{
+				Kubernetes: v1alpha1.KubernetesSpec{Enabled: false},
+			},
+			status:          v1alpha1.AppStatus{KubernetesPort: 0},
+			wantPortLine:    "  KUBERNETES_PORT: 0",
+			wantEnabledLine: "  KUBERNETES_ENABLED: false",
+		},
+		{
+			name: "kubernetes disabled but port previously set still emits port",
+			spec: v1alpha1.AppSpec{
+				Kubernetes: v1alpha1.KubernetesSpec{Enabled: false},
+			},
+			status:          v1alpha1.AppStatus{KubernetesPort: 7444},
+			wantPortLine:    "  KUBERNETES_PORT: 7444",
+			wantEnabledLine: "  KUBERNETES_ENABLED: false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := applySpecToTemplate("", tt.spec, tt.status.KubernetesPort)
+			assert.NilError(t, err)
+			assert.Assert(t, strings.Contains(got, tt.wantPortLine),
+				"expected output to contain %q, got:\n%s", tt.wantPortLine, got)
+			assert.Assert(t, strings.Contains(got, tt.wantEnabledLine),
+				"expected output to contain %q, got:\n%s", tt.wantEnabledLine, got)
+		})
+	}
+}
+
+// newTestScheme returns a scheme with all types the AppReconciler touches.
+func newTestScheme(t *testing.T) *k8sruntime.Scheme {
+	t.Helper()
+	s := k8sruntime.NewScheme()
+	assert.NilError(t, corev1.AddToScheme(s))
+	assert.NilError(t, v1alpha1.AddToScheme(s))
+	assert.NilError(t, limav1alpha1.AddToScheme(s))
+	return s
+}
+
+func Test_Reconcile_resolvesKubernetesPort(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme(t)
+
+	app := &v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName},
+		Spec: v1alpha1.AppSpec{
+			Running:    false,
+			Kubernetes: v1alpha1.KubernetesSpec{Enabled: true, Version: "1.32.0"},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &AppReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		LimaTemplateData: "",
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+
+	// First reconcile: adds the cleanup finalizer and returns early.
+	_, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+
+	// Second reconcile: past the finalizer, discovers KubernetesPort == 0,
+	// calls ResolvePort, and persists a non-zero port to Status.
+	_, err = r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+
+	result := &v1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, result))
+	assert.Assert(t, result.Status.KubernetesPort != 0,
+		"expected Status.KubernetesPort to be set after reconcile, got 0")
+}
+
+func Test_Reconcile_clearsKubernetesPortOnDisable(t *testing.T) {
+	t.Parallel()
+
+	scheme := newTestScheme(t)
+
+	// App starts with Kubernetes disabled but a stale port from a previous enable.
+	app := &v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName},
+		Spec: v1alpha1.AppSpec{
+			Running:    false,
+			Kubernetes: v1alpha1.KubernetesSpec{Enabled: false},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	// Inject a stale port directly into status (simulates a prior enable cycle).
+	app.Status.KubernetesPort = 7443
+	assert.NilError(t, c.Status().Update(context.Background(), app))
+
+	r := &AppReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		LimaTemplateData: "",
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+
+	// First reconcile: adds the cleanup finalizer and returns early.
+	_, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+
+	// Second reconcile: Kubernetes disabled + port set → clears the port.
+	_, err = r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+
+	result := &v1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, result))
+	assert.Equal(t, result.Status.KubernetesPort, 0,
+		"expected Status.KubernetesPort to be cleared when Kubernetes is disabled")
 }

--- a/pkg/controllers/app/app/crd.yaml
+++ b/pkg/controllers/app/app/crd.yaml
@@ -166,13 +166,14 @@ spec:
                   (guestPortRange:[1,65535] → hostPortRange:[0,0]) later binds the same
                   port on the host.
 
-                  There is a TOCTOU window between ResolvePort releasing the port and
-                  Lima binding it (typically seconds to minutes). If another process
-                  claims the port in that window, Lima's forwarding silently fails,
-                  probeK3sAPI returns false, and KubernetesReady stays False until the
-                  App is recreated with a freshly resolved port. A future improvement
-                  would keep the listener open until Lima is ready to bind, or observe
-                  the actual host port from Lima state rather than storing an intent.
+                  The window between ResolvePort releasing the port and Lima binding it
+                  spans VM boot, provisioning, and k3s install — minutes on a cold
+                  start. If another process claims the port during that window, Lima
+                  logs "failed to set up forwarding tcp port" and kubectl gets
+                  connection refused; the LimaVM still reports Running. A future
+                  improvement would keep the listener open until Lima is ready to bind,
+                  or read the bound host port from Lima state instead of storing an
+                  intent.
                 type: integer
             type: object
         type: object

--- a/pkg/controllers/app/app/crd.yaml
+++ b/pkg/controllers/app/app/crd.yaml
@@ -160,8 +160,19 @@ spec:
                 x-kubernetes-list-type: map
               kubernetesPort:
                 description: |-
-                  kubernetesPort is the port that Kubernetes API server listens on.
-                  This is only set if Kubernetes is enabled.
+                  kubernetesPort is the intended port for the Kubernetes API server.
+                  AppReconciler calls ResolvePort to find a free port, closes the
+                  listener, then persists this value. Lima's identity port-forward rule
+                  (guestPortRange:[1,65535] → hostPortRange:[0,0]) later binds the same
+                  port on the host.
+
+                  There is a TOCTOU window between ResolvePort releasing the port and
+                  Lima binding it (typically seconds to minutes). If another process
+                  claims the port in that window, Lima's forwarding silently fails,
+                  probeK3sAPI returns false, and KubernetesReady stays False until the
+                  App is recreated with a freshly resolved port. A future improvement
+                  would keep the listener open until Lima is ready to bind, or observe
+                  the actual host port from Lima state rather than storing an intent.
                 type: integer
             type: object
         type: object

--- a/pkg/controllers/app/app/crd.yaml
+++ b/pkg/controllers/app/app/crd.yaml
@@ -158,6 +158,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              kubernetesPort:
+                description: |-
+                  kubernetesPort is the port that Kubernetes API server listens on.
+                  This is only set if Kubernetes is enabled.
+                type: integer
             type: object
         type: object
         x-kubernetes-validations:

--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -28,22 +28,26 @@ portForwards:
   - 0
   hostSocket: "{{.Param.HOST_DOCKER_SOCKET}}"
 provision:
+# Write runtime parameters as a systemd EnvironmentFile. Using mode:data lets
+# Lima's Go template engine handle quoting via printf "%q", which produces
+# double-quoted strings compatible with systemd's EnvironmentFile parser.
+# Lima's boot script creates parent directories automatically.
+- mode: data
+  path: /etc/sysconfig/rancher-desktop
+  content: |
+    CONTAINER_ENGINE={{printf "%q" .Param.CONTAINER_ENGINE}}
+    HOST_DOCKER_SOCKET={{printf "%q" .Param.HOST_DOCKER_SOCKET}}
+    HOST_HOME_GUEST={{printf "%q" .Param.HOST_HOME_GUEST}}
+    KUBERNETES_ENABLED={{.Param.KUBERNETES_ENABLED}}
+    KUBERNETES_VERSION={{.Param.KUBERNETES_VERSION}}
+    KUBERNETES_PORT={{.Param.KUBERNETES_PORT}}
 - mode: system
   script: |
     #!/bin/bash
 
-    # All param need to be mentioned for Lima validation.
-    # $PARAM_KUBERNETES_PORT
-
     set -o errexit -o nounset -o pipefail -o xtrace
 
     systemctl stop rancher-desktop.target
-
-    # Write runtime parameters; service ExecCondition checks read these from this file.
-    mkdir -p /etc/sysconfig
-    for p in "${!PARAM_@}"; do
-      printf '%s=%q\n' "${p#PARAM_}" "${!p}"
-    done > /etc/sysconfig/rancher-desktop
 
     # Enable the requested container engine and disable the other.
     # containerd.service has a Conflicts=docker, so we must not start both.

--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -33,6 +33,7 @@ provision:
     #!/bin/bash
 
     # All param need to be mentioned for Lima validation.
+    # $PARAM_KUBERNETES_PORT
 
     set -o errexit -o nounset -o pipefail -o xtrace
 
@@ -40,9 +41,9 @@ provision:
 
     # Write runtime parameters; service ExecCondition checks read these from this file.
     mkdir -p /etc/sysconfig
-    printf 'CONTAINER_ENGINE=%s\nKUBERNETES_ENABLED=%s\nKUBERNETES_PORT=6443\n' \
-        "${PARAM_CONTAINER_ENGINE}" "${PARAM_KUBERNETES_ENABLED}" \
-        >/etc/sysconfig/rancher-desktop
+    for p in "${!PARAM_@}"; do
+      printf '%s=%q\n' "${p#PARAM_}" "${!p}"
+    done > /etc/sysconfig/rancher-desktop
 
     # Enable the requested container engine and disable the other.
     # containerd.service has a Conflicts=docker, so we must not start both.


### PR DESCRIPTION
This configures K3s to use a port based on the instance index, but only whatever is free.

Fixes #327 (excluding the bits about traefik)