### PR TITLE
Verify process identity before trusting a recycled PID on Windows

### DIFF
--- a/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
+++ b/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
@@ -200,13 +200,24 @@ func (r *LimaVMReconciler) waitForProcessExit(ctx context.Context, name string) 
 // signalHostagent sends a graceful shutdown signal to the hostagent process.
 // Uses process.Interrupt which sends SIGINT on Unix and CTRL_BREAK on Windows
 // (targeted at the hostagent's process group, not the parent).
-// Returns false if no watcher exists or the signal could not be delivered.
+// Returns false if no watcher exists, the process has already been reaped (its
+// PID may be reused on Windows), or the signal could not be delivered.
 func (r *LimaVMReconciler) signalHostagent(name string) bool {
 	r.instanceStatesMu.RLock()
 	state, ok := r.instanceStates[name]
 	r.instanceStatesMu.RUnlock()
 	if !ok || state.cmd == nil || state.cmd.Process == nil {
 		return false
+	}
+	// Once procExited is closed, cmd.Wait() has released the OS process handle
+	// and the PID may be reused; signalling it could deliver CTRL_BREAK to an
+	// unrelated console process on Windows. While it is open the handle is
+	// normally still held; cmd.Wait() releases it just before closing the
+	// channel, leaving a brief window.
+	select {
+	case <-state.procExited:
+		return false
+	default:
 	}
 	return process.Interrupt(state.cmd.Process.Pid) == nil
 }

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -215,7 +215,13 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		existingInst, err := store.Inspect(ctx, limaVM.Name)
 		if err == nil && existingInst != nil {
 			logger.Info("Deleting leftover Lima instance", "instance", limaVM.Name)
-			if err := limainstance.Delete(ctx, existingInst, true); err != nil {
+			forceStopForDeletion(ctx, logger, existingInst)
+			// Use a timeout because Lima's WSL2 driver calls wsl.exe --unregister
+			// which can hang indefinitely if the WSL subsystem is degraded.
+			deleteCtx, deleteCancel := context.WithTimeout(ctx, time.Minute)
+			err := limainstance.Delete(deleteCtx, existingInst, true)
+			deleteCancel()
+			if err != nil {
 				logger.Error(err, "Failed to delete leftover Lima instance")
 				return ctrl.Result{}, err
 			}
@@ -507,11 +513,23 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 		return
 	}
 
-	// Send graceful shutdown signal to all hostagents in parallel.
+	// Send graceful shutdown signal to all hostagents in parallel. Skip any whose
+	// process has already been reaped: once cmd.Wait() closes procExited it has
+	// released the OS process handle, freeing the PID for reuse. On Windows a
+	// CTRL_BREAK to a recycled PID escapes to the console and kills the service
+	// and terminal. While procExited is open the handle is normally still held,
+	// so the PID is still ours; cmd.Wait() releases it just before closing the
+	// channel, leaving a brief window.
 	for _, state := range states {
-		if state.cmd != nil && state.cmd.Process != nil {
-			_ = process.Interrupt(state.cmd.Process.Pid)
+		if state.cmd == nil || state.cmd.Process == nil {
+			continue
 		}
+		select {
+		case <-state.procExited:
+			continue
+		default:
+		}
+		_ = process.Interrupt(state.cmd.Process.Pid)
 	}
 
 	// Wait for each hostagent process to exit. The watcher goroutine may finish

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -47,34 +47,7 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 		logger.Error(err, "Failed to inspect Lima instance for deletion")
 	}
 	if existingInst != nil {
-		// Only use PID-based force-stop for Running instances. Broken
-		// instances may have stale PID files pointing to recycled processes
-		// on Windows (Lima's ReadPIDFile treats any live PID as valid).
-		// Not tested: simulating stale PID files requires Windows-specific
-		// PID file manipulation that BATS cannot easily reproduce.
-		if existingInst.Status == limatype.StatusRunning {
-			stopInstanceForcibly(ctx, logger, existingInst)
-		} else if existingInst.VMType == limatype.WSL2 {
-			// A "stopped" WSL2 distro can retain kernel state that deadlocks
-			// wsl.exe --unregister. Terminate it without PID-based killing,
-			// since the PIDs may have been recycled on Windows.
-			terminateWSL2Distro(ctx, logger, existingInst.Name)
-		}
-		if runtime.GOOS == "windows" {
-			// Clear PIDs so Lima's Delete → StopForcibly does not kill
-			// unrelated processes if the PIDs were recycled. Windows recycles
-			// PIDs aggressively, and Lima's ReadPIDFile treats any live PID
-			// as valid. On Unix, PID recycling is rare (wraps around 32768+),
-			// so we let Lima's Delete clean up any surviving driver processes.
-			//
-			// This disables Lima's internal kill retry even if stopInstanceForcibly
-			// failed above. That is intentional: a failed kill means KillTree
-			// could not reach the process (access denied, already reaped), and
-			// the PID may already be recycled. Retrying with a stale PID is
-			// worse than letting Delete proceed without a kill.
-			existingInst.DriverPID = 0
-			existingInst.HostAgentPID = 0
-		}
+		forceStopForDeletion(ctx, logger, existingInst)
 		preserveInstanceLogs(ctx, existingInst)
 		logger.Info("Deleting Lima instance", "instance", limaVM.Name)
 		// Use a timeout because Lima's WSL2 driver calls wsl.exe --unregister
@@ -222,18 +195,22 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 		// The VM driver (e.g., QEMU) may outlive the hostagent. Force-stop
 		// the instance so the next hostagent can start with a clean slate.
 		//
-		// On Windows, StatusBroken instances may have stale PID files whose
-		// PIDs were recycled to unrelated processes. stopInstanceForcibly
-		// uses taskkill, which kills by PID without verifying the process
-		// identity. The deletion path (handleDeletion) guards against this
-		// by skipping PID-based kills for StatusBroken, but this path does
-		// not — the self-healing restart that follows limits the blast
-		// radius. The proper fix is to validate process identity (e.g.,
-		// check executable name) before killing, or use Windows Job Objects
-		// to track child processes without relying on PID files.
+		// On Windows the on-disk HostAgentPID may have been recycled to an
+		// unrelated process after the hostagent exited, so clear it unless
+		// IsOurProcess confirms it is still ours; the force path's taskkill
+		// would otherwise reach whatever now holds it. DriverPID is taskkilled
+		// without that check — IsOurProcess matches the rdd image, not the
+		// qemu/wsl driver — so a recycled DriverPID would be killed here.
+		// handleDeletion zeroes DriverPID on Windows; a restart cannot, because
+		// the orphaned driver must die. Job Objects, not PID files, are the
+		// proper fix.
 		if inst.Status == limatype.StatusRunning || inst.Status == limatype.StatusBroken {
 			logger.Info("Force-stopping orphaned VM driver", "status", inst.Status)
-			stopInstanceForcibly(ctx, logger, inst)
+			forceInst := *inst
+			if inst.HostAgentPID > 0 && !process.IsOurProcess(inst.HostAgentPID, "hostagent", inst.Name) {
+				forceInst.HostAgentPID = 0
+			}
+			stopInstanceForcibly(ctx, logger, &forceInst)
 		}
 		return r.startInstance(ctx, limaVM, inst)
 
@@ -295,7 +272,8 @@ func (r *LimaVMReconciler) handleUnwatchedState(ctx context.Context, limaVM *v1a
 	case limatype.StatusRunning, limatype.StatusBroken:
 		// Orphaned hostagent from before controller restart. Kill it so the
 		// next reconcile can start with a watcher.
-		// Same PID recycling caveat as handleWatchedState (see comment above).
+		// killOrphanedHostagent guards the recycled HostAgentPID before signalling
+		// or taskkill, as handleWatchedState does.
 		logger.Info("Found orphaned hostagent, killing it", "status", inst.Status)
 		if err := r.killOrphanedHostagent(ctx, inst); err != nil {
 			logger.Error(err, "Failed to kill orphaned hostagent")
@@ -559,7 +537,17 @@ func (r *LimaVMReconciler) shutdownHostagent(ctx context.Context, name string, i
 				return
 			}
 		}
-		stopInstanceForcibly(forceCtx, logger, forceInst)
+		// forceStop runs after signalHostagent declines (no watcher, or the
+		// process was already reaped) or after a signalled hostagent ignores the
+		// graceful timeout. In the reaped case the stored HostAgentPID may already
+		// be recycled on Windows, so confirm identity before taskkill, as the
+		// other force-stop paths do. DriverPID is not verifiable here —
+		// IsOurProcess matches only the rdd image — so it is taskkilled unchecked.
+		safeInst := *forceInst
+		if safeInst.HostAgentPID > 0 && !process.IsOurProcess(safeInst.HostAgentPID, "hostagent", safeInst.Name) {
+			safeInst.HostAgentPID = 0
+		}
+		stopInstanceForcibly(forceCtx, logger, &safeInst)
 	}
 
 	// After forced termination, wait briefly for the process to exit.
@@ -599,7 +587,18 @@ func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *lima
 	// Try graceful shutdown: signal the hostagent and wait for the instance
 	// to become stopped. The hostagent's own shutdown sequence handles driver
 	// termination, WSL2 distro cleanup, and tmp file removal.
-	if inst.HostAgentPID > 0 {
+	//
+	// HostAgentPID comes from on-disk state written by a previous service, so
+	// on Windows it may have been recycled to an unrelated process. IsOurProcess
+	// confirms it is still our hostagent before signalling. When it is not ours,
+	// clear it from the forced-stop copy below as well: the force path would
+	// otherwise taskkill whatever now holds the recycled PID. DriverPID is
+	// taskkilled without that check — IsOurProcess matches the rdd image, not
+	// the qemu/wsl driver — so a recycled DriverPID would be killed here.
+	// handleDeletion zeroes DriverPID on Windows; a restart cannot, because the
+	// orphaned driver must die. Job Objects, not PID files, are the proper fix.
+	forceInst := *inst
+	if inst.HostAgentPID > 0 && process.IsOurProcess(inst.HostAgentPID, "hostagent", inst.Name) {
 		if err := process.Interrupt(inst.HostAgentPID); err != nil {
 			logger.V(1).Info("Could not signal orphaned hostagent", "pid", inst.HostAgentPID, "error", err)
 		} else {
@@ -611,9 +610,11 @@ func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *lima
 			}
 			logger.Info("Orphaned hostagent did not exit gracefully, forcing stop")
 		}
+	} else {
+		forceInst.HostAgentPID = 0
 	}
 
-	stopInstanceForcibly(ctx, logger, inst)
+	stopInstanceForcibly(ctx, logger, &forceInst)
 	return nil
 }
 
@@ -635,6 +636,46 @@ func waitForInstanceStopped(ctx context.Context, name string) bool {
 				return true
 			}
 		}
