### PR TITLE
Add Kubernetes context controller

### DIFF
--- a/bats/Makefile
+++ b/bats/Makefile
@@ -9,7 +9,7 @@ BATS_CORE := ./lib/bats-core/bin/bats
 # BATS_TIMEOUT=0 disables the wrapper entirely, which also disables
 # support-bundle capture; for long local runs, set a large value
 # (e.g. 86400) instead of 0.
-BATS_TIMEOUT ?= 1800
+BATS_TIMEOUT ?= 2700
 BATS = $(if $(filter-out 0,$(BATS_TIMEOUT)),../scripts/bats-with-timeout.sh $(BATS_TIMEOUT)) $(BATS_CORE)
 
 default: bats-all

--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -337,7 +337,11 @@ EOF
 
 @test "start VM with Kubernetes enabled" {
     skip_on_windows "Kubernetes tests require further setup on Windows"
-    rdd set running=true
+    # Use a generous timeout: rdd set now waits for KubernetesReady=True, which
+    # requires VM boot + k3s startup. On a slow CI runner this can exceed the
+    # default 300s, so give it up to 900s (the outer bats-with-timeout still
+    # enforces the overall suite limit).
+    rdd set --timeout=900s running=true
     rdd ctl wait --for=condition=Running \
         limavm/"${VM_NAME}" --namespace "${RDD_NAMESPACE}" --timeout=300s
 }

--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# Kubernetes context controller tests — verify that the kubernetes controller
+# creates and cleans up the rancher-desktop-{instance} context in
+# ~/.kube/config, sets current-context when appropriate, and reports the
+# KubernetesReady condition on the App resource.
+
+APP_NAME="app"
+VM_NAME="rd"
+K3S_VERSION="1.32.0"
+
+local_setup_file() {
+    skip_on_windows "Kubernetes context tests require Lima"
+
+    # Isolate ~/.kube/config so tests never touch the developer's real kubeconfig.
+    # Set KUBECONFIG before starting the service so the controller process inherits
+    # it; service.Start uses exec.Command without an explicit Env, so it inherits
+    # the caller's environment.
+    export KUBECONFIG="${BATS_FILE_TMPDIR}/kube/config"
+    mkdir -p "$(dirname "${KUBECONFIG}")"
+
+    rdd svc delete
+    rdd set --wait=false running=true kubernetes.enabled=true kubernetes.version="${K3S_VERSION}"
+    rdd ctl wait --for=condition=KubernetesReady app/"${APP_NAME}" --timeout=360s
+}
+
+kube_current_context() {
+    [[ -f "${KUBECONFIG}" ]] || {
+        echo ""
+        return 0
+    }
+
+    kubectl config current-context 2>/dev/null || echo ""
+}
+
+kube_context_exists() { # <context-name>
+    [[ -f "${KUBECONFIG}" ]] || return 1
+    kubectl config get-contexts -o name 2>/dev/null | grep -qx "$1"
+}
+
+kube_cluster_exists() { # <cluster-name>
+    [[ -f "${KUBECONFIG}" ]] || return 1
+    kubectl config get-clusters 2>/dev/null | tail -n +2 | grep -qx "$1"
+}
+
+kube_user_exists() { # <user-name>
+    [[ -f "${KUBECONFIG}" ]] || return 1
+    kubectl config get-users 2>/dev/null | tail -n +2 | grep -qx "$1"
+}
+
+@test "KubernetesReady condition is True when k3s is running" {
+    run -0 rdd ctl get app "${APP_NAME}" \
+        -o jsonpath='{.status.conditions[?(@.type=="KubernetesReady")].status}'
+    assert_output "True"
+}
+
+@test "KubernetesReady reason is Ready" {
+    run -0 rdd ctl get app "${APP_NAME}" \
+        -o jsonpath='{.status.conditions[?(@.type=="KubernetesReady")].reason}'
+    assert_output "Ready"
+}
+
+@test "kubernetes controller creates context entry in user kubeconfig" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    run -0 kube_context_exists "${context_name}"
+}
+
+@test "kubernetes controller creates cluster entry in user kubeconfig" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    run -0 kube_cluster_exists "${context_name}"
+}
+
+@test "kubernetes controller creates user entry in user kubeconfig" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    run -0 kube_user_exists "${context_name}"
+}
+
+@test "context entry points to the instance k3s API server" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+
+    # Read the server URL from the instance kubeconfig (written by k3s).
+    run -0 rdd svc paths config
+    local instance_kubeconfig="${output}"
+
+    run -0 kubectl --kubeconfig="${instance_kubeconfig}" \
+        config view -o jsonpath='{.clusters[0].cluster.server}'
+    local expected_server="${output}"
+
+    run -0 kubectl config view \
+        -o jsonpath="{.clusters[?(@.name==\"${context_name}\")].cluster.server}"
+    assert_output "${expected_server}"
+}
+
+@test "kubernetes controller sets current-context when no healthy context exists" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    # The current-context probe runs in a goroutine after KubernetesReady is
+    # set; poll until it resolves.
+    try --max 6 --delay 2 -- \
+        bash -c "kubectl config current-context 2>/dev/null | grep -qx '${context_name}'"
+
+    run -0 kube_current_context
+    assert_output "${context_name}"
+}
+
+@test "KubernetesReady=NotApplicable when kubernetes is disabled" {
+    rdd set running=true kubernetes.enabled=false
+    run -0 rdd ctl get app "${APP_NAME}" \
+        -o jsonpath='{.status.conditions[?(@.type=="KubernetesReady")].reason}'
+    assert_output "NotApplicable"
+}
+
+@test "kubernetes controller removes context entries when kubernetes is disabled" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    # removeKubeContext runs synchronously in Reconcile; the context should be
+    # gone by the time KubernetesReady=NotApplicable is stamped (which rdd set
+    # above already waited for via Settled).
+    run -1 kube_context_exists "${context_name}"
+    run -1 kube_cluster_exists "${context_name}"
+    run -1 kube_user_exists "${context_name}"
+}
+
+@test "current-context is cleared when kubernetes is disabled" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    run -0 kube_current_context
+    refute_output "${context_name}"
+}
+
+@test "re-enable kubernetes to set up cleanup test" {
+    rdd set --wait=false running=true kubernetes.enabled=true kubernetes.version="${K3S_VERSION}"
+    rdd ctl wait --for=condition=KubernetesReady app/"${APP_NAME}" --timeout=360s
+}
+
+@test "current-context is set again after re-enabling kubernetes" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    try --max 6 --delay 2 -- \
+        bash -c "kubectl config current-context 2>/dev/null | grep -qx '${context_name}'"
+}
+
+@test "stopping VM clears current-context" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    rdd set running=false
+    # removeKubeContext fires on the NotRunning reconcile; poll until done.
+    try --max 10 --delay 1 -- \
+        bash -c "! kube_context_exists '${context_name}'"
+    run -0 kube_current_context
+    refute_output "${context_name}"
+}
+
+@test "stopping VM removes context from user kubeconfig" {
+    local context_name="rancher-desktop-${RDD_INSTANCE}"
+    run -1 kube_context_exists "${context_name}"
+    run -1 kube_cluster_exists "${context_name}"
+    run -1 kube_user_exists "${context_name}"
+}

--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -34,22 +34,27 @@ kube_current_context() {
         return 0
     }
 
