### PR TITLE
Add string function to probeResults

### DIFF
--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -40,6 +40,21 @@ const (
 	kubeProbeRequeue = 5 * time.Second
 )
 
+func (r probeResult) String() string {
+	switch r {
+	case probeHealthy:
+		return "Healthy"
+	case probeUnreachable:
+		return "Unreachable"
+	case probeUnhealthy:
+		return "Unhealthy"
+	case probeAmbiguous:
+		return "Ambiguous"
+	default:
+		return fmt.Sprintf("probeResult(%d)", int(r))
+	}
+}
+
 // KubernetesReconciler watches the App resource and manages the
 // rancher-desktop-{instance} context in ~/.kube/config.
 type KubernetesReconciler struct {


### PR DESCRIPTION
Add `String()` method to `probeResult`, making the logs more readable by implementing the stringer interface.
Before: 
```
"result": 1
```    
After: 
```
"result": "Unreachable"
```