### PR TITLE
Raise kube-context KubernetesReady timeout to 900s

### DIFF
--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -25,7 +25,10 @@ local_setup_file() {
 
     rdd svc delete
     rdd set --wait=false running=true kubernetes.enabled=true kubernetes.version="${K3S_VERSION}"
-    rdd ctl wait --for=condition=KubernetesReady app/"${APP_NAME}" --timeout=360s
+    # VM boot plus k3s startup can run several minutes on a slow CI runner, so
+    # allow up to 900s to match app.bats. The outer bats-with-timeout still caps
+    # the overall suite.
+    rdd ctl wait --for=condition=KubernetesReady app/"${APP_NAME}" --timeout=900s
 }
 
 kube_current_context() {
@@ -135,7 +138,8 @@ kube_current_context_is() { # <expected-context>
 
 @test "re-enable kubernetes to set up cleanup test" {
     rdd set --wait=false running=true kubernetes.enabled=true kubernetes.version="${K3S_VERSION}"
-    rdd ctl wait --for=condition=KubernetesReady app/"${APP_NAME}" --timeout=360s
+    # Allow 900s for VM boot plus k3s startup on a slow CI runner (see local_setup_file).
+    rdd ctl wait --for=condition=KubernetesReady app/"${APP_NAME}" --timeout=900s
 }
 
 @test "current-context is set again after re-enabling kubernetes" {


### PR DESCRIPTION
## Problem

`kube-context.bats` gave VM boot plus k3s startup only 360s to reach `KubernetesReady`. On a slow `macos-15-intel` CI runner that budget runs out. In one [failed run](https://github.com/rancher-sandbox/rancher-desktop-daemon/actions/runs/26538063229/job/78172142937) the `local_setup_file` wait expired at 361s while k3s was still bootstrapping in the guest (cri-dockerd, kubelet, and kube-proxy were all still coming up), which aborted the whole file and skipped 13 tests. A re-run passed.

## Fix

Raise both `--timeout=360s` waits to `900s`, matching `app.bats`, whose "start VM with Kubernetes enabled" test already gives the same VM-boot-plus-k3s operation 900s for exactly this reason. The outer `bats-with-timeout.sh 2700` still caps the overall suite.