### PR TITLE
Add rdd start and rdd stop subcommands

### DIFF
--- a/bats/tests/32-app-controllers/start-stop.bats
+++ b/bats/tests/32-app-controllers/start-stop.bats
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# Tests for `rdd start` and `rdd stop`. Both are thin wrappers around
+# `rdd set running=true|false`, so this suite focuses on what is unique
+# to them: rdd stop short-circuits when the App is absent rather than
+# creating it. Like set.bats, this runs with only the app controller
+# (no lima, no engine), and uses --wait=false so the patches return
+# without waiting on a Settled condition that never fires.
+
+APP_NAME="app"
+
+local_setup_file() {
+    setup_rdd_control_plane "app"
+    rdd ctl delete app "${APP_NAME}" --ignore-not-found
+    rdd ctl wait --for=delete app/"${APP_NAME}" --timeout=30s 2>/dev/null || true
+}
+
+# --- Help (no App needed) ---
+
+@test "rdd start --help shows usage" {
+    run -0 rdd start --help
+    assert_output --partial "Start"
+    assert_output --partial "--wait"
+    assert_output --partial "--timeout"
+}
+
+@test "rdd stop --help shows usage" {
+    run -0 rdd stop --help
+    assert_output --partial "Stop"
+    assert_output --partial "--wait"
+    assert_output --partial "--timeout"
+}
+
+# --- Short-circuit: rdd stop on missing App ---
+
+@test "rdd stop succeeds when App is absent without creating it" {
+    run -1 rdd ctl get app "${APP_NAME}"
+    assert_output --partial "not found"
+
+    run -0 rdd stop
+    assert_output --partial "does not exist"
+
+    # rdd stop must not provision the App as a side effect.
+    run -1 rdd ctl get app "${APP_NAME}"
+    assert_output --partial "not found"
+}
+
+# --- rdd start creates the App with running=true ---
+
+@test "rdd start creates App with running=true" {
+    rdd start --wait=false
+
+    run -0 rdd ctl get app "${APP_NAME}" -o jsonpath='{.metadata.name}'
+    assert_output "${APP_NAME}"
+
+    run -0 rdd ctl get app "${APP_NAME}" -o jsonpath='{.spec.running}'
+    assert_output "true"
+}
+
+# --- rdd stop patches existing App to running=false ---
+
+@test "rdd stop patches existing App to running=false" {
+    run -0 rdd ctl get app "${APP_NAME}" -o jsonpath='{.spec.running}'
+    assert_output "true"
+
+    rdd stop --wait=false
+
+    run -0 rdd ctl get app "${APP_NAME}" -o jsonpath='{.spec.running}'
+    assert_output "false"
+}

--- a/cmd/rdd/app.go
+++ b/cmd/rdd/app.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/help"
+)
+
+func newStartCommand() *cobra.Command {
+	var (
+		wait    bool
+		timeout time.Duration
+	)
+	command := &cobra.Command{
+		Use:   "start",
+		Short: "Start Rancher Desktop",
+		Long: help.Doc(`
+			Start Rancher Desktop, which provides a container engine
+			and, when Kubernetes is enabled, a Kubernetes cluster with
+			its context merged into ~/.kube/config.
+
+			By default, rdd start waits until Rancher Desktop is ready
+			to use. Pass --wait=false to return as soon as the request
+			is queued, or --timeout=0 to wait indefinitely.
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return setAction(cmd.Context(), []string{"running=true"}, false, wait, timeout)
+		},
+	}
+	command.Flags().BoolVar(&wait, "wait", true,
+		"Wait until Rancher Desktop is ready before returning")
+	command.Flags().DurationVar(&timeout, "timeout", 300*time.Second,
+		"Timeout for waiting (0 to wait indefinitely)")
+	return command
+}
+
+func newStopCommand() *cobra.Command {
+	var (
+		wait    bool
+		timeout time.Duration
+	)
+	command := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop Rancher Desktop",
+		Long: help.Doc(`
+			Stop Rancher Desktop.
+
+			By default, rdd stop waits until Rancher Desktop has fully
+			shut down. Pass --wait=false to return as soon as the
+			request is queued, or --timeout=0 to wait indefinitely.
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return stopAction(cmd.Context(), wait, timeout)
+		},
+	}
+	command.Flags().BoolVar(&wait, "wait", true,
+		"Wait until Rancher Desktop has shut down before returning")
+	command.Flags().DurationVar(&timeout, "timeout", 300*time.Second,
+		"Timeout for waiting (0 to wait indefinitely)")
+	return command
+}
+
+// stopAction short-circuits when the App does not exist; otherwise it
+// delegates to setAction so the wait semantics match `rdd set`.
+func stopAction(ctx context.Context, wait bool, timeout time.Duration) error {
+	c, _, err := getAppKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+	var app appv1alpha1.App
+	if err := c.Get(ctx, client.ObjectKey{Name: "app"}, &app); err != nil {
+		if apierrors.IsNotFound(err) {
+			logrus.Info("App does not exist; nothing to stop")
+			return nil
+		}
+		return fmt.Errorf("failed to get App: %w", err)
+	}
+	return setAction(ctx, []string{"running=false"}, false, wait, timeout)
+}

