### PR TITLE
Stop KubernetesReady from flapping on transient probe failures

### DIFF
--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -88,12 +88,12 @@ type KubernetesReconciler struct {
 	// contextProbeWg lets removeKubeContext wait for any probe to finish.
 	contextProbeWg sync.WaitGroup
 
-	// probeMu protects consecutiveProbeFailures.
-	probeMu sync.Mutex
 	// consecutiveProbeFailures counts ambiguous probe failures while the
-	// KubernetesReady condition was True. Resets on any success or any
-	// decisive failure (Unreachable, Unhealthy). When the count reaches
-	// probeFailureThreshold, the reconciler flips Ready to Probing.
+	// KubernetesReady condition was True. Resets on any success or
+	// decisive failure (Unreachable, Unhealthy). Crossing
+	// probeFailureThreshold flips Ready to Probing and resets the counter.
+	// Reconcile runs single-threaded (MaxConcurrentReconciles=1), so the
+	// counter needs no synchronization.
 	consecutiveProbeFailures int
 
 	// probeFn lets tests inject probe results without making real HTTP calls.
@@ -194,8 +194,14 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 				"failures", failures, "threshold", probeFailureThreshold)
 			return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
 		}
-		log.V(1).Info("ambiguous probe failures crossed threshold",
-			"failures", failures, "threshold", probeFailureThreshold)
+		if currentlyReady {
+			log.V(1).Info("ambiguous probe failures crossed threshold",
+				"failures", failures, "threshold", probeFailureThreshold)
+		} else {
+			log.V(1).Info("ambiguous probe failure while not Ready",
+				"failures", failures)
+		}
+		r.resetProbeFailures()
 		if condErr := r.setKubeCondition(ctx, &app,
 			metav1.ConditionFalse,
 			appv1alpha1.AppKubernetesReasonProbing,
@@ -235,16 +241,12 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 
 // resetProbeFailures clears the ambiguous-failure streak counter.
 func (r *KubernetesReconciler) resetProbeFailures() {
-	r.probeMu.Lock()
 	r.consecutiveProbeFailures = 0
-	r.probeMu.Unlock()
 }
 
 // incrementProbeFailures bumps the ambiguous-failure streak counter and
 // returns the new value.
 func (r *KubernetesReconciler) incrementProbeFailures() int {
-	r.probeMu.Lock()
-	defer r.probeMu.Unlock()
 	r.consecutiveProbeFailures++
 	return r.consecutiveProbeFailures
 }

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -9,10 +9,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"sync"
+	"syscall"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +40,33 @@ const (
 
 	// kubeProbeRequeue is the wait between probes when k3s is not yet ready.
 	kubeProbeRequeue = 5 * time.Second
+
+	// kubeHealthyRequeue is the wait between probes when k3s is healthy. Longer
+	// than kubeProbeRequeue to keep steady-state log noise down; sets the
+	// worst-case latency for noticing an unannounced k3s death.
+	kubeHealthyRequeue = 15 * time.Second
+
+	// probeFailureThreshold is the number of consecutive ambiguous probe
+	// failures tolerated while Ready before flipping to Probing. Decisive
+	// failures (Unreachable, Unhealthy) bypass the threshold and flip
+	// immediately. Ambiguous = the probe could not complete within
+	// kubeProbeTimeout, which on a busy laptop is often transient load
+	// rather than k3s genuinely going down.
+	probeFailureThreshold = 3
+)
+
+// probeResult classifies a probe outcome so Reconcile can apply different
+// policies. The split exists because not every failure means the same thing:
+// ECONNREFUSED is k3s being gone, an HTTP 5xx is k3s saying "I'm not ready"
+// on purpose, and a timeout is the only genuinely ambiguous case that
+// warrants smoothing.
+type probeResult int
+
+const (
+	probeHealthy     probeResult = iota // /healthz returned 200
+	probeUnreachable                    // TCP listener gone or connection torn down mid-request
+	probeUnhealthy                      // /healthz returned non-200
+	probeAmbiguous                      // request did not complete within kubeProbeTimeout
 )
 
 // KubernetesReconciler watches the App resource and manages the
@@ -58,6 +87,26 @@ type KubernetesReconciler struct {
 	contextProbeGen int
 	// contextProbeWg lets removeKubeContext wait for any probe to finish.
 	contextProbeWg sync.WaitGroup
+
+	// probeMu protects consecutiveProbeFailures.
+	probeMu sync.Mutex
+	// consecutiveProbeFailures counts ambiguous probe failures while the
+	// KubernetesReady condition was True. Resets on any success or any
+	// decisive failure (Unreachable, Unhealthy). When the count reaches
+	// probeFailureThreshold, the reconciler flips Ready to Probing.
+	consecutiveProbeFailures int
+
+	// probeFn lets tests inject probe results without making real HTTP calls.
+	// Production wiring leaves it nil; Reconcile then calls probeK3sAPI.
+	probeFn func(ctx context.Context) (probeResult, error)
+}
+
+// probe dispatches to probeFn if injected (tests) or probeK3sAPI otherwise.
+func (r *KubernetesReconciler) probe(ctx context.Context) (probeResult, error) {
+	if r.probeFn != nil {
+		return r.probeFn(ctx)
+	}
+	return r.probeK3sAPI(ctx)
 }
 
 // Reconcile drives the KubernetesReady condition and ~/.kube/config lifecycle.
@@ -80,6 +129,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 
 	// When Kubernetes is disabled, stamp the condition and clean up.
 	if !app.Spec.Kubernetes.Enabled {
+		r.resetProbeFailures()
 		r.removeKubeContext(ctx)
 		return ctrl.Result{}, r.setKubeCondition(ctx, &app,
 			metav1.ConditionFalse,
@@ -90,6 +140,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 
 	// Kubernetes is enabled but the VM is not (yet) running.
 	if !running {
+		r.resetProbeFailures()
 		r.removeKubeContext(ctx)
 		return ctrl.Result{}, r.setKubeCondition(ctx, &app,
 			metav1.ConditionFalse,
@@ -99,10 +150,11 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 	}
 
 	// Probe the k3s API server from the instance kubeconfig.
-	healthy, err := r.probeK3sAPI(ctx)
+	result, err := r.probe(ctx)
 	if err != nil {
 		// kubeconfig missing or unreadable — k3s has not started yet.
 		log.V(1).Info("Cannot probe k3s API server", "err", err)
+		r.resetProbeFailures()
 		if condErr := r.setKubeCondition(ctx, &app,
 			metav1.ConditionFalse,
 			appv1alpha1.AppKubernetesReasonProbing,
@@ -112,8 +164,13 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 		}
 		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
 	}
-	if !healthy {
-		log.V(1).Info("k3s API server not yet healthy")
+
+	switch result {
+	case probeUnreachable, probeUnhealthy:
+		// Decisive failure: k3s is gone or said no. Flip immediately
+		// without smoothing so the user sees the state change promptly.
+		log.V(1).Info("k3s API server not yet healthy", "result", result)
+		r.resetProbeFailures()
 		if condErr := r.setKubeCondition(ctx, &app,
 			metav1.ConditionFalse,
 			appv1alpha1.AppKubernetesReasonProbing,
@@ -122,6 +179,35 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 			return ctrl.Result{}, condErr
 		}
 		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
+
+	case probeAmbiguous:
+		// Probe did not complete within kubeProbeTimeout. While Ready, treat
+		// the first probeFailureThreshold-1 ambiguous failures as transient
+		// (machine under heavy load, k3s temporarily slow) and only flip to
+		// Probing once the streak passes the threshold. During startup, the
+		// condition is not yet Ready, so report Probing immediately.
+		failures := r.incrementProbeFailures()
+		currentlyReady := apimeta.IsStatusConditionTrue(
+			app.Status.Conditions, appv1alpha1.AppConditionKubernetesReady)
+		if currentlyReady && failures < probeFailureThreshold {
+			log.V(1).Info("ambiguous probe failure tolerated",
+				"failures", failures, "threshold", probeFailureThreshold)
+			return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
+		}
+		log.V(1).Info("ambiguous probe failures crossed threshold",
+			"failures", failures, "threshold", probeFailureThreshold)
+		if condErr := r.setKubeCondition(ctx, &app,
+			metav1.ConditionFalse,
+			appv1alpha1.AppKubernetesReasonProbing,
+			"Waiting for k3s API server",
+		); condErr != nil {
+			return ctrl.Result{}, condErr
+		}
+		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
+
+	case probeHealthy:
+		r.resetProbeFailures()
+		// Fall through to manageKubeContext / setReady below.
 	}
 
 	// k3s is healthy — merge the context into ~/.kube/config.
@@ -136,27 +222,47 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
 	}
 
-	return ctrl.Result{}, r.setKubeCondition(ctx, &app,
+	// Requeue periodically so a later k3s death surfaces even if no other
+	// controller writes to App in the meantime. Without this, setKubeCondition
+	// is a no-op when Ready→Ready and there is nothing else to trigger a
+	// re-probe until the controller-runtime default resync (~10 min).
+	return ctrl.Result{RequeueAfter: kubeHealthyRequeue}, r.setKubeCondition(ctx, &app,
 		metav1.ConditionTrue,
 		appv1alpha1.AppKubernetesReasonReady,
 		"Kubernetes API server is ready",
 	)
 }
 
+// resetProbeFailures clears the ambiguous-failure streak counter.
+func (r *KubernetesReconciler) resetProbeFailures() {
+	r.probeMu.Lock()
+	r.consecutiveProbeFailures = 0
+	r.probeMu.Unlock()
+}
+
+// incrementProbeFailures bumps the ambiguous-failure streak counter and
+// returns the new value.
+func (r *KubernetesReconciler) incrementProbeFailures() int {
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+	r.consecutiveProbeFailures++
+	return r.consecutiveProbeFailures
+}
+
 // probeK3sAPI reads the instance kubeconfig from r.K3sConfigPath and GETs
-// /healthz on the k3s API server. Returns (false, err) when the kubeconfig
-// is unreadable, (false, nil) when the server is unhealthy, and (true, nil)
-// on success.
-func (r *KubernetesReconciler) probeK3sAPI(ctx context.Context) (bool, error) {
+// /healthz on the k3s API server. Returns an error only when the kubeconfig
+// cannot be loaded; otherwise the result classifies the outcome. See the
+// probeResult type for the meaning of each value.
+func (r *KubernetesReconciler) probeK3sAPI(ctx context.Context) (probeResult, error) {
 	kubeconfigPath := r.K3sConfigPath
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
-		return false, fmt.Errorf("read instance kubeconfig: %w", err)
+		return probeUnreachable, fmt.Errorf("read instance kubeconfig: %w", err)
 	}
 
 	cfg, err := clientcmd.RESTConfigFromKubeConfig(data)
 	if err != nil {
-		return false, fmt.Errorf("parse instance kubeconfig: %w", err)
+		return probeUnreachable, fmt.Errorf("parse instance kubeconfig: %w", err)
 	}
 
 	// Build a TLS-aware HTTP client from the REST config.
@@ -170,7 +276,7 @@ func (r *KubernetesReconciler) probeK3sAPI(ctx context.Context) (bool, error) {
 	if len(cfg.CertData) > 0 && len(cfg.KeyData) > 0 {
 		cert, err := tls.X509KeyPair(cfg.CertData, cfg.KeyData)
 		if err != nil {
-			return false, fmt.Errorf("load client cert: %w", err)
+			return probeUnreachable, fmt.Errorf("load client cert: %w", err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
@@ -183,7 +289,7 @@ func (r *KubernetesReconciler) probeK3sAPI(ctx context.Context) (bool, error) {
 
 	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, cfg.Host+"/healthz", http.NoBody)
 	if err != nil {
-		return false, fmt.Errorf("build healthz request: %w", err)
+		return probeUnreachable, fmt.Errorf("build healthz request: %w", err)
 	}
 	if cfg.BearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+cfg.BearerToken)
@@ -191,14 +297,31 @@ func (r *KubernetesReconciler) probeK3sAPI(ctx context.Context) (bool, error) {
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		logf.FromContext(ctx).V(1).Info("k3s healthz request failed", "url", cfg.Host+"/healthz", "err", err)
-		return false, nil
+		result := classifyProbeError(err)
+		logf.FromContext(ctx).V(1).Info("k3s healthz request failed",
+			"url", cfg.Host+"/healthz", "err", err, "result", result)
+		return result, nil
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		logf.FromContext(ctx).V(1).Info("k3s healthz returned non-200", "url", cfg.Host+"/healthz", "status", resp.StatusCode)
+		logf.FromContext(ctx).V(1).Info("k3s healthz returned non-200",
+			"url", cfg.Host+"/healthz", "status", resp.StatusCode)
+		return probeUnhealthy, nil
 	}
-	return resp.StatusCode == http.StatusOK, nil
+	return probeHealthy, nil
+}
+
+// classifyProbeError maps a transport-level failure from the healthz probe
+// to a probeResult. Only timeouts count as ambiguous; everything else is
+// treated as decisively unreachable so the reconciler reports the state
+// honestly without smoothing. That bucket covers ECONNREFUSED (k3s listener
+// gone), EOF or ECONNRESET (connection closed mid-request), DNS failures,
+// and any unrecognized transport error.
+func classifyProbeError(err error) probeResult {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, syscall.ETIMEDOUT) {
+		return probeAmbiguous
+	}
+	return probeUnreachable
 }
 
 // manageKubeContext merges the instance kubeconfig into ~/.kube/config and

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
@@ -8,10 +8,13 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -98,6 +101,19 @@ func newAppRunning() *appv1alpha1.App {
 	}
 }
 
+// newAppRunningKubeReady extends newAppRunning with a pre-existing
+// KubernetesReady=True condition, simulating an App that has already
+// observed a healthy k3s probe.
+func newAppRunningKubeReady() *appv1alpha1.App {
+	app := newAppRunning()
+	app.Status.Conditions = append(app.Status.Conditions, metav1.Condition{
+		Type:   appv1alpha1.AppConditionKubernetesReady,
+		Status: metav1.ConditionTrue,
+		Reason: appv1alpha1.AppKubernetesReasonReady,
+	})
+	return app
+}
+
 // newAppKubernetesDisabled builds an App with Kubernetes disabled and the
 // Running condition True, so Reconcile takes the NotApplicable branch.
 func newAppKubernetesDisabled() *appv1alpha1.App {
@@ -161,8 +177,8 @@ func Test_Reconcile_KubernetesReady_Ready(t *testing.T) {
 	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
 	result, err := r.Reconcile(context.Background(), req)
 	assert.NilError(t, err)
-	assert.Equal(t, result.RequeueAfter, time.Duration(0),
-		"Ready path should not request a requeue")
+	assert.Equal(t, result.RequeueAfter, kubeHealthyRequeue,
+		"Ready path should requeue after kubeHealthyRequeue so a later k3s death surfaces")
 
 	got := &appv1alpha1.App{}
 	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
@@ -309,7 +325,7 @@ func Test_Reconcile_KubernetesReady_Probing_ProbeError(t *testing.T) {
 func Test_Reconcile_KubernetesReady_Probing_Unhealthy(t *testing.T) {
 	dir := t.TempDir()
 	// fakeK3sServer answers /healthz with 500, so probeK3sAPI takes the
-	// (false, nil) "server reachable but unhealthy" path.
+	// probeUnhealthy "server reachable but said no" path.
 	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusInternalServerError)
 	isolateKubeconfig(t, dir)
 
@@ -339,4 +355,242 @@ func Test_Reconcile_KubernetesReady_Probing_Unhealthy(t *testing.T) {
 	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
 	assert.Equal(t, cond.Status, metav1.ConditionFalse)
 	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonProbing)
+}
+
+// Test_Reconcile_KubernetesReady_Unhealthy_FromReady_ImmediateFlip confirms
+// that a 5xx from k3s flips an already-Ready condition to Probing without
+// being smoothed by the ambiguous-failure counter. 5xx is k3s deliberately
+// reporting "not ready," not transient noise.
+func Test_Reconcile_KubernetesReady_Unhealthy_FromReady_ImmediateFlip(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusInternalServerError)
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunningKubeReady()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:        c,
+		K3sConfigPath: srcPath,
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	_, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonProbing)
+}
+
+// Test_Reconcile_KubernetesReady_Unreachable_ImmediateProbing confirms that a
+// connection-refused-class error flips to Probing immediately, with no
+// smoothing. Uses probeFn injection because httptest can't easily produce
+// ECONNREFUSED in a portable way.
+func Test_Reconcile_KubernetesReady_Unreachable_ImmediateProbing(t *testing.T) {
+	scheme := newKubeScheme(t)
+	app := newAppRunningKubeReady()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:  c,
+		probeFn: func(context.Context) (probeResult, error) { return probeUnreachable, nil },
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, kubeProbeRequeue)
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonProbing)
+}
+
+// Test_Reconcile_KubernetesReady_Ambiguous_TolerateWhileReady confirms that
+// ambiguous probe failures below the threshold keep an already-Ready
+// condition stable instead of immediately flipping to Probing.
+func Test_Reconcile_KubernetesReady_Ambiguous_TolerateWhileReady(t *testing.T) {
+	scheme := newKubeScheme(t)
+	app := newAppRunningKubeReady()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:  c,
+		probeFn: func(context.Context) (probeResult, error) { return probeAmbiguous, nil },
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	for i := 1; i < probeFailureThreshold; i++ {
+		result, err := r.Reconcile(context.Background(), req)
+		assert.NilError(t, err)
+		assert.Equal(t, result.RequeueAfter, kubeProbeRequeue,
+			"ambiguous failure %d should requeue at kubeProbeRequeue", i)
+
+		got := &appv1alpha1.App{}
+		assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+		cond := findKubeReady(got)
+		assert.Assert(t, cond != nil, "KubernetesReady condition missing after failure %d", i)
+		assert.Equal(t, cond.Status, metav1.ConditionTrue,
+			"condition should stay True until the threshold is reached (failure %d)", i)
+	}
+}
+
+// Test_Reconcile_KubernetesReady_Ambiguous_ReachThresholdFlipsToProbing
+// confirms that a streak of ambiguous failures crossing the threshold flips
+// the condition from Ready to Probing.
+func Test_Reconcile_KubernetesReady_Ambiguous_ReachThresholdFlipsToProbing(t *testing.T) {
+	scheme := newKubeScheme(t)
+	app := newAppRunningKubeReady()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:  c,
+		probeFn: func(context.Context) (probeResult, error) { return probeAmbiguous, nil },
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	for i := 1; i <= probeFailureThreshold; i++ {
+		_, err := r.Reconcile(context.Background(), req)
+		assert.NilError(t, err)
+	}
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonProbing)
+}
+
+// Test_Reconcile_KubernetesReady_Ambiguous_HealthyResetsCounter confirms that
+// a successful probe resets the streak counter: after one healthy reconcile,
+// the next ambiguous failure starts counting from 1 again rather than
+// continuing the previous streak.
+func Test_Reconcile_KubernetesReady_Ambiguous_HealthyResetsCounter(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunningKubeReady()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	// Switch probeFn between Ambiguous and the real probeK3sAPI (Healthy) to
+	// simulate a brief slow patch followed by recovery.
+	step := 0
+	r := &KubernetesReconciler{
+		Client:        c,
+		K3sConfigPath: srcPath,
+	}
+	r.probeFn = func(context.Context) (probeResult, error) {
+		step++
+		switch {
+		case step < probeFailureThreshold:
+			return probeAmbiguous, nil
+		case step == probeFailureThreshold:
+			return probeHealthy, nil
+		default:
+			return probeAmbiguous, nil
+		}
+	}
+	t.Cleanup(func() { r.removeKubeContext(context.Background()) })
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	// Run ambiguous streak just under threshold, then a healthy reconcile.
+	for range probeFailureThreshold {
+		_, err := r.Reconcile(context.Background(), req)
+		assert.NilError(t, err)
+	}
+	// Now ambiguous failures should start counting from zero again: the next
+	// probeFailureThreshold-1 reconciles should keep the condition Ready.
+	for i := 1; i < probeFailureThreshold; i++ {
+		_, err := r.Reconcile(context.Background(), req)
+		assert.NilError(t, err)
+
+		got := &appv1alpha1.App{}
+		assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+		cond := findKubeReady(got)
+		assert.Assert(t, cond != nil)
+		assert.Equal(t, cond.Status, metav1.ConditionTrue,
+			"counter should have reset on the healthy probe; ambiguous failure %d should still be tolerated", i)
+	}
+}
+
+// Test_Reconcile_KubernetesReady_Ambiguous_DuringStartupIsImmediate confirms
+// that ambiguous failures during startup (no prior Ready condition) flip to
+// Probing immediately, without waiting for the threshold. The smoothing only
+// applies to transitions away from Ready.
+func Test_Reconcile_KubernetesReady_Ambiguous_DuringStartupIsImmediate(t *testing.T) {
+	scheme := newKubeScheme(t)
+	app := newAppRunning() // no KubernetesReady condition yet
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:  c,
+		probeFn: func(context.Context) (probeResult, error) { return probeAmbiguous, nil },
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, kubeProbeRequeue)
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil)
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonProbing)
+}
+
+func Test_classifyProbeError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want probeResult
+	}{
+		{"context deadline", context.DeadlineExceeded, probeAmbiguous},
+		{"wrapped deadline", fmt.Errorf("get https://x/healthz: %w", context.DeadlineExceeded), probeAmbiguous},
+		{"syscall timeout", syscall.ETIMEDOUT, probeAmbiguous},
+		{"connection refused", syscall.ECONNREFUSED, probeUnreachable},
+		{"connection reset", syscall.ECONNRESET, probeUnreachable},
+		{"plain error", errors.New("dns lookup failed"), probeUnreachable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, classifyProbeError(tc.err), tc.want)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

The kubernetes-reconciler treated every healthz probe failure as "k3s is not ready," so a single 3s `context deadline exceeded` flipped Ready→Probing even when the next probe would have succeeded. The `bats-app` `kube-context` tests 112 and 113 straddled that flip in run #26480815405 on `macos-15-intel`: 112 read `.status` (saw True), the
reconciler's own-write rebound ran another probe that timed out, and 113 read `.reason` (saw "Probing").

This PR classifies probe failures into three kinds and smooths only the genuinely ambiguous ones:

- **Unreachable** (ECONNREFUSED, EOF, ECONNRESET, unrecognized transport error) — k3s is gone. Flip immediately.

- **Unhealthy** (HTTP non-200) — k3s explicitly said "not ready." Flip immediately.

- **Ambiguous** (request did not complete within `kubeProbeTimeout`) — could be load, could be wedged, can't tell from one sample. Only this category is smoothed: while Ready, the reconciler tolerates up to `probeFailureThreshold=3` consecutive ambiguous failures (~15s total) before flipping to Probing. Any success or any decisive failure resets the counter. During startup the condition is not yet True, so the first Ambiguous failure flips immediately.

The shape mirrors the kubelet readiness-probe model (single success flips Ready, N failures flip NotReady) but adds error classification so deliberate k3s stops surface immediately rather than being smoothed for 15s. Rancher Desktop is interactive — a user who just stopped k3s shouldn't sit through a smoothing window when the controller can tell the difference from the failure mode itself.

Also adds an explicit `RequeueAfter=kubeHealthyRequeue=15s` on the healthy path. Without it, `setKubeCondition` is a no-op when Ready→Ready and nothing else would trigger a re-probe until the controller-runtime default resync (~10 min), so a later k3s death would go unnoticed.
