### PR TITLE
debug: surface probe failures and capture rdd goroutines on bats timeout

### DIFF
--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -34,22 +34,27 @@ kube_current_context() {
         return 0
     }
 
-    kubectl config current-context 2>/dev/null || echo ""
+    rdd kubectl config current-context 2>/dev/null || echo ""
 }
 
 kube_context_exists() { # <context-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-contexts -o name 2>/dev/null | grep -qx "$1"
+    rdd kubectl config get-contexts -o name 2>/dev/null | grep -qx "$1"
 }
 
 kube_cluster_exists() { # <cluster-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-clusters 2>/dev/null | tail -n +2 | grep -qx "$1"
+    rdd kubectl config get-clusters 2>/dev/null | tail -n +2 | grep -qx "$1"
 }
 
 kube_user_exists() { # <user-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-users 2>/dev/null | tail -n +2 | grep -qx "$1"
+    rdd kubectl config get-users 2>/dev/null | tail -n +2 | grep -qx "$1"
+}
+
+kube_current_context_is() { # <expected-context>
+    run rdd kubectl config current-context
+    assert_output "$1"
 }
 
 @test "KubernetesReady condition is True when k3s is running" {
@@ -86,11 +91,11 @@ kube_user_exists() { # <user-name>
     run -0 rdd svc paths k3s_config
     local instance_kubeconfig="${output}"
 
-    run -0 kubectl --kubeconfig="${instance_kubeconfig}" \
+    run -0 rdd kubectl --kubeconfig="${instance_kubeconfig}" \
         config view -o jsonpath='{.clusters[0].cluster.server}'
     local expected_server="${output}"
 
-    run -0 kubectl config view \
+    run -0 rdd kubectl config view \
         -o jsonpath="{.clusters[?(@.name==\"${context_name}\")].cluster.server}"
     assert_output "${expected_server}"
 }
@@ -99,8 +104,7 @@ kube_user_exists() { # <user-name>
     local context_name="rancher-desktop-${RDD_INSTANCE}"
     # The current-context probe runs in a goroutine after KubernetesReady is
     # set; poll until it resolves.
-    try --max 6 --delay 2 -- \
-        bash -c "kubectl config current-context 2>/dev/null | grep -qx '${context_name}'"
+    try --max 6 --delay 2 -- kube_current_context_is "${context_name}"
 
     run -0 kube_current_context
     assert_output "${context_name}"
@@ -136,16 +140,14 @@ kube_user_exists() { # <user-name>
 
 @test "current-context is set again after re-enabling kubernetes" {
     local context_name="rancher-desktop-${RDD_INSTANCE}"
-    try --max 6 --delay 2 -- \
-        bash -c "kubectl config current-context 2>/dev/null | grep -qx '${context_name}'"
+    try --max 6 --delay 2 -- kube_current_context_is "${context_name}"
 }
 
 @test "stopping VM clears current-context" {
     local context_name="rancher-desktop-${RDD_INSTANCE}"
     rdd set running=false
     # removeKubeContext fires on the NotRunning reconcile; poll until done.
-    try --max 10 --delay 1 -- \
-        bash -c "! kube_context_exists '${context_name}'"
+    try --max 10 --delay 1 --until-fail -- kube_context_exists "${context_name}"
     run -0 kube_current_context
     refute_output "${context_name}"
 }

--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -83,7 +83,7 @@ kube_user_exists() { # <user-name>
     local context_name="rancher-desktop-${RDD_INSTANCE}"
 
     # Read the server URL from the instance kubeconfig (written by k3s).
-    run -0 rdd svc paths config
+    run -0 rdd svc paths k3s_config
     local instance_kubeconfig="${output}"
 
     run -0 kubectl --kubeconfig="${instance_kubeconfig}" \

--- a/cmd/rdd/service_paths.go
+++ b/cmd/rdd/service_paths.go
@@ -25,6 +25,7 @@ func instancePaths() map[string]string {
 		"lima_home":     instance.LimaHome(),
 		"tls_dir":       instance.TLSDir(),
 		"config":        instance.Config(),
+		"k3s_config":    instance.K3sConfig(),
 		"pid_file":      instance.PIDFile(),
 		"args_file":     instance.ArgsFile(),
 		"docker_socket": instance.DockerSocket(),

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -37,6 +37,7 @@ source <(rdd svc paths --output=shell)
 | `RDD_ARGS_FILE` | Saved startup arguments | `~/Library/Application Support/rancher-desktop-2/args.json` |
 | `RDD_DIR` | Service instance directory | `~/Library/Application Support/rancher-desktop-2` |
 | `RDD_CONFIG` | RDD control plane config file | `~/Library/Application Support/rancher-desktop-2/config.yaml` |
+| `RDD_K3S_CONFIG` | Mirror of the in-VM k3s kubeconfig | `~/Library/Application Support/rancher-desktop-2/k3s.yaml` |
 | `RDD_LIMA_HOME` | Lima home directory | `~/.rd2/lima` |
 | `RDD_LOG_DIR` | Log directory | `~/Library/Logs/rancher-desktop-2` |
 | `RDD_PID_FILE` | Service PID file | `~/Library/Application Support/rancher-desktop-2/rdd.pid` |

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -22,8 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
@@ -539,7 +542,41 @@ func runningLimaVMMessage(runningCond *metav1.Condition, desired string) string 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.App{}).
+		For(&v1alpha1.App{}, builder.WithPredicates(debugWatchLogger("app"))).
 		Owns(&limav1alpha1.LimaVM{}).
 		Complete(r)
+}
+
+// debugWatchLogger logs every watch event delivered to the controller.
+// Investigation-only; remove once the App-watch silence on test 43 is diagnosed.
+func debugWatchLogger(name string) predicate.Predicate {
+	log := logf.Log.WithName(name + ".watch")
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			log.V(1).Info("create",
+				"name", e.Object.GetName(),
+				"generation", e.Object.GetGeneration(),
+				"resourceVersion", e.Object.GetResourceVersion(),
+			)
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			log.V(1).Info("update",
+				"name", e.ObjectNew.GetName(),
+				"oldGeneration", e.ObjectOld.GetGeneration(),
+				"newGeneration", e.ObjectNew.GetGeneration(),
+				"oldResourceVersion", e.ObjectOld.GetResourceVersion(),
+				"newResourceVersion", e.ObjectNew.GetResourceVersion(),
+			)
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			log.V(1).Info("delete", "name", e.Object.GetName())
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			log.V(1).Info("generic", "name", e.Object.GetName())
+			return true
+		},
+	}
 }

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -154,7 +154,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	log.V(1).Info("reconcile entered",
+	log.Info("reconcile entered",
 		"specRunning", app.Spec.Running,
 		"k8sEnabled", app.Spec.Kubernetes.Enabled,
 		"generation", app.Generation,
@@ -553,7 +553,7 @@ func debugWatchLogger(name string) predicate.Predicate {
 	log := logf.Log.WithName(name + ".watch")
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			log.V(1).Info("create",
+			log.Info("create",
 				"name", e.Object.GetName(),
 				"generation", e.Object.GetGeneration(),
 				"resourceVersion", e.Object.GetResourceVersion(),
@@ -561,7 +561,7 @@ func debugWatchLogger(name string) predicate.Predicate {
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			log.V(1).Info("update",
+			log.Info("update",
 				"name", e.ObjectNew.GetName(),
 				"oldGeneration", e.ObjectOld.GetGeneration(),
 				"newGeneration", e.ObjectNew.GetGeneration(),
@@ -571,11 +571,11 @@ func debugWatchLogger(name string) predicate.Predicate {
 			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			log.V(1).Info("delete", "name", e.Object.GetName())
+			log.Info("delete", "name", e.Object.GetName())
 			return true
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			log.V(1).Info("generic", "name", e.Object.GetName())
+			log.Info("generic", "name", e.Object.GetName())
 			return true
 		},
 	}

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -159,7 +159,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		"k8sEnabled", app.Spec.Kubernetes.Enabled,
 		"generation", app.Generation,
 		"resourceVersion", app.ResourceVersion,
-		"deletionTimestamp", app.DeletionTimestamp,
+		"beingDeleted", app.DeletionTimestamp != nil,
 	)
 
 	// Handle deletion, delete owned resources.

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -151,6 +151,14 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	log.V(1).Info("reconcile entered",
+		"specRunning", app.Spec.Running,
+		"k8sEnabled", app.Spec.Kubernetes.Enabled,
+		"generation", app.Generation,
+		"resourceVersion", app.ResourceVersion,
+		"deletionTimestamp", app.DeletionTimestamp,
+	)
+
 	// Handle deletion, delete owned resources.
 	if base.IsBeingDeleted(&app) {
 		log.Info("App resource is being deleted, performing cleanup")

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -116,7 +116,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec) (string, er
 		"param:",
 		fmt.Sprintf("  CONTAINER_ENGINE: %s", spec.ContainerEngine.Name),
 		fmt.Sprintf("  HOST_DOCKER_SOCKET: %q", instance.DockerSocket()),
-		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.Config())),
+		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.K3sConfig())),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
 		"",

--- a/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
@@ -15,8 +15,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-// makeSrcKubeconfig writes a minimal instance kubeconfig (matching what
-// storeKubeConfigToDisk produces) to dir/config.yaml and returns the path.
+// makeSrcKubeconfig writes a minimal k3s kubeconfig (matching what the
+// Lima probe copies) to dir/k3s.yaml and returns the path.
 func makeSrcKubeconfig(t *testing.T, dir string) string {
 	t.Helper()
 	cfg := clientcmdapi.NewConfig()
@@ -28,7 +28,7 @@ func makeSrcKubeconfig(t *testing.T, dir string) string {
 	cfg.Contexts["root"] = &clientcmdapi.Context{Cluster: "root", AuthInfo: "system-admin"}
 	cfg.CurrentContext = "root"
 
-	path := filepath.Join(dir, "config.yaml")
+	path := filepath.Join(dir, "k3s.yaml")
 	err := clientcmd.WriteToFile(*cfg, path)
 	assert.NilError(t, err)
 	return path

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -63,12 +63,12 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 
 	var app appv1alpha1.App
 	if err := r.Get(ctx, client.ObjectKey{Name: appName}, &app); err != nil {
-		log.V(1).Info("reconcile: App get failed", "err", err)
+		log.Info("reconcile: App get failed", "err", err)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	running := apimeta.IsStatusConditionTrue(app.Status.Conditions, appv1alpha1.AppConditionRunning)
-	log.V(1).Info("reconcile entered",
+	log.Info("reconcile entered",
 		"k8sEnabled", app.Spec.Kubernetes.Enabled,
 		"running", running,
 		"generation", app.Generation,
@@ -99,7 +99,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 	healthy, err := probeK3sAPI(ctx)
 	if err != nil {
 		// kubeconfig missing or unreadable — k3s has not started yet.
-		log.V(1).Info("Cannot probe k3s API server", "err", err)
+		log.Info("Cannot probe k3s API server", "err", err)
 		if condErr := r.setKubeCondition(ctx, &app,
 			metav1.ConditionFalse,
 			appv1alpha1.AppKubernetesReasonProbing,
@@ -110,7 +110,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
 	}
 	if !healthy {
-		log.V(1).Info("k3s API server not yet healthy")
+		log.Info("k3s API server not yet healthy")
 		if condErr := r.setKubeCondition(ctx, &app,
 			metav1.ConditionFalse,
 			appv1alpha1.AppKubernetesReasonProbing,
@@ -170,13 +170,13 @@ func probeK3sAPI(ctx context.Context) (bool, error) {
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		logf.FromContext(ctx).V(1).Info("k3s healthz request failed", "url", cfg.Host+"/healthz", "err", err)
+		logf.FromContext(ctx).Info("k3s healthz request failed", "url", cfg.Host+"/healthz", "err", err)
 		return false, nil
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		logf.FromContext(ctx).V(1).Info("k3s healthz returned non-200", "url", cfg.Host+"/healthz", "status", resp.StatusCode, "body", string(body))
+		logf.FromContext(ctx).Info("k3s healthz returned non-200", "url", cfg.Host+"/healthz", "status", resp.StatusCode, "body", string(body))
 	}
 	return resp.StatusCode == http.StatusOK, nil
 }
@@ -376,7 +376,7 @@ func debugWatchLogger(name string) predicate.Predicate {
 	log := logf.Log.WithName(name + ".watch")
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			log.V(1).Info("create",
+			log.Info("create",
 				"name", e.Object.GetName(),
 				"generation", e.Object.GetGeneration(),
 				"resourceVersion", e.Object.GetResourceVersion(),
@@ -384,7 +384,7 @@ func debugWatchLogger(name string) predicate.Predicate {
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			log.V(1).Info("update",
+			log.Info("update",
 				"name", e.ObjectNew.GetName(),
 				"oldGeneration", e.ObjectOld.GetGeneration(),
 				"newGeneration", e.ObjectNew.GetGeneration(),
@@ -394,11 +394,11 @@ func debugWatchLogger(name string) predicate.Predicate {
 			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			log.V(1).Info("delete", "name", e.Object.GetName())
+			log.Info("delete", "name", e.Object.GetName())
 			return true
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			log.V(1).Info("generic", "name", e.Object.GetName())
+			log.Info("generic", "name", e.Object.GetName())
 			return true
 		},
 	}

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -164,7 +165,8 @@ func probeK3sAPI(ctx context.Context) (bool, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		logf.FromContext(ctx).V(1).Info("k3s healthz returned non-200", "url", cfg.Host+"/healthz", "status", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		logf.FromContext(ctx).V(1).Info("k3s healthz returned non-200", "url", cfg.Host+"/healthz", "status", resp.StatusCode, "body", string(body))
 	}
 	return resp.StatusCode == http.StatusOK, nil
 }

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -230,12 +230,6 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
 			cancel()
 		}()
 
-		// Skip if KUBECONFIG is set — rewriting ~/.kube/config current-context
-		// has no effect and may clobber a user preference.
-		if os.Getenv("KUBECONFIG") != "" {
-			return
-		}
-
 		current, err := getCurrentKubeContext()
 		if err != nil {
 			log.Error(err, "Failed to read current Kubernetes context")

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -22,8 +22,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
@@ -362,7 +365,41 @@ func (r *KubernetesReconciler) setKubeCondition(ctx context.Context, app *appv1a
 // SetupWithManager registers the reconciler with the manager.
 func (r *KubernetesReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appv1alpha1.App{}).
+		For(&appv1alpha1.App{}, builder.WithPredicates(debugWatchLogger("kubernetes-reconciler"))).
 		Named("kubernetes-reconciler").
 		Complete(r)
+}
+
+// debugWatchLogger logs every watch event delivered to the controller.
+// Investigation-only; remove once the App-watch silence on test 43 is diagnosed.
+func debugWatchLogger(name string) predicate.Predicate {
+	log := logf.Log.WithName(name + ".watch")
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			log.V(1).Info("create",
+				"name", e.Object.GetName(),
+				"generation", e.Object.GetGeneration(),
+				"resourceVersion", e.Object.GetResourceVersion(),
+			)
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			log.V(1).Info("update",
+				"name", e.ObjectNew.GetName(),
+				"oldGeneration", e.ObjectOld.GetGeneration(),
+				"newGeneration", e.ObjectNew.GetGeneration(),
+				"oldResourceVersion", e.ObjectOld.GetResourceVersion(),
+				"newResourceVersion", e.ObjectNew.GetResourceVersion(),
+			)
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			log.V(1).Info("delete", "name", e.Object.GetName())
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			log.V(1).Info("generic", "name", e.Object.GetName())
+			return true
+		},
+	}
 }

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -60,10 +60,17 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 
 	var app appv1alpha1.App
 	if err := r.Get(ctx, client.ObjectKey{Name: appName}, &app); err != nil {
+		log.V(1).Info("reconcile: App get failed", "err", err)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	running := apimeta.IsStatusConditionTrue(app.Status.Conditions, appv1alpha1.AppConditionRunning)
+	log.V(1).Info("reconcile entered",
+		"k8sEnabled", app.Spec.Kubernetes.Enabled,
+		"running", running,
+		"generation", app.Generation,
+		"resourceVersion", app.ResourceVersion,
+	)
 
 	// When Kubernetes is disabled, stamp the condition and clean up.
 	if !app.Spec.Kubernetes.Enabled {

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -135,7 +135,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 // server. Returns (false, err) when the kubeconfig is unreadable, (false, nil)
 // when the server is unhealthy, and (true, nil) on success.
 func probeK3sAPI(ctx context.Context) (bool, error) {
-	kubeconfigPath := instance.Config()
+	kubeconfigPath := instance.K3sConfig()
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return false, fmt.Errorf("read instance kubeconfig: %w", err)
@@ -196,7 +196,7 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
 	contextName := instance.Name()
 	log := logf.FromContext(ctx).WithName("kube-context")
 
-	if err := createReplaceKubeContext(contextName, instance.Config()); err != nil {
+	if err := createReplaceKubeContext(contextName, instance.K3sConfig()); err != nil {
 		log.Error(err, "Failed to create Kubernetes context", "context", contextName)
 		return
 	}

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -153,6 +153,14 @@ func probeK3sAPI(ctx context.Context) (bool, error) {
 		pool.AppendCertsFromPEM(cfg.CAData)
 		tlsCfg.RootCAs = pool
 	}
+	// Load client cert for mTLS auth (k3s kubeconfig uses client cert, not bearer token).
+	if len(cfg.CertData) > 0 && len(cfg.KeyData) > 0 {
+		cert, err := tls.X509KeyPair(cfg.CertData, cfg.KeyData)
+		if err != nil {
+			return false, fmt.Errorf("load client cert: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},
 	}
@@ -291,6 +299,14 @@ func probeCurrentKubeContext(ctx context.Context, current string) bool {
 		pool := x509.NewCertPool()
 		pool.AppendCertsFromPEM(restCfg.CAData)
 		tlsCfg.RootCAs = pool
+	}
+	// Load client cert for mTLS auth (k3s kubeconfig uses client cert, not bearer token).
+	if len(restCfg.CertData) > 0 && len(restCfg.KeyData) > 0 {
+		cert, err := tls.X509KeyPair(restCfg.CertData, restCfg.KeyData)
+		if err != nil {
+			return true // assume healthy if we can't load the cert
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -86,9 +86,17 @@ var ArgsFile = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "args.json")
 })
 
-// Config returns the path to the kubeconfig file.
+// Config returns the path to the rdd apiserver's kubeconfig.
+// `rdd ctl` pass-throughs export this path as KUBECONFIG.
 var Config = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "config.yaml")
+})
+
+// K3sConfig returns the path where the in-VM k3s kubeconfig is mirrored
+// by the Lima probe. Distinct from Config() so kubectl pass-throughs
+// keep talking to the rdd apiserver, not k3s.
+var K3sConfig = sync.OnceValue(func() string {
+	return filepath.Join(Dir(), "k3s.yaml")
 })
 
 // PIDFile returns the path to the service PID file.

--- a/scripts/bats-with-timeout.sh
+++ b/scripts/bats-with-timeout.sh
@@ -379,6 +379,31 @@ our_leaked_pids() {
     done < <(ps -a -x -o pid=,ucomm= 2>/dev/null || ps -e -o pid=,ucomm= 2>/dev/null || true)
 }
 
+# SIGQUIT the rdd service so its goroutine stacks land in rdd.stderr.log.
+# The service's cmdline does not carry the instance suffix (only env vars
+# do), so matches_our_instance cannot find it; we read the pidfile instead.
+# No-op if the pidfile is missing or the process is gone.
+sig_quit_rdd_service() {
+    local pid_file pid
+    pid_file=$("$rdd_bin" svc paths pid_file 2>/dev/null || true)
+    if [ -z "$pid_file" ] || [ ! -f "$pid_file" ]; then
+        return
+    fi
+    pid=$(cat "$pid_file" 2>/dev/null || true)
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        return
+    fi
+    {
+        echo
+        echo "=== SIGQUIT -> rdd service (RDD_INSTANCE=${instance}, pid=${pid}) ==="
+        echo "cmdline=$(cmdline_of "$pid")"
+    } >>"${bundle_file}" 2>&1
+    kill -QUIT "$pid" 2>/dev/null || true
+    # The dump goes to the service's stderr (captured in rdd.stderr.log).
+    # Pause so the runtime flushes before SIGTERM ends the process.
+    sleep 2
+}
+
 # SIGQUIT Go processes belonging to our RDD_INSTANCE so their goroutine
 # stacks land in the preserved stderr logs. No-op if nothing is leaked.
 sig_quit_our_go_leaks() {
@@ -432,6 +457,7 @@ while kill -0 "${cmd_pid}" 2>/dev/null; do
     if [ "$(date +%s)" -ge "${deadline}" ]; then
         echo "bats-with-timeout: RDD_INSTANCE=${instance} exceeded ${timeout_seconds}s, capturing support bundle" >&2
         capture_state "timeout"
+        sig_quit_rdd_service
         sig_quit_our_go_leaks
         echo "bats-with-timeout: sending SIGTERM to ${cmd_pid}" >&2
         kill -TERM "${cmd_pid}" 2>/dev/null || true

--- a/scripts/bats-with-timeout.sh
+++ b/scripts/bats-with-timeout.sh
@@ -272,28 +272,33 @@ dump_api_state() {
         return
     fi
 
-    if "$rdd_bin" service status 2>/dev/null | grep --quiet 'control plane has been started: true'; then
-        local resource_types
-        echo "=== rdd ctl get (overview) ==="
-        resource_types=$("$rdd_bin" ctl api-resources --output=json \
-            | jq -rc '.resources | map(select((.group // "") | test("rancherdesktop.io")) | .name) | join(",")' \
-            || echo "apps,limavms,containers,images,volumes,containernamespaces")
-        timeout --kill-after=1 10 \
-            "$rdd_bin" ctl get "$resource_types" --all-namespaces 2>&1 || true
+    # Always attempt API capture. The wedge we are diagnosing has the
+    # apiserver alive but the readiness path stuck, so the status gate
+    # would skip exactly when capture is most useful. Each probe has its
+    # own short timeout, so a fully dead daemon cannot block the bundle.
+    local status_line
+    status_line=$(timeout --kill-after=1 5 "$rdd_bin" service status 2>&1 | head -1 || echo "status check timed out")
+    echo "=== rdd service status: ${status_line} ==="
 
-        echo
-        echo "=== rdd ctl get events (by time) ==="
-        timeout --kill-after=1 10 \
-            "$rdd_bin" ctl get events --all-namespaces \
-            --sort-by=.lastTimestamp 2>&1 | tail -100 || true
+    local resource_types
+    echo
+    echo "=== rdd ctl get (overview) ==="
+    resource_types=$(timeout --kill-after=1 5 "$rdd_bin" ctl api-resources --output=json 2>/dev/null \
+        | jq -rc '.resources | map(select((.group // "") | test("rancherdesktop.io")) | .name) | join(",")' \
+        || echo "apps,limavms,containers,images,volumes,containernamespaces")
+    timeout --kill-after=1 10 \
+        "$rdd_bin" ctl get "$resource_types" --all-namespaces 2>&1 || true
 
-        echo
-        echo "=== rdd ctl get (full YAML) ==="
-        timeout --kill-after=1 15 \
-            "$rdd_bin" ctl get "$resource_types" --all-namespaces --output=yaml 2>&1 || true
-    else
-        echo "=== rdd control plane is not running ==="
-    fi
+    echo
+    echo "=== rdd ctl get events (by time) ==="
+    timeout --kill-after=1 10 \
+        "$rdd_bin" ctl get events --all-namespaces \
+        --sort-by=.lastTimestamp 2>&1 | tail -100 || true
+
+    echo
+    echo "=== rdd ctl get (full YAML) ==="
+    timeout --kill-after=1 15 \
+        "$rdd_bin" ctl get "$resource_types" --all-namespaces --output=yaml 2>&1 || true
 
     # Docker state: test suites that exercise the container engine
     # forward the guest Docker socket to a host path. Skip silently


### PR DESCRIPTION
## Purpose

Investigation-only PR layered on top of #356 to diagnose two distinct failures in test 43 ("start VM with Kubernetes enabled"):

- **Ubuntu**: the host-side k3s probe (`kube_reconciler.go:88`) returns "not yet healthy" every ~5s for 26+ minutes. The original code collapsed connection errors and non-200 responses into a single `(false, nil)` return, so the underlying cause never reaches the log.
- **macOS Intel**: after a benign 409 conflict at 22:11:42, the `app` and `kubernetes-reconciler` workers fire zero reconciles for the remaining 28 minutes of the run. No goroutine dump exists in `rdd.stderr.log` because `matches_our_instance` does not match the rdd service (its cmdline carries no instance suffix), so the existing SIGQUIT-on-leak path skips it.

## Changes

- `probeK3sAPI` now returns a single error explaining each failure mode (kubeconfig unreadable, connection error with URL, non-200 with status code and body snippet).
- `bats-with-timeout.sh` reads the rdd service pidfile and SIGQUITs the service before SIGTERM-ing the bats target, so goroutine stacks land in `rdd.stderr.log`.

## Test plan

- [ ] Trigger a fresh BATS run and confirm the new probe error format on Ubuntu (`bats-app` job).
- [ ] Confirm a goroutine dump appears in `rdd-logs-macos-15-intel-bats-app/.../rdd.stderr.log` when the suite times out.

## Do not merge

Diagnostic patch for one CI run. After we have the new logs, the real fix goes to #356.