### PR TITLE
fix(create-k8s-context): make k3s probe pass and unwedge kube-context.bats

### DIFF
--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -34,22 +34,27 @@ kube_current_context() {
         return 0
     }
 
-    kubectl config current-context 2>/dev/null || echo ""
+    rdd kubectl config current-context 2>/dev/null || echo ""
 }
 
 kube_context_exists() { # <context-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-contexts -o name 2>/dev/null | grep -qx "$1"
+    rdd kubectl config get-contexts -o name 2>/dev/null | grep -qx "$1"
 }
 
 kube_cluster_exists() { # <cluster-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-clusters 2>/dev/null | tail -n +2 | grep -qx "$1"
+    rdd kubectl config get-clusters 2>/dev/null | tail -n +2 | grep -qx "$1"
 }
 
 kube_user_exists() { # <user-name>
     [[ -f "${KUBECONFIG}" ]] || return 1
-    kubectl config get-users 2>/dev/null | tail -n +2 | grep -qx "$1"
+    rdd kubectl config get-users 2>/dev/null | tail -n +2 | grep -qx "$1"
+}
+
+kube_current_context_is() { # <expected-context>
+    run rdd kubectl config current-context
+    assert_output "$1"
 }
 
 @test "KubernetesReady condition is True when k3s is running" {
@@ -86,11 +91,11 @@ kube_user_exists() { # <user-name>
     run -0 rdd svc paths k3s_config
     local instance_kubeconfig="${output}"
 
-    run -0 kubectl --kubeconfig="${instance_kubeconfig}" \
+    run -0 rdd kubectl --kubeconfig="${instance_kubeconfig}" \
         config view -o jsonpath='{.clusters[0].cluster.server}'
     local expected_server="${output}"
 
-    run -0 kubectl config view \
+    run -0 rdd kubectl config view \
         -o jsonpath="{.clusters[?(@.name==\"${context_name}\")].cluster.server}"
     assert_output "${expected_server}"
 }
@@ -99,8 +104,7 @@ kube_user_exists() { # <user-name>
     local context_name="rancher-desktop-${RDD_INSTANCE}"
     # The current-context probe runs in a goroutine after KubernetesReady is
     # set; poll until it resolves.
-    try --max 6 --delay 2 -- \
-        bash -c "kubectl config current-context 2>/dev/null | grep -qx '${context_name}'"
+    try --max 6 --delay 2 -- kube_current_context_is "${context_name}"
 
     run -0 kube_current_context
     assert_output "${context_name}"
@@ -136,16 +140,14 @@ kube_user_exists() { # <user-name>
 
 @test "current-context is set again after re-enabling kubernetes" {
     local context_name="rancher-desktop-${RDD_INSTANCE}"
-    try --max 6 --delay 2 -- \
-        bash -c "kubectl config current-context 2>/dev/null | grep -qx '${context_name}'"
+    try --max 6 --delay 2 -- kube_current_context_is "${context_name}"
 }
 
 @test "stopping VM clears current-context" {
     local context_name="rancher-desktop-${RDD_INSTANCE}"
     rdd set running=false
     # removeKubeContext fires on the NotRunning reconcile; poll until done.
-    try --max 10 --delay 1 -- \
-        bash -c "! kube_context_exists '${context_name}'"
+    try --max 10 --delay 1 --until-fail -- kube_context_exists "${context_name}"
     run -0 kube_current_context
     refute_output "${context_name}"
 }

--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -83,7 +83,7 @@ kube_user_exists() { # <user-name>
     local context_name="rancher-desktop-${RDD_INSTANCE}"
 
     # Read the server URL from the instance kubeconfig (written by k3s).
-    run -0 rdd svc paths config
+    run -0 rdd svc paths k3s_config
     local instance_kubeconfig="${output}"
 
     run -0 kubectl --kubeconfig="${instance_kubeconfig}" \

--- a/cmd/rdd/service_paths.go
+++ b/cmd/rdd/service_paths.go
@@ -25,6 +25,7 @@ func instancePaths() map[string]string {
 		"lima_home":     instance.LimaHome(),
 		"tls_dir":       instance.TLSDir(),
 		"config":        instance.Config(),
+		"k3s_config":    instance.K3sConfig(),
 		"pid_file":      instance.PIDFile(),
 		"args_file":     instance.ArgsFile(),
 		"docker_socket": instance.DockerSocket(),

--- a/docs/design/environment.md
+++ b/docs/design/environment.md
@@ -37,6 +37,7 @@ source <(rdd svc paths --output=shell)
 | `RDD_ARGS_FILE` | Saved startup arguments | `~/Library/Application Support/rancher-desktop-2/args.json` |
 | `RDD_DIR` | Service instance directory | `~/Library/Application Support/rancher-desktop-2` |
 | `RDD_CONFIG` | RDD control plane config file | `~/Library/Application Support/rancher-desktop-2/config.yaml` |
+| `RDD_K3S_CONFIG` | Mirror of the in-VM k3s kubeconfig | `~/Library/Application Support/rancher-desktop-2/k3s.yaml` |
 | `RDD_LIMA_HOME` | Lima home directory | `~/.rd2/lima` |
 | `RDD_LOG_DIR` | Log directory | `~/Library/Logs/rancher-desktop-2` |
 | `RDD_PID_FILE` | Service PID file | `~/Library/Application Support/rancher-desktop-2/rdd.pid` |

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -113,7 +113,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec) (string, er
 		"param:",
 		fmt.Sprintf("  CONTAINER_ENGINE: %s", spec.ContainerEngine.Name),
 		fmt.Sprintf("  HOST_DOCKER_SOCKET: %q", instance.DockerSocket()),
-		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.Config())),
+		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.K3sConfig())),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
 		"",

--- a/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
@@ -15,8 +15,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-// makeSrcKubeconfig writes a minimal instance kubeconfig (matching what
-// storeKubeConfigToDisk produces) to dir/config.yaml and returns the path.
+// makeSrcKubeconfig writes a minimal k3s kubeconfig (matching what the
+// Lima probe copies) to dir/k3s.yaml and returns the path.
 func makeSrcKubeconfig(t *testing.T, dir string) string {
 	t.Helper()
 	cfg := clientcmdapi.NewConfig()
@@ -28,7 +28,7 @@ func makeSrcKubeconfig(t *testing.T, dir string) string {
 	cfg.Contexts["root"] = &clientcmdapi.Context{Cluster: "root", AuthInfo: "system-admin"}
 	cfg.CurrentContext = "root"
 
-	path := filepath.Join(dir, "config.yaml")
+	path := filepath.Join(dir, "k3s.yaml")
 	err := clientcmd.WriteToFile(*cfg, path)
 	assert.NilError(t, err)
 	return path

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -124,7 +124,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 // server. Returns (false, err) when the kubeconfig is unreadable, (false, nil)
 // when the server is unhealthy, and (true, nil) on success.
 func probeK3sAPI(ctx context.Context) (bool, error) {
-	kubeconfigPath := instance.Config()
+	kubeconfigPath := instance.K3sConfig()
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return false, fmt.Errorf("read instance kubeconfig: %w", err)
@@ -184,7 +184,7 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
 	contextName := instance.Name()
 	log := logf.FromContext(ctx).WithName("kube-context")
 
-	if err := createReplaceKubeContext(contextName, instance.Config()); err != nil {
+	if err := createReplaceKubeContext(contextName, instance.K3sConfig()); err != nil {
 		log.Error(err, "Failed to create Kubernetes context", "context", contextName)
 		return
 	}

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -142,6 +142,14 @@ func probeK3sAPI(ctx context.Context) (bool, error) {
 		pool.AppendCertsFromPEM(cfg.CAData)
 		tlsCfg.RootCAs = pool
 	}
+	// Load client cert for mTLS auth (k3s kubeconfig uses client cert, not bearer token).
+	if len(cfg.CertData) > 0 && len(cfg.KeyData) > 0 {
+		cert, err := tls.X509KeyPair(cfg.CertData, cfg.KeyData)
+		if err != nil {
+			return false, fmt.Errorf("load client cert: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},
 	}
@@ -279,6 +287,14 @@ func probeCurrentKubeContext(ctx context.Context, current string) bool {
 		pool := x509.NewCertPool()
 		pool.AppendCertsFromPEM(restCfg.CAData)
 		tlsCfg.RootCAs = pool
+	}
+	// Load client cert for mTLS auth (k3s kubeconfig uses client cert, not bearer token).
+	if len(restCfg.CertData) > 0 && len(restCfg.KeyData) > 0 {
+		cert, err := tls.X509KeyPair(restCfg.CertData, restCfg.KeyData)
+		if err != nil {
+			return true // assume healthy if we can't load the cert
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
 	httpClient := &http.Client{
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -218,12 +218,6 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
 			cancel()
 		}()
 
-		// Skip if KUBECONFIG is set — rewriting ~/.kube/config current-context
-		// has no effect and may clobber a user preference.
-		if os.Getenv("KUBECONFIG") != "" {
-			return
-		}
-
 		current, err := getCurrentKubeContext()
 		if err != nil {
 			log.Error(err, "Failed to read current Kubernetes context")

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -86,9 +86,17 @@ var ArgsFile = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "args.json")
 })
 
-// Config returns the path to the kubeconfig file.
+// Config returns the path to the rdd apiserver's kubeconfig.
+// `rdd ctl` pass-throughs export this path as KUBECONFIG.
 var Config = sync.OnceValue(func() string {
 	return filepath.Join(Dir(), "config.yaml")
+})
+
+// K3sConfig returns the path where the in-VM k3s kubeconfig is mirrored
+// by the Lima probe. Distinct from Config() so kubectl pass-throughs
+// keep talking to the rdd apiserver, not k3s.
+var K3sConfig = sync.OnceValue(func() string {
+	return filepath.Join(Dir(), "k3s.yaml")
 })
 
 // PIDFile returns the path to the service PID file.


### PR DESCRIPTION
## Summary

Four-part fix series sitting on top of #356. Each commit addresses a distinct bug the create-k8s-context tests hit after the earlier ones surface. Together they take Ubuntu and macOS `bats-app` from red to green.

## Commits

- **`fix: present client cert to k3s healthz probe`**
  `probeK3sAPI` and `probeCurrentKubeContext` set up TLS with the CA bundle but never loaded the client cert from `cfg.CertData`/`cfg.KeyData`. The k3s default kubeconfig uses client-cert auth (no bearer token), so `/healthz` rejected every probe with HTTP 401. `KubernetesReady` stayed at `Probing` forever and `rdd set running=true` timed out — the original failure on test 43.

- **`fix: split rdd apiserver kubeconfig from k3s mirror`**
  `instance.Config()` was overloaded: it both pointed at the rdd apiserver's kubeconfig (used by `rdd ctl` pass-throughs as `KUBECONFIG`) and was the destination the Lima probe copied the in-VM k3s kubeconfig to. The k3s overwrite clobbered the rdd apiserver kubeconfig, breaking `rdd ctl wait limavm/rd ...` in test 43's second command. Introduces `instance.K3sConfig()` returning `${Dir}/k3s.yaml` for the mirror, exposes it via `rdd svc paths k3s_config`, and documents `RDD_K3S_CONFIG`.

- **`fix: drop redundant KUBECONFIG-set guard in manageKubeContext`**
  `manageKubeContext` skipped `setCurrentKubeContext` whenever `$KUBECONFIG` was set, treating it as "user is curating manually." That conflicted with kube-context.bats setting `KUBECONFIG` for test isolation. `probeCurrentKubeContext` already checks whether the existing current-context is healthy and leaves it alone if so — the `KUBECONFIG`-existence check was redundant safety on top of that. Removing it restores both production safety and test isolation.

- **`fix(test): use rdd kubectl via helper functions in kube-context.bats`**
  kube-context.bats invoked bare `kubectl` for kubeconfig manipulation, which required system `kubectl` in PATH. Ubuntu CI has it; macOS doesn't, so tests 117 and 118 failed with "kubectl: command not found". Switching to bundled `rdd kubectl` (preserves caller's `KUBECONFIG`, unlike `rdd ctl`) removes the runner dependency. Also replaces `bash -c "kubectl ... | grep -qx"` in `try`-loops with a `kube_current_context_is` helper that uses `assert_output` per `bats-style.md`.

## Test plan

- [ ] CI passes on Ubuntu `bats-app` (probe path + kubeconfig handling)
- [ ] CI passes on macOS `bats-app` (test 43 onwards including kube-context tests)
- [ ] No regression in Windows `bats-app` (Kubernetes tests already skipped there)

## Notes

The series came out of a longer investigation tracked in #358. The diagnostic instrumentation that uncovered these bugs stays in that branch and will be extracted as a separate "permanent investigation infrastructure" PR.

## Do not merge separately

Layered on top of #356. Squash into #356 or merge in order after #356 lands.