### PR TITLE
Add support for `stable` and `latest` Kubernetes versions

### DIFF
--- a/bats/tests/32-app-controllers/app.bats
+++ b/bats/tests/32-app-controllers/app.bats
@@ -334,6 +334,26 @@ EOF
     assert_output --partial "not found"
 }
 
+@test "mutating webhook resolves Kubernetes version channels and defaults to stable" {
+    delete_app
+    # --wait=false: the webhook resolves the version at admission, so the test reads it
+    # without waiting for the App to settle. The LimaVM is still created in the background.
+    rdd set --wait=false running=false kubernetes.enabled=true kubernetes.version=stable
+    # The mutating webhook rewrites the "stable" channel to a concrete version
+    # before the validating webhook runs, which would otherwise reject "stable"
+    # as an unsupported version.
+    run -0 rdd ctl get app "${APP_NAME}" -o jsonpath='{.spec.kubernetes.version}'
+    assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+$'
+    stable_version=${output}
+
+    # Omitting the version resolves to the same concrete version as an explicit
+    # "stable", confirming stable is the default channel.
+    delete_app
+    rdd set --wait=false running=false kubernetes.enabled=true
+    run -0 rdd ctl get app "${APP_NAME}" -o jsonpath='{.spec.kubernetes.version}'
+    assert_output "${stable_version}"
+}
+
 @test "valid Kubernetes version allows LimaVM creation" {
     skip_on_windows "Kubernetes tests require further setup on Windows"
     delete_app
@@ -444,20 +464,10 @@ EOF
     assert_output --partial "containerEngine.name"
 }
 
