### PR TITLE
Always reclaim hostagent resources during graceful shutdown

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -63,6 +63,15 @@ lima_instance_running() {
     assert_file_exists "${RDD_LIMA_HOME}/${name}/ha.pid"
 }
 
+# True while the instance's WSL2 distro is still running. wsl.exe prints UTF-16,
+# so strip NUL bytes before matching; WSL_UTF8 makes newer builds emit UTF-8.
+lima_distro_running() {
+    local name=$1
+    local running
+    running=$(MSYS_NO_PATHCONV=1 WSL_UTF8=1 wsl.exe --list --running 2>/dev/null | tr -d '\0')
+    [[ "${running}" == *"lima-${name}"* ]]
+}
+
 get_restart_count() {
     local name=$1
     rdd ctl get limavm "${name}" --namespace "${NAMESPACE}" \
@@ -331,6 +340,21 @@ EOF
     assert_process_alive "${ha_pid}"
 
     rdd svc stop
+
+    # Graceful shutdown must reclaim the hostagent's PID file even when the
+    # hostagent was force-killed rather than self-stopping (the usual case on
+    # Windows, where exec.CommandContext terminates it when the manager context
+    # is cancelled). A leftover PID file makes the next "rdd svc start" mistake
+    # it for an orphan. This assertion is cross-platform: it fails on Windows
+    # before the shutdownAllHostagents cleanup fix.
+    try --max 30 --delay 1 --until-fail -- lima_instance_running "${VM_NAME}"
+
+    # On Windows the hostagent runs inside a WSL2 distro that a force-kill leaves
+    # running — the keepAlive process (nohup sleep) outlives the hostagent — so
+    # graceful shutdown must terminate the distro explicitly.
+    if is_msys; then
+        try --max 30 --delay 1 --until-fail -- lima_distro_running "${VM_NAME}"
+    fi
 
     # On Windows, child process handles (wsl.exe) keep the hostagent PID visible
     # in the process table long after termination. The next test ("restart service

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -496,8 +496,9 @@ func (r *LimaVMReconciler) waitForShutdown(ctx context.Context) error {
 }
 
 // shutdownAllHostagents terminates all running hostagents during graceful shutdown.
-// It sends a graceful shutdown signal to each hostagent, waits for exit, and falls
-// back to process termination after a timeout.
+// It signals each hostagent, waits for it to exit (or time out), then reclaims any
+// resources left behind — always, because a force-killed hostagent skips its own
+// teardown (the usual case on Windows).
 func (r *LimaVMReconciler) shutdownAllHostagents() {
 	r.instanceStatesMu.RLock()
 	states := maps.Clone(r.instanceStates)
@@ -520,35 +521,41 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 	// TODO: Wait on all hostagents in parallel instead of sequentially; with the
 	// current loop, the total wait is N × gracefulShutdownTimeout in the worst case.
 	for name, state := range states {
-		graceful := true
+		// Give the hostagent a chance to exit on its own after the signal above.
 		select {
 		case <-state.procExited:
 		case <-time.After(gracefulShutdownTimeout):
-			graceful = false
 		}
-		if !graceful {
-			// Manager context is cancelled; use a fresh context for cleanup.
-			// Inspect before killing so PIDs are still valid (not yet recycled
-			// to unrelated processes). stopInstanceForcibly kills the process
-			// tree and cleans up PID/socket/tmp files in one pass.
-			logger := ctrl.Log.WithName("shutdownAllHostagents")
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			inst, err := store.Inspect(cleanupCtx, name)
-			if err == nil && inst != nil {
-				stopInstanceForcibly(cleanupCtx, logger, inst)
-			}
-			cancel()
-			// Wait briefly for the process to exit after forced kill.
-			// Without a timeout, cmd.Wait can block indefinitely if a
-			// child process survives KillTree and holds an inherited pipe.
-			waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			select {
-			case <-state.procExited:
-			case <-waitCtx.Done():
-				logger.Info("Timed out waiting for hostagent to exit after forced kill", "instance", name)
-			}
-			waitCancel()
+
+		// Always reclaim the instance's resources, even when procExited closed
+		// promptly. On Windows the hostagent is force-killed by exec.CommandContext
+		// when the manager context is cancelled: procExited then closes right away,
+		// so the exit *looks* graceful, but the hostagent never ran its own teardown
+		// and left its PID file and WSL2 distro behind — which the next `rdd svc
+		// start` mistakes for an orphan. Use a fresh context because the manager
+		// context is already cancelled, and Inspect before killing so PIDs are still
+		// valid (not yet recycled). stopInstanceForcibly removes the PID/socket/tmp
+		// files and terminates the distro; it is a no-op when the hostagent already
+		// cleaned up after itself.
+		logger := ctrl.Log.WithName("shutdownAllHostagents")
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if inst, err := store.Inspect(cleanupCtx, name); err == nil && inst != nil {
+			stopInstanceForcibly(cleanupCtx, logger, inst)
 		}
+		cancel()
+
+		// Wait briefly for the process to exit after a forced kill. Without a
+		// timeout, cmd.Wait can block indefinitely if a child process survives
+		// KillTree and holds an inherited pipe. Returns at once when the process
+		// already exited.
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		select {
+		case <-state.procExited:
+		case <-waitCtx.Done():
+			logger.Info("Timed out waiting for hostagent to exit after forced kill", "instance", name)
+		}
+		waitCancel()
+
 		state.cancel()
 		r.instanceStatesMu.Lock()
 		delete(r.instanceStates, name)


### PR DESCRIPTION
`shutdownAllHostagents` removed the PID file, socket, and tmp files and terminated the WSL2 distro only when a hostagent failed to exit within `gracefulShutdownTimeout`. On Windows that cleanup was usually skipped: `exec.CommandContext` force-kills the hostagent (`TerminateProcess`) when the manager context is cancelled, so `procExited` closes promptly and the exit looks graceful — but the force-killed hostagent never ran its own teardown. It left its PID file and WSL2 distro behind, and the next `rdd svc start` mistook the stale PID file for an orphaned hostagent.

Run `stopInstanceForcibly` after waiting for the process to exit, regardless of how it exited. It is a no-op when the hostagent already cleaned up after itself — the PID file is gone, so `Inspect` reports no PID to kill and the distro is already stopped — and it reclaims the leftovers when the hostagent was force-killed.

The new bats assertion that the PID file is gone after `rdd svc stop` fails on Windows without this change.