### PR TITLE
kubernetes-reconciler: add V(1) tracing and merge-failure handling

### DIFF
--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -72,6 +72,9 @@ func newServiceConfigCommand() *cobra.Command {
 
 func ensureServiceRunning(ctx context.Context) error {
 	if !service.Exists() {
+		// Persist no extra args; the per-start klogArgs below override
+		// verbosity on every start, so baking the caller's logrus level
+		// into args.json would only mislead future inspectors of the file.
 		if err := service.Create(nil); err != nil {
 			return err
 		}
@@ -84,7 +87,9 @@ func ensureServiceRunning(ctx context.Context) error {
 		}
 		return waitForDiscoveryConfigMap(ctx)
 	}
-	return startAndWaitForReady(ctx, nil)
+	// Pass klog verbosity transiently so V(1) tracing fires when
+	// autostart launches the daemon (e.g. from `rdd set`).
+	return startAndWaitForReady(ctx, []string{"-v", logrusLevelToKlog()})
 }
 
 // startAndWaitForReady starts the service, waits for the API server and the

--- a/cmd/rdd/set.go
+++ b/cmd/rdd/set.go
@@ -467,9 +467,10 @@ func patchApp(ctx context.Context, c client.Client, app *appv1alpha1.App, specMa
 // waitForDesiredState waits for the App reconcile chain to settle on
 // the new spec. Every property change waits for Settled=True with
 // ObservedGeneration >= minGen. Settled gates on the LimaVM reaching
-// its terminal phase (Started or Stopped) and, when the engine
-// controller is registered, on ContainerEngineReady=True at the
-// current generation.
+// its terminal phase (Started or Stopped), on ContainerEngineReady=True
+// at the current generation when the engine controller is registered,
+// and on KubernetesReady=True at the current generation when
+// spec.kubernetes.enabled is true.
 //
 // Filtering on ObservedGeneration >= minGen blocks a stale
 // Settled=True from a prior reconcile from satisfying the wait

--- a/docs/design/api_app.md
+++ b/docs/design/api_app.md
@@ -97,7 +97,7 @@ status:
 
 - **status.kubernetesPort**: The host TCP port allocated for the k3s API server (`7441 + instance.Index()` by default). Set by the App reconciler on the first reconcile after `spec.kubernetes.enabled` becomes `true`, and cleared when `spec.kubernetes.enabled` is set back to `false` so that a fresh port is resolved on the next enable. The `KUBERNETES_PORT` Lima template param is set to this value; Lima's identity port-forward rule binds the same port on the host and forwards it to the guest.
 
-- **status.conditions**: Multiple controllers write here. The App controller mirrors `Created` and `Running` from the owned `LimaVM`, computes `Settled`, and the engine controller writes `ContainerEngineReady`. All writers use `retry.RetryOnConflict` with a re-Get so concurrent status updates do not 409.
+- **status.conditions**: Multiple controllers write here. The App controller mirrors `Created` and `Running` from the owned `LimaVM` and computes `Settled`, the engine controller writes `ContainerEngineReady`, and the Kubernetes controller writes `KubernetesReady`. All writers use `retry.RetryOnConflict` with a re-Get so concurrent status updates do not 409.
 
   | Type                   | Status    | Reason           | Description                                                       |
   |------------------------|-----------|------------------|-------------------------------------------------------------------|
@@ -114,15 +114,22 @@ status:
   | `ContainerEngineReady` | `True`    | `NotApplicable`  | Mirroring is not implemented for the current backend (e.g. `containerd`); forced `True` so `rdd set` can finish waiting |
   | `ContainerEngineReady` | `False`   | `ConnectFailed`  | Engine controller failed to connect to Docker                     |
   | `ContainerEngineReady` | `False`   | `Stopped`        | The VM is stopped; the engine watcher is not running              |
+  | `KubernetesReady`      | `True`    | `Ready`          | k3s API server is reachable; instance context merged into `~/.kube/config` |
+  | `KubernetesReady`      | `False`   | `NotApplicable`  | `spec.kubernetes.enabled` is false                                |
+  | `KubernetesReady`      | `False`   | `NotRunning`     | VM is not running, so k3s cannot be healthy                       |
+  | `KubernetesReady`      | `False`   | `Probing`        | Waiting for k3s API server to respond                             |
+  | `KubernetesReady`      | `False`   | `MergeFailed`    | k3s is reachable but merging the instance kubeconfig failed (see `message`) |
   | `Settled`              | `True`    | `Settled`        | Reconcile chain has caught up with the current spec               |
   | `Settled`              | `False`   | `WaitingForLimaVM` | The App has no `Running` condition yet (nothing mirrored from LimaVM) |
   | `Settled`              | `False`   | `WaitingForEngine` | Engine controller has not yet written `ContainerEngineReady`    |
   | `Settled`              | `False`   | `EngineStale`    | Engine controller has not yet observed the current generation     |
-  | `Settled`              | `False`   | *(forwarded)*    | Forwarded from the blocking `Running` or `ContainerEngineReady` reason |
+  | `Settled`              | `False`   | `WaitingForKubernetes` | Kubernetes controller has not yet written `KubernetesReady`  |
+  | `Settled`              | `False`   | `KubernetesStale` | Kubernetes controller has not yet observed the current generation |
+  | `Settled`              | `False`   | *(forwarded)*    | Forwarded from the blocking `Running`, `ContainerEngineReady`, or `KubernetesReady` reason |
 
   `Running=True` means the Lima guest has finished booting and SSH is reachable. It says nothing about the container engine socket; consumers that depend on the engine (container/image/volume mirrors, `docker` against the forwarded socket) must also check `ContainerEngineReady`, which flips to `True` only after the engine controller has connected to the socket and completed its initial full sync.
 
-  The `Created` and `Running` conditions are mirrored from LimaVM, so their `lastTransitionTime` reflects the LimaVM transition rather than the copy — the timestamp is meaningful for staleness checks. The engine reconciler stamps `ContainerEngineReady.observedGeneration` with the App's `metadata.generation` at the time it writes the condition; if the App's generation advances between the reconciler's read and write, the stamp reflects the write-time generation rather than the observed one. The App reconciler computes `Settled` from the mirrored `Running` and the engine-written `ContainerEngineReady`, and stamps its own `observedGeneration` with the `metadata.generation` observed when it computed the condition, not the generation at write time. The retry-on-conflict loop re-reads on 409, so a successful write always carries the current generation. `rdd set` waits for `Settled.status=True` with `observedGeneration >= post-patch metadata.generation`, so stale snapshots cannot prematurely satisfy the wait.
+  The `Created` and `Running` conditions are mirrored from LimaVM, so their `lastTransitionTime` reflects the LimaVM transition rather than the copy — the timestamp is meaningful for staleness checks. The engine reconciler stamps `ContainerEngineReady.observedGeneration` with the App's `metadata.generation` at the time it writes the condition; if the App's generation advances between the reconciler's read and write, the stamp reflects the write-time generation rather than the observed one. The App reconciler computes `Settled` from the mirrored `Running`, the engine-written `ContainerEngineReady`, and the Kubernetes-written `KubernetesReady` (the last only when `spec.kubernetes.enabled` is true), and stamps its own `observedGeneration` with the `metadata.generation` observed when it computed the condition, not the generation at write time. The retry-on-conflict loop re-reads on 409, so a successful write always carries the current generation. `rdd set` waits for `Settled.status=True` with `observedGeneration >= post-patch metadata.generation`, so stale snapshots cannot prematurely satisfy the wait.
 
 Deleting the `App` resource triggers the finalizer to stop and delete the owned LimaVM (and wait for the LimaVM controller to complete its own cleanup before removing the App finalizer).
 

--- a/docs/design/cmd_app.md
+++ b/docs/design/cmd_app.md
@@ -12,7 +12,7 @@ If the App resource does not exist, it is created with default settings before t
 
 By default, `rdd set` waits for the reconcile chain to settle before returning. Every property change — `running`, `containerEngine.name`, `kubernetes.enabled`, or any combination — waits for the App's `Settled` condition to reach `True` with `ObservedGeneration` matching the post-patch generation.
 
-`Settled` goes `False` whenever the App controller sees a generation it has not yet caught up with, and back to `True` once the LimaVM has reached a terminal phase (Started or Stopped) and the engine controller has processed the current generation.
+`Settled` goes `False` whenever the App controller sees a generation it has not yet caught up with, and back to `True` once the LimaVM has reached a terminal phase (Started or Stopped), the engine controller has processed the current generation, and — when `kubernetes.enabled` is true — the Kubernetes controller has confirmed the k3s API server and merged the kubeconfig.
 
 The `ObservedGeneration` filter prevents a stale `Settled=True` from a previous reconcile from prematurely satisfying the wait.
 

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -95,6 +95,10 @@ const (
 	// AppKubernetesReasonProbing means the controller is still waiting for
 	// the k3s API server to respond.
 	AppKubernetesReasonProbing = "Probing"
+
+	// AppKubernetesReasonMergeFailed means the k3s API server is reachable
+	// but merging the instance kubeconfig into ~/.kube/config failed.
+	AppKubernetesReasonMergeFailed = "MergeFailed"
 )
 
 const (

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -45,11 +45,12 @@ const (
 
 	// AppConditionSettled reports whether the reconcile chain has
 	// fully caught up with the current spec: observed generations on
-	// the feeding conditions match the App's generation, and the VM
-	// and engine have reached a stable state for the desired config.
-	// A spec change forces Settled to False; once the chain quiesces,
-	// the App reconciler flips it back to True. `rdd set` waits on
-	// this condition.
+	// the feeding conditions match the App's generation, and the VM,
+	// engine, and (when spec.kubernetes.enabled is true) Kubernetes
+	// have reached a stable state for the desired config. A spec
+	// change forces Settled to False; once the chain quiesces, the
+	// App reconciler flips it back to True. `rdd set` waits on this
+	// condition.
 	AppConditionSettled = "Settled"
 )
 

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -25,12 +25,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/predicates"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
@@ -596,42 +595,7 @@ func runningLimaVMMessage(runningCond *metav1.Condition, desired string) string 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.App{}, builder.WithPredicates(watchEventLogger("app"))).
+		For(&v1alpha1.App{}, builder.WithPredicates(predicates.WatchEventLogger("app"))).
 		Owns(&limav1alpha1.LimaVM{}).
 		Complete(r)
-}
-
-// watchEventLogger returns a predicate that logs every watch event the
-// controller receives, before workqueue dispatch. Logs at V(1), so default
-// verbosity stays quiet.
-func watchEventLogger(name string) predicate.Predicate {
-	log := logf.Log.WithName(name + ".watch")
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			log.V(1).Info("create",
-				"name", e.Object.GetName(),
-				"generation", e.Object.GetGeneration(),
-				"resourceVersion", e.Object.GetResourceVersion(),
-			)
-			return true
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			log.V(1).Info("update",
-				"name", e.ObjectNew.GetName(),
-				"oldGeneration", e.ObjectOld.GetGeneration(),
-				"newGeneration", e.ObjectNew.GetGeneration(),
-				"oldResourceVersion", e.ObjectOld.GetResourceVersion(),
-				"newResourceVersion", e.ObjectNew.GetResourceVersion(),
-			)
-			return true
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			log.V(1).Info("delete", "name", e.Object.GetName())
-			return true
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			log.V(1).Info("generic", "name", e.Object.GetName())
-			return true
-		},
-	}
 }