+	}
+}
+
+// forceStopForDeletion stops a Lima instance in preparation for a forced Delete
+// and, on Windows, clears its on-disk PIDs so Lima's Delete → StopForcibly
+// cannot send CTRL_BREAK to a process that recycled a stale PID.
+//
+// Only Running instances are force-stopped by PID. Broken instances may have
+// stale PID files pointing to recycled processes on Windows (Lima's ReadPIDFile
+// treats any live PID as valid). Not tested: simulating stale PID files requires
+// Windows-specific PID file manipulation that BATS cannot easily reproduce.
+//
+// Clearing the PIDs on Windows disables Lima's internal kill retry even if
+// stopInstanceForcibly failed above. That is intentional: a failed kill means
+// KillTree could not reach the process (access denied, already reaped), and the
+// PID may already be recycled. Retrying with a stale PID is worse than letting
+// Delete proceed without a kill. On Unix, PID recycling is rare (wraps around
+// 32768+), so Lima's Delete may clean up any surviving driver processes.
+func forceStopForDeletion(ctx context.Context, logger logr.Logger, inst *limatype.Instance) {
+	if inst.Status == limatype.StatusRunning {
+		// A StatusRunning WSL2 distro derives its status from wsl --list, not
+		// from HostAgentPID, so that PID may have been recycled on Windows.
+		// Clear it unless it is still ours, as the other force-stop paths do, so
+		// taskkill cannot reach an unrelated process. For QEMU/VZ, Lima reports
+		// StatusRunning only after the hostagent socket answers, so the PID is
+		// genuine and IsOurProcess confirms it.
+		safeInst := *inst
+		if safeInst.HostAgentPID > 0 && !process.IsOurProcess(safeInst.HostAgentPID, "hostagent", safeInst.Name) {
+			safeInst.HostAgentPID = 0
+		}
+		stopInstanceForcibly(ctx, logger, &safeInst)
+	} else if inst.VMType == limatype.WSL2 {
+		// A "stopped" WSL2 distro can retain kernel state that deadlocks
+		// wsl.exe --unregister. Terminate it without PID-based killing, since
+		// the PIDs may have been recycled on Windows.
+		terminateWSL2Distro(ctx, logger, inst.Name)
+	}
+	if runtime.GOOS == "windows" {
+		inst.DriverPID = 0
+		inst.HostAgentPID = 0
 	}
 }
 

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -144,15 +144,28 @@ func PID() int {
 	}
 	pid, err := strconv.Atoi(string(pidStr))
 	if err == nil {
-		var process *os.Process
-		process, err = os.FindProcess(pid)
+		var proc *os.Process
+		proc, err = os.FindProcess(pid)
 		if err == nil {
 			// on non-Windows, FindProcess may return without the process being
 			// alive; on Windows, the result encapsulates a valid handle.
 			if runtime.GOOS != "windows" {
-				err = process.Signal(syscall.Signal(0))
+				err = proc.Signal(syscall.Signal(0))
 			}
-			_ = process.Release()
+			_ = proc.Release()
+		}
+		// On Windows, FindProcess succeeds for any live PID, including one the
+		// OS recycled after a crash left our PID file behind. Confirm the PID
+		// still runs our "service serve" process, so a recycled PID reads as
+		// not-running. IsOurProcess is a no-op (true) on other platforms.
+		//
+		// "service serve" carries no instance name, so this confirms the PID
+		// runs a control plane, not specifically this instance's. A PID recycled
+		// to a *different* instance's control plane would pass. That needs
+		// concurrent instances (dev/test only); a lone instance never recycles a
+		// PID into another "service serve".
+		if err == nil && !process.IsOurProcess(pid, "service", "serve") {
+			err = fmt.Errorf("pid %d is not our control plane", pid)
 		}
 	}
 	if err != nil {

--- a/pkg/util/process/doc.go
+++ b/pkg/util/process/doc.go
@@ -3,6 +3,6 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
 // Package process provides cross-platform utilities for subprocess management,
-// including process group isolation and signal delivery (SIGINT, SIGTERM,
-// SIGKILL).
+// including process group isolation, signal delivery (SIGINT, SIGTERM,
+// SIGKILL), and process-identity verification.
 package process

--- a/pkg/util/process/process_unix.go
+++ b/pkg/util/process/process_unix.go
@@ -27,6 +27,16 @@ func Interrupt(pid int) error {
 	return unix.Kill(pid, unix.SIGINT)
 }
 
+// IsOurProcess reports whether pid is a live process running this program's own
+// executable. On Unix it is always true: PIDs are not recycled within a
+// daemon's lifetime the way they are on Windows, and Interrupt (SIGINT) to a
+// stale PID is a harmless no-op, so callers need no identity guard. The
+// parameters exist only for signature parity with the Windows build, where the
+// check defends GenerateConsoleCtrlEvent against PID reuse.
+func IsOurProcess(_ int, _ ...string) bool {
+	return true
+}
+
 // Kill sends SIGTERM to the process with the given PID.
 func Kill(pid int) error {
 	return unix.Kill(pid, unix.SIGTERM)

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -73,7 +73,7 @@ func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
 	defer func() { _ = windows.CloseHandle(handle) }()
 
 	image, err := processImagePath(handle)
-	if err != nil || !strings.EqualFold(filepath.Clean(image), filepath.Clean(self)) {
+	if err != nil || !samePath(image, self) {
 		return false
 	}
 	cmdline, err := processCommandLine(handle)
@@ -86,6 +86,49 @@ func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
 		}
 	}
 	return true
+}
+
+// samePath reports whether image and self name the same on-disk executable.
+// It resolves each to its long (non-8.3) form first, so a process launched
+// through a short path such as C:\PROGRA~1\... still matches the same binary
+// named by its long path. The two rdd processes compared need not have been
+// launched the same way.
+func samePath(image, self string) bool {
+	return strings.EqualFold(longPath(image), longPath(self))
+}
+
+// longPath returns p in its long, non-8.3 form. If the long form cannot be
+// resolved (for example the file no longer exists), it falls back to
+// filepath.Clean(p) so a transient resolution failure degrades to a lexical
+// comparison rather than a guaranteed mismatch — for the service PID a false
+// "not ours" would orphan a live control plane.
+func longPath(p string) string {
+	if resolved, err := resolveLongPath(p); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(p)
+}
+
+// resolveLongPath expands any 8.3 short components of p via GetLongPathName,
+// growing the buffer up to the Windows extended-path ceiling the way
+// processImagePath does.
+func resolveLongPath(p string) (string, error) {
+	p16, err := windows.UTF16PtrFromString(p)
+	if err != nil {
+		return "", err
+	}
+	for bufSize := uint32(1024); bufSize <= 32768; bufSize *= 2 {
+		buf := make([]uint16, bufSize)
+		n, err := windows.GetLongPathName(p16, &buf[0], bufSize)
+		if err != nil {
+			return "", err
+		}
+		if n < bufSize {
+			return windows.UTF16ToString(buf[:n]), nil
+		}
+		// n >= bufSize: the buffer was too small and n is the required size; grow.
+	}
+	return "", windows.ERROR_INSUFFICIENT_BUFFER
 }
 
 // processImagePath returns the full path to the executable backing the process.

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -8,9 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -31,6 +35,126 @@ func SetGroup(cmd *exec.Cmd) {
 // at the process group (requires CREATE_NEW_PROCESS_GROUP via SetGroup).
 func Interrupt(pid int) error {
 	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(pid))
+}
+
+// IsOurProcess reports whether pid is a live process running this program's own
+// executable with a command line that contains every string in cmdlineSubstrings.
+//
+// It guards graceful shutdown via Interrupt against PID reuse. Windows recycles
+// PIDs aggressively, and GenerateConsoleCtrlEvent(CTRL_BREAK) delivered to a
+// recycled PID can reach unrelated processes that share the console — including
+// the rdd service and the controlling terminal — rather than the intended
+// target. Callers confirm identity here before signalling; on a mismatch they
+// fall back to KillTree, which terminates a single PID and cannot escape to the
+// console.
+//
+// It returns false (never an error) whenever identity cannot be positively
+// confirmed — the process is gone, inaccessible, or no longer ours — so callers
+// treat "unknown" as "not ours" and never signal it.
+//
+// Each substring is matched with strings.Contains, not as a whole argument, so a
+// discriminator must be specific enough that it cannot appear in an unrelated
+// process's command line. An instance name that is a prefix of another (e.g.
+// "vm" and "vm2") matches both; pass a name distinct enough to avoid that.
+//
+// With no substrings the image-path match alone decides the result, which a
+// recycled PID running any other rdd process would satisfy; production callers
+// should always pass a discriminator.
+func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
+	self, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	image, err := processImagePath(handle)
+	if err != nil || !strings.EqualFold(filepath.Clean(image), filepath.Clean(self)) {
+		return false
+	}
+	cmdline, err := processCommandLine(handle)
+	if err != nil {
+		return false
+	}
+	for _, s := range cmdlineSubstrings {
+		if !strings.Contains(cmdline, s) {
+			return false
+		}
+	}
+	return true
+}
+
+// processImagePath returns the full path to the executable backing the process.
+// QueryFullProcessImageName does not report the size it needs on failure, so on
+// ERROR_INSUFFICIENT_BUFFER this doubles the buffer and retries, up to the
+// Windows extended-path ceiling of 32767 characters.
+func processImagePath(handle windows.Handle) (string, error) {
+	for bufSize := 1024; bufSize <= 32768; bufSize *= 2 {
+		buf := make([]uint16, bufSize)
+		size := uint32(len(buf))
+		err := windows.QueryFullProcessImageName(handle, 0, &buf[0], &size)
+		if err == nil {
+			return windows.UTF16ToString(buf[:size]), nil
+		}
+		if !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
+			return "", err
+		}
+	}
+	return "", windows.ERROR_INSUFFICIENT_BUFFER
+}
+
+// processCommandLine reads the target process's command line out of its PEB.
+// Windows exposes no API for another process's command line, so we follow the
+// documented PEB -> RTL_USER_PROCESS_PARAMETERS -> CommandLine chain via
+// ReadProcessMemory. The handle must carry PROCESS_VM_READ.
+func processCommandLine(handle windows.Handle) (string, error) {
+	var pbi windows.PROCESS_BASIC_INFORMATION
+	var retLen uint32
+	if err := windows.NtQueryInformationProcess(handle, windows.ProcessBasicInformation,
+		unsafe.Pointer(&pbi), uint32(unsafe.Sizeof(pbi)), &retLen); err != nil {
+		return "", err
+	}
+
+	var peb windows.PEB
+	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(pbi.PebBaseAddress)),
+		unsafe.Pointer(&peb), unsafe.Sizeof(peb)); err != nil {
+		return "", err
+	}
+
+	var params windows.RTL_USER_PROCESS_PARAMETERS
+	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(peb.ProcessParameters)),
+		unsafe.Pointer(&params), unsafe.Sizeof(params)); err != nil {
+		return "", err
+	}
+
+	length := params.CommandLine.Length
+	if length == 0 || params.CommandLine.Buffer == nil {
+		return "", nil
+	}
+	// NTUnicodeString.Length counts bytes; the buffer holds UTF-16 code units.
+	buf := make([]uint16, length/2)
+	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(params.CommandLine.Buffer)),
+		unsafe.Pointer(&buf[0]), uintptr(length)); err != nil {
+		return "", err
+	}
+	return windows.UTF16ToString(buf), nil
+}
+
+// readProcessMemory copies size bytes at addr in the target process into dest,
+// erroring unless the full range was read.
+func readProcessMemory(handle windows.Handle, addr uintptr, dest unsafe.Pointer, size uintptr) error {
+	var read uintptr
+	if err := windows.ReadProcessMemory(handle, addr, (*byte)(dest), size, &read); err != nil {
+		return err
+	}
+	if read != size {
+		return fmt.Errorf("short read at %#x: got %d of %d bytes", addr, read, size)
+	}
+	return nil
 }
 
 // Kill terminates the process with the given PID.

