### PR TITLE
cli: standardize --wait and --timeout across svc and limavm

### DIFF
--- a/bats/helpers/controller.bash
+++ b/bats/helpers/controller.bash
@@ -75,7 +75,12 @@ patch_resource() {
 setup_rdd_control_plane() {
     local controllers=${1:-"*"}
 
-    rdd svc delete
+    # Bound delete so a stuck prior daemon cannot hang the helper for the
+    # full 5m stopWaitTimeout, and let the bounded delete fail loudly: a
+    # timed-out delete leaves the instance directory behind, which turns
+    # `create` into a no-op and leaks the prior controller set into the
+    # next suite.
+    rdd svc delete --timeout=120s
     rdd svc create --controllers="${controllers}"
     rdd svc start
 }

--- a/bats/tests/20-service/6-timeout.bats
+++ b/bats/tests/20-service/6-timeout.bats
@@ -1,0 +1,41 @@
+load '../../helpers/load'
+
+# Assert `rdd svc stop --wait` and `rdd svc delete` exit with code 4
+# (cliexit.CodeTimeout) when --timeout expires. A 1ms deadline fires before
+# the graceful-shutdown loop observes the service exit, so the wait sends
+# SIGTERM (or TerminateProcess on Windows) and returns
+# context.DeadlineExceeded wrapped in cliexit.Timeout. svc delete also
+# preserves the instance directory on timeout (see docs/design/cmd_service.md)
+# so the user can retry.
+
+local_setup_file() {
+    rdd svc delete --timeout=120s
+    rdd svc create
+    rdd svc start
+}
+
+@test 'svc stop --timeout=1ms exits with code 4' {
+    run -4 rdd svc stop --wait --timeout=1ms
+    assert_output --partial 'context deadline exceeded'
+}
+
+@test 'svc delete --timeout=1ms exits with code 4 and preserves the instance directory' {
+    # Hard reset: the prior test sent SIGTERM but does not wait for the
+    # process to exit, so a plain `rdd svc start` could still see
+    # Running()=true and take the already-running branch.
+    rdd svc delete --timeout=10s || :
+    rdd svc create
+    rdd svc start
+    run -4 rdd svc delete --timeout=1ms
+    assert_output --partial 'context deadline exceeded'
+    run -0 rdd svc status
+    assert_output --partial 'has been created: true'
+}
+
+@test 'svc start --timeout=1ms exits with code 4' {
+    # Reset to a known state; prior tests left the control plane half-dead.
+    rdd svc delete --timeout=120s
+    rdd svc create
+    run -4 rdd svc start --wait --timeout=1ms
+    assert_output --partial 'context deadline exceeded'
+}

--- a/bats/tests/33-lima-controllers/limavm-cli.bats
+++ b/bats/tests/33-lima-controllers/limavm-cli.bats
@@ -75,7 +75,7 @@ assert_created() {
     assert_running "false"
 
     # Delete the VM
-    run -0 rdd limavm delete --wait "test-vm"
+    run -0 rdd limavm delete "test-vm"
     assert_output --partial 'deleted'
     run -1 rdd ctl get limavm "test-vm" --namespace "${LIMA_TEST_NS}"
     assert_output --partial "not found"
@@ -91,7 +91,7 @@ assert_created() {
     run -0 rdd ctl get limavm "start-vm" --namespace "${LIMA_TEST_NS}" -o jsonpath='{.spec.running}'
     assert_output "true"
 
-    run -0 rdd limavm delete --wait "start-vm"
+    rdd limavm delete "start-vm"
 }
 
 @test "lima create with file template" {
@@ -128,9 +128,6 @@ assert_created() {
     # Delete the LimaVM
     run -0 rdd limavm delete "test-vm-file"
     assert_output --partial 'deleted'
-
-    # Wait for LimaVM to be fully deleted
-    rdd ctl wait --for=delete "limavm/test-vm-file" --namespace "${LIMA_TEST_NS}" --timeout="30s"
 
     # Verify ConfigMap was auto-deleted by controller finalizer
     run -1 rdd ctl get configmap "test-vm-file" --namespace "${LIMA_TEST_NS}"
@@ -193,8 +190,7 @@ assert_created() {
     assert_output "true"
 
     # Delete the VM
-    run -0 rdd limavm delete "restart-vm"
-    rdd ctl wait --for=delete "limavm/restart-vm" --namespace "${LIMA_TEST_NS}" --timeout="30s"
+    rdd limavm delete "restart-vm"
 }
 
 @test "lima start --timeout fails when VM cannot reach desired state" {
@@ -204,7 +200,55 @@ assert_created() {
     assert_created "timeout-vm" "${LIMA_TEST_NS}" "timeout-vm"
 
     # Non-functional template cannot boot, so --wait --timeout should fail
-    run -1 rdd limavm start --wait --timeout=3s "timeout-vm"
+    # with exit code 4 (cliexit.CodeTimeout) to match `rdd set`.
+    run -4 rdd limavm start --wait --timeout=3s "timeout-vm"
+    assert_output --partial 'context deadline exceeded'
+}
+
+@test "lima create --start --timeout fails when VM cannot boot" {
+    rdd ctl create configmap "create-timeout-vm" --namespace "${LIMA_TEST_NS}" \
+        --from-literal="template=${TEMPLATE}"
+
+    # Create with --start: the VM never reaches Running=True because the
+    # template is non-functional, so --wait --timeout exits with code 4.
+    run -4 rdd limavm create "create-timeout-vm" "create-timeout-vm" \
+        --namespace "${LIMA_TEST_NS}" --start --wait --timeout=3s
+    assert_output --partial 'context deadline exceeded'
+}
+
+@test "lima restart --timeout fails when VM cannot restart" {
+    rdd ctl create configmap "restart-timeout-vm" --namespace "${LIMA_TEST_NS}" \
+        --from-literal="template=${TEMPLATE}"
+    run_e -0 rdd limavm create "restart-timeout-vm" "restart-timeout-vm" --namespace "${LIMA_TEST_NS}"
+    assert_created "restart-timeout-vm" "${LIMA_TEST_NS}" "restart-timeout-vm"
+
+    # Restart waits for status.restartCount to increment, which requires the
+    # VM to come back up. The non-functional template never boots, so the
+    # counter stays at zero and --wait --timeout exits with code 4.
+    run -4 rdd limavm restart --wait --timeout=3s "restart-timeout-vm"
+    assert_output --partial 'context deadline exceeded'
+}
+
+@test "lima stop --timeout exits with code 4" {
+    rdd ctl create configmap "stop-timeout-vm" --namespace "${LIMA_TEST_NS}" \
+        --from-literal="template=${TEMPLATE}"
+    run_e -0 rdd limavm create "stop-timeout-vm" "stop-timeout-vm" \
+        --namespace "${LIMA_TEST_NS}" --start --wait=false
+    assert_created "stop-timeout-vm" "${LIMA_TEST_NS}" "stop-timeout-vm"
+
+    # 1ms deadline fires before the Running=False condition propagates.
+    run -4 rdd limavm stop --wait --timeout=1ms "stop-timeout-vm"
+    assert_output --partial 'context deadline exceeded'
+}
+
+@test "lima delete --timeout exits with code 4" {
+    rdd ctl create configmap "delete-timeout-vm" --namespace "${LIMA_TEST_NS}" \
+        --from-literal="template=${TEMPLATE}"
+    run_e -0 rdd limavm create "delete-timeout-vm" "delete-timeout-vm" --namespace "${LIMA_TEST_NS}"
+    assert_created "delete-timeout-vm" "${LIMA_TEST_NS}" "delete-timeout-vm"
+
+    # 1ms deadline fires before the finalizer removes the resource.
+    run -4 rdd limavm delete --wait --timeout=1ms "delete-timeout-vm"
     assert_output --partial 'context deadline exceeded'
 }
 

--- a/cmd/rdd/limavm.go
+++ b/cmd/rdd/limavm.go
@@ -25,16 +25,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 	corev1scheme "k8s.io/client-go/kubernetes/scheme"
-	toolswatch "k8s.io/client-go/tools/watch"
+	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
+	cliexit "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/exit"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/tail"
 )
+
+// limaLongWaitTimeout is the default --timeout for VM boot and shutdown waits,
+// which routinely take minutes.
+const limaLongWaitTimeout = 5 * time.Minute
 
 func newLimaVMCommand() *cobra.Command {
 	command := &cobra.Command{
@@ -143,7 +148,7 @@ TEMPLATE can be one of:
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "If set, do not commit any changes to the cluster")
 	command.Flags().BoolVar(&start, "start", false, "Start the VM after creation")
 	command.Flags().BoolVar(&wait, "wait", true, "Wait for the operation to complete (only applies with --start)")
-	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
+	command.Flags().DurationVar(&timeout, "timeout", limaLongWaitTimeout, "Timeout for --wait; ignored without --start or with --wait=false (0 means wait indefinitely)")
 	return command
 }
 
@@ -159,7 +164,7 @@ func newLimaVMStartCommand() *cobra.Command {
 		},
 	}
 	command.Flags().BoolVar(&wait, "wait", true, "Wait for the operation to complete")
-	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
+	command.Flags().DurationVar(&timeout, "timeout", limaLongWaitTimeout, "Timeout for --wait; ignored if --wait=false (0 means wait indefinitely)")
 	return command
 }
 
@@ -175,7 +180,7 @@ func newLimaVMStopCommand() *cobra.Command {
 		},
 	}
 	command.Flags().BoolVar(&wait, "wait", true, "Wait for the operation to complete")
-	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
+	command.Flags().DurationVar(&timeout, "timeout", limaLongWaitTimeout, "Timeout for --wait; ignored if --wait=false (0 means wait indefinitely)")
 	return command
 }
 