--- a/pkg/controllers/app/app/controllers/app_controller.go
+++ b/pkg/controllers/app/app/controllers/app_controller.go
@@ -38,9 +38,9 @@ import (
 // ControllerDiscovery enumerates controllers enabled across all controller
 // managers in this control plane. AppReconciler queries it during
 // reconciliation to decide whether Settled must wait for
-// ContainerEngineReady. The interface mirrors a small subset of
-// pkg/service/controllers.ControllerManagerDiscovery so tests can substitute
-// a fake without taking on the full dependency.
+// ContainerEngineReady or KubernetesReady. The interface mirrors a small
+// subset of pkg/service/controllers.ControllerManagerDiscovery so tests can
+// substitute a fake without taking on the full dependency.
 type ControllerDiscovery interface {
 	GetEnabledControllers(ctx context.Context) ([]string, error)
 }

--- a/pkg/controllers/app/kubernetes/controller.go
+++ b/pkg/controllers/app/kubernetes/controller.go
@@ -14,6 +14,7 @@ import (
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/kubernetes/controllers"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
 func init() {
@@ -43,7 +44,8 @@ func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 	r := &controllers.KubernetesReconciler{
-		Client: mgr.GetClient(),
+		Client:        mgr.GetClient(),
+		K3sConfigPath: instance.K3sConfig(),
 	}
 	return r.SetupWithManager(mgr)
 }

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -66,6 +66,13 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 
 	running := apimeta.IsStatusConditionTrue(app.Status.Conditions, appv1alpha1.AppConditionRunning)
 
+	log.V(1).Info("reconcile entered",
+		"kubernetesEnabled", app.Spec.Kubernetes.Enabled,
+		"running", running,
+		"generation", app.Generation,
+		"resourceVersion", app.ResourceVersion,
+	)
+
 	// When Kubernetes is disabled, stamp the condition and clean up.
 	if !app.Spec.Kubernetes.Enabled {
 		r.removeKubeContext(ctx)
@@ -243,17 +250,24 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
 
 // probeCurrentKubeContext returns true if the named context's API server is
 // healthy. Empty or "default" contexts are treated as unhealthy.
+//
+// Returns true on unexpected internal errors (path lookup, kubeconfig parse,
+// TLS setup) to leave the user's current-context alone; each such path logs
+// the underlying error.
 func probeCurrentKubeContext(ctx context.Context, current string) bool {
+	log := logf.FromContext(ctx).WithName("kube-context-probe").WithValues("context", current)
 	if current == "" || current == "default" {
 		return false
 	}
 	destPath, err := kubeConfigPath()
 	if err != nil {
-		return true // assume healthy if we can't read the path
+		log.Error(err, "Failed to resolve kubeconfig path")
+		return true
 	}
 	cfg, err := loadKubeConfig(destPath)
 	if err != nil {
-		return true // assume healthy on parse error
+		log.Error(err, "Failed to load kubeconfig", "path", destPath)
+		return true
 	}
 	kctx, ok := cfg.Contexts[current]
 	if !ok {
@@ -269,10 +283,12 @@ func probeCurrentKubeContext(ctx context.Context, current string) bool {
 	merged.CurrentContext = current
 	data, err := clientcmd.Write(merged)
 	if err != nil {
+		log.Error(err, "Failed to serialize kubeconfig")
 		return true
 	}
 	restCfg, err := clientcmd.RESTConfigFromKubeConfig(data)
 	if err != nil {
+		log.Error(err, "Failed to build REST config from kubeconfig")
 		return true
 	}
 
@@ -288,7 +304,8 @@ func probeCurrentKubeContext(ctx context.Context, current string) bool {
 	if len(restCfg.CertData) > 0 && len(restCfg.KeyData) > 0 {
 		cert, err := tls.X509KeyPair(restCfg.CertData, restCfg.KeyData)
 		if err != nil {
-			return true // assume healthy if we can't load the cert
+			log.Error(err, "Failed to load client cert")
+			return true
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
@@ -301,6 +318,7 @@ func probeCurrentKubeContext(ctx context.Context, current string) bool {
 	url := clusterEntry.Server + "/healthz"
 	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, http.NoBody)
 	if err != nil {
+		log.Error(err, "Failed to build healthz request", "url", url)
 		return true
 	}
 	if restCfg.BearerToken != "" {

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -45,6 +45,11 @@ const (
 type KubernetesReconciler struct {
 	client.Client
 
+	// K3sConfigPath is the path to the in-VM k3s kubeconfig mirrored by the
+	// Lima probe. Production wiring sets it from instance.K3sConfig(); tests
+	// inject a path under a temp directory.
+	K3sConfigPath string
+
 	// contextMu protects contextProbeCancel and contextProbeGen.
 	contextMu sync.Mutex
 	// contextProbeCancel cancels the in-flight current-context probe goroutine.
@@ -94,7 +99,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 	}
 
 	// Probe the k3s API server from the instance kubeconfig.
-	healthy, err := probeK3sAPI(ctx)
+	healthy, err := r.probeK3sAPI(ctx)
 	if err != nil {
 		// kubeconfig missing or unreadable — k3s has not started yet.
 		log.V(1).Info("Cannot probe k3s API server", "err", err)
@@ -120,7 +125,16 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 	}
 
 	// k3s is healthy — merge the context into ~/.kube/config.
-	r.manageKubeContext(ctx)
+	if err := r.manageKubeContext(ctx); err != nil {
+		if condErr := r.setKubeCondition(ctx, &app,
+			metav1.ConditionFalse,
+			appv1alpha1.AppKubernetesReasonMergeFailed,
+			fmt.Sprintf("Failed to publish Kubernetes context: %v", err),
+		); condErr != nil {
+			return ctrl.Result{}, condErr
+		}
+		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
+	}
 
 	return ctrl.Result{}, r.setKubeCondition(ctx, &app,
 		metav1.ConditionTrue,
@@ -129,11 +143,12 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 	)
 }
 
-// probeK3sAPI reads the instance kubeconfig and GETs /healthz on the k3s API
-// server. Returns (false, err) when the kubeconfig is unreadable, (false, nil)
-// when the server is unhealthy, and (true, nil) on success.
-func probeK3sAPI(ctx context.Context) (bool, error) {
-	kubeconfigPath := instance.K3sConfig()
+// probeK3sAPI reads the instance kubeconfig from r.K3sConfigPath and GETs
+// /healthz on the k3s API server. Returns (false, err) when the kubeconfig
+// is unreadable, (false, nil) when the server is unhealthy, and (true, nil)
+// on success.
+func (r *KubernetesReconciler) probeK3sAPI(ctx context.Context) (bool, error) {
+	kubeconfigPath := r.K3sConfigPath
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return false, fmt.Errorf("read instance kubeconfig: %w", err)
@@ -188,14 +203,16 @@ func probeK3sAPI(ctx context.Context) (bool, error) {
 
 // manageKubeContext merges the instance kubeconfig into ~/.kube/config and
 // launches a goroutine to set current-context if the existing one is unhealthy.
+// Returns an error if the synchronous merge fails; failures from the async
+// current-context probe are logged but not returned.
 // At most one probe runs at a time.
-func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
+func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) error {
 	contextName := instance.Name()
 	log := logf.FromContext(ctx).WithName("kube-context")
 
-	if err := createReplaceKubeContext(contextName, instance.K3sConfig()); err != nil {
+	if err := createReplaceKubeContext(contextName, r.K3sConfigPath); err != nil {
 		log.Error(err, "Failed to create Kubernetes context", "context", contextName)
-		return
+		return fmt.Errorf("create Kubernetes context %q: %w", contextName, err)
 	}
 
 	r.contextMu.Lock()
@@ -246,6 +263,7 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) {
 			}
 		}
 	}()
+	return nil
 }
 
 // probeCurrentKubeContext returns true if the named context's API server is

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -21,10 +21,12 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/predicates"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
@@ -363,7 +365,7 @@ func (r *KubernetesReconciler) setKubeCondition(ctx context.Context, app *appv1a
 // SetupWithManager registers the reconciler with the manager.
 func (r *KubernetesReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appv1alpha1.App{}).
+		For(&appv1alpha1.App{}, builder.WithPredicates(predicates.WatchEventLogger("kubernetes-reconciler"))).
 		Named("kubernetes-reconciler").
 		Complete(r)
 }

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+// fakeK3sServer starts an httptest TLS server that answers /healthz with
+// healthzStatus and writes a matching k3s-shaped kubeconfig to srcPath.
+// Returns the configured kubeconfig path and registers t.Cleanup for the
+// server.
+func fakeK3sServer(t *testing.T, srcPath string, healthzStatus int) string {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/healthz" {
+			w.WriteHeader(healthzStatus)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.Certificate().Raw,
+	})
+
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters["default"] = &clientcmdapi.Cluster{
+		Server:                   srv.URL,
+		CertificateAuthorityData: certPEM,
+	}
+	cfg.AuthInfos["default"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: certPEM,
+		ClientKeyData:         clientKeyPEM(t, srv),
+	}
+	cfg.Contexts["default"] = &clientcmdapi.Context{
+		Cluster:  "default",
+		AuthInfo: "default",
+	}
+	cfg.CurrentContext = "default"
+
+	assert.NilError(t, clientcmd.WriteToFile(*cfg, srcPath))
+	return srcPath
+}
+
+// clientKeyPEM extracts the test server's private key in PEM form.
+// httptest's self-signed cert ships with its own key, which probeK3sAPI
+// requires when the kubeconfig declares ClientCertificateData / ClientKeyData.
+func clientKeyPEM(t *testing.T, srv *httptest.Server) []byte {
+	t.Helper()
+	leaf := srv.TLS.Certificates[0]
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(leaf.PrivateKey)
+	assert.NilError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+}
+
+// newAppRunning builds an App with Kubernetes enabled and the Running condition
+// set to True so Reconcile reaches the probe path.
+func newAppRunning() *appv1alpha1.App {
+	return &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Generation: 1},
+		Spec: appv1alpha1.AppSpec{
+			Running:    true,
+			Kubernetes: appv1alpha1.KubernetesSpec{Enabled: true, Version: "1.32.0"},
+		},
+		Status: appv1alpha1.AppStatus{
+			Conditions: []metav1.Condition{{
+				Type:   appv1alpha1.AppConditionRunning,
+				Status: metav1.ConditionTrue,
+				Reason: "Started",
+			}},
+		},
+	}
+}
+
+// newAppKubernetesDisabled builds an App with Kubernetes disabled and the
+// Running condition True, so Reconcile takes the NotApplicable branch.
+func newAppKubernetesDisabled() *appv1alpha1.App {
+	app := newAppRunning()
+	app.Spec.Kubernetes.Enabled = false
+	return app
+}
+
+// newAppNotRunning builds an App with Kubernetes enabled but the Running
+// condition False, so Reconcile takes the NotRunning branch.
+func newAppNotRunning() *appv1alpha1.App {
+	app := newAppRunning()
+	app.Status.Conditions[0].Status = metav1.ConditionFalse
+	app.Status.Conditions[0].Reason = "Stopped"
+	return app
+}
+
+// isolateKubeconfig points HOME and KUBECONFIG at dir so the reconciler's
+// kubeconfig writes cannot touch the developer's real ~/.kube/config even
+// if a future refactor changes KUBECONFIG-precedence handling.
+func isolateKubeconfig(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("KUBECONFIG", filepath.Join(dir, ".kube", "config"))
+}
+
+func newKubeScheme(t *testing.T) *k8sruntime.Scheme {
+	t.Helper()
+	s := k8sruntime.NewScheme()
+	assert.NilError(t, appv1alpha1.AddToScheme(s))
+	return s
+}
+
+// findKubeReady returns the KubernetesReady condition on app, or nil if absent.
+func findKubeReady(app *appv1alpha1.App) *metav1.Condition {
+	return apimeta.FindStatusCondition(app.Status.Conditions, appv1alpha1.AppConditionKubernetesReady)
+}
+
+func Test_Reconcile_KubernetesReady_Ready(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunning()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:        c,
+		K3sConfigPath: srcPath,
+	}
+	// removeKubeContext cancels the in-flight current-context probe and waits
+	// for the goroutine started by manageKubeContext to finish, so it cannot
+	// still be reading tempdir state after the test returns.
+	t.Cleanup(func() { r.removeKubeContext(context.Background()) })
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, time.Duration(0),
+		"Ready path should not request a requeue")
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionTrue)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonReady)
+}
+
+func Test_Reconcile_KubernetesReady_MergeFailed(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)
+
+	// Plant a regular file where the destination kubeconfig's parent
+	// directory should be. createReplaceKubeContext calls
+	// os.MkdirAll("$HOME/.kube"), which fails with ENOTDIR.
+	kubeDir := filepath.Join(dir, ".kube")
+	assert.NilError(t, os.WriteFile(kubeDir, []byte("not a directory"), 0o600))
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunning()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:        c,
+		K3sConfigPath: srcPath,
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, kubeProbeRequeue,
+		"MergeFailed path should requeue after kubeProbeRequeue")
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonMergeFailed)
+	assert.Assert(t, cond.Message != "",
+		"MergeFailed condition should carry the underlying error in its message")
+}
+
+func Test_Reconcile_KubernetesReady_NotApplicable(t *testing.T) {
+	dir := t.TempDir()
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppKubernetesDisabled()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{Client: c}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, time.Duration(0),
+		"NotApplicable path should not request a requeue")
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonNotApplicable)
+}
+
+func Test_Reconcile_KubernetesReady_NotRunning(t *testing.T) {
+	dir := t.TempDir()
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppNotRunning()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{Client: c}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, time.Duration(0),
+		"NotRunning path should not request a requeue")
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonNotRunning)
+}
+
+func Test_Reconcile_KubernetesReady_Probing_ProbeError(t *testing.T) {
+	dir := t.TempDir()
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunning()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	// Point K3sConfigPath at a file that does not exist so probeK3sAPI
+	// returns the (false, err) "kubeconfig unreadable" path.
+	r := &KubernetesReconciler{
+		Client:        c,
+		K3sConfigPath: filepath.Join(dir, "missing-k3s.yaml"),
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, kubeProbeRequeue,
+		"Probing path should requeue after kubeProbeRequeue")
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonProbing)
+}
+
+func Test_Reconcile_KubernetesReady_Probing_Unhealthy(t *testing.T) {
+	dir := t.TempDir()
+	// fakeK3sServer answers /healthz with 500, so probeK3sAPI takes the
+	// (false, nil) "server reachable but unhealthy" path.
+	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusInternalServerError)
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunning()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:        c,
+		K3sConfigPath: srcPath,
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, kubeProbeRequeue,
+		"Probing path should requeue after kubeProbeRequeue")
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonProbing)
+}