--- a/cmd/rdd/main.go
+++ b/cmd/rdd/main.go
@@ -163,6 +163,8 @@ func main() {
 		newKubectlCommand(),
 		newServiceCommand(context.Background()),
 		newSetCommand(),
+		newStartCommand(),
+		newStopCommand(),
 		newVersionCommand(),
 	)
 	if err := cli.RunNoErrOutput(cmd); err != nil {

--- a/docs/design/api_app.md
+++ b/docs/design/api_app.md
@@ -8,7 +8,7 @@ The `App` object is part of the `app.rancherdesktop.io` API group.
 
 There can be only a single `App` object in an RDD instance. It is **cluster-scoped** and must be named `app`.
 
-Both the [rdd create](cmd_app.md#rdd-create) command and the [GUI](gui.md) app create the cluster-scoped `App` object, setting its `spec.namespace` to the configured "app-namespace" stored in the `config` ConfigMap in the `rdd-system` namespace (`rancher-desktop` by default)[^hardcoded].
+Both the [rdd start](cmd_app.md#rdd-start) command and the [GUI](gui.md) app create the cluster-scoped `App` object, setting its `spec.namespace` to the configured "app-namespace" stored in the `config` ConfigMap in the `rdd-system` namespace (`rancher-desktop` by default)[^hardcoded].
 
 [^hardcoded]: The "app-namespace" is only configurable so that it can be tested that the namespace isn't hardcoded anywhere in the controller.
 

--- a/docs/design/cmd_app.md
+++ b/docs/design/cmd_app.md
@@ -41,20 +41,13 @@ rdd set --wait=false running=true
 
 `2` is reserved for cobra usage errors. Other rdd commands will adopt the same scheme as they grow `--wait` semantics; the codes are defined in `pkg/cli/exit`.
 
-## `rdd create`
-
-
 ## `rdd start`
 
-```bash
-rdd ctl patch app app --type=merge -p '{"spec":{"running":true}}'
-```
+Start Rancher Desktop by setting `running=true` on the App singleton, creating the App with default settings if it does not yet exist. This is shorthand for `rdd set running=true`, sharing its `--wait`, `--timeout`, and exit-code behavior.
 
 ## `rdd stop`
 
-```bash
-rdd ctl patch app app --type=merge -p '{"spec":{"running":false}}'
-```
+Stop Rancher Desktop by setting `running=false` on the App singleton. If the App does not exist, `rdd stop` returns successfully without creating it. Otherwise it behaves like `rdd set running=false`, sharing the same `--wait` and `--timeout` flags.
 
 
 ## `rdd delete`


### PR DESCRIPTION
- Add `rdd start` and `rdd stop` as thin wrappers around `setAction`. `rdd start` patches `spec.running=true` (auto-creating the App); `rdd stop` patches `spec.running=false` and short-circuits when the App is absent rather than creating it.

- Drop the empty `rdd create` stub from `docs/design/cmd_app.md`; `setAction` already creates the App on first call.

- Cover the unique branches in `bats/tests/32-app-controllers/start-stop.bats`.