@@ -192,7 +197,7 @@ func newLimaVMRestartCommand() *cobra.Command {
 		},
 	}
 	command.Flags().BoolVar(&wait, "wait", true, "Wait for the operation to complete")
-	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
+	command.Flags().DurationVar(&timeout, "timeout", limaLongWaitTimeout, "Timeout for --wait; ignored if --wait=false (0 means wait indefinitely)")
 	return command
 }
 
@@ -222,13 +227,13 @@ func limaVMRestartAction(ctx context.Context, name string, wait bool, timeout ti
 	logrus.Infof("LimaVM %q restart requested in namespace %q", name, limaVM.Namespace)
 
 	if wait {
-		waitCtx, cancel := toolswatch.ContextWithOptionalTimeout(ctx, timeout)
+		waitCtx, cancel := watchtools.ContextWithOptionalTimeout(ctx, timeout)
 		defer cancel()
 		key := client.ObjectKeyFromObject(limaVM)
 		if err := watchUntil(waitCtx, c, key, func(vm *limav1alpha1.LimaVM) bool {
 			return vm.Status.RestartCount > beforeCount
 		}); err != nil {
-			return fmt.Errorf("failed waiting for restart to complete: %w", err)
+			return cliexit.Classify(fmt.Errorf("failed waiting for restart to complete: %w", err))
 		}
 		logrus.Infof("LimaVM %q restarted in namespace %q", name, limaVM.Namespace)
 	}
@@ -246,8 +251,8 @@ func newLimaVMDeleteCommand() *cobra.Command {
 			return limaVMDeleteAction(cmd.Context(), args[0], wait, timeout)
 		},
 	}
