### PR TITLE
Harden Windows shutdown against recycled PIDs and leftover hostagent state

### DIFF
--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -58,9 +58,17 @@ assert_stdout_logs_contain() {
     assert_output --partial "${expected}"
 }
 
-lima_instance_running() {
+assert_instance_running() {
     local name=$1
     assert_file_exists "${RDD_LIMA_HOME}/${name}/ha.pid"
+}
+
+# Asserts the instance's WSL2 distro is still running. WSL_UTF8 makes
+# wsl.exe emit UTF-8 instead of its default UTF-16.
+assert_distro_running() {
+    local name=$1
+    run -0 env MSYS_NO_PATHCONV=1 WSL_UTF8=1 wsl.exe --list --running
+    assert_output --partial "lima-${name}"
 }
 
 get_restart_count() {
@@ -128,7 +136,7 @@ editor_cmd() {
 }
 
 @test "verify hostagent PID file exists" {
-    lima_instance_running "${VM_NAME}"
+    assert_instance_running "${VM_NAME}"
 }
 
 @test "logs shows hostagent stderr" {
@@ -187,7 +195,7 @@ EOF
 }
 
 @test "verify hostagent PID file is removed" {
-    try --max 30 --delay 1 --until-fail -- lima_instance_running "${VM_NAME}"
+    try --max 30 --delay 1 --until-fail -- assert_instance_running "${VM_NAME}"
 }
 
 # Crash recovery tests
@@ -331,6 +339,21 @@ EOF
     assert_process_alive "${ha_pid}"
 
     rdd svc stop
+
+    # Graceful shutdown must reclaim the hostagent's PID file even when the
+    # hostagent was force-killed rather than self-stopping (the usual case on
+    # Windows, where exec.CommandContext terminates it when the manager context
+    # is cancelled). A leftover PID file makes the next "rdd svc start" mistake
+    # it for an orphan. This assertion is cross-platform: it fails on Windows
+    # before the shutdownAllHostagents cleanup fix.
+    try --max 30 --delay 1 --until-fail -- assert_instance_running "${VM_NAME}"
+
+    # On Windows the hostagent runs inside a WSL2 distro that a force-kill leaves
+    # running — the keepAlive process (nohup sleep) outlives the hostagent — so
+    # graceful shutdown must terminate the distro explicitly.
+    if is_msys; then
+        try --max 30 --delay 1 --until-fail -- assert_distro_running "${VM_NAME}"
+    fi
 
     # On Windows, child process handles (wsl.exe) keep the hostagent PID visible
     # in the process table long after termination. The next test ("restart service

--- a/bats/tests/33-lima-controllers/limavm-running.bats
+++ b/bats/tests/33-lima-controllers/limavm-running.bats
@@ -350,8 +350,10 @@ EOF
 
     # On Windows the hostagent runs inside a WSL2 distro that a force-kill leaves
     # running — the keepAlive process (nohup sleep) outlives the hostagent — so
-    # graceful shutdown must terminate the distro explicitly.
-    if is_msys; then
+    # graceful shutdown must terminate the distro explicitly. Gate on is_windows,
+    # not is_msys: rdd drives WSL2 distros both from MSYS2 and from a Linux build
+    # running inside a WSL2 distro (both report OS=windows).
+    if is_windows; then
         try --max 30 --delay 1 --until-fail -- assert_distro_running "${VM_NAME}"
     fi
 

--- a/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
+++ b/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
@@ -200,13 +200,24 @@ func (r *LimaVMReconciler) waitForProcessExit(ctx context.Context, name string) 
 // signalHostagent sends a graceful shutdown signal to the hostagent process.
 // Uses process.Interrupt which sends SIGINT on Unix and CTRL_BREAK on Windows
 // (targeted at the hostagent's process group, not the parent).
-// Returns false if no watcher exists or the signal could not be delivered.
+// Returns false if no watcher exists, the process has already been reaped (its
+// PID may be reused on Windows), or the signal could not be delivered.
 func (r *LimaVMReconciler) signalHostagent(name string) bool {
 	r.instanceStatesMu.RLock()
 	state, ok := r.instanceStates[name]
 	r.instanceStatesMu.RUnlock()
 	if !ok || state.cmd == nil || state.cmd.Process == nil {
 		return false
+	}
+	// Once procExited is closed, cmd.Wait() has released the OS process handle
+	// and the PID may be reused; signalling it could deliver CTRL_BREAK to an
+	// unrelated console process on Windows. While it is open the handle is
+	// normally still held; cmd.Wait() releases it just before closing the
+	// channel, leaving a brief window.
+	select {
+	case <-state.procExited:
+		return false
+	default:
 	}
 	return process.Interrupt(state.cmd.Process.Pid) == nil
 }

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -524,8 +524,9 @@ func (r *LimaVMReconciler) waitForShutdown(ctx context.Context) error {
 }
 
 // shutdownAllHostagents terminates all running hostagents during graceful shutdown.
-// It sends a graceful shutdown signal to each hostagent, waits for exit, and falls
-// back to process termination after a timeout.
+// It signals each hostagent, waits for it to exit (or time out), then reclaims any
+// resources left behind — always, because a force-killed hostagent skips its own
+// teardown (the usual case on Windows).
 func (r *LimaVMReconciler) shutdownAllHostagents() {
 	r.instanceStatesMu.RLock()
 	states := maps.Clone(r.instanceStates)
@@ -560,35 +561,49 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 	// TODO: Wait on all hostagents in parallel instead of sequentially; with the
 	// current loop, the total wait is N × gracefulShutdownTimeout in the worst case.
 	for name, state := range states {
-		graceful := true
+		// Give the hostagent a chance to exit on its own after the signal above.
 		select {
 		case <-state.procExited:
 		case <-time.After(gracefulShutdownTimeout):
-			graceful = false
 		}
-		if !graceful {
-			// Manager context is cancelled; use a fresh context for cleanup.
-			// Inspect before killing so PIDs are still valid (not yet recycled
-			// to unrelated processes). stopInstanceForcibly kills the process
-			// tree and cleans up PID/socket/tmp files in one pass.
-			logger := ctrl.Log.WithName("shutdownAllHostagents")
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			inst, err := store.Inspect(cleanupCtx, name)
-			if err == nil && inst != nil {
-				stopInstanceForcibly(cleanupCtx, logger, inst)
+
+		// Always reclaim the instance's resources, even when procExited closed
+		// promptly. On Windows the hostagent is force-killed by exec.CommandContext
+		// when the manager context is cancelled: procExited then closes right away,
+		// so the exit *looks* graceful, but the hostagent never ran its own teardown
+		// and left its PID file and WSL2 distro behind — which the next `rdd svc
+		// start` mistakes for an orphan. Use a fresh context because the manager
+		// context is already cancelled. stopInstanceForcibly removes the PID/socket/tmp
+		// files and terminates the distro; it is a no-op when the hostagent already
+		// cleaned up after itself.
+		logger := ctrl.Log.WithName("shutdownAllHostagents")
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if inst, err := store.Inspect(cleanupCtx, name); err == nil && inst != nil {
+			// A force-killed hostagent leaves its PID file behind, and on Windows
+			// that PID can already be recycled by the time we taskkill. Clear
+			// HostAgentPID unless it is still our hostagent, as the other force-stop
+			// paths do, so taskkill cannot reach an unrelated process. On the timeout
+			// branch the hostagent is still running and still ours, so IsOurProcess
+			// keeps the PID for stopInstanceForcibly to terminate.
+			if inst.HostAgentPID > 0 && !process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
+				inst.HostAgentPID = 0
 			}
-			cancel()
-			// Wait briefly for the process to exit after forced kill.
-			// Without a timeout, cmd.Wait can block indefinitely if a
-			// child process survives KillTree and holds an inherited pipe.
-			waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			select {
-			case <-state.procExited:
-			case <-waitCtx.Done():
-				logger.Info("Timed out waiting for hostagent to exit after forced kill", "instance", name)
-			}
-			waitCancel()
+			stopInstanceForcibly(cleanupCtx, logger, inst)
 		}
+		cancel()
+
+		// Wait briefly for the process to exit after a forced kill. Without a
+		// timeout, cmd.Wait can block indefinitely if a child process survives
+		// KillTree and holds an inherited pipe. Returns at once when the process
+		// already exited.
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		select {
+		case <-state.procExited:
+		case <-waitCtx.Done():
+			logger.Info("Timed out waiting for hostagent to exit after forced kill", "instance", name)
+		}
+		waitCancel()
+
 		state.cancel()
 		r.instanceStatesMu.Lock()
 		delete(r.instanceStates, name)

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -216,7 +216,13 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		existingInst, err := store.Inspect(ctx, limaVM.Name)
 		if err == nil && existingInst != nil {
 			logger.Info("Deleting leftover Lima instance", "instance", limaVM.Name)
-			if err := limainstance.Delete(ctx, existingInst, true); err != nil {
+			forceStopForDeletion(ctx, logger, existingInst)
+			// Use a timeout because Lima's WSL2 driver calls wsl.exe --unregister
+			// which can hang indefinitely if the WSL subsystem is degraded.
+			deleteCtx, deleteCancel := context.WithTimeout(ctx, time.Minute)
+			err := limainstance.Delete(deleteCtx, existingInst, true)
+			deleteCancel()
+			if err != nil {
 				logger.Error(err, "Failed to delete leftover Lima instance")
 				return ctrl.Result{}, err
 			}
@@ -529,11 +535,23 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 		return
 	}
 
-	// Send graceful shutdown signal to all hostagents in parallel.
+	// Send graceful shutdown signal to all hostagents in parallel. Skip any whose
+	// process has already been reaped: once cmd.Wait() closes procExited it has
+	// released the OS process handle, freeing the PID for reuse. On Windows a
+	// CTRL_BREAK to a recycled PID escapes to the console and kills the service
+	// and terminal. While procExited is open the handle is normally still held,
+	// so the PID is still ours; cmd.Wait() releases it just before closing the
+	// channel, leaving a brief window.
 	for _, state := range states {
-		if state.cmd != nil && state.cmd.Process != nil {
-			_ = process.Interrupt(state.cmd.Process.Pid)
+		if state.cmd == nil || state.cmd.Process == nil {
+			continue
 		}
+		select {
+		case <-state.procExited:
+			continue
+		default:
+		}
+		_ = process.Interrupt(state.cmd.Process.Pid)
 	}
 
 	// Wait for each hostagent process to exit. The watcher goroutine may finish

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -575,27 +575,25 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 		// start` mistakes for an orphan. Use a fresh context because the manager
 		// context is already cancelled. stopInstanceForcibly removes the PID/socket/tmp
 		// files and terminates the distro; it is a no-op when the hostagent already
-		// cleaned up after itself.
+		// cleaned up after itself. The loop runs on every platform; off Windows the
+		// hostagent self-terminates and distro termination is a no-op, so the
+		// reclaim finds nothing to do.
 		logger := ctrl.Log.WithName("shutdownAllHostagents")
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		if inst, err := store.Inspect(cleanupCtx, name); err == nil && inst != nil {
 			// A force-killed hostagent leaves its PID file behind, and on Windows
-			// that PID can already be recycled by the time we taskkill. Clear
-			// HostAgentPID unless it is still our hostagent, as the other force-stop
-			// paths do, so taskkill cannot reach an unrelated process. On the timeout
-			// branch the hostagent is still running and still ours, so IsOurProcess
-			// keeps the PID for stopInstanceForcibly to terminate.
-			if inst.HostAgentPID > 0 && !process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
-				inst.HostAgentPID = 0
-			}
+			// that PID can already be recycled by the time we taskkill;
+			// stopInstanceForcibly screens it. On the timeout branch the hostagent
+			// is still running and still ours, so the PID is kept and terminated.
 			stopInstanceForcibly(cleanupCtx, logger, inst)
 		}
 		cancel()
 
-		// Wait briefly for the process to exit after a forced kill. Without a
-		// timeout, cmd.Wait can block indefinitely if a child process survives
-		// KillTree and holds an inherited pipe. Returns at once when the process
-		// already exited.
+		// Wait briefly for the process to exit after a forced kill. This returns
+		// at once when the watcher has already reaped the hostagent (closing
+		// procExited); the timeout only bounds shutdown if reaping stalls. The
+		// hostagent's stdio are plain log files, not pipes, so cmd.Wait runs no
+		// I/O-copy goroutine that could keep it blocked.
 		waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		select {
 		case <-state.procExited:

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -794,13 +794,15 @@ func unregisterWSL2Distro(ctx context.Context, logger logr.Logger, instName stri
 
 // removeStaleInstance removes a stale Lima instance directory left behind by
 // a previous service run whose cleanup failed. On Windows, the WSL2 distro is
-// unregistered first (removing its ext4.vhdx and releasing any file locks)
-// before the remaining Lima metadata directory is deleted. On non-Windows the
-// directory is removed directly.
+// terminated and then unregistered (removing its ext4.vhdx and releasing any
+// file locks) before the remaining Lima metadata directory is deleted; the WSL2
+// calls are no-ops on other platforms, where the directory is removed directly.
 func removeStaleInstance(ctx context.Context, logger logr.Logger, instName, instanceDir string) error {
-	if runtime.GOOS == "windows" {
-		unregisterWSL2Distro(ctx, logger, instName)
-	}
+	// Terminate the distro before unregistering it: wsl.exe --unregister can
+	// deadlock on a distro that still holds kernel state, the same hazard
+	// forceStopForDeletion guards against. Both calls are no-ops off Windows.
+	terminateWSL2Distro(ctx, logger, instName)
+	unregisterWSL2Distro(ctx, logger, instName)
 	return os.RemoveAll(instanceDir)
 }
 

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -633,6 +633,9 @@ func hostAgentPIDFile(inst *limatype.Instance) string {
 // on other platforms IsOurProcess is a no-op, so the PID is kept. DriverPID is
 // not screened here — IsOurProcess matches the rdd image, not the qemu/wsl
 // driver — so a recycled DriverPID is still taskkilled by the caller.
+//
+// TODO: track the hostagent and driver in a Windows Job Object so termination
+// no longer trusts a stored DriverPID that the OS may have recycled.
 func clearRecycledHostAgentPID(inst *limatype.Instance) {
 	if inst.HostAgentPID > 0 && !process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
 		inst.HostAgentPID = 0

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -47,34 +47,7 @@ func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.
 		logger.Error(err, "Failed to inspect Lima instance for deletion")
 	}
 	if existingInst != nil {
-		// Only use PID-based force-stop for Running instances. Broken
-		// instances may have stale PID files pointing to recycled processes
-		// on Windows (Lima's ReadPIDFile treats any live PID as valid).
-		// Not tested: simulating stale PID files requires Windows-specific
-		// PID file manipulation that BATS cannot easily reproduce.
-		if existingInst.Status == limatype.StatusRunning {
-			stopInstanceForcibly(ctx, logger, existingInst)
-		} else if existingInst.VMType == limatype.WSL2 {
-			// A "stopped" WSL2 distro can retain kernel state that deadlocks
-			// wsl.exe --unregister. Terminate it without PID-based killing,
-			// since the PIDs may have been recycled on Windows.
-			terminateWSL2Distro(ctx, logger, existingInst.Name)
-		}
-		if runtime.GOOS == "windows" {
-			// Clear PIDs so Lima's Delete → StopForcibly does not kill
-			// unrelated processes if the PIDs were recycled. Windows recycles
-			// PIDs aggressively, and Lima's ReadPIDFile treats any live PID
-			// as valid. On Unix, PID recycling is rare (wraps around 32768+),
-			// so we let Lima's Delete clean up any surviving driver processes.
-			//
-			// This disables Lima's internal kill retry even if stopInstanceForcibly
-			// failed above. That is intentional: a failed kill means KillTree
-			// could not reach the process (access denied, already reaped), and
-			// the PID may already be recycled. Retrying with a stale PID is
-			// worse than letting Delete proceed without a kill.
-			existingInst.DriverPID = 0
-			existingInst.HostAgentPID = 0
-		}
+		forceStopForDeletion(ctx, logger, existingInst)
 		preserveInstanceLogs(ctx, existingInst)
 		logger.Info("Deleting Lima instance", "instance", limaVM.Name)
 		// Use a timeout because Lima's WSL2 driver calls wsl.exe --unregister
@@ -222,18 +195,22 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 		// The VM driver (e.g., QEMU) may outlive the hostagent. Force-stop
 		// the instance so the next hostagent can start with a clean slate.
 		//
-		// On Windows, StatusBroken instances may have stale PID files whose
-		// PIDs were recycled to unrelated processes. stopInstanceForcibly
-		// uses taskkill, which kills by PID without verifying the process
-		// identity. The deletion path (handleDeletion) guards against this
-		// by skipping PID-based kills for StatusBroken, but this path does
-		// not — the self-healing restart that follows limits the blast
-		// radius. The proper fix is to validate process identity (e.g.,
-		// check executable name) before killing, or use Windows Job Objects
-		// to track child processes without relying on PID files.
+		// On Windows the on-disk HostAgentPID may have been recycled to an
+		// unrelated process after the hostagent exited, so clear it unless
+		// IsOurProcess confirms it is still ours; the force path's taskkill
+		// would otherwise reach whatever now holds it. DriverPID is taskkilled
+		// without that check — IsOurProcess matches the rdd image, not the
+		// qemu/wsl driver — so a recycled DriverPID would be killed here.
+		// handleDeletion zeroes DriverPID on Windows; a restart cannot, because
+		// the orphaned driver must die. Job Objects, not PID files, are the
+		// proper fix.
 		if inst.Status == limatype.StatusRunning || inst.Status == limatype.StatusBroken {
 			logger.Info("Force-stopping orphaned VM driver", "status", inst.Status)
-			stopInstanceForcibly(ctx, logger, inst)
+			forceInst := *inst
+			if inst.HostAgentPID > 0 && !process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
+				forceInst.HostAgentPID = 0
+			}
+			stopInstanceForcibly(ctx, logger, &forceInst)
 		}
 		return r.startInstance(ctx, limaVM, inst)
 
@@ -295,7 +272,8 @@ func (r *LimaVMReconciler) handleUnwatchedState(ctx context.Context, limaVM *v1a
 	case limatype.StatusRunning, limatype.StatusBroken:
 		// Orphaned hostagent from before controller restart. Kill it so the
 		// next reconcile can start with a watcher.
-		// Same PID recycling caveat as handleWatchedState (see comment above).
+		// killOrphanedHostagent guards the recycled HostAgentPID before signalling
+		// or taskkill, as handleWatchedState does.
 		logger.Info("Found orphaned hostagent, killing it", "status", inst.Status)
 		if err := r.killOrphanedHostagent(ctx, inst); err != nil {
 			logger.Error(err, "Failed to kill orphaned hostagent")
@@ -559,7 +537,17 @@ func (r *LimaVMReconciler) shutdownHostagent(ctx context.Context, name string, i
 				return
 			}
 		}
-		stopInstanceForcibly(forceCtx, logger, forceInst)
+		// forceStop runs after signalHostagent declines (no watcher, or the
+		// process was already reaped) or after a signalled hostagent ignores the
+		// graceful timeout. In the reaped case the stored HostAgentPID may already
+		// be recycled on Windows, so confirm identity before taskkill, as the
+		// other force-stop paths do. DriverPID is not verifiable here —
+		// IsOurProcess matches only the rdd image — so it is taskkilled unchecked.
+		safeInst := *forceInst
+		if safeInst.HostAgentPID > 0 && !process.IsOurProcess(safeInst.HostAgentPID, "hostagent", hostAgentPIDFile(&safeInst)) {
+			safeInst.HostAgentPID = 0
+		}
+		stopInstanceForcibly(forceCtx, logger, &safeInst)
 	}
 
 	// After forced termination, wait briefly for the process to exit.
@@ -599,7 +587,19 @@ func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *lima
 	// Try graceful shutdown: signal the hostagent and wait for the instance
 	// to become stopped. The hostagent's own shutdown sequence handles driver
 	// termination, WSL2 distro cleanup, and tmp file removal.
-	if inst.HostAgentPID > 0 {
+	//
+	// HostAgentPID comes from on-disk state written by a previous service, so
+	// on Windows it may have been recycled to an unrelated process. IsOurProcess
+	// confirms it is still our hostagent before signalling, and again before the
+	// forced stop below, because the PID can be recycled during the graceful
+	// wait; the force path would otherwise taskkill whatever now holds the
+	// recycled PID. DriverPID is taskkilled without that check — IsOurProcess
+	// matches the rdd image, not the qemu/wsl driver — so a recycled DriverPID
+	// would be killed here. handleDeletion zeroes DriverPID on Windows; a restart
+	// cannot, because the orphaned driver must die. Job Objects, not PID files,
+	// are the proper fix.
+	forceInst := *inst
+	if inst.HostAgentPID > 0 && process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
 		if err := process.Interrupt(inst.HostAgentPID); err != nil {
 			logger.V(1).Info("Could not signal orphaned hostagent", "pid", inst.HostAgentPID, "error", err)
 		} else {
@@ -613,7 +613,12 @@ func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *lima
 		}
 	}
 
-	stopInstanceForcibly(ctx, logger, inst)
+	// Re-verify before the forced stop: the PID checked above may have been
+	// recycled during the graceful wait, as the other force-stop paths guard.
+	if forceInst.HostAgentPID > 0 && !process.IsOurProcess(forceInst.HostAgentPID, "hostagent", hostAgentPIDFile(&forceInst)) {
+		forceInst.HostAgentPID = 0
+	}
+	stopInstanceForcibly(ctx, logger, &forceInst)
 	return nil
 }
 
@@ -635,6 +640,55 @@ func waitForInstanceStopped(ctx context.Context, name string) bool {
 				return true
 			}
 		}
+	}
+}
+
+// hostAgentPIDFile returns the --pidfile path passed when starting inst's
+// hostagent. It is an unambiguous per-instance discriminator for
+// process.IsOurProcess: an instance name alone can be a prefix of another
+// (e.g. "vm" and "vm2"), but the pidfile path is bounded by the instance
+// directory, so it cannot match a sibling instance's command line.
+func hostAgentPIDFile(inst *limatype.Instance) string {
+	return filepath.Join(inst.Dir, filenames.HostAgentPID)
+}
+
+// forceStopForDeletion stops a Lima instance in preparation for a forced Delete
+// and, on Windows, clears its on-disk PIDs so Lima's Delete → StopForcibly
+// cannot send CTRL_BREAK to a process that recycled a stale PID.
+//
+// Only Running instances are force-stopped by PID. Broken instances may have
+// stale PID files pointing to recycled processes on Windows (Lima's ReadPIDFile
+// treats any live PID as valid). Not tested: simulating stale PID files requires
+// Windows-specific PID file manipulation that BATS cannot easily reproduce.
+//
+// Clearing the PIDs on Windows disables Lima's internal kill retry even if
+// stopInstanceForcibly failed above. That is intentional: a failed kill means
+// KillTree could not reach the process (access denied, already reaped), and the
+// PID may already be recycled. Retrying with a stale PID is worse than letting
+// Delete proceed without a kill. On Unix, PID recycling is rare (wraps around
+// 32768+), so Lima's Delete may clean up any surviving driver processes.
+func forceStopForDeletion(ctx context.Context, logger logr.Logger, inst *limatype.Instance) {
+	if inst.Status == limatype.StatusRunning {
+		// A StatusRunning WSL2 distro derives its status from wsl --list, not
+		// from HostAgentPID, so that PID may have been recycled on Windows.
+		// Clear it unless it is still ours, as the other force-stop paths do, so
+		// taskkill cannot reach an unrelated process. For QEMU/VZ, Lima reports
+		// StatusRunning only after the hostagent socket answers, so the PID is
+		// genuine and IsOurProcess confirms it.
+		safeInst := *inst
+		if safeInst.HostAgentPID > 0 && !process.IsOurProcess(safeInst.HostAgentPID, "hostagent", hostAgentPIDFile(&safeInst)) {
+			safeInst.HostAgentPID = 0
+		}
+		stopInstanceForcibly(ctx, logger, &safeInst)
+	} else if inst.VMType == limatype.WSL2 {
+		// A "stopped" WSL2 distro can retain kernel state that deadlocks
+		// wsl.exe --unregister. Terminate it without PID-based killing, since
+		// the PIDs may have been recycled on Windows.
+		terminateWSL2Distro(ctx, logger, inst.Name)
+	}
+	if runtime.GOOS == "windows" {
+		inst.DriverPID = 0
+		inst.HostAgentPID = 0
 	}
 }
 

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -192,25 +192,15 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 		if inst == nil {
 			return ctrl.Result{}, errors.New("instance not found")
 		}
-		// The VM driver (e.g., QEMU) may outlive the hostagent. Force-stop
-		// the instance so the next hostagent can start with a clean slate.
-		//
-		// On Windows the on-disk HostAgentPID may have been recycled to an
-		// unrelated process after the hostagent exited, so clear it unless
-		// IsOurProcess confirms it is still ours; the force path's taskkill
-		// would otherwise reach whatever now holds it. DriverPID is taskkilled
-		// without that check — IsOurProcess matches the rdd image, not the
-		// qemu/wsl driver — so a recycled DriverPID would be killed here.
-		// handleDeletion zeroes DriverPID on Windows; a restart cannot, because
-		// the orphaned driver must die. Job Objects, not PID files, are the
-		// proper fix.
+		// The VM driver (e.g., QEMU) may outlive the hostagent. Force-stop the
+		// instance so the next hostagent can start with a clean slate.
+		// stopInstanceForcibly screens the on-disk HostAgentPID; the DriverPID it
+		// cannot screen is still killed, so handleDeletion zeroes DriverPID on
+		// Windows while a restart cannot — the orphaned driver must die. Job
+		// Objects, not PID files, are the proper fix.
 		if inst.Status == limatype.StatusRunning || inst.Status == limatype.StatusBroken {
 			logger.Info("Force-stopping orphaned VM driver", "status", inst.Status)
-			forceInst := *inst
-			if inst.HostAgentPID > 0 && !process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
-				forceInst.HostAgentPID = 0
-			}
-			stopInstanceForcibly(ctx, logger, &forceInst)
+			stopInstanceForcibly(ctx, logger, inst)
 		}
 		return r.startInstance(ctx, limaVM, inst)
 
@@ -540,14 +530,9 @@ func (r *LimaVMReconciler) shutdownHostagent(ctx context.Context, name string, i
 		// forceStop runs after signalHostagent declines (no watcher, or the
 		// process was already reaped) or after a signalled hostagent ignores the
 		// graceful timeout. In the reaped case the stored HostAgentPID may already
-		// be recycled on Windows, so confirm identity before taskkill, as the
-		// other force-stop paths do. DriverPID is not verifiable here —
-		// IsOurProcess matches only the rdd image — so it is taskkilled unchecked.
-		safeInst := *forceInst
-		if safeInst.HostAgentPID > 0 && !process.IsOurProcess(safeInst.HostAgentPID, "hostagent", hostAgentPIDFile(&safeInst)) {
-			safeInst.HostAgentPID = 0
-		}
-		stopInstanceForcibly(forceCtx, logger, &safeInst)
+		// be recycled on Windows; stopInstanceForcibly screens it before the
+		// taskkill.
+		stopInstanceForcibly(forceCtx, logger, forceInst)
 	}
 
 	// After forced termination, wait briefly for the process to exit.
@@ -588,17 +573,11 @@ func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *lima
 	// to become stopped. The hostagent's own shutdown sequence handles driver
 	// termination, WSL2 distro cleanup, and tmp file removal.
 	//
-	// HostAgentPID comes from on-disk state written by a previous service, so
-	// on Windows it may have been recycled to an unrelated process. IsOurProcess
-	// confirms it is still our hostagent before signalling, and again before the
-	// forced stop below, because the PID can be recycled during the graceful
-	// wait; the force path would otherwise taskkill whatever now holds the
-	// recycled PID. DriverPID is taskkilled without that check — IsOurProcess
-	// matches the rdd image, not the qemu/wsl driver — so a recycled DriverPID
-	// would be killed here. handleDeletion zeroes DriverPID on Windows; a restart
-	// cannot, because the orphaned driver must die. Job Objects, not PID files,
-	// are the proper fix.
-	forceInst := *inst
+	// HostAgentPID comes from on-disk state written by a previous service, so on
+	// Windows it may name a recycled process. Signal it only when IsOurProcess
+	// confirms it is still our hostagent; stopInstanceForcibly re-screens before
+	// the forced stop below, because the PID can be recycled during the graceful
+	// wait.
 	if inst.HostAgentPID > 0 && process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
 		if err := process.Interrupt(inst.HostAgentPID); err != nil {
 			logger.V(1).Info("Could not signal orphaned hostagent", "pid", inst.HostAgentPID, "error", err)
@@ -613,12 +592,7 @@ func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *lima
 		}
 	}
 
-	// Re-verify before the forced stop: the PID checked above may have been
-	// recycled during the graceful wait, as the other force-stop paths guard.
-	if forceInst.HostAgentPID > 0 && !process.IsOurProcess(forceInst.HostAgentPID, "hostagent", hostAgentPIDFile(&forceInst)) {
-		forceInst.HostAgentPID = 0
-	}
-	stopInstanceForcibly(ctx, logger, &forceInst)
+	stopInstanceForcibly(ctx, logger, inst)
 	return nil
 }
 
@@ -652,6 +626,19 @@ func hostAgentPIDFile(inst *limatype.Instance) string {
 	return filepath.Join(inst.Dir, filenames.HostAgentPID)
 }
 
+// clearRecycledHostAgentPID zeroes inst.HostAgentPID unless it still names our
+// live hostagent, so a force-stop's taskkill cannot reach an unrelated process
+// that recycled the PID. The stored PID comes from on-disk state a previous
+// service wrote, which Windows may have reassigned after the hostagent exited;
+// on other platforms IsOurProcess is a no-op, so the PID is kept. DriverPID is
+// not screened here — IsOurProcess matches the rdd image, not the qemu/wsl
+// driver — so a recycled DriverPID is still taskkilled by the caller.
+func clearRecycledHostAgentPID(inst *limatype.Instance) {
+	if inst.HostAgentPID > 0 && !process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
+		inst.HostAgentPID = 0
+	}
+}
+
 // forceStopForDeletion stops a Lima instance in preparation for a forced Delete
 // and, on Windows, clears its on-disk PIDs so Lima's Delete → StopForcibly
 // cannot send CTRL_BREAK to a process that recycled a stale PID.
@@ -670,16 +657,11 @@ func hostAgentPIDFile(inst *limatype.Instance) string {
 func forceStopForDeletion(ctx context.Context, logger logr.Logger, inst *limatype.Instance) {
 	if inst.Status == limatype.StatusRunning {
 		// A StatusRunning WSL2 distro derives its status from wsl --list, not
-		// from HostAgentPID, so that PID may have been recycled on Windows.
-		// Clear it unless it is still ours, as the other force-stop paths do, so
-		// taskkill cannot reach an unrelated process. For QEMU/VZ, Lima reports
-		// StatusRunning only after the hostagent socket answers, so the PID is
-		// genuine and IsOurProcess confirms it.
-		safeInst := *inst
-		if safeInst.HostAgentPID > 0 && !process.IsOurProcess(safeInst.HostAgentPID, "hostagent", hostAgentPIDFile(&safeInst)) {
-			safeInst.HostAgentPID = 0
-		}
-		stopInstanceForcibly(ctx, logger, &safeInst)
+		// from HostAgentPID, so that PID may have been recycled on Windows;
+		// stopInstanceForcibly screens it before taskkill. For QEMU/VZ, Lima
+		// reports StatusRunning only after the hostagent socket answers, so the
+		// PID is genuine and IsOurProcess confirms it.
+		stopInstanceForcibly(ctx, logger, inst)
 	} else if inst.VMType == limatype.WSL2 {
 		// A "stopped" WSL2 distro can retain kernel state that deadlocks
 		// wsl.exe --unregister. Terminate it without PID-based killing, since
@@ -703,7 +685,15 @@ func forceStopForDeletion(ctx context.Context, logger logr.Logger, inst *limatyp
 //
 // On WSL2, also terminates the distro because the keepAlive process
 // (nohup sleep) would keep it running after the hostagent is killed.
+//
+// It screens HostAgentPID with clearRecycledHostAgentPID before killing, so a
+// recycled PID is never taskkilled. The screen runs on a copy, leaving the
+// caller's instance unchanged.
 func stopInstanceForcibly(ctx context.Context, logger logr.Logger, inst *limatype.Instance) {
+	safeInst := *inst
+	clearRecycledHostAgentPID(&safeInst)
+	inst = &safeInst
+
 	allKilled := true
 	for _, pid := range []int{inst.DriverPID, inst.HostAgentPID} {
 		if pid > 0 {

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -137,7 +137,10 @@ func Exists() bool {
 // PIDNotFound indicates no running service process was found.
 const PIDNotFound = 0
 
-// PID returns the process ID of the running service, or PIDNotFound if it is not running.
+// PID returns the process ID of the running service, or PIDNotFound if it is
+// not running. On Windows it walks the candidate process's PEB to read its
+// command line (see process.IsOurProcess), so callers that poll it in a tight
+// loop pay a cross-process read each call.
 func PID() int {
 	pidStr, err := os.ReadFile(instance.PIDFile())
 	if err != nil {
@@ -145,15 +148,39 @@ func PID() int {
 	}
 	pid, err := strconv.Atoi(string(pidStr))
 	if err == nil {
-		var process *os.Process
-		process, err = os.FindProcess(pid)
+		var proc *os.Process
+		proc, err = os.FindProcess(pid)
 		if err == nil {
 			// on non-Windows, FindProcess may return without the process being
 			// alive; on Windows, the result encapsulates a valid handle.
 			if runtime.GOOS != "windows" {
-				err = process.Signal(syscall.Signal(0))
+				err = proc.Signal(syscall.Signal(0))
 			}
-			_ = process.Release()
+			_ = proc.Release()
+		}
+		// On Windows, FindProcess succeeds for any live PID, including one the
+		// OS recycled after a crash left our PID file behind. Confirm the PID
+		// still runs our control plane, so a recycled PID reads as not-running.
+		// IsOurProcess is a no-op (true) on other platforms.
+		//
+		// Match the "serve" token alone, not "service serve": the daemon can be
+		// launched through the "svc" alias as `rdd svc serve`, whose command line
+		// holds "svc serve". No other rdd subcommand name contains "serve", and
+		// the image-path match already rejects unrelated rdd processes.
+		//
+		// "serve" carries no instance name, so this confirms the PID runs a
+		// control plane, not specifically this instance's. A PID recycled to a
+		// *different* instance's control plane would pass. That needs concurrent
+		// instances (dev/test only); a lone instance never recycles a PID into
+		// another control plane.
+		//
+		// IsOurProcess returns false for any state it cannot confirm — a denied
+		// OpenProcess or a short PEB read on a live control plane included. Such a
+		// false negative reads as not-running and removes the PID file below; we
+		// accept that as the cost of the guard, which needs only the low query
+		// rights a same-user process always grants.
+		if err == nil && !process.IsOurProcess(pid, "serve") {
+			err = fmt.Errorf("pid %d is not our control plane", pid)
 		}
 	}
 	if err != nil {

--- a/pkg/service/cmd/service.go
+++ b/pkg/service/cmd/service.go
@@ -139,8 +139,8 @@ const PIDNotFound = 0
 
 // PID returns the process ID of the running service, or PIDNotFound if it is
 // not running. On Windows it walks the candidate process's PEB to read its
-// command line (see process.IsOurProcess), so callers that poll it in a tight
-// loop pay a cross-process read each call.
+// command line (see process.IsOurProcessWithArg), so callers that poll it in a
+// tight loop pay a cross-process read each call.
 func PID() int {
 	pidStr, err := os.ReadFile(instance.PIDFile())
 	if err != nil {
@@ -161,12 +161,14 @@ func PID() int {
 		// On Windows, FindProcess succeeds for any live PID, including one the
 		// OS recycled after a crash left our PID file behind. Confirm the PID
 		// still runs our control plane, so a recycled PID reads as not-running.
-		// IsOurProcess is a no-op (true) on other platforms.
+		// IsOurProcessWithArg is a no-op (true) on other platforms.
 		//
-		// Match the "serve" token alone, not "service serve": the daemon can be
-		// launched through the "svc" alias as `rdd svc serve`, whose command line
-		// holds "svc serve". No other rdd subcommand name contains "serve", and
-		// the image-path match already rejects unrelated rdd processes.
+		// Match "serve" as a whole command-line argument, not a substring: the
+		// daemon runs as `service serve` (the canonical self-spawn) or `svc serve`
+		// (the alias), so "serve" is always an argument and no other rdd subcommand
+		// is. Whole-argument matching ignores argv[0], so an install path that
+		// happens to contain "serve" cannot make an unrelated rdd process — a CLI
+		// command or a hostagent — read as the control plane.
 		//
 		// "serve" carries no instance name, so this confirms the PID runs a
 		// control plane, not specifically this instance's. A PID recycled to a
@@ -174,12 +176,12 @@ func PID() int {
 		// instances (dev/test only); a lone instance never recycles a PID into
 		// another control plane.
 		//
-		// IsOurProcess returns false for any state it cannot confirm — a denied
-		// OpenProcess or a short PEB read on a live control plane included. Such a
-		// false negative reads as not-running and removes the PID file below; we
-		// accept that as the cost of the guard, which needs only the low query
-		// rights a same-user process always grants.
-		if err == nil && !process.IsOurProcess(pid, "serve") {
+		// IsOurProcessWithArg returns false for any state it cannot confirm — a
+		// denied OpenProcess or a short PEB read on a live control plane included.
+		// Such a false negative reads as not-running and removes the PID file
+		// below; we accept that as the cost of the guard, which needs only the low
+		// query rights a same-user process always grants.
+		if err == nil && !process.IsOurProcessWithArg(pid, "serve") {
 			err = fmt.Errorf("pid %d is not our control plane", pid)
 		}
 	}
@@ -461,11 +463,17 @@ func Wait(ctx context.Context) error {
 // blocks until the process exits, ctx is cancelled, or timeout elapses; pass
 // timeout 0 to wait indefinitely (bounded only by ctx).
 func StopWithWait(ctx context.Context, wait bool, timeout time.Duration) error {
-	if !Running() {
+	// Read the PID once and reject PIDNotFound before signalling. A second PID()
+	// call (the old Running()-then-PID() pattern) can return PIDNotFound when the
+	// daemon exits, a concurrent stop removes the file, or the identity check
+	// transiently fails between the two reads; signalling 0 then broadcasts —
+	// GenerateConsoleCtrlEvent(CTRL_BREAK, 0) reaches every process sharing the
+	// console on Windows, and kill(0) the caller's whole process group on Unix.
+	pid := PID()
+	if pid == PIDNotFound {
 		return fmt.Errorf("%q control plane is not running", instance.Name())
 	}
 
-	pid := PID()
 	// Try graceful shutdown first. On Unix, Kill already sends SIGTERM which
 	// triggers the Go signal handler. On Windows, Kill uses TerminateProcess
 	// which bypasses all handlers, so we send Interrupt (CTRL_BREAK_EVENT)

--- a/pkg/util/process/doc.go
+++ b/pkg/util/process/doc.go
@@ -3,6 +3,6 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
 // Package process provides cross-platform utilities for subprocess management,
-// including process group isolation and signal delivery (SIGINT, SIGTERM,
-// SIGKILL).
+// including process group isolation, signal delivery (SIGINT, SIGTERM,
+// SIGKILL), and process-identity verification.
 package process

--- a/pkg/util/process/process_unix.go
+++ b/pkg/util/process/process_unix.go
@@ -27,6 +27,22 @@ func Interrupt(pid int) error {
 	return unix.Kill(pid, unix.SIGINT)
 }
 
+// IsOurProcess reports whether pid is a live process running this program's own
+// executable. On Unix it is always true: a deliberate no-op, not a guard, so
+// the parameters go unused (they exist for signature parity with the Windows
+// build, where the check defends GenerateConsoleCtrlEvent against PID reuse — a
+// console-signal hazard that does not exist on Unix).
+//
+// Residual risk: callers that read an on-disk PID (ha.pid from a previous
+// service) can, after a crash or reboot leaves the file behind, act on a PID
+// the OS recycled to an unrelated live process — SIGINT on the signal path,
+// SIGKILL of its process group on the forced path. We accept it because Unix
+// recycles PIDs only after the counter wraps, far less aggressively than
+// Windows.
+func IsOurProcess(_ int, _ ...string) bool {
+	return true
+}
+
 // Kill sends SIGTERM to the process with the given PID.
 func Kill(pid int) error {
 	return unix.Kill(pid, unix.SIGTERM)

--- a/pkg/util/process/process_unix.go
+++ b/pkg/util/process/process_unix.go
@@ -43,6 +43,13 @@ func IsOurProcess(_ int, _ ...string) bool {
 	return true
 }
 
+// IsOurProcessWithArg is the whole-argument counterpart of IsOurProcess. On
+// Unix it is the same deliberate no-op, returning true for signature parity
+// with the Windows build.
+func IsOurProcessWithArg(_ int, _ string) bool {
+	return true
+}
+
 // Kill sends SIGTERM to the process with the given PID.
 func Kill(pid int) error {
 	return unix.Kill(pid, unix.SIGTERM)

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -8,9 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -31,6 +35,132 @@ func SetGroup(cmd *exec.Cmd) {
 // at the process group (requires CREATE_NEW_PROCESS_GROUP via SetGroup).
 func Interrupt(pid int) error {
 	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(pid))
+}
+
+// IsOurProcess reports whether pid is a live process running this program's own
+// executable with a command line that contains every string in cmdlineSubstrings.
+//
+// It guards graceful shutdown via Interrupt against PID reuse. Windows recycles
+// PIDs aggressively, and GenerateConsoleCtrlEvent(CTRL_BREAK) delivered to a
+// recycled PID can reach unrelated processes that share the console — including
+// the rdd service and the controlling terminal — rather than the intended
+// target. Callers confirm identity here before signalling; on a mismatch they
+// fall back to KillTree, which terminates a single PID and cannot escape to the
+// console.
+//
+// It returns false (never an error) whenever identity cannot be positively
+// confirmed — the process is gone, inaccessible, or no longer ours — so callers
+// treat "unknown" as "not ours" and never signal it.
+//
+// Each substring is matched with strings.Contains, not as a whole argument, so a
+// discriminator must be specific enough that it cannot appear in an unrelated
+// process's command line. An instance name that is a prefix of another (e.g.
+// "vm" and "vm2") matches both; pass a name distinct enough to avoid that.
+//
+// With no substrings the image-path match alone decides the result, which a
+// recycled PID running any other rdd process would satisfy; production callers
+// should always pass a discriminator.
+func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
+	self, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	image, err := processImagePath(handle)
+	if err != nil || !strings.EqualFold(filepath.Clean(image), filepath.Clean(self)) {
+		return false
+	}
+	cmdline, err := processCommandLine(handle)
+	if err != nil {
+		return false
+	}
+	for _, s := range cmdlineSubstrings {
+		if !strings.Contains(cmdline, s) {
+			return false
+		}
+	}
+	return true
+}
+
+// processImagePath returns the full path to the executable backing the process.
+// QueryFullProcessImageName does not report the size it needs on failure, so on
+// ERROR_INSUFFICIENT_BUFFER this doubles the buffer and retries, up to the
+// Windows extended-path ceiling of 32767 characters.
+func processImagePath(handle windows.Handle) (string, error) {
+	for bufSize := 1024; bufSize <= 32768; bufSize *= 2 {
+		buf := make([]uint16, bufSize)
+		size := uint32(len(buf))
+		err := windows.QueryFullProcessImageName(handle, 0, &buf[0], &size)
+		if err == nil {
+			return windows.UTF16ToString(buf[:size]), nil
+		}
+		if !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
+			return "", err
+		}
+	}
+	return "", windows.ERROR_INSUFFICIENT_BUFFER
+}
+
+// processCommandLine reads the target process's command line out of its PEB.
+// Windows exposes no API for another process's command line, so we follow the
+// documented PEB -> RTL_USER_PROCESS_PARAMETERS -> CommandLine chain via
+// ReadProcessMemory. The handle must carry PROCESS_VM_READ.
+func processCommandLine(handle windows.Handle) (string, error) {
+	var pbi windows.PROCESS_BASIC_INFORMATION
+	var retLen uint32
+	if err := windows.NtQueryInformationProcess(handle, windows.ProcessBasicInformation,
+		unsafe.Pointer(&pbi), uint32(unsafe.Sizeof(pbi)), &retLen); err != nil {
+		return "", err
+	}
+
+	var peb windows.PEB
+	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(pbi.PebBaseAddress)),
+		unsafe.Pointer(&peb), unsafe.Sizeof(peb)); err != nil {
+		return "", err
+	}
+
+	var params windows.RTL_USER_PROCESS_PARAMETERS
+	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(peb.ProcessParameters)),
+		unsafe.Pointer(&params), unsafe.Sizeof(params)); err != nil {
+		return "", err
+	}
+
+	length := params.CommandLine.Length
+	// Under one UTF-16 unit — including an impossible odd byte count — there is
+	// no command line to read, and length/2 would size buf to zero and panic the
+	// &buf[0] deref below. Treat it as empty.
+	if length < 2 || params.CommandLine.Buffer == nil {
+		return "", nil
+	}
+	// NTUnicodeString.Length counts bytes; the buffer holds UTF-16 code units.
+	// Read len(buf)*2 bytes rather than Length itself, so the read can never
+	// exceed the buffer if Length is ever odd — it is not on supported Windows,
+	// but pairing the read size to the buffer makes the invariant explicit.
+	buf := make([]uint16, length/2)
+	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(params.CommandLine.Buffer)),
+		unsafe.Pointer(&buf[0]), uintptr(len(buf)*2)); err != nil {
+		return "", err
+	}
+	return windows.UTF16ToString(buf), nil
+}
+
+// readProcessMemory copies size bytes at addr in the target process into dest,
+// erroring unless the full range was read.
+func readProcessMemory(handle windows.Handle, addr uintptr, dest unsafe.Pointer, size uintptr) error {
+	var read uintptr
+	if err := windows.ReadProcessMemory(handle, addr, (*byte)(dest), size, &read); err != nil {
+		return err
+	}
+	if read != size {
+		return fmt.Errorf("short read at %#x: got %d of %d bytes", addr, read, size)
+	}
+	return nil
 }
 
 // Kill terminates the process with the given PID.

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -73,7 +73,7 @@ func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
 	defer func() { _ = windows.CloseHandle(handle) }()
 
 	image, err := processImagePath(handle)
-	if err != nil || !strings.EqualFold(filepath.Clean(image), filepath.Clean(self)) {
+	if err != nil || !samePath(image, self) {
 		return false
 	}
 	cmdline, err := processCommandLine(handle)
@@ -86,6 +86,49 @@ func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
 		}
 	}
 	return true
+}
+
+// samePath reports whether image and self name the same on-disk executable.
+// It resolves each to its long (non-8.3) form first, so a process launched
+// through a short path such as C:\PROGRA~1\... still matches the same binary
+// named by its long path. The two rdd processes compared need not have been
+// launched the same way.
+func samePath(image, self string) bool {
+	return strings.EqualFold(longPath(image), longPath(self))
+}
+
+// longPath returns p in its long, non-8.3 form. If the long form cannot be
+// resolved (for example the file no longer exists), it falls back to
+// filepath.Clean(p) so a transient resolution failure degrades to a lexical
+// comparison rather than a guaranteed mismatch — for the service PID a false
+// "not ours" would orphan a live control plane.
+func longPath(p string) string {
+	if resolved, err := resolveLongPath(p); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(p)
+}
+
+// resolveLongPath expands any 8.3 short components of p via GetLongPathName,
+// growing the buffer up to the Windows extended-path ceiling the way
+// processImagePath does.
+func resolveLongPath(p string) (string, error) {
+	p16, err := windows.UTF16PtrFromString(p)
+	if err != nil {
+		return "", err
+	}
+	for bufSize := uint32(1024); bufSize <= 32768; bufSize *= 2 {
+		buf := make([]uint16, bufSize)
+		n, err := windows.GetLongPathName(p16, &buf[0], bufSize)
+		if err != nil {
+			return "", err
+		}
+		if n < bufSize {
+			return windows.UTF16ToString(buf[:n]), nil
+		}
+		// n >= bufSize: the buffer was too small and n is the required size; grow.
+	}
+	return "", windows.ERROR_INSUFFICIENT_BUFFER
 }
 
 // processImagePath returns the full path to the executable backing the process.

--- a/pkg/util/process/process_windows.go
+++ b/pkg/util/process/process_windows.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -59,25 +60,12 @@ func Interrupt(pid int) error {
 //
 // With no substrings the image-path match alone decides the result, which a
 // recycled PID running any other rdd process would satisfy; production callers
-// should always pass a discriminator.
+// should always pass a discriminator. To match a short token that could also
+// appear inside the image path, use IsOurProcessWithArg, which compares whole
+// arguments instead of substrings.
 func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
-	self, err := os.Executable()
-	if err != nil {
-		return false
-	}
-	handle, err := windows.OpenProcess(
-		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
-	if err != nil {
-		return false
-	}
-	defer func() { _ = windows.CloseHandle(handle) }()
-
-	image, err := processImagePath(handle)
-	if err != nil || !samePath(image, self) {
-		return false
-	}
-	cmdline, err := processCommandLine(handle)
-	if err != nil {
+	cmdline, ok := ourProcessCommandLine(pid)
+	if !ok {
 		return false
 	}
 	for _, s := range cmdlineSubstrings {
@@ -86,6 +74,64 @@ func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
 		}
 	}
 	return true
+}
+
+// IsOurProcessWithArg reports whether pid is a live process running this
+// program's own executable with arg as one of its command-line arguments
+// (argv[1:], excluding the executable path). Unlike IsOurProcess, which matches
+// a raw substring of the whole command line, this matches a complete argument,
+// so a short token such as a subcommand name cannot be satisfied by an
+// unrelated process whose image path merely contains that text.
+//
+// It shares IsOurProcess's identity guarantees and failure semantics: it
+// returns false (never an error) whenever identity cannot be positively
+// confirmed, so callers treat "unknown" as "not ours". On non-Windows it is a
+// no-op that returns true, like IsOurProcess.
+func IsOurProcessWithArg(pid int, arg string) bool {
+	cmdline, ok := ourProcessCommandLine(pid)
+	if !ok {
+		return false
+	}
+	return commandLineHasArg(cmdline, arg)
+}
+
+// commandLineHasArg reports whether arg appears as a complete argument in
+// commandLine, ignoring argv[0] (the executable path). It parses the command
+// line with the same rules Windows uses (CommandLineToArgvW, via
+// DecomposeCommandLine), so a quoted path containing spaces stays a single
+// argument and a token that is only a substring of argv[0] is not matched.
+func commandLineHasArg(commandLine, arg string) bool {
+	args, err := windows.DecomposeCommandLine(commandLine)
+	if err != nil || len(args) < 2 {
+		return false
+	}
+	return slices.Contains(args[1:], arg)
+}
+
+// ourProcessCommandLine returns pid's command line when pid is a live process
+// running this program's own executable, and false otherwise. It centralises
+// the OpenProcess and image-path comparison that the identity checks share.
+func ourProcessCommandLine(pid int) (string, bool) {
+	self, err := os.Executable()
+	if err != nil {
+		return "", false
+	}
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	image, err := processImagePath(handle)
+	if err != nil || !samePath(image, self) {
+		return "", false
+	}
+	cmdline, err := processCommandLine(handle)
+	if err != nil {
+		return "", false
+	}
+	return cmdline, true
 }
 
 // samePath reports whether image and self name the same on-disk executable.

--- a/pkg/util/process/process_windows_test.go
+++ b/pkg/util/process/process_windows_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+	"gotest.tools/v3/assert"
+)
+
+func openSelf(t *testing.T) windows.Handle {
+	t.Helper()
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(os.Getpid()))
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = windows.CloseHandle(handle) })
+	return handle
+}
+
+// TestProcessCommandLineReadsOwnCommandLine exercises the PEB walk against the
+// running test process, catching struct-offset regressions in the unsafe reads.
+func TestProcessCommandLineReadsOwnCommandLine(t *testing.T) {
+	cmdline, err := processCommandLine(openSelf(t))
+	assert.NilError(t, err)
+	assert.Assert(t, cmdline != "", "command line should not be empty")
+
+	base := filepath.Base(os.Args[0])
+	assert.Assert(t, strings.Contains(cmdline, base),
+		"command line %q should contain argv0 base %q", cmdline, base)
+}
+
+// TestIsOurProcess confirms identity matching: the running process matches its
+// own executable and command line, and rejects absent substrings and dead PIDs.
+func TestIsOurProcess(t *testing.T) {
+	pid := os.Getpid()
+	base := filepath.Base(os.Args[0])
+
+	assert.Assert(t, IsOurProcess(pid), "current process should match its own executable")
+	assert.Assert(t, IsOurProcess(pid, base),
+		"current process should match its own argv0 base %q", base)
+	assert.Assert(t, !IsOurProcess(pid, "substring-that-cannot-appear-9c1f"),
+		"a substring absent from the command line should not match")
+	// A PID this high is never assigned, so OpenProcess fails and the result
+	// must be false rather than an accidental match.
+	assert.Assert(t, !IsOurProcess(0xFFFFFFF0, "hostagent"),
+		"a nonexistent PID should not match")
+}
+
+// TestIsOurProcessRejectsForeignExecutable confirms the image-path check: a live
+// process running a different executable is not ours, even when a requested
+// substring appears in its command line. This is the branch that defends against
+// PID reuse.
+func TestIsOurProcessRejectsForeignExecutable(t *testing.T) {
+	// ping runs for several seconds without console input, giving a stable live
+	// PID backed by an executable other than the test binary.
+	cmd := exec.CommandContext(t.Context(), "ping.exe", "-n", "10", "127.0.0.1")
+	assert.NilError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	pid := cmd.Process.Pid
+
+	// Confirm the rejection comes from the image-path mismatch rather than an
+	// OpenProcess failure or an already-exited process: open the child the way
+	// IsOurProcess does and verify its image is readable and differs from the
+	// test binary. Without this, a denied OpenProcess would let the assertions
+	// below pass without exercising the defense.
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
+	assert.NilError(t, err)
+	defer func() { _ = windows.CloseHandle(handle) }()
+	image, err := processImagePath(handle)
+	assert.NilError(t, err)
+	self, err := os.Executable()
+	assert.NilError(t, err)
+	assert.Assert(t, !strings.EqualFold(filepath.Clean(image), filepath.Clean(self)),
+		"ping image %q must differ from the test binary %q", image, self)
+
+	assert.Assert(t, !IsOurProcess(pid),
+		"a live process running a different executable should not match")
+	assert.Assert(t, !IsOurProcess(pid, "ping"),
+		"a command-line substring match must not override an executable mismatch")
+}

--- a/pkg/util/process/process_windows_test.go
+++ b/pkg/util/process/process_windows_test.go
@@ -90,3 +90,35 @@ func TestIsOurProcessRejectsForeignExecutable(t *testing.T) {
 	assert.Assert(t, !IsOurProcess(pid, "ping"),
 		"a command-line substring match must not override an executable mismatch")
 }
+
+// TestSamePathMatchesShortAndLongForms confirms samePath treats an 8.3 short
+// path and its long form as the same executable. A user can launch rdd through
+// either form, so the identity check must recognize a live control plane no
+// matter which form named the process being checked.
+func TestSamePathMatchesShortAndLongForms(t *testing.T) {
+	// A directory name with no natural 8.3 form makes Windows synthesize a
+	// distinct short name where 8.3 generation is enabled on the volume.
+	longDir := filepath.Join(t.TempDir(), "LongDirectoryNameBeyond8dot3")
+	assert.NilError(t, os.Mkdir(longDir, 0o755))
+	longFile := filepath.Join(longDir, "control-plane-binary.exe")
+	assert.NilError(t, os.WriteFile(longFile, []byte("stub"), 0o644))
+
+	short := shortPathName(t, longFile)
+	if strings.EqualFold(filepath.Clean(short), filepath.Clean(longFile)) {
+		t.Skip("8.3 short-name generation is disabled on this volume")
+	}
+	assert.Assert(t, samePath(short, longFile),
+		"short form %q and long form %q must resolve to the same executable", short, longFile)
+}
+
+// shortPathName returns the 8.3 short form of p via GetShortPathName.
+func shortPathName(t *testing.T, p string) string {
+	t.Helper()
+	p16, err := windows.UTF16PtrFromString(p)
+	assert.NilError(t, err)
+	buf := make([]uint16, 1024)
+	n, err := windows.GetShortPathName(p16, &buf[0], uint32(len(buf)))
+	assert.NilError(t, err)
+	assert.Assert(t, n < uint32(len(buf)), "short-path buffer too small")
+	return windows.UTF16ToString(buf[:n])
+}

--- a/pkg/util/process/process_windows_test.go
+++ b/pkg/util/process/process_windows_test.go
@@ -53,6 +53,50 @@ func TestIsOurProcess(t *testing.T) {
 		"a nonexistent PID should not match")
 }
 
+// TestCommandLineHasArg confirms whole-argument matching: a token is matched
+// only as a complete argument in argv[1:], never as a substring of argv[0] or
+// of another argument. This is the property that keeps the service-PID guard
+// from accepting an unrelated rdd process whose image path contains "serve".
+func TestCommandLineHasArg(t *testing.T) {
+	assert.Assert(t, commandLineHasArg(`C:\rdd.exe service serve --secure-port 6443`, "serve"),
+		"the canonical self-spawn carries serve as an argument")
+	assert.Assert(t, commandLineHasArg(`C:\rdd.exe svc serve`, "serve"),
+		"the svc alias also carries serve as an argument")
+	assert.Assert(t, commandLineHasArg(`"C:\Program Files\rdd\rdd.exe" service serve`, "serve"),
+		"a quoted image path with spaces stays a single argv[0]")
+	// argv[0] containing the token as a substring must not match.
+	assert.Assert(t, !commandLineHasArg(`C:\observer\rdd.exe ctl get`, "serve"),
+		"serve inside the image path is not an argument")
+	assert.Assert(t, !commandLineHasArg(`C:\webserver\rdd.exe ctl`, "serve"),
+		"serve inside the image path is not an argument")
+	// Another rdd subcommand is not the control plane.
+	assert.Assert(t, !commandLineHasArg(`C:\rdd.exe hostagent --pidfile C:\x\ha.pid vm`, "serve"),
+		"the hostagent subcommand is not serve")
+	// argv[0] alone, with no arguments, never matches.
+	assert.Assert(t, !commandLineHasArg(`C:\rdd.exe`, "serve"),
+		"a bare image path has no arguments to match")
+}
+
+// TestIsOurProcessWithArg confirms the whole-argument identity check: the argv0
+// base name is a substring of the command line but not an argument, so it must
+// not match — the behaviour that distinguishes IsOurProcessWithArg from
+// IsOurProcess and closes the image-path over-match.
+func TestIsOurProcessWithArg(t *testing.T) {
+	pid := os.Getpid()
+	base := filepath.Base(os.Args[0])
+
+	assert.Assert(t, !IsOurProcessWithArg(pid, base),
+		"the argv0 base %q is part of argv0, not an argument", base)
+	assert.Assert(t, !IsOurProcessWithArg(pid, "arg-that-cannot-appear-9c1f"),
+		"an argument absent from the command line should not match")
+	assert.Assert(t, !IsOurProcessWithArg(0xFFFFFFF0, "serve"),
+		"a nonexistent PID should not match")
+	if len(os.Args) > 1 {
+		assert.Assert(t, IsOurProcessWithArg(pid, os.Args[1]),
+			"the running process should match its own argument %q", os.Args[1])
+	}
+}
+
 // TestIsOurProcessRejectsForeignExecutable confirms the image-path check: a live
 // process running a different executable is not ours, even when a requested
 // substring appears in its command line. This is the branch that defends against


### PR DESCRIPTION
Windows recycles PIDs quickly, so a PID read from on-disk state — the service PID file, or the hostagent's Lima state — can resolve to an unrelated process long after the original exited. rdd then signals or force-kills that bystander.

This PR adds `process.IsOurProcess`, which confirms a stored PID still runs our own executable, and applies it to every path that acts on such a PID.

1. **Verify hostagent identity before sending CTRL_BREAK on Windows** — adds `process.IsOurProcess` and guards the signal and force-stop paths that trust an on-disk PID, so `GenerateConsoleCtrlEvent(CTRL_BREAK)` cannot escape to the console and kill the rdd service or controlling terminal.

2. **Reject a recycled service PID on Windows** — guards `service.PID()` so a recycled PID left in the PID file after a crash reads as not-running, instead of making `Running()` report a dead control plane as alive.

3. **Always reclaim hostagent resources during graceful shutdown** — `shutdownAllHostagents` force-stops after every wait, not only on timeout, and screens the on-disk PID with `IsOurProcess` before taskkill.