--- a/pkg/util/process/process_windows_test.go
+++ b/pkg/util/process/process_windows_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+	"gotest.tools/v3/assert"
+)
+
+func openSelf(t *testing.T) windows.Handle {
+	t.Helper()
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(os.Getpid()))
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = windows.CloseHandle(handle) })
+	return handle
+}
+
+// TestProcessCommandLineReadsOwnCommandLine exercises the PEB walk against the
+// running test process, catching struct-offset regressions in the unsafe reads.
+func TestProcessCommandLineReadsOwnCommandLine(t *testing.T) {
+	cmdline, err := processCommandLine(openSelf(t))
+	assert.NilError(t, err)
+	assert.Assert(t, cmdline != "", "command line should not be empty")
+
+	base := filepath.Base(os.Args[0])
+	assert.Assert(t, strings.Contains(cmdline, base),
+		"command line %q should contain argv0 base %q", cmdline, base)
+}
+
+// TestIsOurProcess confirms identity matching: the running process matches its
+// own executable and command line, and rejects absent substrings and dead PIDs.
+func TestIsOurProcess(t *testing.T) {
+	pid := os.Getpid()
+	base := filepath.Base(os.Args[0])
+
+	assert.Assert(t, IsOurProcess(pid), "current process should match its own executable")
+	assert.Assert(t, IsOurProcess(pid, base),
+		"current process should match its own argv0 base %q", base)
+	assert.Assert(t, !IsOurProcess(pid, "substring-that-cannot-appear-9c1f"),
+		"a substring absent from the command line should not match")
+	// A PID this high is never assigned, so OpenProcess fails and the result
+	// must be false rather than an accidental match.
+	assert.Assert(t, !IsOurProcess(0xFFFFFFF0, "hostagent"),
+		"a nonexistent PID should not match")
+}
+
+// TestIsOurProcessRejectsForeignExecutable confirms the image-path check: a live
+// process running a different executable is not ours, even when a requested
+// substring appears in its command line. This is the branch that defends against
+// PID reuse.
+func TestIsOurProcessRejectsForeignExecutable(t *testing.T) {
+	// ping runs for several seconds without console input, giving a stable live
+	// PID backed by an executable other than the test binary.
+	cmd := exec.CommandContext(t.Context(), "ping.exe", "-n", "10", "127.0.0.1")
+	assert.NilError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	pid := cmd.Process.Pid
+
+	// Confirm the rejection comes from the image-path mismatch rather than an
+	// OpenProcess failure or an already-exited process: open the child the way
+	// IsOurProcess does and verify its image is readable and differs from the
+	// test binary. Without this, a denied OpenProcess would let the assertions
+	// below pass without exercising the defense.
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
+	assert.NilError(t, err)
+	defer func() { _ = windows.CloseHandle(handle) }()
+	image, err := processImagePath(handle)
+	assert.NilError(t, err)
+	self, err := os.Executable()
+	assert.NilError(t, err)
+	assert.Assert(t, !strings.EqualFold(filepath.Clean(image), filepath.Clean(self)),
+		"ping image %q must differ from the test binary %q", image, self)
+
+	assert.Assert(t, !IsOurProcess(pid),
+		"a live process running a different executable should not match")
+	assert.Assert(t, !IsOurProcess(pid, "ping"),
+		"a command-line substring match must not override an executable mismatch")
+}