-    kubectl config current-context 2>/dev/null || echo ""
+    rdd kubectl config current-context 2>/dev/null || echo ""
 }
 
 kube_context_exists() { # <context-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-contexts -o name 2>/dev/null | grep -qx "$1"
+    rdd kubectl config get-contexts -o name 2>/dev/null | grep -qx "$1"
 }
 
 kube_cluster_exists() { # <cluster-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-clusters 2>/dev/null | tail -n +2 | grep -qx "$1"
+    rdd kubectl config get-clusters 2>/dev/null | tail -n +2 | grep -qx "$1"
 }
 
 kube_user_exists() { # <user-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-users 2>/dev/null | tail -n +2 | grep -qx "$1"
+    rdd kubectl config get-users 2>/dev/null | tail -n +2 | grep -qx "$1"
+}
+
+kube_current_context_is() { # <expected-context>
+    run rdd kubectl config current-context
+    assert_output "$1"
 }
 
 @test "KubernetesReady condition is True when k3s is running" {
@@ -83,14 +88,14 @@ kube_user_exists() { # <user-name>
     local context_name="rancher-desktop-${RDD_INSTANCE}"
 
     # Read the server URL from the instance kubeconfig (written by k3s).
-    run -0 rdd svc paths config
+    run -0 rdd svc paths k3s_config
     local instance_kubeconfig="${output}"
 
-    run -0 kubectl --kubeconfig="${instance_kubeconfig}" \
+    run -0 rdd kubectl --kubeconfig="${instance_kubeconfig}" \
         config view -o jsonpath='{.clusters[0].cluster.server}'
     local expected_server="${output}"
 
-    run -0 kubectl config view \
+    run -0 rdd kubectl config view \
         -o jsonpath="{.clusters[?(@.name==\"${context_name}\")].cluster.server}"
     assert_output "${expected_server}"
 }
@@ -99,8 +104,7 @@ kube_user_exists() { # <user-name>
     local context_name="rancher-desktop-${RDD_INSTANCE}"
     # The current-context probe runs in a goroutine after KubernetesReady is
     # set; poll until it resolves.
-    try --max 6 --delay 2 -- \
-        bash -c "kubectl config current-context 2>/dev/null | grep -qx '${context_name}'"
+    try --max 6 --delay 2 -- kube_current_context_is "${context_name}"
 
     run -0 kube_current_context
     assert_output "${context_name}"
@@ -136,16 +140,14 @@ kube_user_exists() { # <user-name>
 
 @test "current-context is set again after re-enabling kubernetes" {
     local context_name="rancher-desktop-${RDD_INSTANCE}"
-    try --max 6 --delay 2 -- \
-        bash -c "kubectl config current-context 2>/dev/null | grep -qx '${context_name}'"
+    try --max 6 --delay 2 -- kube_current_context_is "${context_name}"
 }
 
 @test "stopping VM clears current-context" {
     local context_name="rancher-desktop-${RDD_INSTANCE}"
     rdd set running=false
     # removeKubeContext fires on the NotRunning reconcile; poll until done.
-    try --max 10 --delay 1 -- \
-        bash -c "! kube_context_exists '${context_name}'"
+    try --max 10 --delay 1 --until-fail -- kube_context_exists "${context_name}"
     run -0 kube_current_context
     refute_output "${context_name}"
 }

--- a/cmd/rdd/service_paths.go
+++ b/cmd/rdd/service_paths.go
@@ -25,6 +25,7 @@ func instancePaths() map[string]string {
 		"lima_home":     instance.LimaHome(),
 		"tls_dir":       instance.TLSDir(),
 		"config":        instance.Config(),
+		"k3s_config":    instance.K3sConfig(),
 		"pid_file":      instance.PIDFile(),
 		"args_file":     instance.ArgsFile(),
 		"docker_socket": instance.DockerSocket(),

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -37,6 +37,7 @@ source <(rdd svc paths --output=shell)
 | `RDD_ARGS_FILE` | Saved startup arguments | `~/Library/Application Support/rancher-desktop-2/args.json` |
 | `RDD_DIR` | Service instance directory | `~/Library/Application Support/rancher-desktop-2` |
 | `RDD_CONFIG` | RDD control plane config file | `~/Library/Application Support/rancher-desktop-2/config.yaml` |
+| `RDD_K3S_CONFIG` | Mirror of the in-VM k3s kubeconfig | `~/Library/Application Support/rancher-desktop-2/k3s.yaml` |
 | `RDD_LIMA_HOME` | Lima home directory | `~/.rd2/lima` |
 | `RDD_LOG_DIR` | Log directory | `~/Library/Logs/rancher-desktop-2` |
 | `RDD_PID_FILE` | Service PID file | `~/Library/Application Support/rancher-desktop-2/rdd.pid` |

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -16,6 +16,9 @@ const AppKind = "App"
 // discovery query reference this constant so they cannot drift.
 const EngineControllerName = "engine"
 
+// KubernetesControllerName is the registry name of the Kubernetes context controller.
+const KubernetesControllerName = "kubernetes"
+
 // App condition types.
 const (
 	// AppConditionRunning mirrors the LimaVM Running condition: True
@@ -32,6 +35,13 @@ const (
 	// ObservedGeneration, so `rdd set` can distinguish a stale True
 	// from a fresh one.
 	AppConditionContainerEngineReady = "ContainerEngineReady"
+
+	// AppConditionKubernetesReady goes True once the Kubernetes controller has
+	// confirmed that the k3s API server is reachable and has merged the
+	// rancher-desktop-{instance} context into ~/.kube/config. It is only
+	// meaningful when spec.kubernetes.enabled is true; when Kubernetes is
+	// disabled the condition is absent or False with reason NotApplicable.
+	AppConditionKubernetesReady = "KubernetesReady"
 
 	// AppConditionSettled reports whether the reconcile chain has
 	// fully caught up with the current spec: observed generations on
@@ -59,6 +69,32 @@ const (
 
 	// AppSettledReasonEngineStale means the engine controller has not yet observed the current generation.
 	AppSettledReasonEngineStale = "EngineStale"
+
+	// AppSettledReasonWaitingForKubernetes means the Kubernetes controller has not yet written KubernetesReady.
+	AppSettledReasonWaitingForKubernetes = "WaitingForKubernetes"
+
+	// AppSettledReasonKubernetesStale means the Kubernetes controller has not yet observed the current generation.
+	AppSettledReasonKubernetesStale = "KubernetesStale"
+)
+
+// Reasons for the KubernetesReady condition.
+const (
+	// AppKubernetesReasonReady means the k3s API server is reachable and the
+	// kubeconfig context has been merged into ~/.kube/config.
+	AppKubernetesReasonReady = "Ready"
+
+	// AppKubernetesReasonNotApplicable means spec.kubernetes.enabled is false;
+	// the condition is set to False with this reason so consumers can
+	// distinguish "disabled" from "still starting".
+	AppKubernetesReasonNotApplicable = "NotApplicable"
+
+	// AppKubernetesReasonNotRunning means the VM is not running, so k3s
+	// cannot be healthy.
+	AppKubernetesReasonNotRunning = "NotRunning"
+
+	// AppKubernetesReasonProbing means the controller is still waiting for
+	// the k3s API server to respond.
+	AppKubernetesReasonProbing = "Probing"
 )
 
 const (

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -10,6 +10,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	goruntime "runtime"
 	"slices"
 	"strings"

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -10,7 +10,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"os"
 	goruntime "runtime"
 	"slices"
 	"strings"
@@ -58,11 +57,13 @@ const (
 // Messages for the Settled condition. Kept as constants so tests can
 // assert on them without duplicating string literals.
 const (
-	settledMessageSettled          = "App has reached the desired state"
-	settledMessageWaitingForLimaVM = "Waiting for LimaVM to report its state"
-	settledMessageWaitingForEngine = "Waiting for container engine condition"
-	settledMessageEngineStale      = "Container engine needs to be synchronized"
-	settledMessageLimaVMNotReached = "LimaVM has not yet reached "
+	settledMessageSettled              = "App has reached the desired state"
+	settledMessageWaitingForLimaVM     = "Waiting for LimaVM to report its state"
+	settledMessageWaitingForEngine     = "Waiting for container engine condition"
+	settledMessageEngineStale          = "Container engine needs to be synchronized"
+	settledMessageWaitingForKubernetes = "Waiting for Kubernetes condition"
+	settledMessageKubernetesStale      = "Kubernetes context needs to be synchronized"
+	settledMessageLimaVMNotReached     = "LimaVM has not yet reached "
 )
 
 // AppReconciler reconciles the singleton App resource and manages its LimaVM lifecycle.
@@ -72,10 +73,10 @@ type AppReconciler struct {
 	LimaTemplateData string
 
 	// Discovery is consulted on each reconcile to determine whether the
-	// engine controller is enabled in any controller manager. When it
-	// is, Settled gates on ContainerEngineReady; when it is not, the
-	// engine condition is ignored. nil disables the engine gate, which
-	// is appropriate for unit tests that do not exercise the engine.
+	// engine and/or kubernetes controllers are enabled in any controller
+	// manager. When enabled, Settled gates on ContainerEngineReady /
+	// KubernetesReady respectively. nil disables both gates, which is
+	// appropriate for unit tests that do not exercise those controllers.
 	Discovery ControllerDiscovery
 }
 
@@ -94,6 +95,22 @@ func (r *AppReconciler) engineEnabled(ctx context.Context) bool {
 	return slices.Contains(enabled, v1alpha1.EngineControllerName)
 }
 
+// kubernetesEnabled reports whether KubernetesReady should gate Settled
+// (only when spec.kubernetes.enabled is also true).
+// On discovery errors it defaults to true so the wait does not return
+// prematurely while discovery is transiently unavailable.
+func (r *AppReconciler) kubernetesEnabled(ctx context.Context) bool {
+	if r.Discovery == nil {
+		return false
+	}
+	enabled, err := r.Discovery.GetEnabledControllers(ctx)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to query controller-manager discovery; assuming kubernetes controller is enabled")
+		return true
+	}
+	return slices.Contains(enabled, v1alpha1.KubernetesControllerName)
+}
+
 func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesPort int) (string, error) {
 	hostHome, err := os.UserHomeDir()
 	if err != nil {
@@ -105,6 +122,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesP
 		fmt.Sprintf("  CONTAINER_ENGINE: %s", spec.ContainerEngine.Name),
 		fmt.Sprintf("  HOST_DOCKER_SOCKET: %q", instance.DockerSocket()),
 		fmt.Sprintf("  HOST_HOME_GUEST: %q", toLinuxPath(hostHome)),
+		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.Config())),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
 		fmt.Sprintf("  KUBERNETES_PORT: %d", kubernetesPort),
@@ -412,6 +430,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 	// EngineReconciler.setEngineCondition; without it, concurrent
 	// writers 409-loop through controller-runtime requeues.
 	engineEnabled := r.engineEnabled(ctx)
+	kubernetesEnabled := r.kubernetesEnabled(ctx)
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest := &v1alpha1.App{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(&app), latest); err != nil {
@@ -430,7 +449,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 				LastTransitionTime: cond.LastTransitionTime,
 			}) || changed
 		}
-		settled := computeSettledCondition(latest, engineEnabled)
+		settled := computeSettledCondition(latest, engineEnabled, kubernetesEnabled)
 		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, settled) || changed
 		if !changed {
 			return nil
@@ -446,24 +465,28 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 
 // computeSettledCondition derives Settled from the feeding conditions
 // that live on app.Status.Conditions: the LimaVM Running condition
-// (mirrored just above) and ContainerEngineReady (written by the
-// engine controller). The output condition carries the App's current
-// generation, so waiters can filter out snapshots from earlier spec
-// versions.
+// (mirrored just above), ContainerEngineReady (written by the engine
+// controller), and KubernetesReady (written by the kubernetes controller).
+// The output condition carries the App's current generation, so waiters can
+// filter out snapshots from earlier spec versions.
 //
 // Settled answers "has the reconcile chain caught up with the current
 // spec?". It goes True when the VM has reached the desired running
-// state with a terminal reason (Started/Stopped) and the engine has
-// observed and processed the current generation. A transient phase
-// (Starting, Stopping, Reconciling, RestartNeeded) holds Settled at
-// False even if the VM is momentarily running, so `rdd set` does not
-// return before the chain stabilises.
+// state with a terminal reason (Started/Stopped) and all enabled
+// sub-controllers have observed and processed the current generation.
+// A transient phase (Starting, Stopping, Reconciling, RestartNeeded)
+// holds Settled at False even if the VM is momentarily running, so
+// `rdd set` does not return before the chain stabilises.
 //
 // engineEnabled is false when no controller in this process writes
 // ContainerEngineReady; in that case the engine condition is ignored.
-func computeSettledCondition(app *v1alpha1.App, engineEnabled bool) metav1.Condition {
+// kubernetesEnabled is false when no controller writes KubernetesReady;
+// it also gates on spec.kubernetes.enabled so a stopped cluster does not
+// hold Settled pending.
+func computeSettledCondition(app *v1alpha1.App, engineEnabled, kubernetesEnabled bool) metav1.Condition {
 	runningCond := apimeta.FindStatusCondition(app.Status.Conditions, v1alpha1.AppConditionRunning)
 	engineCond := apimeta.FindStatusCondition(app.Status.Conditions, v1alpha1.AppConditionContainerEngineReady)
+	kubeCond := apimeta.FindStatusCondition(app.Status.Conditions, v1alpha1.AppConditionKubernetesReady)
 	desiredRunning := app.Spec.Running
 
 	settled := metav1.Condition{
@@ -486,11 +509,11 @@ func computeSettledCondition(app *v1alpha1.App, engineEnabled bool) metav1.Condi
 		settled.Status = metav1.ConditionFalse
 		settled.Reason = runningCond.Reason
 		settled.Message = runningLimaVMMessage(runningCond, "Stopped")
-	case !engineEnabled:
+	case !engineEnabled && !kubernetesEnabled:
 		settled.Status = metav1.ConditionTrue
 		settled.Reason = v1alpha1.AppSettledReasonSettled
 		settled.Message = settledMessageSettled
-	case !desiredRunning:
+	case !desiredRunning && engineEnabled:
 		// Wait for the engine reconciler to confirm cleanup for this
 		// generation before declaring settled. Two conditions must both
 		// hold:
@@ -520,18 +543,36 @@ func computeSettledCondition(app *v1alpha1.App, engineEnabled bool) metav1.Condi
 			settled.Reason = v1alpha1.AppSettledReasonSettled
 			settled.Message = settledMessageSettled
 		}
-	case engineCond == nil:
+	case !desiredRunning:
+		// Engine is disabled; kubernetes context cleanup is async and
+		// does not block settling. A stopped VM is settled regardless.
+		settled.Status = metav1.ConditionTrue
+		settled.Reason = v1alpha1.AppSettledReasonSettled
+		settled.Message = settledMessageSettled
+	case engineEnabled && engineCond == nil:
 		settled.Status = metav1.ConditionFalse
 		settled.Reason = v1alpha1.AppSettledReasonWaitingForEngine
 		settled.Message = settledMessageWaitingForEngine
-	case engineCond.ObservedGeneration < app.Generation:
+	case engineEnabled && engineCond.ObservedGeneration < app.Generation:
 		settled.Status = metav1.ConditionFalse
 		settled.Reason = v1alpha1.AppSettledReasonEngineStale
 		settled.Message = settledMessageEngineStale
-	case engineCond.Status != metav1.ConditionTrue:
+	case engineEnabled && engineCond.Status != metav1.ConditionTrue:
 		settled.Status = metav1.ConditionFalse
 		settled.Reason = engineCond.Reason
 		settled.Message = engineCond.Message
+	case kubernetesEnabled && app.Spec.Kubernetes.Enabled && kubeCond == nil:
+		settled.Status = metav1.ConditionFalse
+		settled.Reason = v1alpha1.AppSettledReasonWaitingForKubernetes
+		settled.Message = settledMessageWaitingForKubernetes
+	case kubernetesEnabled && app.Spec.Kubernetes.Enabled && kubeCond.ObservedGeneration < app.Generation:
+		settled.Status = metav1.ConditionFalse
+		settled.Reason = v1alpha1.AppSettledReasonKubernetesStale
+		settled.Message = settledMessageKubernetesStale
+	case kubernetesEnabled && app.Spec.Kubernetes.Enabled && kubeCond.Status != metav1.ConditionTrue:
+		settled.Status = metav1.ConditionFalse
+		settled.Reason = kubeCond.Reason
+		settled.Message = kubeCond.Message
 	default:
 		settled.Status = metav1.ConditionTrue
 		settled.Reason = v1alpha1.AppSettledReasonSettled

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -122,7 +122,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesP
 		fmt.Sprintf("  CONTAINER_ENGINE: %s", spec.ContainerEngine.Name),
 		fmt.Sprintf("  HOST_DOCKER_SOCKET: %q", instance.DockerSocket()),
 		fmt.Sprintf("  HOST_HOME_GUEST: %q", toLinuxPath(hostHome)),
-		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.Config())),
+		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.K3sConfig())),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
 		fmt.Sprintf("  KUBERNETES_PORT: %d", kubernetesPort),

--- a/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -67,12 +67,13 @@ func Test_computeSettledCondition(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		app           *v1alpha1.App
-		engineEnabled bool
-		wantStatus    metav1.ConditionStatus
-		wantReason    string
-		wantMessage   string
+		name              string
+		app               *v1alpha1.App
+		engineEnabled     bool
+		kubernetesEnabled bool
+		wantStatus        metav1.ConditionStatus
+		wantReason        string
+		wantMessage       string
 	}{
 		{
 			name:          "no Running condition yet",
@@ -243,13 +244,94 @@ func Test_computeSettledCondition(t *testing.T) {
 			wantReason:    "ImplosionFailed",
 			wantMessage:   "the virtual machine did not implode",
 		},
+		// Kubernetes-gating cases.
+		{
+			name: "kubernetes disabled does not gate Settled",
+			app: makeApp(2, true,
+				running("Started", "VM is running", metav1.ConditionTrue, 2),
+				engine("Ready", "engine is ready", metav1.ConditionTrue, 2),
+			),
+			engineEnabled:     true,
+			kubernetesEnabled: true,
+			// spec.kubernetes.enabled == false (default) → kube gate skipped
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  v1alpha1.AppSettledReasonSettled,
+			wantMessage: settledMessageSettled,
+		},
+		{
+			name: "kubernetes enabled but condition missing holds Settled false",
+			app: func() *v1alpha1.App {
+				a := makeApp(2, true,
+					running("Started", "VM is running", metav1.ConditionTrue, 2),
+					engine("Ready", "engine is ready", metav1.ConditionTrue, 2),
+				)
+				a.Spec.Kubernetes.Enabled = true
+				return a
+			}(),
+			engineEnabled:     true,
+			kubernetesEnabled: true,
+			wantStatus:        metav1.ConditionFalse,
+			wantReason:        v1alpha1.AppSettledReasonWaitingForKubernetes,
+			wantMessage:       settledMessageWaitingForKubernetes,
+		},
+		{
+			name: "kubernetes ready at stale generation blocks Settled",
+			app: func() *v1alpha1.App {
+				a := makeApp(2, true,
+					running("Started", "VM is running", metav1.ConditionTrue, 2),
+					engine("Ready", "engine is ready", metav1.ConditionTrue, 2),
+					cond(v1alpha1.AppConditionKubernetesReady, v1alpha1.AppKubernetesReasonReady, "ready", metav1.ConditionTrue, 1),
+				)
+				a.Spec.Kubernetes.Enabled = true
+				return a
+			}(),
+			engineEnabled:     true,
+			kubernetesEnabled: true,
+			wantStatus:        metav1.ConditionFalse,
+			wantReason:        v1alpha1.AppSettledReasonKubernetesStale,
+			wantMessage:       settledMessageKubernetesStale,
+		},
+		{
+			name: "kubernetes not ready surfaces its reason",
+			app: func() *v1alpha1.App {
+				a := makeApp(2, true,
+					running("Started", "VM is running", metav1.ConditionTrue, 2),
+					engine("Ready", "engine is ready", metav1.ConditionTrue, 2),
+					cond(v1alpha1.AppConditionKubernetesReady, v1alpha1.AppKubernetesReasonProbing, "waiting", metav1.ConditionFalse, 2),
+				)
+				a.Spec.Kubernetes.Enabled = true
+				return a
+			}(),
+			engineEnabled:     true,
+			kubernetesEnabled: true,
+			wantStatus:        metav1.ConditionFalse,
+			wantReason:        v1alpha1.AppKubernetesReasonProbing,
+			wantMessage:       "waiting",
+		},
+		{
+			name: "all conditions ready with kubernetes settles",
+			app: func() *v1alpha1.App {
+				a := makeApp(2, true,
+					running("Started", "VM is running", metav1.ConditionTrue, 2),
+					engine("Ready", "engine is ready", metav1.ConditionTrue, 2),
+					cond(v1alpha1.AppConditionKubernetesReady, v1alpha1.AppKubernetesReasonReady, "ready", metav1.ConditionTrue, 2),
+				)
+				a.Spec.Kubernetes.Enabled = true
+				return a
+			}(),
+			engineEnabled:     true,
+			kubernetesEnabled: true,
+			wantStatus:        metav1.ConditionTrue,
+			wantReason:        v1alpha1.AppSettledReasonSettled,
+			wantMessage:       settledMessageSettled,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := computeSettledCondition(tt.app, tt.engineEnabled)
+			got := computeSettledCondition(tt.app, tt.engineEnabled, tt.kubernetesEnabled)
 			assert.Equal(t, got.Type, v1alpha1.AppConditionSettled)
 			assert.Equal(t, got.Status, tt.wantStatus)
 			assert.Equal(t, got.Reason, tt.wantReason)

--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -11,6 +11,9 @@ containerd:
   system: false
   user: false
 portForwards:
+- guestPort: 6443
+  hostIP: 127.0.0.1
+  hostPort: 6443
 - guestIPMustBeZero: true
   guestPortRange:
   - 1
@@ -87,7 +90,7 @@ provision:
     systemctl start --no-block rancher-desktop.target
 
 probes:
-- description: Update kube config on the host
+- description: Write k3s kubeconfig to instance config path
   script: |
     #!/bin/bash
 
@@ -103,21 +106,11 @@ probes:
     for _ in $(seq 300); do
         if [[ -e $K3S_YAML ]]; then
             sleep 1
-            # Rename the default context/user/cluster to "rancher-desktop".
-            KUBECONFIG_LOCAL="$HOME/.kube/config"
-            mkdir -p "$(dirname "$KUBECONFIG_LOCAL")"
-            sudo sed 's/: default$/: rancher-desktop/g' "$K3S_YAML" >"$KUBECONFIG_LOCAL"
-            # Merge into the host kubeconfig.
-            KUBECONFIG_MERGED=$HOME/kubeconfig
-            KUBECONFIG_HOST="$PARAM_HOST_HOME_GUEST/.kube/config"
-            export KUBECONFIG="$KUBECONFIG_HOST:$KUBECONFIG_LOCAL"
-            kubectl config view --merge --flatten >"$KUBECONFIG_MERGED" || break
-            # Only overwrite if the merged config has at least as many contexts.
-            HOST_CONFIGS=$(KUBECONFIG=$KUBECONFIG_HOST kubectl config get-contexts -o name | wc -l)
-            MERGED_CONFIGS=$(KUBECONFIG=$KUBECONFIG_MERGED kubectl config get-contexts -o name | wc -l)
-            if [[ "$HOST_CONFIGS" -le "$MERGED_CONFIGS" ]]; then
-                cp "$KUBECONFIG_MERGED" "$KUBECONFIG_HOST"
-            fi
+            # Copy the raw k3s kubeconfig to the host instance config path.
+            # The kubernetes controller on the host reads this file to probe
+            # the API server and manage the user's ~/.kube/config context.
+            mkdir -p "$(dirname "$PARAM_HOST_INSTANCE_CONFIG")"
+            sudo cp "$K3S_YAML" "$PARAM_HOST_INSTANCE_CONFIG"
             exit 0
         fi
         sleep 1

--- a/pkg/controllers/app/kubernetes/controller.go
+++ b/pkg/controllers/app/kubernetes/controller.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package kubernetes registers the Kubernetes context controller. The
+// controller probes the k3s API server and manages the
+// rancher-desktop-{instance} context in ~/.kube/config whenever
+// spec.kubernetes.enabled is true and the VM is running.
+package kubernetes
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/kubernetes/controllers"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+)
+
+func init() {
+	base.RegisterController(&controller{})
+}
+
+type controller struct{}
+
+var _ base.Controller = &controller{}
+
+func (c *controller) GetName() string {
+	return appv1alpha1.KubernetesControllerName
+}
+
+func (c *controller) GetAPIGroup() string {
+	// No additional CRD group beyond app; return empty to signal that no
+	// extra scheme registration is needed.
+	return ""
+}
+
+func (c *controller) GetCRDData() string {
+	return ""
+}
+
+func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+	if err := appv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+	r := &controllers.KubernetesReconciler{
+		Client: mgr.GetClient(),
+	}
+	return r.SetupWithManager(mgr)
+}

--- a/pkg/controllers/app/kubernetes/controllers/kube_context.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_context.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// kubeConfigPath returns ~/.kube/config, or $KUBECONFIG if set.
+// Computed dynamically so t.Setenv("HOME", …) works in tests.
+func kubeConfigPath() (string, error) {
+	if kc := os.Getenv("KUBECONFIG"); kc != "" {
+		return kc, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".kube", "config"), nil
+}
+
+// loadKubeConfig loads the kubeconfig at path; returns an empty config if absent.
+func loadKubeConfig(path string) (*clientcmdapi.Config, error) {
+	cfg, err := clientcmd.LoadFromFile(path)
+	if os.IsNotExist(err) {
+		return clientcmdapi.NewConfig(), nil
+	}
+	return cfg, err
+}
+
+// createReplaceKubeContext reads the instance kubeconfig from srcPath, renames
+// its cluster/user/context entries to contextName, and merges them into
+// ~/.kube/config.
+func createReplaceKubeContext(contextName, srcPath string) error {
+	src, err := clientcmd.LoadFromFile(srcPath)
+	if err != nil {
+		return fmt.Errorf("load instance kubeconfig: %w", err)
+	}
+
+	// Extract the single cluster and user (k3s names them "default").
+	var cluster *clientcmdapi.Cluster
+	for _, c := range src.Clusters {
+		cluster = c
+		break
+	}
+	if cluster == nil {
+		return errors.New("instance kubeconfig has no cluster entry")
+	}
+
+	var user *clientcmdapi.AuthInfo
+	for _, u := range src.AuthInfos {
+		user = u
+		break
+	}
+	if user == nil {
+		return errors.New("instance kubeconfig has no user entry")
+	}
+
+	destPath, err := kubeConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
+		return fmt.Errorf("create .kube dir: %w", err)
+	}
+
+	cfg, err := loadKubeConfig(destPath)
+	if err != nil {
+		return fmt.Errorf("load ~/.kube/config: %w", err)
+	}
+
+	cfg.Clusters[contextName] = cluster
+	cfg.AuthInfos[contextName] = user
+	cfg.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  contextName,
+		AuthInfo: contextName,
+	}
+
+	return clientcmd.WriteToFile(*cfg, destPath)
+}
+
+// deleteKubeContext removes the cluster, user, and context named contextName
+// from ~/.kube/config. No-op if any entry is absent.
+func deleteKubeContext(contextName string) error {
+	destPath, err := kubeConfigPath()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := loadKubeConfig(destPath)
+	if err != nil {
+		return fmt.Errorf("load ~/.kube/config: %w", err)
+	}
+
+	delete(cfg.Clusters, contextName)
+	delete(cfg.AuthInfos, contextName)
+	delete(cfg.Contexts, contextName)
+
+	return clientcmd.WriteToFile(*cfg, destPath)
+}
+
+// getCurrentKubeContext returns current-context from ~/.kube/config,
+// or empty string if unset or the file is absent.
+func getCurrentKubeContext() (string, error) {
+	destPath, err := kubeConfigPath()
+	if err != nil {
+		return "", err
+	}
+	cfg, err := loadKubeConfig(destPath)
+	if err != nil {
+		return "", fmt.Errorf("load ~/.kube/config: %w", err)
+	}
+	return cfg.CurrentContext, nil
+}
+
+// setCurrentKubeContext sets current-context in ~/.kube/config. No-op if already set.
+func setCurrentKubeContext(name string) error {
+	destPath, err := kubeConfigPath()
+	if err != nil {
+		return err
+	}
+	cfg, err := loadKubeConfig(destPath)
+	if err != nil {
+		return fmt.Errorf("load ~/.kube/config: %w", err)
+	}
+	if cfg.CurrentContext == name {
+		return nil
+	}
+	cfg.CurrentContext = name
+	return clientcmd.WriteToFile(*cfg, destPath)
+}
+
+// clearCurrentKubeContext clears current-context if it matches name; no-op otherwise.
+func clearCurrentKubeContext(name string) error {
+	destPath, err := kubeConfigPath()
+	if err != nil {
+		return err
+	}
+	cfg, err := loadKubeConfig(destPath)
+	if err != nil {
+		return fmt.Errorf("load ~/.kube/config: %w", err)
+	}
+	if cfg.CurrentContext != name {
+		return nil
+	}
+	cfg.CurrentContext = ""
+	return clientcmd.WriteToFile(*cfg, destPath)
+}

--- a/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// makeSrcKubeconfig writes a minimal instance kubeconfig (matching what
+// storeKubeConfigToDisk produces) to dir/config.yaml and returns the path.
+func makeSrcKubeconfig(t *testing.T, dir string) string {
+	t.Helper()
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters["root"] = &clientcmdapi.Cluster{
+		Server:                   "https://127.0.0.1:6443",
+		CertificateAuthorityData: []byte("fake-ca"),
+	}
+	cfg.AuthInfos["system-admin"] = &clientcmdapi.AuthInfo{Token: "fake-token"}
+	cfg.Contexts["root"] = &clientcmdapi.Context{Cluster: "root", AuthInfo: "system-admin"}
+	cfg.CurrentContext = "root"
+
+	path := filepath.Join(dir, "config.yaml")
+	err := clientcmd.WriteToFile(*cfg, path)
+	assert.NilError(t, err)
+	return path
+}
+
+// loadDest loads the kubeconfig at destPath, failing the test on error.
+func loadDest(t *testing.T, destPath string) *clientcmdapi.Config {
+	t.Helper()
+	cfg, err := clientcmd.LoadFromFile(destPath)
+	assert.NilError(t, err)
+	return cfg
+}
+
+func TestCreateReplaceKubeContext(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KUBECONFIG", filepath.Join(dir, ".kube", "config"))
+
+	srcPath := makeSrcKubeconfig(t, dir)
+
+	err := createReplaceKubeContext("rancher-desktop-2", srcPath)
+	assert.NilError(t, err)
+
+	destPath, _ := kubeConfigPath()
+	cfg := loadDest(t, destPath)
+
+	cluster, ok := cfg.Clusters["rancher-desktop-2"]
+	assert.Assert(t, ok, "cluster rancher-desktop-2 not found")
+	assert.Equal(t, cluster.Server, "https://127.0.0.1:6443")
+
+	user, ok := cfg.AuthInfos["rancher-desktop-2"]
+	assert.Assert(t, ok, "user rancher-desktop-2 not found")
+	assert.Equal(t, user.Token, "fake-token")
+
+	ctx, ok := cfg.Contexts["rancher-desktop-2"]
+	assert.Assert(t, ok, "context rancher-desktop-2 not found")
+	assert.Equal(t, ctx.Cluster, "rancher-desktop-2")
+	assert.Equal(t, ctx.AuthInfo, "rancher-desktop-2")
+}
+
+func TestCreateReplaceKubeContext_MergesWithExisting(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+
+	// Pre-populate with an unrelated context.
+	existing := clientcmdapi.NewConfig()
+	existing.Clusters["other"] = &clientcmdapi.Cluster{Server: "https://other:6443"}
+	existing.AuthInfos["other-user"] = &clientcmdapi.AuthInfo{Token: "other-token"}
+	existing.Contexts["other"] = &clientcmdapi.Context{Cluster: "other", AuthInfo: "other-user"}
+	existing.CurrentContext = "other"
+	assert.NilError(t, os.MkdirAll(filepath.Dir(destPath), 0o700))
+	assert.NilError(t, clientcmd.WriteToFile(*existing, destPath))
+
+	srcPath := makeSrcKubeconfig(t, dir)
+	assert.NilError(t, createReplaceKubeContext("rancher-desktop-2", srcPath))
+
+	cfg := loadDest(t, destPath)
+
+	// Existing entry is preserved.
+	_, ok := cfg.Clusters["other"]
+	assert.Assert(t, ok, "existing cluster should be preserved")
+
+	// New entry was added.
+	_, ok = cfg.Clusters["rancher-desktop-2"]
+	assert.Assert(t, ok, "new cluster should be present")
+
+	// current-context is not touched by createReplace.
+	assert.Equal(t, cfg.CurrentContext, "other")
+}
+
+func TestDeleteKubeContext(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+
+	srcPath := makeSrcKubeconfig(t, dir)
+	assert.NilError(t, createReplaceKubeContext("rancher-desktop-2", srcPath))
+
+	assert.NilError(t, deleteKubeContext("rancher-desktop-2"))
+
+	cfg := loadDest(t, destPath)
+	_, ok := cfg.Clusters["rancher-desktop-2"]
+	assert.Assert(t, !ok, "cluster should be deleted")
+	_, ok = cfg.AuthInfos["rancher-desktop-2"]
+	assert.Assert(t, !ok, "user should be deleted")
+	_, ok = cfg.Contexts["rancher-desktop-2"]
+	assert.Assert(t, !ok, "context should be deleted")
+}
+
+func TestDeleteKubeContext_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KUBECONFIG", filepath.Join(dir, ".kube", "config"))
+
+	// Deleting a non-existent context on a missing file is a no-op.
+	assert.NilError(t, deleteKubeContext("rancher-desktop-2"))
+}
+
+func TestSetCurrentKubeContext(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+
+	srcPath := makeSrcKubeconfig(t, dir)
+	assert.NilError(t, createReplaceKubeContext("rancher-desktop-2", srcPath))
+
+	assert.NilError(t, setCurrentKubeContext("rancher-desktop-2"))
+
+	cfg := loadDest(t, destPath)
+	assert.Equal(t, cfg.CurrentContext, "rancher-desktop-2")
+}
+
+func TestSetCurrentKubeContext_NoOpIfAlreadySet(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+
+	srcPath := makeSrcKubeconfig(t, dir)
+	assert.NilError(t, createReplaceKubeContext("rancher-desktop-2", srcPath))
+	assert.NilError(t, setCurrentKubeContext("rancher-desktop-2"))
+
+	// Record mtime to verify the file is not rewritten.
+	info1, err := os.Stat(destPath)
+	assert.NilError(t, err)
+
+	assert.NilError(t, setCurrentKubeContext("rancher-desktop-2"))
+
+	info2, err := os.Stat(destPath)
+	assert.NilError(t, err)
+	assert.Equal(t, info1.ModTime(), info2.ModTime())
+}
+
+func TestClearCurrentKubeContext(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+
+	srcPath := makeSrcKubeconfig(t, dir)
+	assert.NilError(t, createReplaceKubeContext("rancher-desktop-2", srcPath))
+	assert.NilError(t, setCurrentKubeContext("rancher-desktop-2"))
+	assert.NilError(t, clearCurrentKubeContext("rancher-desktop-2"))
+
+	cfg := loadDest(t, destPath)
+	assert.Equal(t, cfg.CurrentContext, "")
+}
+
+func TestClearCurrentKubeContext_NoOpIfDifferent(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+
+	// Set current to a different context.
+	existing := clientcmdapi.NewConfig()
+	existing.CurrentContext = "other"
+	assert.NilError(t, os.MkdirAll(filepath.Dir(destPath), 0o700))
+	assert.NilError(t, clientcmd.WriteToFile(*existing, destPath))
+
+	assert.NilError(t, clearCurrentKubeContext("rancher-desktop-2"))
+
+	cfg := loadDest(t, destPath)
+	assert.Equal(t, cfg.CurrentContext, "other")
+}
+
+func TestGetCurrentKubeContext(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+
+	// Missing file returns empty string.
+	current, err := getCurrentKubeContext()
+	assert.NilError(t, err)
+	assert.Equal(t, current, "")
+
+	// After setting, returns the set value.
+	srcPath := makeSrcKubeconfig(t, dir)
+	assert.NilError(t, createReplaceKubeContext("rancher-desktop-2", srcPath))
+	assert.NilError(t, setCurrentKubeContext("rancher-desktop-2"))
+
+	current, err = getCurrentKubeContext()
+	assert.NilError(t, err)
+	assert.Equal(t, current, "rancher-desktop-2")
+}

--- a/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
@@ -15,8 +15,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-// makeSrcKubeconfig writes a minimal instance kubeconfig (matching what
-// storeKubeConfigToDisk produces) to dir/config.yaml and returns the path.
+// makeSrcKubeconfig writes a minimal k3s kubeconfig (matching what the
+// Lima probe copies) to dir/k3s.yaml and returns the path.
 func makeSrcKubeconfig(t *testing.T, dir string) string {
 	t.Helper()
 	cfg := clientcmdapi.NewConfig()
@@ -28,7 +28,7 @@ func makeSrcKubeconfig(t *testing.T, dir string) string {
 	cfg.Contexts["root"] = &clientcmdapi.Context{Cluster: "root", AuthInfo: "system-admin"}
 	cfg.CurrentContext = "root"
 
-	path := filepath.Join(dir, "config.yaml")
+	path := filepath.Join(dir, "k3s.yaml")
 	err := clientcmd.WriteToFile(*cfg, path)
 	assert.NilError(t, err)
 	return path

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package controllers implements the Kubernetes context reconciler.
+package controllers
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+)
+
+const (
+	appName = "app"
+
+	// kubeProbeTimeout is the per-probe deadline for reaching the k3s API server.
+	kubeProbeTimeout = 3 * time.Second
+
+	// kubeProbeRequeue is the wait between probes when k3s is not yet ready.
+	kubeProbeRequeue = 5 * time.Second
+)
+
+// KubernetesReconciler watches the App resource and manages the
+// rancher-desktop-{instance} context in ~/.kube/config.
+type KubernetesReconciler struct {
+	client.Client
+
+	// contextMu protects contextProbeCancel and contextProbeGen.
+	contextMu sync.Mutex
+	// contextProbeCancel cancels the in-flight current-context probe goroutine.
+	contextProbeCancel context.CancelFunc
+	// contextProbeGen detects superseded goroutines.
+	contextProbeGen int
+	// contextProbeWg lets removeKubeContext wait for any probe to finish.
+	contextProbeWg sync.WaitGroup
+}
+
+// Reconcile drives the KubernetesReady condition and ~/.kube/config lifecycle.
+func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	var app appv1alpha1.App
+	if err := r.Get(ctx, client.ObjectKey{Name: appName}, &app); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	running := apimeta.IsStatusConditionTrue(app.Status.Conditions, appv1alpha1.AppConditionRunning)
+
+	// When Kubernetes is disabled, stamp the condition and clean up.
+	if !app.Spec.Kubernetes.Enabled {
+		r.removeKubeContext(ctx)
+		return ctrl.Result{}, r.setKubeCondition(ctx, &app,
+			metav1.ConditionFalse,
+			appv1alpha1.AppKubernetesReasonNotApplicable,
+			"Kubernetes is not enabled",
+		)
+	}
+
+	// Kubernetes is enabled but the VM is not (yet) running.
+	if !running {
+		r.removeKubeContext(ctx)
+		return ctrl.Result{}, r.setKubeCondition(ctx, &app,
+			metav1.ConditionFalse,
+			appv1alpha1.AppKubernetesReasonNotRunning,
+			"VM is not running",
+		)
+	}
+
+	// Probe the k3s API server from the instance kubeconfig.
+	healthy, err := probeK3sAPI(ctx)
+	if err != nil {
+		// kubeconfig missing or unreadable — k3s has not started yet.
+		log.V(1).Info("Cannot probe k3s API server", "err", err)
+		if condErr := r.setKubeCondition(ctx, &app,
+			metav1.ConditionFalse,
+			appv1alpha1.AppKubernetesReasonProbing,
+			"Waiting for k3s API server",
+		); condErr != nil {
+			return ctrl.Result{}, condErr
+		}
+		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
+	}
+	if !healthy {
+		log.V(1).Info("k3s API server not yet healthy")
+		if condErr := r.setKubeCondition(ctx, &app,
+			metav1.ConditionFalse,
+			appv1alpha1.AppKubernetesReasonProbing,
+			"Waiting for k3s API server",
+		); condErr != nil {
+			return ctrl.Result{}, condErr
+		}
+		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
+	}
+
+	// k3s is healthy — merge the context into ~/.kube/config.
+	r.manageKubeContext(ctx)
+
+	return ctrl.Result{}, r.setKubeCondition(ctx, &app,
+		metav1.ConditionTrue,
+		appv1alpha1.AppKubernetesReasonReady,
+		"Kubernetes API server is ready",
+	)
+}
+
+// probeK3sAPI reads the instance kubeconfig and GETs /healthz on the k3s API
+// server. Returns (false, err) when the kubeconfig is unreadable, (false, nil)
+// when the server is unhealthy, and (true, nil) on success.
+func probeK3sAPI(ctx context.Context) (bool, error) {
+	kubeconfigPath := instance.Config()
+	data, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return false, fmt.Errorf("read instance kubeconfig: %w", err)
+	}
+
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(data)
+	if err != nil {
+		return false, fmt.Errorf("parse instance kubeconfig: %w", err)
+	}
+
+	// Build a TLS-aware HTTP client from the REST config.
+	tlsCfg := &tls.Config{ServerName: cfg.ServerName}
+	if len(cfg.CAData) > 0 {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(cfg.CAData)
+		tlsCfg.RootCAs = pool
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, kubeProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, cfg.Host+"/healthz", http.NoBody)
+	if err != nil {
+		return false, fmt.Errorf("build healthz request: %w", err)
+	}
+	if cfg.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.BearerToken)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		logf.FromContext(ctx).V(1).Info("k3s healthz request failed", "url", cfg.Host+"/healthz", "err", err)
+		return false, nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		logf.FromContext(ctx).V(1).Info("k3s healthz returned non-200", "url", cfg.Host+"/healthz", "status", resp.StatusCode)
+	}
+	return resp.StatusCode == http.StatusOK, nil
+}
+
+// manageKubeContext merges the instance kubeconfig into ~/.kube/config and
+// launches a goroutine to set current-context if the existing one is unhealthy.
+// At most one probe runs at a time.
+func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
+	contextName := instance.Name()
+	log := logf.FromContext(ctx).WithName("kube-context")
+
+	if err := createReplaceKubeContext(contextName, instance.Config()); err != nil {
+		log.Error(err, "Failed to create Kubernetes context", "context", contextName)
+		return
+	}
+
+	r.contextMu.Lock()
+	if r.contextProbeCancel != nil {
+		r.contextProbeCancel()
+	}
+	probeCtx, cancel := context.WithCancel(ctx)
+	r.contextProbeCancel = cancel
+	r.contextProbeGen++
+	myGen := r.contextProbeGen
+	r.contextMu.Unlock()
+
+	r.contextProbeWg.Add(1)
+	go func() {
+		// Use sync.Once so contextProbeWg.Done() fires exactly once, either
+		// explicitly after the HTTP probe or via defer on early return.
+		// Crucially, Done() must be called BEFORE setCurrentKubeContext so that
+		// removeKubeContext.Wait() is not held hostage by a slow or blocking
+		// write to ~/.kube/config.
+		var wgDone sync.Once
+		signalDone := func() { wgDone.Do(r.contextProbeWg.Done) }
+		defer signalDone()
+		defer func() {
+			r.contextMu.Lock()
+			if r.contextProbeGen == myGen {
+				r.contextProbeCancel = nil
+			}
+			r.contextMu.Unlock()
+			cancel()
+		}()
+
+		// Skip if KUBECONFIG is set — rewriting ~/.kube/config current-context
+		// has no effect and may clobber a user preference.
+		if os.Getenv("KUBECONFIG") != "" {
+			return
+		}
+
+		current, err := getCurrentKubeContext()
+		if err != nil {
+			log.Error(err, "Failed to read current Kubernetes context")
+			return
+		}
+
+		healthy := probeCurrentKubeContext(probeCtx, current)
+
+		// Signal the WaitGroup before writing to ~/.kube/config so that
+		// removeKubeContext.Wait() is not blocked by a slow file write.
+		signalDone()
+
+		// Guard against writing after removeKubeContext cancelled probeCtx.
+		if !healthy && probeCtx.Err() == nil {
+			if err := setCurrentKubeContext(contextName); err != nil {
+				log.Error(err, "Failed to set current Kubernetes context", "context", contextName)
+			}
+		}
+	}()
+}
+
+// probeCurrentKubeContext returns true if the named context's API server is
+// healthy. Empty or "default" contexts are treated as unhealthy.
+func probeCurrentKubeContext(ctx context.Context, current string) bool {
+	if current == "" || current == "default" {
+		return false
+	}
+	destPath, err := kubeConfigPath()
+	if err != nil {
+		return true // assume healthy if we can't read the path
+	}
+	cfg, err := loadKubeConfig(destPath)
+	if err != nil {
+		return true // assume healthy on parse error
+	}
+	kctx, ok := cfg.Contexts[current]
+	if !ok {
+		return false
+	}
+	clusterEntry, ok := cfg.Clusters[kctx.Cluster]
+	if !ok {
+		return false
+	}
+
+	// Build a REST config from the extracted cluster+user for the TLS probe.
+	merged := *cfg
+	merged.CurrentContext = current
+	data, err := clientcmd.Write(merged)
+	if err != nil {
+		return true
+	}
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(data)
+	if err != nil {
+		return true
+	}
+
+	tlsCfg := &tls.Config{
+		ServerName: restCfg.ServerName,
+	}
+	if len(restCfg.CAData) > 0 {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(restCfg.CAData)
+		tlsCfg.RootCAs = pool
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, kubeProbeTimeout)
+	defer cancel()
+
+	url := clusterEntry.Server + "/healthz"
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return true
+	}
+	if restCfg.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+restCfg.BearerToken)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// removeKubeContext cancels any in-flight probe, waits for it to finish, then
+// removes the context entries and clears current-context if it matched.
+func (r *KubernetesReconciler) removeKubeContext(ctx context.Context) {
+	r.contextMu.Lock()
+	if r.contextProbeCancel != nil {
+		r.contextProbeCancel()
+		r.contextProbeCancel = nil
+	}
+	r.contextMu.Unlock()
+
+	r.contextProbeWg.Wait()
+
+	contextName := instance.Name()
+	log := logf.FromContext(ctx).WithName("kube-context")
+
+	if err := clearCurrentKubeContext(contextName); err != nil {
+		log.Error(err, "Failed to clear current Kubernetes context", "context", contextName)
+	}
+	if err := deleteKubeContext(contextName); err != nil {
+		log.Error(err, "Failed to delete Kubernetes context", "context", contextName)
+	}
+}
+
+// setKubeCondition updates KubernetesReady on the App resource.
+// RetryOnConflict handles concurrent writes from other controllers.
+func (r *KubernetesReconciler) setKubeCondition(ctx context.Context, app *appv1alpha1.App, status metav1.ConditionStatus, reason, message string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &appv1alpha1.App{}
+		if err := r.Get(ctx, client.ObjectKey{Name: app.Name}, latest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		changed := apimeta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+			Type:               appv1alpha1.AppConditionKubernetesReady,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: latest.Generation,
+		})
+		if !changed {
+			return nil
+		}
+		return r.Status().Update(ctx, latest)
+	})
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *KubernetesReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appv1alpha1.App{}).
+		Named("kubernetes-reconciler").
+		Complete(r)
+}

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -124,7 +124,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 // server. Returns (false, err) when the kubeconfig is unreadable, (false, nil)
 // when the server is unhealthy, and (true, nil) on success.
 func probeK3sAPI(ctx context.Context) (bool, error) {
-	kubeconfigPath := instance.Config()
+	kubeconfigPath := instance.K3sConfig()
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return false, fmt.Errorf("read instance kubeconfig: %w", err)
@@ -141,6 +141,14 @@ func probeK3sAPI(ctx context.Context) (bool, error) {
 		pool := x509.NewCertPool()
 		pool.AppendCertsFromPEM(cfg.CAData)
 		tlsCfg.RootCAs = pool
+	}
+	// Load client cert for mTLS auth (k3s kubeconfig uses client cert, not bearer token).
+	if len(cfg.CertData) > 0 && len(cfg.KeyData) > 0 {
+		cert, err := tls.X509KeyPair(cfg.CertData, cfg.KeyData)
+		if err != nil {
+			return false, fmt.Errorf("load client cert: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},
@@ -176,7 +184,7 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
 	contextName := instance.Name()
 	log := logf.FromContext(ctx).WithName("kube-context")
 
-	if err := createReplaceKubeContext(contextName, instance.Config()); err != nil {
+	if err := createReplaceKubeContext(contextName, instance.K3sConfig()); err != nil {
 		log.Error(err, "Failed to create Kubernetes context", "context", contextName)
 		return
 	}
@@ -209,12 +217,6 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
 			r.contextMu.Unlock()
 			cancel()
 		}()
-
-		// Skip if KUBECONFIG is set — rewriting ~/.kube/config current-context
-		// has no effect and may clobber a user preference.
-		if os.Getenv("KUBECONFIG") != "" {
-			return
-		}
 
 		current, err := getCurrentKubeContext()
 		if err != nil {
@@ -279,6 +281,14 @@ func probeCurrentKubeContext(ctx context.Context, current string) bool {
 		pool := x509.NewCertPool()
 		pool.AppendCertsFromPEM(restCfg.CAData)
 		tlsCfg.RootCAs = pool
+	}
+	// Load client cert for mTLS auth (k3s kubeconfig uses client cert, not bearer token).
+	if len(restCfg.CertData) > 0 && len(restCfg.KeyData) > 0 {
+		cert, err := tls.X509KeyPair(restCfg.CertData, restCfg.KeyData)
+		if err != nil {
+			return true // assume healthy if we can't load the cert
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -86,9 +86,17 @@ var ArgsFile = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "args.json")
 })
 
-// Config returns the path to the kubeconfig file.
+// Config returns the path to the rdd apiserver's kubeconfig.
+// `rdd ctl` pass-throughs export this path as KUBECONFIG.
 var Config = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "config.yaml")
+})
+
+// K3sConfig returns the path where the in-VM k3s kubeconfig is mirrored
+// by the Lima probe. Distinct from Config() so kubectl pass-throughs
+// keep talking to the rdd apiserver, not k3s.
+var K3sConfig = sync.OnceValue(func() string {
+	return filepath.Join(Dir(), "k3s.yaml")
 })
 
 // PIDFile returns the path to the service PID file.

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -57,6 +57,7 @@ import (
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/app"
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/demo"
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/engine"
+	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/kubernetes"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 	// Import built-in system controllers.
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/builtin/namespace"


### PR DESCRIPTION
- Add KubernetesReconciler that probes k3s `/healthz` and manages the rancher-desktop instance context in `~/.kube/config`
- Add KubernetesReady condition and related constants to app_types.go
- Gate `computeSettledCondition` on KubernetesReady when k8s is enabled
- Pass `HOST_INSTANCE_CONFIG` param to Lima so the probe script writes the raw k3s kubeconfig to the host instance config path
- Replace old kubeconfig merge logic in lima-template.yaml with a simple copy, context merging is now handled by the controller

Fixes: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/325