### PR TITLE
Add Stringer to `probeResult` to improve output

### DIFF
--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -69,6 +69,21 @@ const (
 	probeAmbiguous                      // request did not complete within kubeProbeTimeout
 )
 
+func (r probeResult) String() string {
+	switch r {
+	case probeHealthy:
+		return "Healthy"
+	case probeUnreachable:
+		return "Unreachable"
+	case probeUnhealthy:
+		return "Unhealthy"
+	case probeAmbiguous:
+		return "Ambiguous"
+	default:
+		return fmt.Sprintf("probeResult(%d)", int(r))
+	}
+}
+
 // KubernetesReconciler watches the App resource and manages the
 // rancher-desktop-{instance} context in ~/.kube/config.
 type KubernetesReconciler struct {


### PR DESCRIPTION
Add `String()` method to `probeResult`, making the logs more readable by implementing the stringer interface.
Before: 
```
"result": 1
```    
After: 
```
"result": "Unreachable"
```