-@test "dry-run rejects kubernetes.enabled=true with empty version" {
-    run -1 rdd ctl apply --dry-run=server -f - <<EOF
-apiVersion: app.rancherdesktop.io/v1alpha1
-kind: App
-metadata:
-  name: app
-spec:
-  running: false
-  containerEngine:
-    name: moby
-  kubernetes:
-    enabled: true
-EOF
-    assert_output --partial "kubernetes.version must not be empty"
+@test "dry-run accepts kubernetes.enabled=true with empty version" {
+    # The mutating webhook defaults the version to the stable channel, so
+    # enabling Kubernetes without one passes validation.
+    rdd set --dry-run running=false containerEngine.name=moby kubernetes.enabled=true
 }
 
 @test "dry-run rejects unsupported kubernetes.version" {

--- a/pkg/controllers/app/app/controller.go
+++ b/pkg/controllers/app/app/controller.go
@@ -64,6 +64,10 @@ const (
 	appValidatorWebhookName = "app-validator.app.rancherdesktop.io"
 	// appValidatorConfigName is the name of the App ValidatingWebhookConfiguration.
 	appValidatorConfigName = "app-validator"
+	// appDefaulterWebhookName is the name used for the App mutating webhook.
+	appDefaulterWebhookName = "app-defaulter.app.rancherdesktop.io"
+	// appDefaulterConfigName is the name of the App MutatingWebhookConfiguration.
+	appDefaulterConfigName = "app-defaulter"
 )
 
 // controller implements the base.Controller interface for app.
@@ -112,8 +116,31 @@ func (c *controller) GetWebhookManagers() []base.WebhookManager {
 	return c.webhookManagers
 }
 
-// setupWebhook sets up the App validating webhook.
+// setupWebhook sets up the App mutating and validating webhooks. The mutating
+// webhook resolves Kubernetes version channels (e.g. "stable") to concrete
+// versions before the validating webhook checks them.
 func (c *controller) setupWebhook(mgr ctrl.Manager) error {
+	defaulter, err := controllers.NewAppDefaulter(k3sVersionsData)
+	if err != nil {
+		return err
+	}
+	mutatingConfig := base.WebhookConfig[*v1alpha1.App]{
+		Name:        appDefaulterConfigName,
+		WebhookName: appDefaulterWebhookName,
+		WebhookPort: c.webhookPort,
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
+			admissionregistrationv1.Update,
+		},
+		Defaulter: defaulter,
+	}
+
+	managers, err := base.SetupWebhookForResource(mgr, &v1alpha1.App{}, mutatingConfig)
+	if err != nil {
+		return err
+	}
+	c.webhookManagers = append(c.webhookManagers, managers...)
+
 	validator, err := controllers.NewAppValidator(k3sVersionsData)
 	if err != nil {
 		return err
@@ -129,7 +156,7 @@ func (c *controller) setupWebhook(mgr ctrl.Manager) error {
 		Validator: validator,
 	}
 
-	managers, err := base.SetupWebhookForResource(mgr, &v1alpha1.App{}, validatingConfig)
+	managers, err = base.SetupWebhookForResource(mgr, &v1alpha1.App{}, validatingConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/app/app/controllers/app_defaulter.go
+++ b/pkg/controllers/app/app/controllers/app_defaulter.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	ctrlwebhookadmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+// defaultK8sChannel is the channel used when Kubernetes is enabled without a version.
+const defaultK8sChannel = "stable"
+
+// AppDefaulter resolves channel aliases in App resources via a mutating
+// admission webhook. It runs before the validating webhook, so an alias such
+// as "stable" or "latest" becomes a concrete version that AppValidator accepts.
+type AppDefaulter struct {
+	channels map[string]string
+}
+
+// NewAppDefaulter parses k3sVersionsData once at construction time so that a
+// malformed JSON fixture causes controller startup to fail rather than the
+// first admission request.
+func NewAppDefaulter(k3sVersionsData string) (*AppDefaulter, error) {
+	channels, err := parseK3sChannels(k3sVersionsData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Kubernetes version channels: %w", err)
+	}
+	return &AppDefaulter{channels: channels}, nil
+}
+
+var _ ctrlwebhookadmission.Defaulter[*v1alpha1.App] = &AppDefaulter{}
+
+// Default resolves a channel alias in spec.kubernetes.version to a concrete
+// version. When Kubernetes is enabled without a version, it uses the "stable"
+// channel. It leaves a version that matches no channel unchanged for
+// AppValidator to accept or reject.
+func (d *AppDefaulter) Default(_ context.Context, app *v1alpha1.App) error {
+	k8s := &app.Spec.Kubernetes
+	version := k8s.Version
+	if version == "" {
+		if !k8s.Enabled {
+			return nil
+		}
+		version = defaultK8sChannel
+	}
+	if resolved, ok := d.channels[strings.TrimPrefix(version, "v")]; ok {
+		k8s.Version = resolved
+	}
+	return nil
+}

--- a/pkg/controllers/app/app/controllers/app_defaulter_test.go
+++ b/pkg/controllers/app/app/controllers/app_defaulter_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+// testK3sVersions is a minimal k3s-versions.json fixture for defaulter tests.
+const testK3sVersions = `{
+  "channels": {
+    "latest": "1.35.3",
+    "stable": "1.34.6",
+    "v1.32": "1.32.13"
+  },
+  "versions": ["v1.32.13+k3s1", "v1.34.6+k3s1", "v1.35.3+k3s1"]
+}`
+
+func Test_AppDefaulter_Default(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		enabled bool
+		version string
+		want    string
+	}{
+		{
+			name:    "enabled without version defaults to stable",
+			enabled: true,
+			version: "",
+			want:    "1.34.6",
+		},
+		{
+			name:    "disabled without version stays empty",
+			enabled: false,
+			version: "",
+			want:    "",
+		},
+		{
+			name:    "stable resolves to its concrete version",
+			enabled: true,
+			version: "stable",
+			want:    "1.34.6",
+		},
+		{
+			name:    "latest resolves to its concrete version",
+			enabled: true,
+			version: "latest",
+			want:    "1.35.3",
+		},
+		{
+			name:    "v-prefixed minor channel resolves",
+			enabled: true,
+			version: "v1.32",
+			want:    "1.32.13",
+		},
+		{
+			name:    "bare minor channel resolves",
+			enabled: true,
+			version: "1.32",
+			want:    "1.32.13",
+		},
+		{
+			name:    "concrete version passes through unchanged",
+			enabled: true,
+			version: "1.34.6",
+			want:    "1.34.6",
+		},
+		{
+			name:    "unknown version passes through for the validator to reject",
+			enabled: true,
+			version: "9.9.9",
+			want:    "9.9.9",
+		},
+		{
+			name:    "channel resolves even when Kubernetes is disabled",
+			enabled: false,
+			version: "stable",
+			want:    "1.34.6",
+		},
+	}
+
+	d, err := NewAppDefaulter(testK3sVersions)
+	assert.NilError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Kubernetes: v1alpha1.KubernetesSpec{
+						Enabled: tt.enabled,
+						Version: tt.version,
+					},
+				},
+			}
+			err := d.Default(context.Background(), app)
+			assert.NilError(t, err)
+			assert.Equal(t, app.Spec.Kubernetes.Version, tt.want)
+		})
+	}
+}