--- a/pkg/util/process/process_windows_test.go
+++ b/pkg/util/process/process_windows_test.go
@@ -90,3 +90,35 @@ func TestIsOurProcessRejectsForeignExecutable(t *testing.T) {
 	assert.Assert(t, !IsOurProcess(pid, "ping"),
 		"a command-line substring match must not override an executable mismatch")
 }
+
+// TestSamePathMatchesShortAndLongForms confirms samePath treats an 8.3 short
+// path and its long form as the same executable. A user can launch rdd through
+// either form, so the identity check must recognize a live control plane no
+// matter which form named the process being checked.
+func TestSamePathMatchesShortAndLongForms(t *testing.T) {
+	// A directory name with no natural 8.3 form makes Windows synthesize a
+	// distinct short name where 8.3 generation is enabled on the volume.
+	longDir := filepath.Join(t.TempDir(), "LongDirectoryNameBeyond8dot3")
+	assert.NilError(t, os.Mkdir(longDir, 0o755))
+	longFile := filepath.Join(longDir, "control-plane-binary.exe")
+	assert.NilError(t, os.WriteFile(longFile, []byte("stub"), 0o644))
+
+	short := shortPathName(t, longFile)
+	if strings.EqualFold(filepath.Clean(short), filepath.Clean(longFile)) {
+		t.Skip("8.3 short-name generation is disabled on this volume")
+	}
+	assert.Assert(t, samePath(short, longFile),
+		"short form %q and long form %q must resolve to the same executable", short, longFile)
+}
+
+// shortPathName returns the 8.3 short form of p via GetShortPathName.
+func shortPathName(t *testing.T, p string) string {
+	t.Helper()
+	p16, err := windows.UTF16PtrFromString(p)
+	assert.NilError(t, err)
+	buf := make([]uint16, 1024)
+	n, err := windows.GetShortPathName(p16, &buf[0], uint32(len(buf)))
+	assert.NilError(t, err)
+	assert.Assert(t, n < uint32(len(buf)), "short-path buffer too small")
+	return windows.UTF16ToString(buf[:n])
+}


