### PR TITLE
debug: pidfile SIGQUIT, API capture, and V(1) app-reconcile logs

### DIFF
--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -23,8 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
@@ -502,7 +505,42 @@ func runningLimaVMMessage(runningCond *metav1.Condition, desired string) string 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.App{}).
+		For(&v1alpha1.App{}, builder.WithPredicates(watchEventLogger("app"))).
 		Owns(&limav1alpha1.LimaVM{}).
 		Complete(r)
+}
+
+// watchEventLogger returns a predicate that logs every watch event the
+// controller receives, before workqueue dispatch. Logs at V(1), so default
+// verbosity stays quiet.
+func watchEventLogger(name string) predicate.Predicate {
+	log := logf.Log.WithName(name + ".watch")
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			log.V(1).Info("create",
+				"name", e.Object.GetName(),
+				"generation", e.Object.GetGeneration(),
+				"resourceVersion", e.Object.GetResourceVersion(),
+			)
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			log.V(1).Info("update",
+				"name", e.ObjectNew.GetName(),
+				"oldGeneration", e.ObjectOld.GetGeneration(),
+				"newGeneration", e.ObjectNew.GetGeneration(),
+				"oldResourceVersion", e.ObjectOld.GetResourceVersion(),
+				"newResourceVersion", e.ObjectNew.GetResourceVersion(),
+			)
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			log.V(1).Info("delete", "name", e.Object.GetName())
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			log.V(1).Info("generic", "name", e.Object.GetName())
+			return true
+		},
+	}
 }

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -138,6 +138,13 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	log.V(1).Info("reconcile entered",
+		"specRunning", app.Spec.Running,
+		"generation", app.Generation,
+		"resourceVersion", app.ResourceVersion,
+		"beingDeleted", app.DeletionTimestamp != nil,
+	)
+
 	// Handle deletion, delete owned resources.
 	if base.IsBeingDeleted(&app) {
 		log.Info("App resource is being deleted, performing cleanup")

--- a/scripts/bats-with-timeout.sh
+++ b/scripts/bats-with-timeout.sh
@@ -272,28 +272,33 @@ dump_api_state() {
         return
     fi
 
-    if "$rdd_bin" service status 2>/dev/null | grep --quiet 'control plane has been started: true'; then
-        local resource_types
-        echo "=== rdd ctl get (overview) ==="
-        resource_types=$("$rdd_bin" ctl api-resources --output=json \
-            | jq -rc '.resources | map(select((.group // "") | test("rancherdesktop.io")) | .name) | join(",")' \
-            || echo "apps,limavms,containers,images,volumes,containernamespaces")
-        timeout --kill-after=1 10 \
-            "$rdd_bin" ctl get "$resource_types" --all-namespaces 2>&1 || true
+    # Always attempt API capture. The hangs we are most often diagnosing
+    # have the apiserver alive but the readiness path stuck, so the status
+    # gate would skip exactly when capture is most useful. Each probe has
+    # its own short timeout, so a fully dead daemon cannot block the bundle.
+    local status_line
+    status_line=$(timeout --kill-after=1 5 "$rdd_bin" service status 2>&1 | head -1 || echo "status check timed out")
+    echo "=== rdd service status: ${status_line} ==="
 
-        echo
-        echo "=== rdd ctl get events (by time) ==="
-        timeout --kill-after=1 10 \
-            "$rdd_bin" ctl get events --all-namespaces \
-            --sort-by=.lastTimestamp 2>&1 | tail -100 || true
+    local resource_types
+    echo
+    echo "=== rdd ctl get (overview) ==="
+    resource_types=$(timeout --kill-after=1 5 "$rdd_bin" ctl api-resources --output=json 2>/dev/null \
+        | jq -rc '.resources | map(select((.group // "") | test("rancherdesktop.io")) | .name) | join(",")' \
+        || echo "apps,limavms,containers,images,volumes,containernamespaces")
+    timeout --kill-after=1 10 \
+        "$rdd_bin" ctl get "$resource_types" --all-namespaces 2>&1 || true
 
-        echo
-        echo "=== rdd ctl get (full YAML) ==="
-        timeout --kill-after=1 15 \
-            "$rdd_bin" ctl get "$resource_types" --all-namespaces --output=yaml 2>&1 || true
-    else
-        echo "=== rdd control plane is not running ==="
-    fi
+    echo
+    echo "=== rdd ctl get events (by time) ==="
+    timeout --kill-after=1 10 \
+        "$rdd_bin" ctl get events --all-namespaces \
+        --sort-by=.lastTimestamp 2>&1 | tail -100 || true
+
+    echo
+    echo "=== rdd ctl get (full YAML) ==="
+    timeout --kill-after=1 15 \
+        "$rdd_bin" ctl get "$resource_types" --all-namespaces --output=yaml 2>&1 || true
 
     # Docker state: test suites that exercise the container engine
     # forward the guest Docker socket to a host path. Skip silently

--- a/scripts/bats-with-timeout.sh
+++ b/scripts/bats-with-timeout.sh
@@ -379,6 +379,31 @@ our_leaked_pids() {
     done < <(ps -a -x -o pid=,ucomm= 2>/dev/null || ps -e -o pid=,ucomm= 2>/dev/null || true)
 }
 
+# SIGQUIT the rdd service so its goroutine stacks land in rdd.stderr.log.
+# The service's cmdline does not carry the instance suffix (only env vars
+# do), so matches_our_instance cannot find it; we read the pidfile instead.
+# No-op if the pidfile is missing or the process is gone.
+sig_quit_rdd_service() {
+    local pid_file pid
+    pid_file=$("$rdd_bin" svc paths pid_file 2>/dev/null || true)
+    if [ -z "$pid_file" ] || [ ! -f "$pid_file" ]; then
+        return
+    fi
+    pid=$(cat "$pid_file" 2>/dev/null || true)
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        return
+    fi
+    {
+        echo
+        echo "=== SIGQUIT -> rdd service (RDD_INSTANCE=${instance}, pid=${pid}) ==="
+        echo "cmdline=$(cmdline_of "$pid")"
+    } >>"${bundle_file}" 2>&1
+    kill -QUIT "$pid" 2>/dev/null || true
+    # The dump goes to the service's stderr (captured in rdd.stderr.log).
+    # Pause so the runtime flushes before SIGTERM ends the process.
+    sleep 2
+}
+
 # SIGQUIT Go processes belonging to our RDD_INSTANCE so their goroutine
 # stacks land in the preserved stderr logs. No-op if nothing is leaked.
 sig_quit_our_go_leaks() {
@@ -432,6 +457,7 @@ while kill -0 "${cmd_pid}" 2>/dev/null; do
     if [ "$(date +%s)" -ge "${deadline}" ]; then
         echo "bats-with-timeout: RDD_INSTANCE=${instance} exceeded ${timeout_seconds}s, capturing support bundle" >&2
         capture_state "timeout"
+        sig_quit_rdd_service
         sig_quit_our_go_leaks
         echo "bats-with-timeout: sending SIGTERM to ${cmd_pid}" >&2
         kill -TERM "${cmd_pid}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Four pieces of permanent diagnostic infrastructure extracted from the #358 investigation. Each helps debug a different layer when a CI run hangs or a reconciler misbehaves. None depends on #356.

## Commits

- **`debug: SIGQUIT the rdd service before SIGTERM in bats-with-timeout.sh`**
  The existing leak-cleanup path SIGQUITs Go processes matching `RDD_INSTANCE`, but the rdd service's cmdline carries no instance suffix (only env vars do), so the service was always skipped — even when it was the process under test. Read the pidfile via `rdd svc paths pid_file` and SIGQUIT that PID directly. The goroutine dump flushes to the service's stderr, preserved across restarts by `logfile.Rotate`.

- **`debug: capture API state in dump_api_state regardless of readiness`**
  The status-gated branch skipped `rdd ctl get` calls when `rdd service status` did not say "control plane has been started: true." Hangs we typically diagnose have the apiserver alive but the readiness path stuck — exactly when API capture would be most useful. Always attempt the capture; the status output becomes a header line. Per-probe `timeout --kill-after=1` already bounds a dead daemon.

- **`debug: log entry into the app reconciler at V(1)`**
  When the app controller goes quiet during a CI failure it is unclear whether `Reconcile` fires at all or fires and silently early-returns. A V(1) "reconcile entered" log right after the App Get distinguishes the two without adding noise at default verbosity. Fields: `specRunning`, `generation`, `resourceVersion`, `beingDeleted` (nil-safe).

- **`debug: log every watch event the app controller receives`**
  A `predicate.Funcs` wrapper on `For(&App{})` logs every Create/Update/Delete/Generic event before workqueue dispatch, at V(1). Combined with the entry-point log above, the pair distinguishes: events delivered with no `Reconcile` → workqueue dispatch issue, events delivered with `Reconcile` → check the silent early-return paths, no events at all → informer issue.

## Verbosity

All logs at V(1). Default verbosity stays quiet. CI's `--v=4` shows them. Production users see no change.

## Companion work

After #356 lands, the same shape will be ported to `kube_reconciler.go` (entry-point log + watch event predicate). The `watchEventLogger` helper will likely move to a shared location in `pkg/controllers/app` when both controllers use it. Tracked separately.

## Test plan

- [ ] CI passes on all platforms (no behavior change at V(0))
- [ ] BATS `--v=4` shows the new lines in `rdd.stderr.log`