### PR TITLE
Keep the container engine up when a k3s install fails

### DIFF
--- a/pkg/controllers/app/app/lima-template.yaml
+++ b/pkg/controllers/app/app/lima-template.yaml
@@ -50,6 +50,12 @@ provision:
 
     set -o errexit -o nounset -o pipefail -o xtrace
 
+    # Restart rancher-desktop.target on exit, even if a step below fails. The
+    # container engine belongs to this target but does not depend on
+    # Kubernetes, so a failed k3s install must not leave it stopped. --no-block
+    # returns immediately; the kubeconfig probe below absorbs k3s startup time.
+    trap 'systemctl start --no-block rancher-desktop.target' EXIT
+
     systemctl stop rancher-desktop.target
 
     # Enable the requested container engine and disable the other.
@@ -68,9 +74,34 @@ provision:
         if [[ $INSTALL_K3S_VERSION != "${INSTALLED_VERSION}" ]]; then
             # Don't enable k3s at install time; add it as a want of rancher-desktop.target instead.
             export INSTALL_K3S_SKIP_ENABLE=true
+            # Before reinstalling, remove any existing k3s want; otherwise a
+            # failed upgrade leaves rancher-desktop.target still wanting the
+            # previous k3s version. daemon-reload rebuilds systemd's in-memory
+            # dependency tree from disk so the EXIT trap's restart honors the
+            # removal even on the failure path, where add-wants below (the only
+            # other reload) never runs. The want is re-added on success below.
+            rm -f /etc/systemd/system/rancher-desktop.target.wants/k3s.service
+            systemctl daemon-reload
             (
                 export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/sbin:/bin
-                curl -sfL https://get.k3s.io | sh -
+                # The interface can have an address before the host-switch
+                # network is routable, so the install can fail right after a
+                # restart. Retry the whole download-and-install until it
+                # succeeds; the curl timeouts bound the installer-script fetch
+                # so a black-holed network fails fast instead of hanging that
+                # step. --show-error surfaces the error without --silent's
+                # progress meter spamming the log.
+                attempt=0
+                until curl --fail --silent --show-error --location --connect-timeout 10 --max-time 60 https://get.k3s.io | sh -; do
+                    attempt=$((attempt + 1))
+                    if (( attempt >= 30 )); then
+                        echo "k3s install failed after ${attempt} attempts" >&2
+                        # Fail provisioning so Lima records the error; the EXIT
+                        # trap still restarts the engine, which does not need k3s.
+                        exit 1
+                    fi
+                    sleep 2
+                done
             )
             systemctl add-wants rancher-desktop.target k3s.service
         fi
@@ -86,10 +117,7 @@ provision:
         rm -f /etc/rancher/k3s/k3s.yaml
     fi
 
-    # Use --no-block so the provision script exits immediately. Lima writes
-    # lima-boot-done as soon as all provision scripts finish, and k3s startup
-    # time is absorbed by the kubeconfig probe below instead of blocking here.
-    systemctl start --no-block rancher-desktop.target
+    # rancher-desktop.target is restarted by the EXIT trap above.
 
 probes:
 - description: Write k3s kubeconfig to instance config path


### PR DESCRIPTION
## Problem

A Kubernetes version change rewrites the LimaVM template and restarts the VM, and the provision script reinstalls k3s on reboot. But the script stops `rancher-desktop.target` at the top and only restarts it on the last line, all under `set -o errexit`. So when the k3s download fails — common right after a restart, when the interface has an address but the host-switch network is not yet routable — the script aborts before the restart, leaving the **container engine** (which has nothing to do with Kubernetes) stopped. `docker.sock` goes unreachable and the App never settles.

## Fix

- **Restart `rancher-desktop.target` from an EXIT trap**, so the engine comes back regardless of the k3s install outcome.
- **Retry the k3s download** in a bounded loop, so a transient early-boot failure resolves on its own instead of aborting the script.
- **`curl -fsSL`** — `-S` surfaces the real error on failure, while `-s` still keeps the progress meter out of the logs.

## Verification

**Deterministic mock** (engine survives a k3s-install failure): with `curl` forced to fail, the new script restarts the target via the trap; the old script exits 6 and never restarts it.

```
new template:  systemctl start --no-block rancher-desktop.target   -> engine recovers
old template:  (never reached)                                     -> engine stays down
```

**Live VM**: initial k8s 1.32.2 install settled in 34s; a 1.32.2 -> 1.32.3 change went `ConnectFailed -> Starting -> Probing -> Settled`, ending with docker active, k3s active, k3s v1.32.3, `ContainerEngineReady=Connected`.

`bash -n` clean; app-controller Go tests (incl. `Test_applySpecToTemplate`) pass.

## Notes

The provision script is intentionally left without a unit test. A mocked harness would stub out `systemctl` and `curl`, so it would only exercise `trap ... EXIT` (basic bash), not this change's behavior. Inducing a real k3s-download failure is impractical — the App webhook rejects unknown versions, and the trigger is a nondeterministic early-boot network race — so the behavior is verified manually as above.