### PR DESCRIPTION
On Windows, graceful hostagent shutdown signals the hostagent's PID with `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT)`. Windows recycles PIDs quickly, so a stale PID — especially one a later service reads from on-disk Lima state — can resolve to an unrelated process. When it does, the `CTRL_BREAK` escapes the intended process group and reaches every process sharing the console, killing the rdd service and the controlling terminal. In CI this aborted a bats run with `STATUS_CONTROL_C_EXIT` right after `killOrphanedHostagent` signalled a recycled PID.

The forced-stop path already sidesteps this by using `taskkill` instead of `CTRL_BREAK`; the graceful paths did not.

Add `process.IsOurProcess`, which confirms a PID still runs our own executable with the expected command line, and apply it where a PID comes from on-disk state with no open handle: `killOrphanedHostagent` and the force fallbacks. The in-memory paths that signal a live `*exec.Cmd` (`signalHostagent`, the `shutdownAllHostagents` loop) instead rely on the held process handle, which keeps Windows from recycling the PID while it is open. A failed check falls through to the reuse-safe forced stop, so an unverifiable PID is never signalled.

The service's own PID file carries the same on-disk hazard. `PID()` confirmed only that some process held the recorded PID, so after a crash left the file behind, a recycled PID made `Running()` report a dead control plane as running: `rdd svc start` waited on a control plane that never became ready and timed out, and `StopWithWait` could signal an unrelated process. Guard `PID()` with `IsOurProcess` too, so a recycled PID reads as not-running and the stale file is removed.

`IsOurProcess` compares the target's image path against `os.Executable()`. Because a user can launch rdd through an 8.3 short path (`C:\PROGRA~1\...`), it normalizes both paths to their long form before comparing, so a short-path launch never false-negatives a live process into an orphan.

On Unix the check is a no-op: `SIGINT` to a stale PID is harmless and PIDs are not recycled within a daemon's lifetime.