--- a/pkg/controllers/app/predicates/predicates.go
+++ b/pkg/controllers/app/predicates/predicates.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package predicates provides controller-runtime predicates for the App
+// controllers.
+package predicates
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// WatchEventLogger returns a predicate that logs every watch event the
+// controller receives, before workqueue dispatch. Logs at V(1), so default
+// verbosity stays quiet.
+func WatchEventLogger(name string) predicate.Predicate {
+	log := logf.Log.WithName(name + ".watch")
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			log.V(1).Info("create",
+				"name", e.Object.GetName(),
+				"generation", e.Object.GetGeneration(),
+				"resourceVersion", e.Object.GetResourceVersion(),
+			)
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			log.V(1).Info("update",
+				"name", e.ObjectNew.GetName(),
+				"oldGeneration", e.ObjectOld.GetGeneration(),
+				"newGeneration", e.ObjectNew.GetGeneration(),
+				"oldResourceVersion", e.ObjectOld.GetResourceVersion(),
+				"newResourceVersion", e.ObjectNew.GetResourceVersion(),
+			)
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			log.V(1).Info("delete", "name", e.Object.GetName())
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			log.V(1).Info("generic", "name", e.Object.GetName())
+			return true
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- Promote `watchEventLogger` to a shared `pkg/controllers/app/predicates` package so the App and kubernetes reconcilers share one implementation.
- Add a V(1) `reconcile entered` log and the watch-event predicate to the kubernetes reconciler, and log the six return-true paths in `probeCurrentKubeContext` (the function still returns true to preserve the user's current-context).
- Set `KubernetesReady=False` with reason `MergeFailed` when `manageKubeContext` cannot merge the instance kubeconfig. Previously the controller silently logged the error and set True, contradicting the condition's doc contract.

## Test plan

- [x] `go build ./...`, `go vet ./...`, unit tests under `pkg/controllers/app/...` and `pkg/apis/...` pass locally.
- [x] Smoke-tested via `rdd svc start --wait=false` then `rdd set running=false`; observed `FLAG: --v="4"` and 17 V(1) `reconcile entered` lines in stderr, plus watch events under `kubernetes-reconciler.watch`.
- [x] CI green.

Follow-up to #358.