### PR TITLE
rdd kubectl: embed kuberlr-style version resolver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,3 +100,12 @@ updates:
   groups:
     golang-x:
       patterns: [ golang.org/x/* ]
+
+# Pre-positioned: the fake-kube test fixtures are stdlib-only today, so this
+# scans for any dependency they grow later.
+- package-ecosystem: gomod
+  directory: /rdd/bats/tests/10-cli/fake-kube
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7

--- a/rdd/bats/helpers/os.bash
+++ b/rdd/bats/helpers/os.bash
@@ -96,11 +96,24 @@ sudo_needs_password() {
 # Cross-platform process management.
 # MSYS2's kill cannot reach Win32 processes, so use taskkill.exe on Windows.
 
+# Translate an MSYS PID to its Win32 PID: taskkill/tasklist filter on
+# the Win32 PID, but MSYS bash's $! returns the MSYS one for native children.
+winpid() {
+    local pid=$1
+    if is_msys && [[ -r /proc/${pid}/winpid ]]; then
+        cat "/proc/${pid}/winpid"
+    else
+        printf '%s' "${pid}"
+    fi
+}
+
 # Check if a process is alive. Returns 0 if alive, non-zero otherwise.
 assert_process_alive() {
-    local pid=$1
+    local pid wpid
+    pid=$1
     if is_windows; then
-        MSYS_NO_PATHCONV=1 tasklist.exe /FI "PID eq ${pid}" /NH 2>/dev/null | grep -qw "${pid}"
+        wpid=$(winpid "${pid}")
+        MSYS_NO_PATHCONV=1 tasklist.exe /FI "PID eq ${wpid}" /NH 2>/dev/null | grep -qw "${wpid}"
     else
         kill -0 "${pid}" 2>/dev/null
     fi
@@ -108,9 +121,11 @@ assert_process_alive() {
 
 # Send SIGKILL (or TerminateProcess on Windows) to a process.
 process_kill() {
-    local pid=$1
+    local pid wpid
+    pid=$1
     if is_windows; then
-        MSYS_NO_PATHCONV=1 taskkill.exe /PID "${pid}" /F >/dev/null 2>&1
+        wpid=$(winpid "${pid}")
+        MSYS_NO_PATHCONV=1 taskkill.exe /PID "${wpid}" /F >/dev/null 2>&1
     else
         kill -9 "${pid}"
     fi

--- a/rdd/bats/helpers/paths.bash
+++ b/rdd/bats/helpers/paths.bash
@@ -6,6 +6,19 @@ inside_repo_clone() {
     [[ -d "${PATH_REPO_ROOT}/pkg/rancher-desktop-daemon" ]]
 }
 
+# winpath converts a POSIX path to its Windows-native path (e.g.
+# /tmp/x -> C:\msys64\tmp\x on MSYS), for args reaching a native binary
+# outside rdd()'s own conversions.
+winpath() {
+    if is_msys; then
+        cygpath -w "$1"
+    elif is_windows && using_windows_exe; then
+        wslpath -w "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
+
 # Convert 'export KEY="C:\win\path"' to POSIX paths (WSL or MSYS2).
 win_to_posix_exports() {
     tr -d "\r" | while IFS= read -r line; do

--- a/rdd/bats/tests/10-cli/5-paths.bats
+++ b/rdd/bats/tests/10-cli/5-paths.bats
@@ -1,6 +1,6 @@
 load '../../helpers/load'
 
-ALL_KEYS="args_file config dir lima_home log_dir pid_file short_dir tls_dir"
+ALL_KEYS="args_file cache_dir config dir docker_socket k3s_config kubectl_cache lima_home log_dir pid_file short_dir tls_dir"
 
 @test 'rdd svc paths prints all keys in table format' {
     run -0 rdd svc paths
@@ -37,4 +37,15 @@ ALL_KEYS="args_file config dir lima_home log_dir pid_file short_dir tls_dir"
     assert_output --partial 'unknown key'
     assert_output --partial 'no_such_key'
     assert_output --partial 'valid keys'
+}
+
+@test 'rdd svc paths honors RDD_CACHE_DIR override' {
+    cache_override=$(winpath "${BATS_TEST_TMPDIR}/cache-override")
+
+    RDD_CACHE_DIR="${cache_override}" run -0 rdd svc paths cache_dir
+    assert_output "${cache_override}"
+
+    RDD_CACHE_DIR="${cache_override}" run -0 rdd svc paths kubectl_cache
+    assert_output --partial "${cache_override}"
+    assert_output --regexp 'kubectl[/\\][a-z0-9]+-[a-z0-9]+$'
 }

--- a/rdd/bats/tests/10-cli/7-kubectl-cache.bats
+++ b/rdd/bats/tests/10-cli/7-kubectl-cache.bats
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# End-to-end test of the rdd kubectl resolver's download/cache cycle. A
+# fake apiserver (v1.99.0, far newer than the embedded kubectl) and fake
+# mirror (fake-kube/server) stand in for the real ones. The mirror's
+# stable-1.99.txt marker names v1.99.5, so a passing download test
+# proves the resolver picked the latest patch release of the server's
+# minor, sha-verified it, and exec'd it.
+
+load '../../helpers/load'
+
+local_setup_file() {
+    GOOS=$(go env GOOS)
+    export GOOS
+    GOARCH=$(go env GOARCH)
+    export GOARCH
+    # EXE (.exe on Windows, set in commands.bash) is re-exported below
+    # for the rdd subprocess — don't shadow it locally.
+    export EXE
+
+    # Stage the fake kubectl into the mirror tree at the path the
+    # resolver will GET after reading v1.99.5 from stable-1.99.txt.
+    export MIRROR_ROOT=${BATS_FILE_TMPDIR}/mirror
+    export MIRROR_BIN_DIR=${MIRROR_ROOT}/release/v1.99.5/bin/${GOOS}/${GOARCH}
+    mkdir -p "${MIRROR_BIN_DIR}"
+    # Build inside fake-kube/ so go.mod resolution picks the sibling
+    # module; -o paths need winpath for the same reason the server's do.
+    (
+        cd "${BATS_TEST_DIRNAME}/fake-kube" || exit
+        go build -ldflags='-s -w' \
+            -o "$(winpath "${MIRROR_BIN_DIR}/kubectl${EXE}")" \
+            ./kubectl
+        go build -ldflags='-s -w' \
+            -o "$(winpath "${BATS_FILE_TMPDIR}/fake-kube-server${EXE}")" \
+            ./server
+    )
+    SERVER_BIN=${BATS_FILE_TMPDIR}/fake-kube-server${EXE}
+
+    PORT_FILE=${BATS_FILE_TMPDIR}/port
+    export LOG_FILE=${BATS_FILE_TMPDIR}/server.log
+    export GIT_VERSION_FILE=${BATS_FILE_TMPDIR}/git-version
+    export VERSION_STATUS_FILE=${BATS_FILE_TMPDIR}/version-status
+    # On MSYS the server is a native .exe that can't read MSYS-namespace
+    # paths, so path args go through winpath (production rdd never does this).
+    "${SERVER_BIN}" \
+        --root "$(winpath "${MIRROR_ROOT}")" \
+        --major 1 --minor 99 --git-version v1.99.0 \
+        --git-version-file "$(winpath "${GIT_VERSION_FILE}")" \
+        --version-status-file "$(winpath "${VERSION_STATUS_FILE}")" \
+        --port-file "$(winpath "${PORT_FILE}")" \
+        --log-file "$(winpath "${LOG_FILE}")" &
+    SERVER_PID=$!
+    # setup_file and teardown_file run in separate subshells, so the env
+    # var alone would vanish; save_var persists it via BATS_RUN_TMPDIR.
+    save_var SERVER_PID
+    # Wait for the port file. Server picks an ephemeral port, so we read it back.
+    local i
+    for i in {1..50}; do
+        [[ -s ${PORT_FILE} ]] && break
+        sleep 0.1
+    done
+    [[ -s ${PORT_FILE} ]] || fail "fake-kube-server did not write a port file"
+    PORT=$(<"${PORT_FILE}")
+    export PORT
+
+    KUBECONFIG_PATH=${BATS_FILE_TMPDIR}/kubeconfig
+    export KUBECONFIG_PATH
+    cat >"${KUBECONFIG_PATH}" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: fake
+  cluster:
+    server: http://127.0.0.1:${PORT}
+    insecure-skip-tls-verify: true
+contexts:
+- name: fake
+  context:
+    cluster: fake
+    user: ""
+current-context: fake
+EOF
+
+    export CACHE_DIR=${BATS_FILE_TMPDIR}/cache
+}
+
+# rdd_env sets vars via env(1), not bash export: on Git Bash, exported
+# values get their MSYS-root prefix stripped before exec'ing native
+# children, landing cache writes on the wrong drive.
+rdd_env() {
+    env \
+        "RDD_CACHE_DIR=$(winpath "${CACHE_DIR}")" \
+        "RDD_KUBECTL_MIRROR=http://127.0.0.1:${PORT}" \
+        "KUBECONFIG=$(winpath "${KUBECONFIG_PATH}")" \
+        rdd "$@"
+}
+
+local_teardown_file() {
+    # Deviates from "no teardown_file": an ephemeral-port HTTP server
+    # shouldn't survive between runs (unlike rdd state, which the rule protects).
+    if load_var SERVER_PID; then
+        process_kill "${SERVER_PID}" 2>/dev/null || true
+    fi
+}
+
+local_setup() {
+    rm -rf "${CACHE_DIR}"
+    : >"${LOG_FILE}"
+    # Reset /version overrides so each test starts at v1.99.0 / 200.
+    rm -f "${GIT_VERSION_FILE}" "${VERSION_STATUS_FILE}"
+    # Republish the kubectl checksum and version marker every test so the
+    # sha-mismatch and missing-version tests cannot leak their fixtures
+    # into a later run.
+    write_kubectl_sha512
+    write_stable_marker
+}
+
+write_kubectl_sha512() {
+    if is_macos; then
+        shasum -a 512 "${MIRROR_BIN_DIR}/kubectl${EXE}" | awk '{print $1}' >"${MIRROR_BIN_DIR}/kubectl${EXE}.sha512"
+    else
+        sha512sum "${MIRROR_BIN_DIR}/kubectl${EXE}" | awk '{print $1}' >"${MIRROR_BIN_DIR}/kubectl${EXE}.sha512"
+    fi
+}
+
+write_stable_marker() {
+    echo 'v1.99.5' >"${MIRROR_ROOT}/release/stable-1.99.txt"
+}
+
+place_cached_kubectl() { # <version, e.g. v1.99.2>
+    mkdir -p "${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}"
+    cp "${MIRROR_BIN_DIR}/kubectl${EXE}" "${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-${1}${EXE}"
+    chmod 0755 "${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-${1}${EXE}"
+}
+
+@test 'rdd kubectl downloads the latest patch release of the server minor on cache miss' {
+    cached=${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-v1.99.5${EXE}
+    assert_file_not_exists "${cached}"
+
+    run -0 rdd_env kubectl get pods
+
+    assert_output --partial 'fake-kubectl: get pods'
+    # v1.99.5 comes from the stable-1.99.txt marker, not from the
+    # server's own v1.99.0.
+    assert_output --partial 'Downloading kubectl v1.99.5'
+    assert_file_executable "${cached}"
+    assert_file_contains "${LOG_FILE}" '^GET /version'
+    assert_file_contains "${LOG_FILE}" '^GET /release/stable-1.99.txt$'
+    assert_file_contains "${LOG_FILE}" "^GET /release/v1.99.5/bin/${GOOS}/${GOARCH}/kubectl${EXE}.sha512$"
+    assert_file_contains "${LOG_FILE}" "^GET /release/v1.99.5/bin/${GOOS}/${GOARCH}/kubectl${EXE}$"
+}
+
+@test 'rdd kubectl accepts any cached patch of the server minor' {
+    # Patch 2 matches neither the server's v1.99.0 nor the marker's
+    # v1.99.5 — only the minor version counts, and a cache hit skips
+    # the mirror entirely.
+    place_cached_kubectl v1.99.2
+
+    run -0 rdd_env kubectl get pods
+
+    assert_output --partial 'fake-kubectl: get pods'
+    refute_output --partial 'Downloading kubectl'
+    assert_file_contains "${LOG_FILE}" '^GET /version'
+    refute_file_contains "${LOG_FILE}" '/release/'
+}
+
+@test 'rdd kubectl accepts a cached kubectl one minor newer than the server' {
+    place_cached_kubectl v1.100.1
+
+    run -0 rdd_env kubectl get pods
+
+    assert_output --partial 'fake-kubectl: get pods'
+    refute_output --partial 'Downloading kubectl'
+    refute_file_contains "${LOG_FILE}" '/release/'
+}
+
+@test 'rdd kubectl rejects a cached kubectl older than the server' {
+    # v1.98.7 is within kubectl's official ±1 skew, but cannot drive
+    # features new in 1.99, so the resolver must download v1.99.5.
+    place_cached_kubectl v1.98.7
+
+    run -0 rdd_env kubectl get pods
+
+    assert_output --partial 'fake-kubectl: get pods'
+    assert_output --partial 'Downloading kubectl v1.99.5'
+    assert_file_executable "${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-v1.99.5${EXE}"
+}
+
+@test 'rdd kubectl falls back to embedded when the mirror has no release for the server minor' {
+    # No stable-1.98.txt exists on the mirror; the resolver warns and
+    # runs the embedded kubectl as the final fallback.
+    echo v1.98.0 >"${GIT_VERSION_FILE}"
+
+    run -0 rdd_env kubectl version
+
+    # 'Client Version' proves the embedded kubectl actually ran.
+    assert_output --partial 'using embedded kubectl'
+    assert_output --partial 'Client Version'
+    refute_output --partial 'fake-kubectl:'
+    refute_output --partial 'Downloading kubectl'
+    assert_file_contains "${LOG_FILE}" '^GET /release/stable-1.98.txt$'
+}
+
+@test 'rdd kubectl errors when the mirror lacks the release the marker names' {
+    # The marker names v1.99.9, but the mirror tree only holds v1.99.5.
+    # The resolver's first GET (.sha512) hits a 404 and surfaces the error.
+    echo 'v1.99.9' >"${MIRROR_ROOT}/release/stable-1.99.txt"
+
+    run rdd_env kubectl get pods
+
+    assert_failure
+    assert_output --partial 'resolving kubectl version'
+    assert_output --partial '404'
+    refute_output --partial 'fake-kubectl:'
+    assert_file_not_exists "${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-v1.99.9${EXE}"
+}
+
+@test 'rdd kubectl errors on sha512 mismatch' {
+    # Replace the published checksum with a wrong one. The download
+    # succeeds, the sha verification fails, and no cache file lands.
+    echo "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" \
+        >"${MIRROR_BIN_DIR}/kubectl${EXE}.sha512"
+
+    run rdd_env kubectl get pods
+
+    assert_failure
+    assert_output --partial 'resolving kubectl version'
+    assert_output --partial 'checksum mismatch'
+    refute_output --partial 'fake-kubectl:'
+    assert_file_not_exists "${CACHE_DIR}/kubectl/${GOOS}-${GOARCH}/kubectl-v1.99.5${EXE}"
+}
+
+@test 'rdd kubectl falls through to embedded when the apiserver returns 500 on /version' {
+    echo 500 >"${VERSION_STATUS_FILE}"
+
+    # `kubectl version` (no --client) reaches the probe; exit code is
+    # unasserted since it varies by kubectl version — this only checks
+    # probe-then-fall-through.
+    run rdd_env kubectl version
+
+    # Embedded kubectl ran; the resolver neither downloaded nor errored.
+    assert_output
+    refute_output --partial 'fake-kubectl:'
+    refute_output --partial 'resolving kubectl version'
+    refute_file_contains "${LOG_FILE}" '/release/'
+
+    # Count /version hits: resolver + embedded kubectl's own `version`
+    # call should total >=2. A regression that short-circuits the
+    # resolver would drop this to 1, which assert_file_contains can't catch.
+    run -0 awk '/^GET \/version$/ {n++} END {print n+0}' "${LOG_FILE}"
+    version_requests=${output}
+    if [[ ${version_requests} -lt 2 ]]; then
+        run -0 cat "${LOG_FILE}"
+        fail "expected >= 2 GET /version (resolver + embedded kubectl), got ${version_requests}: ${output}"
+    fi
+}

--- a/rdd/bats/tests/10-cli/fake-kube/README.md
+++ b/rdd/bats/tests/10-cli/fake-kube/README.md
@@ -1,0 +1,29 @@
+# fake-kube
+
+Test fixtures for `7-kubectl-cache.bats`, sitting next to the test that uses them.
+
+## Programs
+
+- **`kubectl/`** — a stand-in `kubectl` binary. Prints `fake-kubectl: <args>`
+  and exits 0. The BATS test serves it from the fake mirror and asserts
+  the output to confirm the resolver downloaded, sha-verified, and exec'd
+  it. Compiles to a real PE on Windows so `CreateProcess` accepts it.
+
+- **`server/`** — a single HTTP server playing two roles:
+  1. The Kubernetes apiserver: `GET /version` returns a configurable
+     `version.Info` JSON. The resolver hits this first to decide whether
+     to download.
+  2. The Kubernetes release mirror: `GET /release/...` serves files from
+     a configurable directory tree. `RDD_KUBECTL_MIRROR` points at this
+     URL during the test.
+
+## Why a separate Go module
+
+Keeps this directory off the main `./...` build path so the fixtures
+never enter the rdd binary, and so the parent `go.mod` stays free of
+test-only dependencies.
+
+## Build
+
+`local_setup_file()` in `7-kubectl-cache.bats` builds both binaries
+into `$BATS_FILE_TMPDIR` on each test run.

--- a/rdd/bats/tests/10-cli/fake-kube/go.mod
+++ b/rdd/bats/tests/10-cli/fake-kube/go.mod
@@ -1,0 +1,6 @@
+// Test fixture: see the sibling README.md for the role this module plays.
+// Stays a separate module so its programs neither inflate the rdd binary
+// nor pull test-only dependencies into the main go.mod.
+module fake-kube
+
+go 1.25.0

--- a/rdd/bats/tests/10-cli/fake-kube/kubectl/main.go
+++ b/rdd/bats/tests/10-cli/fake-kube/kubectl/main.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Command fake-kubectl stands in for real kubectl in resolver tests: it
+// prints its args with a marker prefix and exits 0, proving a caller ran it.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	fmt.Println("fake-kubectl:", strings.Join(os.Args[1:], " "))
+}

--- a/rdd/bats/tests/10-cli/fake-kube/server/main.go
+++ b/rdd/bats/tests/10-cli/fake-kube/server/main.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Command fake-kube-server fakes the two endpoints kuberlr touches:
+// apiserver /version and release-mirror /release/*, both on one port
+// so KUBECONFIG and RDD_KUBECTL_MIRROR can point at the same server.
+//
+// It picks an ephemeral port (written to --port-file) and logs each
+// request as "METHOD path" to --log-file, for the BATS test to assert.
+//
+// --git-version-file and --version-status-file let a test override
+// /version's response (gitVersion, HTTP status) without restarting the
+// server — read fresh per request, falling back to --git-version/200
+// when empty or missing.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+func main() {
+	root := flag.String("root", "", "directory served under /release/")
+	major := flag.String("major", "1", "kubernetes server Major version")
+	minor := flag.String("minor", "99", "kubernetes server Minor version")
+	gitVersion := flag.String("git-version", "v1.99.0", "default kubernetes server gitVersion")
+	gitVersionFile := flag.String("git-version-file", "", "optional file overriding gitVersion at request time")
+	versionStatusFile := flag.String("version-status-file", "", "optional file overriding /version HTTP status at request time")
+	portFile := flag.String("port-file", "", "file to receive the assigned port")
+	logFile := flag.String("log-file", "", "file to receive one request line per request")
+	flag.Parse()
+	if *root == "" || *portFile == "" || *logFile == "" {
+		log.Fatal("--root, --port-file, and --log-file are required")
+	}
+
+	// O_APPEND so BATS's per-test truncation (`: > log`) is honored —
+	// without it, writes land past the new EOF in a hole grep treats as binary.
+	logFD, err := os.OpenFile(*logFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		log.Fatalf("opening log file: %v", err)
+	}
+	defer logFD.Close()
+	var logMu sync.Mutex
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+		recordRequest(logFD, &logMu, r)
+		status := readIntFile(*versionStatusFile, http.StatusOK)
+		gv := readStringFile(*gitVersionFile, *gitVersion)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_, _ = fmt.Fprintf(w,
+				`{"major":%q,"minor":%q,"gitVersion":%q,"gitCommit":"fake","gitTreeState":"clean","buildDate":"2026-01-01T00:00:00Z","goVersion":"go1.21","compiler":"gc","platform":"%s/%s"}`,
+				*major, *minor, gv, runtime.GOOS, runtime.GOARCH,
+			)
+		}
+	})
+	mux.Handle("/release/", logging(logFD, &logMu, http.StripPrefix("/release/", http.FileServer(http.Dir(filepath.Join(*root, "release"))))))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := os.WriteFile(*portFile, []byte(strconv.Itoa(port)), 0o644); err != nil {
+		log.Fatalf("writing port file: %v", err)
+	}
+
+	server := &http.Server{Handler: mux}
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("serve: %v", err)
+	}
+}
+
+// logging wraps h so every request is logged first, even the release
+// file server sitting behind StripPrefix.
+func logging(fd *os.File, mu *sync.Mutex, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recordRequest(fd, mu, r)
+		h.ServeHTTP(w, r)
+	})
+}
+
+func recordRequest(fd *os.File, mu *sync.Mutex, r *http.Request) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(fd, "%s %s\n", r.Method, r.URL.Path)
+}
+
+// readStringFile returns the trimmed contents of path, or fallback when
+// path is empty, missing, or unreadable.
+func readStringFile(path, fallback string) string {
+	if path == "" {
+		return fallback
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fallback
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+// readIntFile returns the parsed integer in path, or fallback when path
+// is empty, missing, unreadable, or unparseable.
+func readIntFile(path string, fallback int) int {
+	s := readStringFile(path, "")
+	if s == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fallback
+	}
+	return n
+}

--- a/rdd/bats/tests/32-app-controllers/kube-context.bats
+++ b/rdd/bats/tests/32-app-controllers/kube-context.bats
@@ -130,7 +130,7 @@ kube_current_context_is() { # <expected-context>
     # namespace UID is a stable per-cluster identity: read it through the
     # known-good shared context and through rdd run's maintained config, and
     # require the two to match.
-    run -0 rdd kubectl --context "${CONTEXT_NAME}" \
+    run_e -0 rdd kubectl --context "${CONTEXT_NAME}" \
         get namespace kube-system -o jsonpath='{.metadata.uid}'
     expected_uid=${output}
 
@@ -201,7 +201,7 @@ wait_for_k3s_bootstrap() {
         --name=test-connect --port=80 --type=NodePort
     rdd kubectl --context "${CONTEXT_NAME}" rollout status deployment/test-connect --timeout=240s
 
-    run -0 rdd kubectl --context "${CONTEXT_NAME}" get service test-connect \
+    run_e -0 rdd kubectl --context "${CONTEXT_NAME}" get service test-connect \
         -o jsonpath='{.spec.ports[0].nodePort}'
     node_port=${output}
 

--- a/rdd/cmd/rdd/kubectl.go
+++ b/rdd/cmd/rdd/kubectl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	// Import to initialize client auth plugins.
@@ -17,6 +18,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/kuberlr"
 )
 
 func newCtlCommand() *cobra.Command {
@@ -40,6 +42,9 @@ func ctlAction(cmd *cobra.Command, args []string) error {
 	if err := os.Setenv("KUBECONFIG", instance.Config()); err != nil {
 		return fmt.Errorf("failed to set KUBECONFIG: %w", err)
 	}
+	// Always targets the embedded apiserver, version-matched to the
+	// embedded kubectl by construction (see SkipResolver).
+	kuberlr.SkipResolver()
 	return kubectlAction(cmd, args)
 }
 
@@ -54,7 +59,18 @@ func newKubectlCommand() *cobra.Command {
 	return command
 }
 
-func kubectlAction(*cobra.Command, []string) error {
+func kubectlAction(cmd *cobra.Command, args []string) error {
+	path, err := kuberlr.Resolve(cmd.Context(), args)
+	if err != nil {
+		// Falling back here would hide a download/sha-mismatch error
+		// behind confusing kubectl errors; probe failures return "" from
+		// Resolve instead and never reach this branch.
+		return fmt.Errorf("resolving kubectl version: %w", err)
+	}
+	if path != "" {
+		logrus.WithField("path", path).Debug("using cached kubectl")
+		return kuberlr.Exec(cmd.Context(), path, args)
+	}
 	os.Args = os.Args[1:]
 	command := kubectlcmd.NewDefaultKubectlCommand()
 	if err := cli.RunNoErrOutput(command); err != nil {

--- a/rdd/cmd/rdd/main.go
+++ b/rdd/cmd/rdd/main.go
@@ -174,11 +174,10 @@ func main() {
 		newVersionCommand(),
 	)
 	if err := cli.RunNoErrOutput(cmd); err != nil {
-		// *cliexit.Error lets a subcommand opt into a specific exit code; everything else gets exit 1.
+		// *cliexit.Error lets a subcommand pick its exit code (else exit 1). A
+		// nil inner Err (rdd run, kuberlr.Exec) means it already logged, so skip.
 		var exitErr *cliexit.Error
 		if errors.As(err, &exitErr) {
-			// A propagated child-exit code carries no message (nil Err); logging it
-			// would emit a bare level=error line, so log only when there is one.
 			if exitErr.Err != nil {
 				logrus.Error(err)
 			}

--- a/rdd/cmd/rdd/service_paths.go
+++ b/rdd/cmd/rdd/service_paths.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/kuberlr"
 )
 
 func instancePaths() map[string]string {
@@ -29,6 +30,8 @@ func instancePaths() map[string]string {
 		"pid_file":      instance.PIDFile(),
 		"args_file":     instance.ArgsFile(),
 		"docker_socket": instance.DockerSocket(),
+		"cache_dir":     kuberlr.CacheRoot(),
+		"kubectl_cache": kuberlr.CacheDir(),
 	}
 }
 

--- a/rdd/docs/design/cmd_other.md
+++ b/rdd/docs/design/cmd_other.md
@@ -8,6 +8,20 @@ Runs the regular `kubectl` program. Since `rdd` needs to be a kube client anyway
 
 There is also the [rdd ctl](cmd_service.md#rdd-ctl) command that automatically sets the kube config and context to the rdd control plane before executing `kubectl`.
 
+### Version selection
+
+`rdd kubectl` runs a kubectl that supports every feature of the cluster it talks to. An older kubectl is *compatible* with a newer server — the official skew policy allows ±1 minor version — but cannot drive features added in the server's minor version. The rule is therefore stricter: **the kubectl minor version must equal the server's, or be one higher**. Patch versions are ignored.
+
+For every invocation that may contact a cluster, `rdd kubectl` probes the server version (with a 2-second timeout) and picks the first acceptable kubectl from:
+
+1. The embedded kubectl.
+2. The highest version in the download cache (`rdd svc paths kubectl_cache`).
+3. A fresh download of the latest patch release of the server's minor version, looked up via the mirror's `stable-<major>.<minor>.txt` marker (e.g. `stable-1.34.txt` → `v1.34.9`), sha512-verified, and stored in the cache.
+
+When the cluster is unreachable, and for client-only commands (`kubectl config`, `completion`, ...), the embedded kubectl runs. It is also the final fallback when nothing acceptable is cached and the version marker cannot be fetched (offline, or a pre-GA minor with no marker yet): rdd warns and runs it anyway, since rdd embeds a recent kubectl and Kubernetes rarely breaks backward compatibility. Once the marker has named a version, a failed or corrupted download aborts the command rather than hiding the problem. [rdd ctl](cmd_service.md#rdd-ctl) skips the probe entirely: the embedded apiserver always matches the embedded kubectl.
+
+`RDD_KUBECTL_MIRROR` overrides the release mirror (default `https://dl.k8s.io`) and `RDD_CACHE_DIR` the cache root; see [environment.md](environment.md).
+
 ## `rdd cache`
 
 TBD

--- a/rdd/docs/design/cmd_service.md
+++ b/rdd/docs/design/cmd_service.md
@@ -12,7 +12,7 @@ This service directory contains the following files:
 
 | File | Description |
 | --- | --- |
-| `config.json` | service config settings (written by `rdd service create` or `rdd service start`)
+| `config.yaml` | service config settings (written by `rdd service create` or `rdd service start`)
 | `rdd.pid`     | pid of the control plane process (normally a background daemon) |
 | `rdd.sqlite3` | control plane data store |
 
@@ -38,7 +38,7 @@ It runs in a background process, which is started on demand by `rdd service serv
 
 Creates the service without starting it. This will rarely be used; the `rdd service start` command will call it automatically when the service does not yet exist.
 
-Creates the service directory with the `rdd.sqlite3` data store. Stores the configuration settings in the `config.json` file.
+Creates the service directory with the `rdd.sqlite3` data store. Stores the configuration settings in the `config.yaml` file.
 
 Configuration options (incomplete):
 
@@ -75,16 +75,16 @@ Additional configuration for individual controllers:
 
 Backgrounds itself (fork && exec) unless invoked with `--background=false` for easier debugging.
 
-Saves its own PID into `rdd.pid` and then starts the apiserver and the controller-manager using the configuration found in `config.json`.
+Saves its own PID into `rdd.pid` and then starts the apiserver and the controller-manager using the configuration found in `config.yaml`.
 
-Once the apiserver is running the config data will be copied into the `config` map in the `rdd-system` namespace. No controller should access `config.json` directly.
+Once the apiserver is running the config data will be copied into the `config` map in the `rdd-system` namespace. No controller should access `config.yaml` directly.
 
 
 ### `rdd service start`
 
 Starts the service. Calls `rdd service create` if the service does not yet exist.
 
-Takes all the same options as `rdd service create` and updates `config.json` with latest settings.
+Takes all the same options as `rdd service create` and updates `config.yaml` with latest settings.
 
 Runs `rdd service serve` to actually start the control plane in the background
 
@@ -153,8 +153,12 @@ Prints instance directory and file paths. Accepts an optional key argument to pr
 | `lima_home` | Lima home directory (`$short_dir/lima`) |
 | `tls_dir` | TLS certificate directory |
 | `config` | RDD control plane config file path |
+| `k3s_config` | Mirror of the in-VM k3s kubeconfig |
 | `pid_file` | PID file path |
 | `args_file` | Saved arguments file path |
+| `docker_socket` | Host-side Docker socket |
+| `cache_dir` | rdd-wide cache root (shared across instances) |
+| `kubectl_cache` | Cache directory for downloaded kubectl binaries (shared across instances) |
 
 Output formats (`--output`, `-o`):
 
@@ -170,14 +174,18 @@ Examples:
 
 ```console
 $ rdd svc paths
-args_file  /path/to/rancher-desktop-default/rdd.args
-config     /path/to/rancher-desktop-default/config.json
-dir        /path/to/rancher-desktop-default
-lima_home  /path/to/.rd2/lima
-log_dir    /path/to/rancher-desktop-default/log
-pid_file   /path/to/rancher-desktop-default/rdd.pid
-short_dir  /path/to/.rd2
-tls_dir    /path/to/rancher-desktop-default/tls
+args_file      /path/to/rancher-desktop-default/args.json
+cache_dir      /path/to/Caches/rancher-desktop
+config         /path/to/rancher-desktop-default/config.yaml
+dir            /path/to/rancher-desktop-default
+docker_socket  /path/to/.rd2/docker.sock
+k3s_config     /path/to/rancher-desktop-default/k3s.yaml
+kubectl_cache  /path/to/Caches/rancher-desktop/kubectl/darwin-arm64
+lima_home      /path/to/.rd2/lima
+log_dir        /path/to/rancher-desktop-default/log
+pid_file       /path/to/rancher-desktop-default/rdd.pid
+short_dir      /path/to/.rd2
+tls_dir        /path/to/rancher-desktop-default/tls
 
 $ rdd svc paths log_dir
 /path/to/rancher-desktop-default/log

--- a/rdd/docs/design/environment.md
+++ b/rdd/docs/design/environment.md
@@ -14,6 +14,8 @@ These variables control RDD behavior. Set them before running `rdd` commands.
 | `RDD_LOG_DIR` | Override the logging directory; usually used for tests. | unset |
 | `RDD_LOG_LEVEL` | Sets the log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`). Overridden by `--log-level` flag. When unset, defaults to `debug` in developer mode, `warn` otherwise. | unset |
 | `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
+| `RDD_CACHE_DIR` | Overrides the rdd-wide cache root. The kubectl resolver appends `kubectl/<os>-<arch>/` inside it. | `os.UserCacheDir()`/`rancher-desktop` (e.g. `~/Library/Caches/rancher-desktop` on macOS) |
+| `RDD_KUBECTL_MIRROR` | Overrides the Kubernetes release mirror for kubectl downloads. Must serve both the release binaries and the `stable-<major>.<minor>.txt` version markers (see [Version selection](cmd_other.md#version-selection)). | `https://dl.k8s.io` |
 | `RDD_TRACE_PACKETS` | Adds `--trace-packets` to the guest vm-switch network setup, logging every packet sent or received. Requires `RDD_KEEP_LOGS`, and affects throughput and timing, so use it only when diagnosing network failures. | unset |
 | `RDD_VM_CPUS` | Overrides the app VM's CPU count (the Lima template default is 2). Intended for CI, where runner sizing differs from user machines. A set-but-invalid value is an error, not a fallback. To be replaced by an App spec property. | unset |
 
@@ -29,9 +31,17 @@ These variables configure the BATS test framework. They have no effect on `rdd` 
 | `RDD_CONTAINER_ENGINE` | Container engine the docker test suite drives (`moby` or `containerd`). | `moby` |
 | `RDD_KEEP_RUNNING` | Keeps the control plane running between test files instead of stopping it in `teardown_file`, so a VM-booting suite boots once per run. | unset |
 
+### Internal Variables
+
+`rdd` sets these variables itself; users should leave them alone. They appear here so a developer reading a process tree or strace output can identify them.
+
+| Variable | Description |
+| --- | --- |
+| `RDD_KUBECTL_RESOLVED` | Recursion guard for the kubectl version resolver. `kuberlr.Exec` sets it on the kubectl child process so a downloaded kubectl that re-execs `rdd` through a shim cannot recurse back into version resolution. `rdd ctl` achieves the same skip via the in-process `kuberlr.SkipResolver()` helper, not this env var. |
+
 ## Path Variables
 
-`rdd svc paths --output=shell` exports these variables. They reflect the paths RDD uses for the current instance; setting them has no effect on RDD's behavior, other than `RDD_LOG_DIR` as listed above.
+`rdd svc paths --output=shell` exports these variables. They reflect the paths RDD uses for the current instance; setting them has no effect on RDD's behavior, other than `RDD_LOG_DIR` and `RDD_CACHE_DIR` as listed above.
 
 ```shell
 source <(rdd svc paths --output=shell)
@@ -40,9 +50,12 @@ source <(rdd svc paths --output=shell)
 | Variable | Description | Example (macOS, instance `2`) |
 | --- | --- | --- |
 | `RDD_ARGS_FILE` | Saved startup arguments | `~/Library/Application Support/rancher-desktop-2/args.json` |
+| `RDD_CACHE_DIR` | rdd-wide cache root (shared across instances) | `~/Library/Caches/rancher-desktop` |
 | `RDD_DIR` | Service instance directory | `~/Library/Application Support/rancher-desktop-2` |
 | `RDD_CONFIG` | RDD control plane config file | `~/Library/Application Support/rancher-desktop-2/config.yaml` |
+| `RDD_DOCKER_SOCKET` | Host-side Docker socket | `~/.rd2/docker.sock` |
 | `RDD_K3S_CONFIG` | Mirror of the in-VM k3s kubeconfig | `~/Library/Application Support/rancher-desktop-2/k3s.yaml` |
+| `RDD_KUBECTL_CACHE` | Cache directory for downloaded kubectl binaries (shared across instances) | `~/Library/Caches/rancher-desktop/kubectl/darwin-arm64` |
 | `RDD_LIMA_HOME` | Lima home directory | `~/.rd2/lima` |
 | `RDD_LOG_DIR` | Log directory | `~/Library/Logs/rancher-desktop-2` |
 | `RDD_PID_FILE` | Service PID file | `~/Library/Application Support/rancher-desktop-2/rdd.pid` |

--- a/rdd/go.mod
+++ b/rdd/go.mod
@@ -6,6 +6,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Microsoft/go-winio v0.6.2
+	github.com/blang/semver/v4 v4.0.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/containers/gvisor-tap-vsock v0.8.9
 	github.com/coreos/go-semver v0.3.1
@@ -36,6 +37,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/apiserver v0.36.2
+	k8s.io/cli-runtime v0.36.2
 	k8s.io/client-go v0.36.2
 	k8s.io/component-base v0.36.2
 	k8s.io/klog/v2 v2.140.0
@@ -96,7 +98,6 @@ require (
 	github.com/balajiv113/fd v0.0.0-20230330094840-143eec500f3e // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
@@ -430,7 +431,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gvisor.dev/gvisor v0.0.0-20240916094835-a174eb65023f // indirect
 	honnef.co/go/tools v0.6.1 // indirect
-	k8s.io/cli-runtime v0.36.2 // indirect
 	k8s.io/cloud-provider v0.36.2 // indirect
 	k8s.io/cluster-bootstrap v0.36.2 // indirect
 	k8s.io/code-generator v0.36.2 // indirect

--- a/rdd/pkg/kuberlr/cache.go
+++ b/rdd/pkg/kuberlr/cache.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package kuberlr resolves a kubectl binary for the cluster targeted
+// by the user's kubeconfig: it execs the embedded kubectl when
+// acceptable, otherwise a cached or freshly downloaded one from
+// dl.k8s.io. Modeled on github.com/flavio/kuberlr, but where kuberlr
+// accepts any kubectl within the ±1 minor skew, rdd insists on one
+// that also supports every server feature (see acceptable).
+package kuberlr
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/blang/semver/v4"
+)
+
+// envCacheDir lets tests and operators override the rdd-wide cache
+// root, anticipating future consumers (k3s images, lima templates).
+const envCacheDir = "RDD_CACHE_DIR"
+
+// CacheDir returns the directory holding downloaded kubectl binaries,
+// shared across rdd instances; RDD_CACHE_DIR overrides the root.
+//
+//	macOS:   ~/Library/Caches/rancher-desktop/kubectl/<os>-<arch>/
+//	Linux:   ~/.cache/rancher-desktop/kubectl/<os>-<arch>/  ($XDG_CACHE_HOME)
+//	Windows: %LocalAppData%\rancher-desktop\kubectl\<os>-<arch>\
+//
+// TODO(eviction): the cache only grows (~50 MB per minor version), and
+// a SIGKILL mid-download can leak the .kubectl-* temp file. Add a TTL
+// or LRU sweep before the footprint grows noticeable.
+func CacheDir() string {
+	return filepath.Join(CacheRoot(), "kubectl", runtime.GOOS+"-"+runtime.GOARCH)
+}
+
+// CacheRoot returns the rdd-wide cache root (RDD_CACHE_DIR overrides
+// the OS default); future cache consumers should nest under it.
+func CacheRoot() string {
+	if root := os.Getenv(envCacheDir); root != "" {
+		return root
+	}
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		panic(fmt.Errorf("could not determine user cache directory: %w", err))
+	}
+	return filepath.Join(cache, "rancher-desktop")
+}
+
+// bestCached returns the path of the highest-versioned cached kubectl
+// acceptable for server; ok is false when none qualifies. Any
+// acceptable patch level counts as a hit, so a cache warmed with an
+// older patch release keeps working without network access.
+func bestCached(server semver.Version) (path string, ok bool) {
+	entries, err := os.ReadDir(CacheDir())
+	if err != nil {
+		return "", false
+	}
+	var best semver.Version
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() {
+			continue
+		}
+		v, valid := parseCachedName(entry.Name())
+		if !valid {
+			continue
+		}
+		if acceptable(v, server) && (!ok || v.GT(best)) {
+			best, ok = v, true
+		}
+	}
+	if !ok {
+		return "", false
+	}
+	return cachedPath(best), true
+}
+
+// parseCachedName extracts the version from a cache file name written
+// by cachedPath; temp files and foreign names report valid=false.
+func parseCachedName(name string) (v semver.Version, valid bool) {
+	if runtime.GOOS == "windows" {
+		var found bool
+		if name, found = strings.CutSuffix(name, ".exe"); !found {
+			return semver.Version{}, false
+		}
+	}
+	rest, found := strings.CutPrefix(name, "kubectl-v")
+	if !found {
+		return semver.Version{}, false
+	}
+	v, err := semver.Parse(rest)
+	return v, err == nil
+}

--- a/rdd/pkg/kuberlr/downloader.go
+++ b/rdd/pkg/kuberlr/downloader.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package kuberlr
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/version"
+)
+
+// defaultKubeMirror is the canonical Kubernetes release CDN (SIG Release).
+const defaultKubeMirror = "https://dl.k8s.io"
+
+// envKubeMirror points the resolver at an alternate mirror — offline
+// mirrors, and the BATS test's local fake server.
+const envKubeMirror = "RDD_KUBECTL_MIRROR"
+
+// downloadTimeout bounds a hung mirror request while still covering a
+// ~50 MB kubectl download on slow links (~170 kB/s).
+const downloadTimeout = 5 * time.Minute
+
+// httpClient enforces downloadTimeout, since http.DefaultClient and the
+// cobra context impose none (a shorter request-context deadline still wins).
+var httpClient = &http.Client{Timeout: downloadTimeout}
+
+// userAgent names rdd-kuberlr traffic so proxies and air-gapped mirrors
+// don't rate-limit or denylist the default Go client UA.
+var userAgent = "rdd-kuberlr/" + version.Version
+
+// mirrorURL returns the mirror base URL the resolver downloads from.
+//
+// TODO(offline): pair this with a "may we download?" toggle so air-gapped
+// users can pre-populate CacheDir() and forbid network fetches.
+func mirrorURL() string {
+	if v := os.Getenv(envKubeMirror); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return defaultKubeMirror
+}
+
+// latestPatch returns the latest patch release of the server's minor,
+// read from the mirror's stable-<major>.<minor>.txt version marker
+// (e.g. stable-1.34.txt → v1.34.9). The release CDN publishes markers
+// only for GA minors, so a pre-GA server version fails here with a 404.
+func latestPatch(ctx context.Context, server semver.Version) (semver.Version, error) {
+	url := fmt.Sprintf("%s/release/stable-%d.%d.txt", mirrorURL(), server.Major, server.Minor)
+	var sb strings.Builder
+	if err := streamGet(ctx, url, &sb, maxTextBytes); err != nil {
+		return semver.Version{}, err
+	}
+	v, err := semver.ParseTolerant(strings.TrimSpace(sb.String()))
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("malformed version marker from %s: %w", url, err)
+	}
+	if v.Major != server.Major || v.Minor != server.Minor {
+		return semver.Version{}, fmt.Errorf("version marker %s names v%s, not a v%d.%d release", url, v, server.Major, server.Minor)
+	}
+	return v, nil
+}
+
+// ensureCached returns the cached kubectl path for want, downloading
+// and sha512-verifying it first if the cache misses.
+func ensureCached(ctx context.Context, want semver.Version) (string, error) {
+	path := cachedPath(want)
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	// User-facing progress, printed to stderr (not logged) so it shows at
+	// the default log level (warn outside developer mode).
+	fmt.Fprintf(os.Stderr, "Downloading kubectl v%d.%d.%d from %s ...\n", want.Major, want.Minor, want.Patch, mirrorURL())
+	if err := download(ctx, want, path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// cachedPath returns the absolute path of the cached kubectl for v.
+func cachedPath(v semver.Version) string {
+	name := fmt.Sprintf("kubectl-v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(CacheDir(), name)
+}
+
+// download fetches kubectl v, sha512-verifies it, and renames it to
+// dst atomically — a failure leaves no partial file behind.
+func download(ctx context.Context, v semver.Version, dst string) error {
+	base := fmt.Sprintf("%s/release/v%d.%d.%d/bin/%s/%s/kubectl", mirrorURL(), v.Major, v.Minor, v.Patch, runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		base += ".exe"
+	}
+	want, err := fetchSha512(ctx, base+".sha512")
+	if err != nil {
+		return fmt.Errorf("fetching checksum: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".kubectl-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	h := sha512.New()
+	if err := streamGet(ctx, base, io.MultiWriter(tmp, h), maxKubectlBytes); err != nil {
+		tmp.Close()
+		return fmt.Errorf("downloading %s: %w", base, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != want {
+		return fmt.Errorf("checksum mismatch for %s: want %s, got %s", base, want, got)
+	}
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, dst)
+}
+
+// Body-size caps for streamGet: maxTextBytes covers a one-line text
+// response (sha512sum line, version marker); maxKubectlBytes covers
+// the binary with headroom. A truncated binary surfaces as "checksum
+// mismatch", not a size error — bump the cap if real kubectl exceeds it.
+const (
+	maxTextBytes    = 4 << 10   // 4 KiB
+	maxKubectlBytes = 256 << 20 // 256 MiB
+)
+
+// fetchSha512 downloads the sha512 hex digest at url (bare, or
+// sha512sum-style with a trailing filename Fields drops). Rejecting
+// non-hex tokens up front gives "malformed checksum", not a misleading
+// "checksum mismatch".
+func fetchSha512(ctx context.Context, url string) (string, error) {
+	var sb strings.Builder
+	if err := streamGet(ctx, url, &sb, maxTextBytes); err != nil {
+		return "", err
+	}
+	fields := strings.Fields(sb.String())
+	if len(fields) == 0 {
+		return "", fmt.Errorf("empty checksum response from %s", url)
+	}
+	// Lowercase to match hex.EncodeToString's output — PowerShell's
+	// Get-FileHash emits uppercase, which would otherwise look mismatched.
+	digest := strings.ToLower(fields[0])
+	if len(digest) != sha512.Size*2 {
+		return "", fmt.Errorf("malformed checksum from %s: %d chars, want %d", url, len(digest), sha512.Size*2)
+	}
+	for _, c := range digest {
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+			return "", fmt.Errorf("malformed checksum from %s: non-hex character %q", url, c)
+		}
+	}
+	return digest, nil
+}
+
+// streamGet GETs url into w, capped at maxBytes so a malicious or
+// misconfigured mirror can't stream unbounded data; non-200 is an error.
+func streamGet(ctx context.Context, url string, w io.Writer, maxBytes int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	_, err = io.Copy(w, io.LimitReader(resp.Body, maxBytes))
+	return err
+}

--- a/rdd/pkg/kuberlr/exec_unix.go
+++ b/rdd/pkg/kuberlr/exec_unix.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build !windows
+
+package kuberlr
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Exec replaces the current process with kubectl plus a recursion
+// guard, so the shell sees kubectl's exit status directly. ctx is
+// unused (signature parity with the Windows variant only).
+func Exec(_ context.Context, path string, args []string) error {
+	env := append(os.Environ(), envSkipResolver+"=1")
+	if err := syscall.Exec(path, append([]string{path}, args...), env); err != nil {
+		return fmt.Errorf("exec %s: %w", path, err)
+	}
+	return nil
+}

--- a/rdd/pkg/kuberlr/exec_windows.go
+++ b/rdd/pkg/kuberlr/exec_windows.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build windows
+
+package kuberlr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	cliexit "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/exit"
+)
+
+// Exec runs kubectl at path as a child process (Windows has no unix
+// exec()) and returns a *cliexit.Error so main re-issues its exit code.
+// Both processes share the console, so Ctrl+C/Break reach kubectl directly.
+func Exec(ctx context.Context, path string, args []string) error {
+	// CommandContext hard-kills on ctx cancellation; ctx is never canceled
+	// today, but signal-driven cancellation later would race kubectl's
+	// graceful Ctrl+C shutdown — revisit this site first.
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Env = append(os.Environ(), envSkipResolver+"=1")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return &cliexit.Error{Code: exitErr.ExitCode()}
+	}
+	if err != nil {
+		return fmt.Errorf("running %s: %w", path, err)
+	}
+	return nil
+}

--- a/rdd/pkg/kuberlr/resolver.go
+++ b/rdd/pkg/kuberlr/resolver.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package kuberlr
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	componentbasever "k8s.io/component-base/version"
+)
+
+// envSkipResolver tells Resolve to short-circuit — Exec sets it on the
+// kubectl child so a re-exec'd kubectl can't recurse into resolution.
+const envSkipResolver = "RDD_KUBECTL_RESOLVED"
+
+// skipResolver is the same-process counterpart to envSkipResolver.
+var skipResolver bool
+
+// SkipResolver short-circuits Resolve for the rest of this process.
+// rdd ctl calls this because its embedded apiserver always matches
+// the embedded kubectl's version by construction.
+func SkipResolver() {
+	skipResolver = true
+}
+
+// serverProbeTimeout caps the discovery call so an unreachable cluster
+// can't stall every kubectl invocation; reachable clusters answer in <100ms.
+const serverProbeTimeout = 2 * time.Second
+
+// Resolve returns the path of a kubectl acceptable for the cluster the
+// user's kubeconfig points at, or "" to use the embedded kubectl.
+//
+// It prefers the embedded kubectl, then the highest acceptable cached
+// binary, and only when both miss downloads the latest patch release
+// of the server's minor. It returns "" when the probe fails for any
+// reason, for client-only commands (see isClientOnly), and — with a
+// warning — when the version to download cannot be determined; a
+// determined version that fails to download or verify is an error.
+func Resolve(ctx context.Context, args []string) (string, error) {
+	if skipResolver || os.Getenv(envSkipResolver) != "" {
+		return "", nil
+	}
+	if isClientOnly(args) {
+		return "", nil
+	}
+	embedded, err := embeddedVersion()
+	if err != nil {
+		// `go run` and IDE debug builds skip the Makefile's -X flags,
+		// leaving the unparseable in-tree default (v0.0.0-master+...);
+		// fall through rather than break every dev invocation.
+		logrus.WithError(err).Debug("kubectl resolver: embedded version not parseable; using embedded kubectl")
+		return "", nil
+	}
+	server, ok := serverVersion(args)
+	if !ok {
+		return "", nil
+	}
+	if acceptable(embedded, server) {
+		return "", nil
+	}
+	if path, ok := bestCached(server); ok {
+		return path, nil
+	}
+	want, err := latestPatch(ctx, server)
+	if err != nil {
+		// Final fallback: rdd embeds a recent kubectl and Kubernetes
+		// rarely breaks backward compatibility, so running it beats
+		// failing when the mirror is unreachable or has no marker yet.
+		logrus.WithError(err).Warnf("kubectl resolver: cannot determine the latest v%d.%d patch release; using embedded kubectl", server.Major, server.Minor)
+		return "", nil
+	}
+	return ensureCached(ctx, want)
+}
+
+// acceptable reports whether a kubectl of client's version supports
+// every feature of a server of server's version: same Major, and a
+// Minor equal to the server's or one higher. One minor behind is
+// still within the official ±1 skew, but lacks the features added in
+// the server's minor, so it is rejected. Patch versions never matter.
+func acceptable(client, server semver.Version) bool {
+	if client.Major != server.Major {
+		return false
+	}
+	diff := int64(client.Minor) - int64(server.Minor)
+	return diff == 0 || diff == 1
+}
+
+// embeddedVersion reads the kubectl version baked in via the Makefile's
+// -X flags; it's a var so tests can stub the dev-build parse failure.
+var embeddedVersion = func() (semver.Version, error) {
+	return semver.ParseTolerant(componentbasever.Get().GitVersion)
+}
+
+// serverVersion probes the cluster named by args. ok is false on any
+// failure, all logged at debug except unparseable version (warn — a
+// garbled apiserver /version response is worth surfacing by default).
+func serverVersion(args []string) (semver.Version, bool) {
+	cfg, err := loadClientConfig(args)
+	if err != nil {
+		logrus.WithError(err).Debug("kubectl resolver: cannot load kubeconfig; using embedded kubectl")
+		return semver.Version{}, false
+	}
+	// Force the fast probe timeout, overriding any --request-timeout in
+	// args; the kubectl child itself still honors the user's value.
+	cfg.Timeout = serverProbeTimeout
+	client, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		logrus.WithError(err).Debug("kubectl resolver: cannot build discovery client; using embedded kubectl")
+		return semver.Version{}, false
+	}
+	info, err := client.ServerVersion()
+	if err != nil {
+		logrus.WithError(err).Debug("kubectl resolver: cluster probe failed; using embedded kubectl")
+		return semver.Version{}, false
+	}
+	v, err := semver.ParseTolerant(info.GitVersion)
+	if err != nil {
+		logrus.WithError(err).Warnf("kubectl resolver: cannot parse server version %q; using embedded kubectl", info.GitVersion)
+		return semver.Version{}, false
+	}
+	return v, true
+}
+
+// loadClientConfig builds a rest.Config from KUBECONFIG and args'
+// kubectl connection flags, so the probe targets the same cluster.
+func loadClientConfig(args []string) (*rest.Config, error) {
+	cf, err := parseKubeConfigFlags(args)
+	if err != nil {
+		return nil, err
+	}
+	return cf.ToRawKubeConfigLoader().ClientConfig()
+}
+
+// parseKubeConfigFlags parses kubectl's connection-override flags into a
+// ConfigFlags. A malformed known flag returns the parse error, so the
+// caller falls through to the embedded kubectl instead of silently
+// probing the default cluster; unknown flags pass through untouched.
+//
+// --username/--password stay unbound: binding them would make
+// ToRawKubeConfigLoader prompt on stdin, hanging a background probe.
+func parseKubeConfigFlags(args []string) (*genericclioptions.ConfigFlags, error) {
+	fs := pflag.NewFlagSet("rdd-kubectl", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+	cf := genericclioptions.NewConfigFlags(true)
+	cf.AddFlags(fs)
+	return cf, fs.Parse(args)
+}
+
+// clientOnlySubcommands lists kubectl subcommands that never contact a
+// cluster: config/completion touch local state, kustomize renders local
+// manifests, plugin lists local PATH entries, options/help print text.
+var clientOnlySubcommands = map[string]bool{
+	"completion": true,
+	"config":     true,
+	"kustomize":  true,
+	"plugin":     true,
+	"options":    true,
+	"help":       true,
+}
+
+// isClientOnly reports whether args need no cluster probe. When unsure
+// it defaults to false (probe), to avoid running a mismatched kubectl.
+//
+// Klog flags (--v, ...) stay unbound to avoid leaking into klog's
+// process-global state. A malformed bool like --client=garbage is safe:
+// it lands in the empty-args (true) branch, and kubectl rejects it too.
+func isClientOnly(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	fs := pflag.NewFlagSet("rdd-kubectl", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+
+	cf := genericclioptions.NewConfigFlags(true)
+	cf.AddFlags(fs)
+
+	var help, client, warningsAsErrors, matchServerVersion bool
+	fs.BoolVarP(&help, "help", "h", false, "")
+	fs.BoolVar(&client, "client", false, "")
+	fs.BoolVar(&warningsAsErrors, "warnings-as-errors", false, "")
+	fs.BoolVar(&matchServerVersion, "match-server-version", false, "")
+
+	_ = fs.Parse(args)
+
+	if help {
+		return true
+	}
+	positionals := fs.Args()
+	if len(positionals) == 0 {
+		return true
+	}
+	subcommand := positionals[0]
+	if subcommand == "version" {
+		// `kubectl version` without --client probes the server, so
+		// treat it as cluster-bound.
+		return client
+	}
+	return clientOnlySubcommands[subcommand]
+}

--- a/rdd/pkg/kuberlr/resolver_test.go
+++ b/rdd/pkg/kuberlr/resolver_test.go
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package kuberlr
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/sirupsen/logrus"
+	"gotest.tools/v3/assert"
+)
+
+func TestAcceptable(t *testing.T) {
+	v := func(major, minor uint64) semver.Version {
+		return semver.Version{Major: major, Minor: minor}
+	}
+	// EKS/GKE/AKS rows verify ParseTolerant accepts vendor build suffixes
+	// and compatible reads only the leading semver fields.
+	mustParse := func(s string) semver.Version {
+		ver, err := semver.ParseTolerant(s)
+		assert.NilError(t, err, "ParseTolerant(%q)", s)
+		return ver
+	}
+	type testCase struct {
+		name   string
+		client semver.Version
+		server semver.Version
+		want   bool
+	}
+	cases := []testCase{
+		{"same minor", v(1, 30), v(1, 30), true},
+		{"client one ahead", v(1, 31), v(1, 30), true},
+		{"client one behind", v(1, 29), v(1, 30), false},
+		{"client two ahead", v(1, 32), v(1, 30), false},
+		{"client two behind", v(1, 28), v(1, 30), false},
+		{"server at zero, client at zero", v(1, 0), v(1, 0), true},
+		{"server at zero, client at one", v(1, 1), v(1, 0), true},
+		{"patch differences ignored", semver.Version{Major: 1, Minor: 30, Patch: 99}, semver.Version{Major: 1, Minor: 30, Patch: 0}, true},
+		{"different major rules out", v(1, 30), semver.Version{Major: 2, Minor: 30}, false},
+		{"EKS suffix server same minor", v(1, 30), mustParse("v1.30.0-eks-1234"), true},
+		{"GKE suffix server client one ahead", v(1, 31), mustParse("v1.30.7-gke.500"), true},
+		{"AKS suffix server client behind", v(1, 30), mustParse("v1.32.0-aks.1"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, acceptable(tc.client, tc.server), tc.want)
+		})
+	}
+}
+
+func TestBestCached(t *testing.T) {
+	t.Setenv(envCacheDir, t.TempDir())
+	server := semver.Version{Major: 1, Minor: 34, Patch: 1}
+	exe := ""
+	if runtime.GOOS == "windows" {
+		exe = ".exe"
+	}
+	dir := CacheDir()
+	place := func(name string) {
+		t.Helper()
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"), 0o755))
+	}
+	assertMiss := func(comment string) {
+		t.Helper()
+		path, ok := bestCached(server)
+		assert.Assert(t, !ok, "%s: unexpected hit %q", comment, path)
+	}
+	assertHit := func(name string) {
+		t.Helper()
+		path, ok := bestCached(server)
+		assert.Assert(t, ok, "expected a hit for %q", name)
+		assert.Equal(t, path, filepath.Join(dir, name+exe))
+	}
+
+	assertMiss("cache directory does not exist yet")
+
+	assert.NilError(t, os.MkdirAll(dir, 0o755))
+	place(".kubectl-tmp123" + exe)
+	place("README")
+	assert.NilError(t, os.Mkdir(filepath.Join(dir, "kubectl-v1.34.9"+exe), 0o755))
+	assertMiss("temp files, foreign names, and directories")
+
+	place("kubectl-v1.33.9" + exe)
+	place("kubectl-v1.36.0" + exe)
+	assertMiss("one minor older and two minors newer")
+
+	place("kubectl-v1.34.0" + exe)
+	assertHit("kubectl-v1.34.0")
+
+	place("kubectl-v1.35.2" + exe)
+	place("kubectl-v1.34.7" + exe)
+	assertHit("kubectl-v1.35.2")
+}
+
+func TestLatestPatch(t *testing.T) {
+	server := semver.Version{Major: 1, Minor: 34, Patch: 0}
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		want    string // expected version; empty means an error containing errPart
+		errPart string
+	}{
+		{"trailing newline", http.StatusOK, "v1.34.9\n", "1.34.9", ""},
+		{"bare version", http.StatusOK, "1.34.10", "1.34.10", ""},
+		{"wrong minor", http.StatusOK, "v1.35.1\n", "", "not a v1.34 release"},
+		{"garbage", http.StatusOK, "<html>oops</html>", "", "malformed version marker"},
+		{"missing marker", http.StatusNotFound, "", "", "404"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/release/stable-1.34.txt", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			})
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+			t.Setenv(envKubeMirror, ts.URL)
+
+			got, err := latestPatch(context.Background(), server)
+			if tc.want == "" {
+				assert.ErrorContains(t, err, tc.errPart)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, got.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestCachedPath(t *testing.T) {
+	v := semver.Version{Major: 1, Minor: 30, Patch: 5}
+	got := cachedPath(v)
+	wantSuffix := "kubectl-v1.30.5"
+	if runtime.GOOS == "windows" {
+		wantSuffix += ".exe"
+	}
+	assert.Assert(t, strings.HasSuffix(got, wantSuffix), "cachedPath = %q, want suffix %q", got, wantSuffix)
+	assert.Assert(t, strings.HasPrefix(got, CacheDir()), "cachedPath = %q, want prefix %q", got, CacheDir())
+}
+
+func TestParseKubeConfigFlags(t *testing.T) {
+	deref := func(p *string) string {
+		if p == nil {
+			return ""
+		}
+		return *p
+	}
+	derefBool := func(p *bool) bool {
+		if p == nil {
+			return false
+		}
+		return *p
+	}
+
+	type want struct {
+		kubeconfig string
+		context    string
+		server     string
+		cluster    string
+		user       string
+		token      string
+		caFile     string
+		certFile   string
+		keyFile    string
+		tlsName    string
+		insecure   bool
+		username   string
+		password   string
+		namespace  string
+	}
+	cases := []struct {
+		name string
+		args []string
+		want want
+	}{
+		{"empty", nil, want{}},
+		{"unrelated args", []string{"get", "pods"}, want{}},
+		{"--kubeconfig spaced", []string{"--kubeconfig", "/k", "get", "pods"}, want{kubeconfig: "/k"}},
+		{"--kubeconfig equals", []string{"--kubeconfig=/k", "get", "pods"}, want{kubeconfig: "/k"}},
+		{"--context spaced", []string{"--context", "c", "get", "pods"}, want{context: "c"}},
+		{"--context equals", []string{"--context=c", "get", "pods"}, want{context: "c"}},
+		{"--server spaced", []string{"--server", "https://x:6443", "get"}, want{server: "https://x:6443"}},
+		{"--server equals", []string{"--server=https://x:6443", "get"}, want{server: "https://x:6443"}},
+		{"-s alias spaced", []string{"-s", "https://x:6443", "get"}, want{server: "https://x:6443"}},
+		{"-s alias equals", []string{"-s=https://x:6443", "get"}, want{server: "https://x:6443"}},
+		{"--cluster", []string{"--cluster=prod", "get"}, want{cluster: "prod"}},
+		{"--user", []string{"--user=alice", "get"}, want{user: "alice"}},
+		{"--token", []string{"--token=eyJabc", "get"}, want{token: "eyJabc"}},
+		{"--certificate-authority", []string{"--certificate-authority=/ca.crt", "get"}, want{caFile: "/ca.crt"}},
+		{"--client-certificate", []string{"--client-certificate=/c.crt", "get"}, want{certFile: "/c.crt"}},
+		{"--client-key", []string{"--client-key=/c.key", "get"}, want{keyFile: "/c.key"}},
+		{"--tls-server-name", []string{"--tls-server-name=api.example", "get"}, want{tlsName: "api.example"}},
+		{"--insecure-skip-tls-verify bare", []string{"--insecure-skip-tls-verify", "get"}, want{insecure: true}},
+		{"--insecure-skip-tls-verify=true", []string{"--insecure-skip-tls-verify=true", "get"}, want{insecure: true}},
+		{"--namespace spaced", []string{"--namespace", "kube-system", "get"}, want{namespace: "kube-system"}},
+		{"-n alias", []string{"-n", "kube-system", "get"}, want{namespace: "kube-system"}},
+		{"all auth/tls together", []string{"--server=https://x", "--token=tk", "--certificate-authority=/ca", "--insecure-skip-tls-verify", "get"}, want{server: "https://x", token: "tk", caFile: "/ca", insecure: true}},
+		{"later flag wins", []string{"--context=a", "--context=b"}, want{context: "b"}},
+		{"stops at --", []string{"exec", "pod", "--", "tool", "--kubeconfig=/other", "--server=https://other"}, want{}},
+		{"flags before -- still parse", []string{"--kubeconfig=/k", "--server=https://x", "exec", "pod", "--", "tool", "--context=other"}, want{kubeconfig: "/k", server: "https://x"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cf, err := parseKubeConfigFlags(tc.args)
+			assert.NilError(t, err)
+			actual := want{
+				kubeconfig: deref(cf.KubeConfig),
+				context:    deref(cf.Context),
+				server:     deref(cf.APIServer),
+				cluster:    deref(cf.ClusterName),
+				user:       deref(cf.AuthInfoName),
+				token:      deref(cf.BearerToken),
+				caFile:     deref(cf.CAFile),
+				certFile:   deref(cf.CertFile),
+				keyFile:    deref(cf.KeyFile),
+				tlsName:    deref(cf.TLSServerName),
+				insecure:   derefBool(cf.Insecure),
+				username:   deref(cf.Username),
+				password:   deref(cf.Password),
+				namespace:  deref(cf.Namespace),
+			}
+			assert.Equal(t, actual, tc.want)
+		})
+	}
+}
+
+// Locks in parseKubeConfigFlags' malformed-flag behavior (see its doc).
+func TestParseKubeConfigFlagsRejectsMalformedFlag(t *testing.T) {
+	_, err := parseKubeConfigFlags([]string{"get", "--server"})
+	assert.Assert(t, err != nil, "expected a parse error for --server without a value")
+}
+
+func TestIsClientOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"empty", nil, true},
+		{"--help alone", []string{"--help"}, true},
+		{"-h alone", []string{"-h"}, true},
+		{"--help after subcommand", []string{"get", "pods", "--help"}, true},
+		{"--help=true alone", []string{"--help=true"}, true},
+		{"--help=1 after subcommand", []string{"get", "pods", "--help=1"}, true},
+		{"-h=true alone", []string{"-h=true"}, true},
+		{"--help=false probes", []string{"--help=false", "get", "pods"}, false},
+		{"-h=0 probes", []string{"-h=0", "get", "pods"}, false},
+		{"--help=garbage stops parse, no positionals", []string{"--help=garbage", "get", "pods"}, true},
+		{"version --client", []string{"version", "--client"}, true},
+		{"version --client with --output", []string{"version", "--client", "--output=json"}, true},
+		{"version --client=true", []string{"version", "--client=true"}, true},
+		{"version --client=false", []string{"version", "--client=false"}, false},
+		{"version --client=1", []string{"version", "--client=1"}, true},
+		{"version --client then --client=false (last wins)", []string{"version", "--client", "--client=false"}, false},
+		{"version --client=false then --client (last wins)", []string{"version", "--client=false", "--client"}, true},
+		{"version --client=garbage stays false", []string{"version", "--client=garbage"}, false},
+		{"version without --client", []string{"version"}, false},
+		{"completion bash", []string{"completion", "bash"}, true},
+		{"config view", []string{"config", "view"}, true},
+		{"config get-contexts", []string{"config", "get-contexts"}, true},
+		{"kustomize bare", []string{"kustomize"}, true},
+		{"kustomize with dir", []string{"kustomize", "./manifests"}, true},
+		{"kustomize with --enable-helm", []string{"kustomize", "./m", "--enable-helm"}, true},
+		{"plugin bare", []string{"plugin"}, true},
+		{"plugin list", []string{"plugin", "list"}, true},
+		{"options", []string{"options"}, true},
+		{"help subcommand", []string{"help", "get"}, true},
+		{"get pods", []string{"get", "pods"}, false},
+		{"apply -f", []string{"apply", "-f", "manifest.yaml"}, false},
+		{"with kubeconfig flag spaced", []string{"--kubeconfig", "/k", "completion", "bash"}, true},
+		{"with kubeconfig flag equals", []string{"--kubeconfig=/k", "completion", "bash"}, true},
+		{"with --server before subcommand", []string{"--server", "https://x", "config", "view"}, true},
+		{"--server URL must not be read as subcommand", []string{"--server", "completion", "get", "pods"}, false},
+		{"-n namespace before subcommand", []string{"-n", "kube-system", "get", "pods"}, false},
+		{"-n with config", []string{"-n", "ns", "config", "view"}, true},
+		{"--as-user-extra spaced before subcommand", []string{"--as-user-extra", "k=v", "config", "view"}, true},
+		{"--as-user-extra equals before subcommand", []string{"--as-user-extra=k=v", "config", "view"}, true},
+		{"unknown long flag swallows next non-flag arg as assumed value", []string{"--unknown", "config", "view"}, false},
+		{"stops at --", []string{"exec", "pod", "--", "completion"}, false},
+		{"-- before subcommand still finds the subcommand", []string{"--", "get", "pods"}, false},
+		{"unknown --v spaced rides UnknownFlags path", []string{"--v", "4", "config", "view"}, true},
+		{"unknown --v=N equals form rides UnknownFlags path", []string{"--v=4", "config", "view"}, true},
+		{"unknown --vmodule spaced rides UnknownFlags path", []string{"--vmodule", "foo=2", "config", "view"}, true},
+		{"--warnings-as-errors bare bool", []string{"--warnings-as-errors", "config", "view"}, true},
+		{"--warnings-as-errors=true", []string{"--warnings-as-errors=true", "config", "view"}, true},
+		{"--match-server-version bare bool", []string{"--match-server-version", "config", "view"}, true},
+		{"--match-server-version=true", []string{"--match-server-version=true", "config", "view"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, isClientOnly(tc.args), tc.want)
+		})
+	}
+}
+
+// TestResolveFallsBackToEmbeddedWhenMarkerUnavailable locks in the
+// final fallback: no acceptable cache entry and no reachable version
+// marker resolve to the embedded kubectl, with a warning.
+func TestResolveFallsBackToEmbeddedWhenMarkerUnavailable(t *testing.T) {
+	orig := embeddedVersion
+	t.Cleanup(func() { embeddedVersion = orig })
+	embeddedVersion = func() (semver.Version, error) {
+		return semver.Version{Major: 1, Minor: 36}, nil
+	}
+
+	// One server plays apiserver and mirror, like the BATS fixture: it
+	// answers /version with a minor the embedded kubectl does not
+	// satisfy, and 404s the version-marker request.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"major":"1","minor":"30","gitVersion":"v1.30.0"}`)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
+	config := fmt.Sprintf(`
+apiVersion: v1
+kind: Config
+clusters:
+- name: fake
+  cluster:
+    server: %s
+contexts:
+- name: fake
+  context:
+    cluster: fake
+    user: ""
+current-context: fake
+`, ts.URL)
+	assert.NilError(t, os.WriteFile(kubeconfig, []byte(config), 0o600))
+	t.Setenv("KUBECONFIG", kubeconfig)
+	t.Setenv(envKubeMirror, ts.URL)
+	t.Setenv(envCacheDir, t.TempDir())
+
+	// Capture the warning: it must be asserted, not printed into the
+	// test output.
+	var logBuf bytes.Buffer
+	origOut := logrus.StandardLogger().Out
+	logrus.StandardLogger().SetOutput(&logBuf)
+	t.Cleanup(func() { logrus.StandardLogger().SetOutput(origOut) })
+
+	path, err := Resolve(context.Background(), []string{"get", "pods"})
+	assert.NilError(t, err)
+	assert.Equal(t, path, "")
+	assert.Assert(t, strings.Contains(logBuf.String(), "using embedded kubectl"),
+		"expected fallback warning, got: %q", logBuf.String())
+}
+
+// TestResolveEmbeddedVersionUnparseable locks in Resolve's dev-build
+// fall-through: an unparseable embeddedVersion returns ("", nil).
+func TestResolveEmbeddedVersionUnparseable(t *testing.T) {
+	orig := embeddedVersion
+	t.Cleanup(func() { embeddedVersion = orig })
+	embeddedVersion = func() (semver.Version, error) {
+		return semver.Version{}, errors.New("test: unparseable embedded version")
+	}
+
+	// Args that would otherwise reach the cluster probe (not client-only).
+	path, err := Resolve(context.Background(), []string{"get", "pods"})
+	assert.NilError(t, err)
+	assert.Equal(t, path, "")
+}
+
+// TestResolveSkipsWhenRecursionGuardSet locks in the envSkipResolver
+// short-circuit, asserted via embeddedVersion never being called.
+func TestResolveSkipsWhenRecursionGuardSet(t *testing.T) {
+	t.Setenv(envSkipResolver, "1")
+	orig := embeddedVersion
+	t.Cleanup(func() { embeddedVersion = orig })
+	embeddedVersionCalled := false
+	embeddedVersion = func() (semver.Version, error) {
+		embeddedVersionCalled = true
+		return semver.Version{}, nil
+	}
+
+	// Args that would otherwise reach the cluster probe.
+	path, err := Resolve(context.Background(), []string{"get", "pods"})
+	assert.NilError(t, err)
+	assert.Equal(t, path, "")
+	assert.Assert(t, !embeddedVersionCalled, "Resolve reached embeddedVersion despite envSkipResolver")
+}


### PR DESCRIPTION
Recreates #348 from a new fork after a visibility flip broke the cross-repo PR link.

`rdd kubectl` runs a kubectl that supports every feature of the target cluster: the client's minor version must equal the server's or be one higher. kuberlr itself settles for the official ±1 skew, but a kubectl one minor older misses features added in the server's minor.

The resolver probes the server version, then prefers the embedded kubectl, then the highest acceptable binary in a shared cache, and otherwise downloads the latest patch release of the server's minor (via the mirror's `stable-<major>.<minor>.txt` marker) from dl.k8s.io, sha512-verifies it, and execs it. When the cluster is unreachable it runs the embedded kubectl. `rdd ctl` always talks to its own embedded apiserver, where a mismatch can never happen, so it calls kuberlr.SkipResolver() to skip the probe entirely. kuberlr's own resolver lives under internal/, unimportable outside its module, so pkg/kuberlr/ reimplements it inline instead.

The cache lives under os.UserCacheDir()/rancher-desktop, shared across instances (`rdd svc paths kubectl_cache` reports the path); RDD_CACHE_DIR overrides the cache root, RDD_KUBECTL_MIRROR the release mirror.

When nothing acceptable is cached and the version marker cannot be fetched (offline mirror, pre-GA minor), the resolver warns and falls back to the embedded kubectl: rdd embeds a recent kubectl and Kubernetes rarely breaks backward compatibility, so running it beats failing. Once a version is determined, download failures (404, sha512 mismatch, network) exit non-zero rather than hide the problem. Probe failures (unreachable cluster, missing kubeconfig) fall through silently.

docs/design/cmd_other.md#version-selection documents the selection rule. pkg/kuberlr/resolver_test.go covers the acceptance rule, cache scanning, version-marker parsing, the embedded fallback, ConfigFlags binding, client-only detection, and the dev-build and recursion-guard fallbacks. bats/tests/10-cli/7-kubectl-cache.bats drives a fake mirror and apiserver through cache-miss, cache-hit (same minor and one newer), stale-cache re-download, marker-404 fallback, binary-404, checksum-mismatch, and probe-500 scenarios, and also runs under Git Bash on Windows.