-	command.Flags().BoolVar(&wait, "wait", false, "Wait for the VM to be deleted before returning")
-	command.Flags().DurationVar(&timeout, "timeout", 0, "Timeout for --wait (0 means wait indefinitely)")
+	command.Flags().BoolVar(&wait, "wait", true, "Wait for the VM to be deleted before returning")
+	command.Flags().DurationVar(&timeout, "timeout", limaLongWaitTimeout, "Timeout for --wait; ignored if --wait=false (0 means wait indefinitely)")
 	return command
 }
 
@@ -402,13 +407,13 @@ func limaVMCreateAction(ctx context.Context, name, template, namespace string, d
 	}
 
 	if start && wait && !dryRun {
-		waitCtx, cancel := toolswatch.ContextWithOptionalTimeout(ctx, timeout)
+		waitCtx, cancel := watchtools.ContextWithOptionalTimeout(ctx, timeout)
 		defer cancel()
 		key := client.ObjectKeyFromObject(limaVM)
 		if err := watchUntil(waitCtx, c, key, func(vm *limav1alpha1.LimaVM) bool {
 			return apimeta.IsStatusConditionPresentAndEqual(vm.Status.Conditions, "Running", metav1.ConditionTrue)
 		}); err != nil {
-			return fmt.Errorf("failed waiting for LimaVM to start: %w", err)
+			return cliexit.Classify(fmt.Errorf("failed waiting for LimaVM to start: %w", err))
 		}
 		logrus.Infof("LimaVM %q started in namespace %q", name, namespace)
 	}
@@ -442,13 +447,13 @@ func limaVMSetRunningAction(ctx context.Context, name string, running, wait bool
 	logrus.Infof("LimaVM %q %s in namespace %q", name, action, limaVM.Namespace)
 
 	if wait {
-		waitCtx, cancel := toolswatch.ContextWithOptionalTimeout(ctx, timeout)
+		waitCtx, cancel := watchtools.ContextWithOptionalTimeout(ctx, timeout)
 		defer cancel()
 		key := client.ObjectKeyFromObject(limaVM)
 		if err := watchUntil(waitCtx, c, key, func(vm *limav1alpha1.LimaVM) bool {
 			return apimeta.IsStatusConditionPresentAndEqual(vm.Status.Conditions, "Running", desiredStatus)
 		}); err != nil {
-			return fmt.Errorf("failed waiting for LimaVM to be %s: %w", action, err)
+			return cliexit.Classify(fmt.Errorf("failed waiting for LimaVM to be %s: %w", action, err))
 		}
 	}
 	return nil
@@ -489,7 +494,22 @@ func watchUntil(ctx context.Context, c client.WithWatch, key client.ObjectKey, c
 			return nil
 		}
 	}
-	return ctx.Err()
+	// ResultChan closed. If ctx ended, return its error. Otherwise the
+	// watch dropped (server close, proxy timeout, watch expiry); re-read
+	// and re-evaluate to distinguish a satisfied predicate from a drop.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := c.Get(ctx, key, &vm); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("LimaVM %q was deleted while waiting", key.Name)
+		}
+		return err
+	}
+	if check(&vm) {
+		return nil
+	}
+	return fmt.Errorf("watch closed before LimaVM %q reached the desired state", key.Name)
 }
 
 // watchUntilDeleted watches a LimaVM until it is deleted.
@@ -527,7 +547,23 @@ func watchUntilDeleted(ctx context.Context, c client.WithWatch, limaVM *limav1al
 			return apierrors.FromObject(ev.Object)
 		}
 	}
-	return ctx.Err()
+	// ResultChan closed. If ctx ended, return its error. Otherwise the
+	// watch dropped; re-read and treat NotFound or a new UID as
+	// confirmation of deletion.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	var current limav1alpha1.LimaVM
+	if err := c.Get(ctx, key, &current); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if current.UID != limaVM.UID {
+		return nil
+	}
+	return fmt.Errorf("watch closed before LimaVM %q was deleted", key.Name)
 }
 
 func limaVMDeleteAction(ctx context.Context, name string, wait bool, timeout time.Duration) error {
@@ -546,10 +582,10 @@ func limaVMDeleteAction(ctx context.Context, name string, wait bool, timeout tim
 	}
 
 	if wait {
-		waitCtx, cancel := toolswatch.ContextWithOptionalTimeout(ctx, timeout)
+		waitCtx, cancel := watchtools.ContextWithOptionalTimeout(ctx, timeout)
 		defer cancel()
 		if err := watchUntilDeleted(waitCtx, c, limaVM); err != nil {
-			return fmt.Errorf("failed to wait for LimaVM deletion: %w", err)
+			return cliexit.Classify(fmt.Errorf("failed to wait for LimaVM deletion: %w", err))
 		}
 	}
 

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -18,13 +18,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	watchtools "k8s.io/client-go/tools/watch"
 
+	cliexit "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/exit"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/developer"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	service "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/cmd"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/controllers"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/tail"
 )
