### PR TITLE
Show progress during control-plane startup and rdd set

### DIFF
--- a/bats/tests/20-service/2-create.bats
+++ b/bats/tests/20-service/2-create.bats
@@ -37,10 +37,10 @@ load '../../helpers/load'
 @test 'start instance' {
     run -0 rdd svc start
     run -0 extract_msg
-    assert_output <<EOT
-successfully started "rancher-desktop-${RDD_INSTANCE}" control plane
-waiting for "rancher-desktop-${RDD_INSTANCE}" control plane to be ready
-EOT
+    # The phase lines between these bookends (waiting for API server, etc.)
+    # depend on poll timing, so assert only the stable start and ready lines.
+    assert_line "starting \"rancher-desktop-${RDD_INSTANCE}\" control plane"
+    assert_line "\"rancher-desktop-${RDD_INSTANCE}\" control plane is ready"
 }
 
 @test 'verify instance has been started' {

--- a/cmd/rdd/service.go
+++ b/cmd/rdd/service.go
@@ -108,6 +108,7 @@ func startAndWaitForReady(ctx context.Context, serveArgs []string) error {
 	if err := service.Start(ctx, serveArgs); err != nil {
 		return err
 	}
+	logrus.Infof("starting %q control plane", instance.Name())
 
 	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()

--- a/cmd/rdd/set.go
+++ b/cmd/rdd/set.go
@@ -481,10 +481,57 @@ func waitForDesiredState(ctx context.Context, config *rest.Config, timeout time.
 	defer cancel()
 
 	logrus.Info("Waiting for App to settle")
+	reporter := newConditionReporter(minGen)
 	return watchCondition(ctx, config, func(obj *unstructured.Unstructured) bool {
+		// Surface reconcile progress: log each App condition as its
+		// status, reason, or message changes while we wait.
+		reporter.report(obj)
 		status, gen, present := conditionInfo(obj, appv1alpha1.AppConditionSettled)
 		return present && gen >= minGen && status == metav1.ConditionTrue
 	})
+}
+
+// conditionReporter logs App status condition changes as they happen, so
+// `rdd set --wait` shows reconcile progress instead of blocking silently. It
+// reports only conditions observed at or after the target generation, so the
+// output tracks this change rather than a stale snapshot from an earlier spec
+// version — the same generation filter waitForDesiredState applies to Settled.
+type conditionReporter struct {
+	minGen int64
+	seen   map[string]string
+}
+
+func newConditionReporter(minGen int64) *conditionReporter {
+	return &conditionReporter{minGen: minGen, seen: make(map[string]string)}
+}
+
+// report logs each App condition at or after the target generation whose
+// status, reason, or message changed since the last snapshot.
+func (r *conditionReporter) report(obj *unstructured.Unstructured) {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		observedGen, _, _ := unstructured.NestedInt64(cond, "observedGeneration")
+		if observedGen < r.minGen {
+			continue // Stale snapshot from an earlier spec version.
+		}
+		condType, _ := cond["type"].(string)
+		status, _ := cond["status"].(string)
+		reason, _ := cond["reason"].(string)
+		message, _ := cond["message"].(string)
+		key := status + "|" + reason + "|" + message
+		if r.seen[condType] == key {
+			continue
+		}
+		r.seen[condType] = key
+		logrus.Infof("%s=%s: %s (%s)", condType, status, message, reason)
+	}
 }
 
 // watchCondition watches the App singleton until the predicate

--- a/pkg/apis/app/v1alpha1/app_types.go
+++ b/pkg/apis/app/v1alpha1/app_types.go
@@ -20,6 +20,11 @@ const EngineControllerName = "engine"
 const KubernetesControllerName = "kubernetes"
 
 // App condition types.
+//
+// Load-bearing invariant: every condition written to App status must stamp
+// ObservedGeneration with the App's generation. `rdd set` filters conditions
+// by generation, both to wait on a fresh Settled and to report reconcile
+// progress, so an unstamped condition reads as stale and never appears.
 const (
 	// AppConditionRunning mirrors the LimaVM Running condition: True
 	// means the Lima guest has finished booting and SSH is reachable.

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -289,15 +289,42 @@ func Start(ctx context.Context, args []string) error {
 	return cmd.Start()
 }
 
-// checkReadiness performs a single readiness check.
-func checkReadiness(ctx context.Context) error {
+// startupPhase identifies the control-plane startup stage the readiness
+// check is waiting on, so callers can report progress as the phase advances.
+type startupPhase int
+
+const (
+	phaseAPIServer startupPhase = iota
+	phaseControllers
+	phaseCRDs
+)
+
+// String returns the user-facing progress message for the phase.
+func (p startupPhase) String() string {
+	switch p {
+	case phaseAPIServer:
+		return "waiting for API server"
+	case phaseControllers:
+		return "waiting for controllers to register"
+	case phaseCRDs:
+		return "waiting for CRDs to be established"
+	default:
+		return ""
+	}
+}
+
+// checkReadiness performs a single readiness check, reporting via onPhase the
+// phase it ends up waiting on.
+func checkReadiness(ctx context.Context, onPhase func(startupPhase)) error {
 	config, err := GetKubeRestConfig()
 	if err != nil {
+		onPhase(phaseAPIServer)
 		klog.V(2).Infof("Waiting for kubeconfig to be available: %v", err)
 		return err
 	}
 
 	if err := checkSupportedVersion(config); err != nil {
+		onPhase(phaseAPIServer)
 		klog.V(2).Infof("%v", err)
 		return err
 	}
@@ -305,6 +332,7 @@ func checkReadiness(ctx context.Context) error {
 	// Wait for the controller manager to register with the actual running controllers
 	runtimeControllers, err := getRuntimeControllersFromCluster(ctx, config)
 	if err != nil {
+		onPhase(phaseControllers)
 		klog.V(2).Infof("getRuntimeControllersFromCluster: %v", err)
 		return err
 	}
@@ -312,10 +340,12 @@ func checkReadiness(ctx context.Context) error {
 	if runtimeControllers == nil {
 		// Discovery ConfigMap doesn't exist yet; the serve subprocess hasn't
 		// finished initializing. Keep polling.
+		onPhase(phaseControllers)
 		klog.V(2).Info("Discovery configmap not found yet - waiting for control plane initialization")
 		return errors.New("waiting for controller manager registration")
 	}
 
+	onPhase(phaseCRDs)
 	if len(runtimeControllers) == 0 {
 		// ConfigMap exists but no controllers are registered.
 		klog.V(2).Info("No controllers registered - checking API server readiness")
@@ -355,8 +385,20 @@ func checkReadiness(ctx context.Context) error {
 
 // Wait until the control plane is ready or the context is cancelled.
 func Wait(ctx context.Context) error {
-	if err := checkReadiness(ctx); err == nil {
+	// Fast path: stay silent when the control plane is already ready.
+	if err := checkReadiness(ctx, func(startupPhase) {}); err == nil {
 		return nil
+	}
+
+	// Log each startup phase once, as it becomes the phase we wait on.
+	// Phases only advance, so a transient regression does not re-log an
+	// earlier phase.
+	lastPhase := startupPhase(-1)
+	reportPhase := func(p startupPhase) {
+		if p > lastPhase {
+			lastPhase = p
+			logrus.Info(p.String())
+		}
 	}
 
 	ticker := time.NewTicker(500 * time.Millisecond)
@@ -367,7 +409,7 @@ func Wait(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			err := checkReadiness(ctx)
+			err := checkReadiness(ctx, reportPhase)
 			if err == nil {
 				return nil
 			} else if errors.As(err, &errorServerVersionUnsupported{}) {


### PR DESCRIPTION
## Summary

`rdd svc start` and `rdd set` waited silently through their slow paths and printed only a final line. Both now report progress as it happens.

```console
❯ rdd set running=true
INFO[0000] starting "rancher-desktop-2" control plane
INFO[0000] waiting for API server
INFO[0001] waiting for CRDs to be established
INFO[0008] App created
INFO[0008] Waiting for App to settle
INFO[0012] Created: Lima instance created successfully (Created)
INFO[0012] Settled: LimaVM has not yet reached Started (Reconciling)
INFO[0012] Running: Verifying instance state after controller restart (Reconciling)
INFO[0012] Settled: LimaVM has not yet reached Started (Starting)
INFO[0012] Running: Lima instance is starting (Starting)
INFO[0029] Settled: Container engine stopped (Stopped)
INFO[0029] Running: Lima instance is running (Started)
INFO[0029] ContainerEngineReady: Container engine synced (Connected)
INFO[0029] Settled: App has reached the desired state (Settled)

❯ rdd set kubernetes.enabled=true kubernetes.version=1.32.3
INFO[0000] App updated
INFO[0000] Waiting for App to settle
INFO[0000] ContainerEngineReady: Container engine synced (Connected)
INFO[0000] KubernetesReady: Waiting for k3s API server (Probing)
INFO[0000] Created: Lima instance created successfully (Created)
INFO[0000] Settled: Waiting for k3s API server (Probing)
INFO[0000] Running: Lima instance is running (Started)
INFO[0000] ContainerEngineReady: failed to ping Docker: failed to connect to the docker API at unix:///Users/jan/.rd2/docker.sock; check if the path is correct and if the daemon is running: dial unix /Users/jan/.rd2/docker.sock: connect: no such file or directory (ConnectFailed)
INFO[0000] Settled: failed to ping Docker: failed to connect to the docker API at unix:///Users/jan/.rd2/docker.sock; check if the path is correct and if the daemon is running: dial unix /Users/jan/.rd2/docker.sock: connect: no such file or directory (ConnectFailed)
INFO[0002] Settled: LimaVM has not yet reached Started (Stopped)
INFO[0002] Running: Stopped for restart (Stopped)
INFO[0002] KubernetesReady: VM is not running (NotRunning)
INFO[0002] Settled: LimaVM has not yet reached Started (Reconciling)
INFO[0002] Running: Verifying instance state after controller restart (Reconciling)
INFO[0002] Settled: LimaVM has not yet reached Started (Starting)
INFO[0002] Running: Lima instance is starting (Starting)
INFO[0002] ContainerEngineReady: Container engine stopped (Stopped)
INFO[0024] Settled: Container engine stopped (Stopped)
INFO[0024] Running: Lima instance is running (Started)
INFO[0024] KubernetesReady: Kubernetes API server is ready (Ready)
INFO[0024] ContainerEngineReady: Container engine synced (Connected)
INFO[0024] Settled: App has reached the desired state (Settled)
```

Log messages are at INFO level, so don't show unless developer mode is true, or the log level has explicitly been set to INFO or lower.

We can change the formatting later, and maybe filter some updates, but for now I like to see the individual transitions.