### PR TITLE
BATS CI fixes: k3s SIGPIPE and support-bundle log pruning

### DIFF
--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -62,7 +62,9 @@ provision:
     if [[ $PARAM_KUBERNETES_ENABLED == "true" ]]; then
         export INSTALL_K3S_VERSION="v${PARAM_KUBERNETES_VERSION}+k3s1"
         INSTALLED_VERSION=""
-        [[ -x /usr/local/bin/k3s ]] && INSTALLED_VERSION=$(/usr/local/bin/k3s --version | awk '{print $3; exit}')
+        # awk must read to EOF; `{print; exit}` closes the pipe while k3s
+        # is still writing, and the SIGPIPE propagates via pipefail + errexit.
+        [[ -x /usr/local/bin/k3s ]] && INSTALLED_VERSION=$(/usr/local/bin/k3s --version | awk 'NR==1{print $3}')
         if [[ $INSTALL_K3S_VERSION != "${INSTALLED_VERSION}" ]]; then
             # Don't enable k3s at install time; add it as a want of rancher-desktop.target instead.
             export INSTALL_K3S_SKIP_ENABLE=true

--- a/scripts/bats-with-timeout.sh
+++ b/scripts/bats-with-timeout.sh
@@ -18,6 +18,13 @@
 
 set -o errexit -o nounset -o pipefail
 
+# The rdd ctl probes in dump_api_state auto-start the service when bats
+# stopped it. Each start rotates rdd.stderr.log; without RDD_KEEP_LOGS,
+# rotation prunes the oldest numbered files, and a failure in the first
+# .bats file of a suite loses its log forever. bats itself sets this in
+# bats/helpers/defaults.bash, but that scope ends when bats exits.
+export RDD_KEEP_LOGS=1
+
 timeout_seconds=$1
 shift
 


### PR DESCRIPTION
## Summary

Two unrelated CI-infra fixes that both surfaced while investigating a failing `bats-app` run on `macos-15-intel`. Bundled because both are small and share a discovery context; each commit stands alone.

- **`Fix SIGPIPE in k3s version check during provision`** — the lima provision script's `k3s --version | awk '{print $3; exit}'` races k3s. When awk exits first, k3s gets SIGPIPE on its next write; `pipefail + errexit` then abort the script, k3s never starts, and `bats-app` `kube-context` tests 122/123 time out waiting 360s for `KubernetesReady`. Reproduction over a slow producer: old returns rc=141, new returns rc=0. Fix: use `NR==1{print $3}` so awk consumes all input.

- **`bats: stop pruning oldest service logs in support bundle`** — `scripts/bats-with-timeout.sh`'s post-test `rdd ctl get` probes auto-start the rdd service when bats has stopped it. Each start rotates `rdd.stderr.log`; because `RDD_KEEP_LOGS` is only set inside the bats subprocess (via `bats/helpers/defaults.bash`), the wrapper's rotation prunes logs older than `retentionCount=5`. Every CI artifact loses its two oldest service logs — exactly the ones for the alphabetically-first `.bats` files, which is where the `bats-lima` test 7 failure on this same run lived. Fix: export `RDD_KEEP_LOGS=1` from the wrapper.