+
+// startWaitTimeout bounds the wait for the API server, CRDs, and
+// controller-manager registration to land. Cold start can take well over 30s
+// in CI on slower runners.
+const startWaitTimeout = 90 * time.Second
+
+// stopWaitTimeout bounds the CLI wait for the control plane to shut down.
+// Run caps the internal drain at 45s (see pkg/service/cmd/service.go).
+// The CLI deadline exceeds that cap to absorb slow disks, misconfigured
+// hosts, and sequential multi-VM drains. Aliased to limaLongWaitTimeout
+// (defined in limavm.go) so the per-VM ceiling stays the single tuning
+// knob for long CLI waits.
+const stopWaitTimeout = limaLongWaitTimeout
 
 // logrusLevelToKlog converts current logrus level to klog level.
 func logrusLevelToKlog() string {
@@ -70,6 +85,11 @@ func newServiceConfigCommand() *cobra.Command {
 	return command
 }
 
+// ensureServiceRunning readies the control plane before a CLI command
+// relies on it. It bounds the already-running and cold-start paths by
+// startWaitTimeout (90s), independent of the caller's --timeout. The
+// cap lets a broken service fail fast so rdd limavm *, rdd set, rdd
+// kubectl, and rdd service config stay responsive on a long deadline.
 func ensureServiceRunning(ctx context.Context) error {
 	if !service.Exists() {
 		// Persist no extra args; the per-start klogArgs below override
@@ -80,16 +100,20 @@ func ensureServiceRunning(ctx context.Context) error {
 		}
 	}
 	if service.Running() {
-		ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
-		defer cancel()
-		if err := service.Wait(ctx); err != nil {
+		startTime, err := service.StartTime()
+		if err != nil {
 			return err
 		}
-		return waitForDiscoveryConfigMap(ctx)
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, startWaitTimeout)
+		defer cancel()
+		if err := service.Wait(ctx); err != nil {
+			return cliexit.Classify(err)
+		}
+		return cliexit.Classify(waitForFreshDiscoveryConfigMap(ctx, startTime))
 	}
 	// Pass klog verbosity transiently so V(1) tracing fires when
 	// autostart launches the daemon (e.g. from `rdd set`).
-	return startAndWaitForReady(ctx, []string{"-v", logrusLevelToKlog()})
+	return cliexit.Classify(startAndWaitForReady(ctx, []string{"-v", logrusLevelToKlog()}, startWaitTimeout))
 }
 
 // startAndWaitForReady starts the service, waits for the API server and the
@@ -97,10 +121,10 @@ func ensureServiceRunning(ctx context.Context) error {
 // survive with stale data, so the freshness check waits for a ConfigMap whose
 // creationTimestamp is at or after the current startup.
 //
-// Both the API server readiness and ConfigMap freshness polls share a single
-// 90-second timeout, because the apiserver may become ready before the
-// serve command creates the ConfigMap.
-func startAndWaitForReady(ctx context.Context, serveArgs []string) error {
+// Pass timeout 0 to wait indefinitely. A finite timeout bounds both the API
+// server readiness poll and the ConfigMap freshness poll together, because
+// the apiserver may become ready before the serve command creates the ConfigMap.
+func startAndWaitForReady(ctx context.Context, serveArgs []string, timeout time.Duration) error {
 	// Truncate to second precision because metav1.Time drops sub-seconds
 	// during JSON serialization. Without this, a server that starts in the
 	// same second would appear to have a startTime *before* beforeStart.
@@ -109,18 +133,13 @@ func startAndWaitForReady(ctx context.Context, serveArgs []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, timeout)
 	defer cancel()
 
 	if err := service.Wait(ctx); err != nil {
 		return err
 	}
 	return waitForFreshDiscoveryConfigMap(ctx, beforeStart)
-}
-
-// waitForDiscoveryConfigMap polls until the discovery ConfigMap exists.
-func waitForDiscoveryConfigMap(ctx context.Context) error {
-	return waitForFreshDiscoveryConfigMap(ctx, time.Time{})
 }
 
 // waitForFreshDiscoveryConfigMap polls until the discovery ConfigMap
@@ -130,7 +149,6 @@ func waitForDiscoveryConfigMap(ctx context.Context) error {
 // instance. The ready annotation is set after CRDs are installed and
 // every controller manager has registered, so waiting for it lets
 // clients use both CRDs and discovery data without racing startup.
-// Pass zero time to skip the freshness check.
 func waitForFreshDiscoveryConfigMap(ctx context.Context, beforeStart time.Time) error {
 	restConfig, err := service.GetKubeRestConfig()
 	if err != nil {
@@ -219,6 +237,7 @@ func newServiceStartCommand() *cobra.Command {
 		RunE: serviceStartAction,
 	}
 	command.Flags().Bool("wait", true, "Wait for control plane to be ready")
+	command.Flags().Duration("timeout", startWaitTimeout, "Timeout for --wait; ignored if --wait=false (0 means wait indefinitely)")
 
 	// Add serve command flags to start command so they can be passed through
 	command.Flags().String("controllers", "", "Controllers to enable for this session (overrides create defaults)")
@@ -231,6 +250,15 @@ func newServiceStartCommand() *cobra.Command {
 }
 
 func serviceStartAction(cmd *cobra.Command, args []string) error {
+	waitFlag, err := cmd.Flags().GetBool("wait")
+	if err != nil {
+		return err
+	}
+	timeout, err := cmd.Flags().GetDuration("timeout")
+	if err != nil {
+		return err
+	}
+
 	if !service.Exists() {
 		if err := service.Create(args); err != nil {
 			return err
@@ -239,12 +267,24 @@ func serviceStartAction(cmd *cobra.Command, args []string) error {
 	}
 	if service.Running() {
 		logrus.Infof("%q control plane is already running", instance.Name())
-		wait, err := cmd.Flags().GetBool("wait")
-		if err == nil && wait {
-			logrus.Infof("waiting for %q control plane to be ready", instance.Name())
-			err = service.WaitWithTimeout(cmd.Context())
+		if !waitFlag {
+			return nil
 		}
-		return err
+		startTime, err := service.StartTime()
+		if err != nil {
+			return err
+		}
+		logrus.Infof("waiting for %q control plane to be ready", instance.Name())
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(cmd.Context(), timeout)
+		defer cancel()
+		if err := service.Wait(ctx); err != nil {
+			return cliexit.Classify(err)
+		}
+		if err := waitForFreshDiscoveryConfigMap(ctx, startTime); err != nil {
+			return cliexit.Classify(err)
+		}
+		logrus.Infof("%q control plane is ready", instance.Name())
+		return nil
 	}
 
 	// Collect all provided flags as arguments for serve subprocess
@@ -266,10 +306,9 @@ func serviceStartAction(cmd *cobra.Command, args []string) error {
 	serveArgs = append(serveArgs, "-v", logrusLevelToKlog())
 	serveArgs = append(serveArgs, args...)
 
-	wait, err := cmd.Flags().GetBool("wait")
-	if err == nil && wait {
-		if err := startAndWaitForReady(cmd.Context(), serveArgs); err != nil {
-			return err
+	if waitFlag {
+		if err := startAndWaitForReady(cmd.Context(), serveArgs, timeout); err != nil {
+			return cliexit.Classify(err)
 		}
 		logrus.Infof("%q control plane is ready", instance.Name())
 	} else {
@@ -291,15 +330,19 @@ func serviceStopAction(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	wait, err := cmd.Flags().GetBool("wait")
+	waitFlag, err := cmd.Flags().GetBool("wait")
+	if err != nil {
+		return err
+	}
+	timeout, err := cmd.Flags().GetDuration("timeout")
 	if err != nil {
 		return err
 	}
 
-	if err := service.StopWithWait(wait); err != nil {
-		return err
+	if err := service.StopWithWait(cmd.Context(), waitFlag, timeout); err != nil {
+		return cliexit.Classify(err)
 	}
-	if wait {
+	if waitFlag {
 		logrus.Infof("%q control plane has stopped", instance.Name())
 	} else {
 		logrus.Infof("%q control plane is stopping", instance.Name())
@@ -314,6 +357,7 @@ func newServiceStopCommand() *cobra.Command {
 		RunE: serviceStopAction,
 	}
 	command.Flags().Bool("wait", true, "Wait for control plane to actually stop")
+	command.Flags().Duration("timeout", stopWaitTimeout, "Timeout for --wait; ignored if --wait=false (0 means wait indefinitely)")
 	return command
 }
 
@@ -321,19 +365,26 @@ func newServiceDeleteCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:  "delete",
 		Long: "Delete RDD control plane",
-		RunE: func(*cobra.Command, []string) error {
-			if !service.Exists() {
-				logrus.Infof("%q control plane does not exist", instance.Name())
-				return nil
-			}
-			if err := service.Delete(); err != nil {
-				return err
-			}
-			logrus.Infof("%q control plane has been deleted", instance.Name())
-			return nil
-		},
+		RunE: serviceDeleteAction,
 	}
+	command.Flags().Duration("timeout", stopWaitTimeout, "Timeout for the control plane to exit before deletion (0 means wait indefinitely)")
 	return command
+}
+
+func serviceDeleteAction(cmd *cobra.Command, _ []string) error {
+	if !service.Exists() {
+		logrus.Infof("%q control plane does not exist", instance.Name())
+		return nil
+	}
+	timeout, err := cmd.Flags().GetDuration("timeout")
+	if err != nil {
+		return err
+	}
+	if err := service.Delete(cmd.Context(), timeout); err != nil {
+		return cliexit.Classify(err)
+	}
+	logrus.Infof("%q control plane has been deleted", instance.Name())
+	return nil
 }
 
 func newServiceStatusCommand() *cobra.Command {

--- a/cmd/rdd/set.go
+++ b/cmd/rdd/set.go
@@ -89,8 +89,8 @@ func newSetCommand() *cobra.Command {
 		"Validate changes against the API server without persisting them")
 	command.Flags().BoolVar(&wait, "wait", true,
 		"Wait for the desired state after the patch is accepted")
-	command.Flags().DurationVar(&timeout, "timeout", 300*time.Second,
-		"Timeout for waiting (0 to wait indefinitely)")
+	command.Flags().DurationVar(&timeout, "timeout", limaLongWaitTimeout,
+		"Timeout for --wait; ignored if --wait=false (0 means wait indefinitely)")
 
 	// Override help to append live property descriptions from the CRD schema.
 	defaultHelp := command.HelpFunc()
@@ -322,10 +322,7 @@ func setAction(ctx context.Context, args []string, dryRun, wait bool, timeout ti
 		return nil
 	}
 	if err := waitForDesiredState(ctx, restConfig, timeout, targetGen); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return cliexit.Timeout(err)
-		}
-		return err
+		return cliexit.Classify(err)
 	}
 	return nil
 }

--- a/docs/design/api_service.md
+++ b/docs/design/api_service.md
@@ -18,7 +18,10 @@ Unless otherwise specified, all objects mentioned here will be created in the `r
 
 ## Service shutdown
 
-The control plane will be notified to shut down, either by receiving a SIGTERM signal from the user (via `rdd service stop`), or by the OS preparing to shut down the host.
+The control plane is notified to shut down, either by `rdd service stop`
+(SIGINT on Unix, `CTRL_BREAK_EVENT` on Windows; if the wait deadline expires
+the wait force-terminates with SIGTERM on Unix or `TerminateProcess` on
+Windows), or by the OS preparing to shut down the host.
 
 Some controllers need to be notified of pending shutdown so they can gracefully terminate, e.g. shut down virtual machines.
 

--- a/docs/design/cmd_lima.md
+++ b/docs/design/cmd_lima.md
@@ -14,28 +14,28 @@ Create a new `LimaVM` instance `NAME` in `NAMESPACE` (or `default`) using `TEMPL
 
 - `--start` (default `false`): Set `spec.running=true` to start the VM immediately after creation.
 - `--wait` (default `true`): When used with `--start`, wait until the Running condition becomes True before returning.
-- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely. Accepts Go duration strings (e.g., `30s`, `5m`).
+- `--timeout` (default `5m`): Maximum time to wait. A value of `0` waits indefinitely. Accepts Go duration strings (e.g., `30s`, `5m`). If the deadline expires, `rdd` exits with code 4.
 
 ### `rdd limavm start NAME`
 
 Set `spec.running` of the specified instance to `true`. There is no `--namespace` option because `LimaVM` names are globally unique (within the control plane).
 
 - `--wait` (default `true`): Wait until the Running condition becomes True before returning.
-- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely. Accepts Go duration strings (e.g., `30s`, `5m`).
+- `--timeout` (default `5m`): Maximum time to wait. A value of `0` waits indefinitely. If the deadline expires, `rdd` exits with code 4.
 
 ### `rdd limavm stop NAME`
 
 Set `spec.running` of the specified instance to `false`.
 
 - `--wait` (default `true`): Wait until the Running condition becomes False before returning.
-- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely.
+- `--timeout` (default `5m`): Maximum time to wait. A value of `0` waits indefinitely. If the deadline expires, `rdd` exits with code 4.
 
 ### `rdd limavm delete NAME`
 
 Stop and delete the instance. The `LimaVM` resource deletion triggers cleanup of all owned resources: the `status.templateConfigMap`, and the `spec.templateRef.name` template if `rdd limavm create` created it.
 
-- `--wait` (default `false`): Wait until the resource is fully deleted before returning.
-- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely.
+- `--wait` (default `true`): Wait until the resource is fully deleted before returning.
+- `--timeout` (default `5m`): Maximum time to wait. A value of `0` waits indefinitely. If the deadline expires, `rdd` exits with code 4.
 
 ### `rdd limavm params NAME1=VALUE1 NAME2=VALUE2`
 
@@ -54,7 +54,7 @@ Set `lima.rancherdesktop.io/resetRequested` annotation to the current timestamp.
 Set `lima.rancherdesktop.io/restartRequested` annotation and `spec.running=true` in a single patch. The annotation tells the reconciler to stop the instance if it is running; setting `spec.running=true` ensures the instance starts afterward, even if it had been stopped initially.
 
 - `--wait` (default `true`): Wait until `status.restartCount` increments (the instance has fully restarted) before returning.
-- `--timeout` (default `0`): Maximum time to wait. A value of `0` waits indefinitely.
+- `--timeout` (default `5m`): Maximum time to wait. A value of `0` waits indefinitely. If the deadline expires, `rdd` exits with code 4.
 
 ### `rdd limavm shell NAME CMD`
 

--- a/docs/design/cmd_service.md
+++ b/docs/design/cmd_service.md
@@ -90,20 +90,36 @@ Runs `rdd service serve` to actually start the control plane in the background
 
 Additional options:
 
-*   `--no-wait`
-    Return immediately and don't wait for all controllers to be ready. The user can force a wait
-    later by running `rdd service start` without any options.
+*   `--wait=false`
+    Return immediately, without waiting for all controllers to be ready. Run `rdd service start`
+    again with no options to wait.
+
+*   `--timeout=90s`
+    How long to wait for the control plane to become ready. Pass `0` to wait indefinitely.
+    If the deadline expires, `rdd` exits with code 4.
 
 
 ### `rdd service stop`
 
-Sends SIGTERM signal to control plane process (`rdd.pid`).
+Sends SIGINT to the control plane process (`rdd.pid`) and waits up to 5 minutes for
+it to exit. On Windows the signal is delivered as `CTRL_BREAK_EVENT`. If the deadline
+expires, the wait sends SIGTERM on Unix (or calls `TerminateProcess` on Windows)
+as a fallback and `rdd` exits with code 4. Pass `--wait=false` to return immediately,
+or `--timeout=0` to wait indefinitely. The default matches the per-VM ceiling because
+graceful shutdown will eventually stop every running LimaVM before the service exits.
 
 ### `rdd service delete`
 
 Stops the control plane and removes the instance directory, the short directory
 (which contains the Lima home), and — unless `RDD_KEEP_LOGS` is set — the log
 directory.
+
+Delete always waits for the control plane to exit before removing files, because
+removing the instance directory under a live process corrupts it on Windows and
+breaks PID-file mutual exclusion on Unix. Use `--timeout` to bound that wait
+(default `5m`); `0` waits indefinitely. If the deadline expires, `rdd` exits
+with code 4 and the directory is left in place. See [`rdd service stop`](#rdd-service-stop)
+for the signal and fallback details of the shutdown itself.
 
 ### `rdd service reset`
 

--- a/pkg/cli/exit/exit.go
+++ b/pkg/cli/exit/exit.go
@@ -6,6 +6,11 @@
 // admission rejection, wait timeout, and generic internal errors.
 package exit
 
+import (
+	"context"
+	"errors"
+)
+
 // Predefined exit codes. 0 and 1 are the defaults handled by main; 2 is
 // reserved for cobra usage errors, so named codes start at 3.
 const (
@@ -43,4 +48,18 @@ func Rejected(err error) *Error {
 // Timeout wraps err with [CodeTimeout].
 func Timeout(err error) *Error {
 	return &Error{Code: CodeTimeout, Err: err}
+}
+
+// Classify wraps err with [CodeTimeout] when err wraps
+// [context.DeadlineExceeded]. Already-classified errors and unrelated
+// errors pass through unchanged, so callers may Classify repeatedly.
+func Classify(err error) error {
+	var exitErr *Error
+	if errors.As(err, &exitErr) {
+		return err
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return Timeout(err)
+	}
+	return err
 }

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	watchtools "k8s.io/client-go/tools/watch"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
 	logsapi "k8s.io/component-base/logs/api/v1"
@@ -167,6 +168,17 @@ func Running() bool {
 	return PID() != PIDNotFound
 }
 
+// StartTime returns the start time of the running service, read
+// from the PID file's mtime. Use it to anchor freshness checks for
+// state the service creates after startup.
+func StartTime() (time.Time, error) {
+	fi, err := os.Stat(instance.PIDFile())
+	if err != nil {
+		return time.Time{}, err
+	}
+	return fi.ModTime().Truncate(time.Second), nil
+}
+
 // Create a new control plane instance with the given arguments.
 func Create(args []string) error {
 	if Exists() {
@@ -247,11 +259,9 @@ func getRuntimeControllersFromCluster(ctx context.Context, config *rest.Config) 
 	return enabledControllers, nil
 }
 
-// Start the service in a background subprocess.
+// Start the service in a background subprocess. Callers must verify Exists()
+// first; Start assumes the instance exists.
 func Start(ctx context.Context, args []string) error {
-	if !Exists() {
-		return fmt.Errorf("%q create control plane does not exist", instance.Name())
-	}
 	if Running() {
 		return fmt.Errorf("%q control plane is already running", instance.Name())
 	}
@@ -378,16 +388,10 @@ func Wait(ctx context.Context) error {
 	}
 }
 
-// WaitWithTimeout calls Wait with a timeout.
-func WaitWithTimeout(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 90*time.Second) // Increased timeout for CRD establishment
-	defer cancel()
-	return Wait(ctx)
-}
-
-// StopWithWait sends a shutdown signal to the service. If wait is true, it blocks
-// until the process exits or a timeout expires.
-func StopWithWait(wait bool) error {
+// StopWithWait sends a shutdown signal to the service. When wait is true, it
+// blocks until the process exits, ctx is cancelled, or timeout elapses; pass
+// timeout 0 to wait indefinitely (bounded only by ctx).
+func StopWithWait(ctx context.Context, wait bool, timeout time.Duration) error {
 	if !Running() {
 		return fmt.Errorf("%q control plane is not running", instance.Name())
 	}
@@ -411,24 +415,31 @@ func StopWithWait(wait bool) error {
 	}
 
 	if wait {
-		// Wait for the process to actually terminate. The service needs up to
-		// 30s for graceful hostagent shutdown plus overhead, so allow 60s total.
-		timeout := time.After(60 * time.Second)
+		ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, timeout)
+		defer cancel()
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 
 		for {
 			select {
-			case <-timeout:
-				// Graceful shutdown timed out; terminate so we don't leave
-				// a hung service process. Kill targets only the service; on
-				// Windows (TerminateProcess) this avoids killing hostagents
-				// that are children of the service but run in their own
-				// process groups. On Unix, SIGTERM suffices because the
-				// service is responsive to signals (it's just slow shutting
-				// down hostagents sequentially).
+			case <-ctx.Done():
+				// Deadline fired or caller cancelled; terminate either way
+				// to ensure the service process exits. Kill targets the
+				// service alone: on Windows (TerminateProcess) it spares
+				// hostagents, which live in their own process groups. On
+				// Unix, Kill delivers SIGTERM, which is the second
+				// shutdown signal after the earlier SIGINT; the apiserver's
+				// SetupSignalContext handler responds to a second signal
+				// with os.Exit(1), forcing immediate exit. The daemon also
+				// caps its own drain at 45s before returning from Run, so
+				// timeout values shorter than stopWaitTimeout (5m) routinely
+				// race a still-draining daemon.
 				_ = process.Kill(pid)
-				return fmt.Errorf("timed out waiting for %q control plane with pid %d to stop", instance.Name(), pid)
+				err := ctx.Err()
+				if errors.Is(err, context.DeadlineExceeded) {
+					return fmt.Errorf("timed out waiting for %q control plane with pid %d to stop: %w", instance.Name(), pid, err)
+				}
+				return fmt.Errorf("wait for %q control plane with pid %d to stop cancelled: %w", instance.Name(), pid, err)
 			case <-ticker.C:
 				if !Running() {
 					_ = os.Remove(instance.Config()) // Ignore error as file might not exist
@@ -438,22 +449,36 @@ func StopWithWait(wait bool) error {
 		}
 	}
 
-	_ = os.Remove(instance.Config()) // Ignore error as file might not exist
+	// --wait=false: the daemon may still be serving for tens of seconds.
+	// Leave instance.Config() alone so concurrent `rdd ctl`/`rdd kubectl`
+	// calls keep working; the next `Start` rewrites it.
 	return nil
 }
 
-// Stop the service and wait for the process to exit.
-func Stop() error {
-	// For backward compatibility, always wait
-	return StopWithWait(true)
-}
-
-// Delete the service and remove all instance data.
-func Delete() error {
-	if !Exists() {
-		return fmt.Errorf("%q control plane does not exist", instance.Name())
+// Delete removes all instance data. Callers must verify Exists() first; Delete
+// assumes the instance exists. If the service is running, Delete waits up to
+// timeout for it to exit before removing files; removing instance.Dir() while
+// the serve process holds rdd.pid, rdd.sqlite3, and log files corrupts the
+// directory on Windows and breaks PID-file mutual exclusion on Unix.
+// Pass timeout 0 to wait indefinitely (bounded only by ctx).
+func Delete(ctx context.Context, timeout time.Duration) error {
+	if Running() {
+		if err := StopWithWait(ctx, true, timeout); err != nil {
+			// Return the error whenever the process is alive or the
+			// deadline expired, so deletion never races a live daemon
+			// and the CLI exits 4 on timeout per docs/design/cmd_service.md.
+			// The predicate also absorbs signal-delivery failures and
+			// context cancellation when the process has already exited;
+			// the invariant is "the directory survives unless the daemon
+			// is confirmed gone." context.Canceled is unreachable today
+			// because the CLI runs on context.Background(); wiring SIGINT
+			// into cmd.Context() would let Ctrl-C fall through to deletion
+			// during a live stop, and needs an explicit decision here.
+			if errors.Is(err, context.DeadlineExceeded) || Running() {
+				return err
+			}
+		}
 	}
-	_ = Stop()
 	preserveAllInstanceLogs()
 	if os.Getenv("RDD_KEEP_LOGS") == "" {
 		_ = os.RemoveAll(instance.LogDir())


### PR DESCRIPTION
Recreates #336, which GitHub auto-closed after a visibility flip broke the fork relationship.

Every wait-capable subcommand under `rdd svc` and `rdd limavm` now defaults to `--wait=true` with a finite `--timeout`, and exits with code 4 on deadline expiry to match `rdd set`.

Previously the defaults were inconsistent: `rdd limavm delete` shipped with `--wait=false`; `rdd svc start/stop` exposed `--wait` but no `--timeout`, with 90s / 60s hardcoded in the service package; and `rdd svc delete` exposed neither flag. On timeout, every command exited 1. Users who scripted around the CLI had no way to distinguish "did not settle in time" from a real error.

## Default timeouts

- **90s:** `svc start` (CRD establishment + controller-manager registration)
- **5m:**  `svc stop`, `svc delete`, and every `limavm create/start/stop/restart/delete`

`--timeout=0` on any command waits indefinitely.

`svc delete` drops `--wait=false` entirely: removing `instance.Dir()` under a live process corrupts the directory on Windows and breaks PID-file mutual exclusion on Unix. `--timeout` still bounds the embedded shutdown wait. `Delete` also re-checks `Running()` on a stop failure so a process that exits in the race window between the outer and inner check no longer blocks deletion.

`ensureServiceRunning` routes `context.DeadlineExceeded` through `timeoutError`, so the exit-code-4 contract holds for every command that autostarts the service (`rdd set`, `rdd limavm *`, `rdd kubectl`, `rdd service config`). `serviceStartAction`'s already-running branch now waits for the discovery ConfigMap's `ReadyAnnotation`, matching the cold-start path.

## Library surface

- `service.StopWithWait(wait, timeout)` replaces the single-arg version and drives the wait off a `context.WithTimeout`.
- `service.Delete(timeout)` replaces `Delete()` and always waits for the process to exit before removing state.
- `service.Stop()` and `service.WaitWithTimeout()` are gone; the CLI was their only caller and now builds its own timed context.

`cmd/rdd/*` routes `context.DeadlineExceeded` (including wrapped forms) through a small `timeoutError` helper that tags the error with `cliexit.Timeout` at the CLI boundary.

## Documentation

- `docs/design/cmd_service.md` documents `--wait=false` and `--timeout`, names SIGINT as the shutdown signal, explains the safety reason for removing `--wait=false` on `svc delete`, and cross-references `svc stop`.
- `docs/design/cmd_lima.md` matches the new 5m defaults and the `--wait=true` default on `limavm delete`.
- `docs/design/api_service.md` shutdown signal description matches the implementation (SIGINT on Unix, `CTRL_BREAK_EVENT` on Windows).

## Tests

- `bats/tests/33-lima-controllers/limavm-cli.bats` adds `lima create --start --timeout` and `lima restart --timeout` exit-code-4 assertions.
- `bats/tests/20-service/6-timeout.bats` asserts `svc stop --timeout=1ms` exits with code 4 and emits `context deadline exceeded`.