--- a/pkg/controllers/app/app/controllers/k3s_versions.go
+++ b/pkg/controllers/app/app/controllers/k3s_versions.go
@@ -10,25 +10,55 @@ import (
 	"strings"
 )
 
-// k3sVersionsJSON mirrors the k3s-versions.json versions.
+// k3sVersionsJSON mirrors the k3s-versions.json fields we consume.
 type k3sVersionsJSON struct {
-	Versions []string `json:"versions"`
+	Versions []string          `json:"versions"`
+	Channels map[string]string `json:"channels"`
+}
+
+// bareVersion strips the leading "v" and "+k3s*" suffix, turning
+// "v1.32.0+k3s1" into "1.32.0".
+func bareVersion(v string) string {
+	v = strings.TrimPrefix(v, "v")
+	v, _, _ = strings.Cut(v, "+")
+	return v
+}
+
+// unmarshalK3sVersions parses the embedded k3s-versions.json into its Go form.
+func unmarshalK3sVersions(data string) (k3sVersionsJSON, error) {
+	var parsed k3sVersionsJSON
+	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+		return parsed, fmt.Errorf("failed to parse k3s versions: %w", err)
+	}
+	return parsed, nil
 }
 
 // parseK3sVersions returns the supported Kubernetes versions from the
-// embedded k3s-versions.json. The versions are stripped and stored as bare semver strings
+// embedded k3s-versions.json. The versions are stored as bare semver strings
 // (e.g. "1.32.0") so they can be compared directly against App spec values.
 func parseK3sVersions(data string) (map[string]struct{}, error) {
-	var parsed k3sVersionsJSON
-	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
-		return nil, fmt.Errorf("failed to parse k3s versions: %w", err)
+	parsed, err := unmarshalK3sVersions(data)
+	if err != nil {
+		return nil, err
 	}
 	set := make(map[string]struct{}, len(parsed.Versions))
 	for _, v := range parsed.Versions {
-		// Strip leading "v" and "+k3s*" suffix: "v1.32.0+k3s1" → "1.32.0"
-		bare := strings.TrimPrefix(v, "v")
-		bare, _, _ = strings.Cut(bare, "+")
-		set[bare] = struct{}{}
+		set[bareVersion(v)] = struct{}{}
 	}
 	return set, nil
+}
+
+// parseK3sChannels maps each channel alias from the embedded k3s-versions.json
+// (e.g. "stable", "latest", "1.32") to its concrete bare version. It strips a
+// leading "v" from each alias so that both "v1.32" and "1.32" resolve.
+func parseK3sChannels(data string) (map[string]string, error) {
+	parsed, err := unmarshalK3sVersions(data)
+	if err != nil {
+		return nil, err
+	}
+	channels := make(map[string]string, len(parsed.Channels))
+	for name, version := range parsed.Channels {
+		channels[strings.TrimPrefix(name, "v")] = bareVersion(version)
+	}
+	return channels, nil
 }

--- a/pkg/controllers/app/app/controllers/k3s_versions_test.go
+++ b/pkg/controllers/app/app/controllers/k3s_versions_test.go
@@ -76,3 +76,50 @@ func Test_parseK3sVersions(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseK3sChannels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "aliases and minor-version channels",
+			input: `{"channels":{"stable":"1.34.6","latest":"1.35.3","v1.32":"1.32.13"}}`,
+			// parseK3sChannels strips the "v" prefix from the channel name, so "1.32" resolves too.
+			want: map[string]string{"stable": "1.34.6", "latest": "1.35.3", "1.32": "1.32.13"},
+		},
+		{
+			name:  "channel value normalizes to bare semver",
+			input: `{"channels":{"stable":"v1.34.6+k3s1"}}`,
+			want:  map[string]string{"stable": "1.34.6"},
+		},
+		{
+			name:  "no channels",
+			input: `{"versions":[]}`,
+			want:  map[string]string{},
+		},
+		{
+			name:    "malformed JSON",
+			input:   `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseK3sChannels(tt.input)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected an error but got nil")
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
A mutating admission webhook resolves channel aliases in `spec.kubernetes.version` to concrete versions before the validating webhook runs. The aliases come from the bundled `k3s-versions.json`, which maps `stable`, `latest`, and each minor version (`v1.32`, `v1.33`, ...) to a concrete release.

When Kubernetes is enabled without a version, the webhook fills in the `stable` channel. It strips a leading "v" so both "v1.32" and "1.32" resolve, and leaves an unknown alias unchanged for the validating webhook to reject as unsupported.

Enabling Kubernetes with an empty version now succeeds, so the dry-run test that asserted rejection asserts acceptance.

Closes #387