### PR TITLE
Add the `rdd run` command

### DIFF
--- a/bats/tests/32-app-controllers/engine-docker.bats
+++ b/bats/tests/32-app-controllers/engine-docker.bats
@@ -9,6 +9,8 @@ load '../../helpers/load'
 # resources, and that deletions and action annotations on Container
 # resources are forwarded to Docker.
 
+CONTEXT_NAME="rancher-desktop-${RDD_INSTANCE}"
+
 local_setup_file() {
     # Isolate all Docker config reads and writes from the developer's real
     # ~/.docker directory. Set DOCKER_CONFIG before starting the service so
@@ -291,7 +293,7 @@ do_websocket() { # endpoint
         skip "curl does not support WebSocket"
     fi
 
-    local command='true'
+    command='true'
     for ((i = 0; i < 10; i++)); do
         command="${command}; echo line number ${i}"
     done
@@ -607,7 +609,7 @@ EOF
     # Record the pre-restart StartedAt so we can verify the container
     # was actually restarted rather than left untouched.
     run -0 docker inspect test-restart --format '{{.State.StartedAt}}'
-    local before=${output}
+    before=${output}
 
     request_action "${cid}" restart
     assert_last_action "${cid}" restart Succeeded
@@ -787,9 +789,7 @@ assert_docker_context() { # <expected-context>
     rdd ctl wait --for=condition=ContainerEngineReady \
         app/app --timeout=30s
 
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
-    local meta_file
-    meta_file="$(docker_context_dir "${context_name}")/meta.json"
+    meta_file="$(docker_context_dir "${CONTEXT_NAME}")/meta.json"
 
     assert_file_exists "${meta_file}"
 
@@ -797,7 +797,7 @@ assert_docker_context() { # <expected-context>
     meta=${output}
 
     run -0 jq_raw '.Name' "${meta}"
-    assert_output "${context_name}"
+    assert_output "${CONTEXT_NAME}"
 
     if is_windows; then
         run -0 jq_raw '.Endpoints.docker.Host' "${meta}"
@@ -810,9 +810,25 @@ assert_docker_context() { # <expected-context>
     fi
 }
 
-@test "moby engine sets currentContext when no healthy context exists" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
+@test "rdd run targets the instance Docker context" {
+    # rdd run sets DOCKER_CONTEXT to the instance and clears DOCKER_HOST
+    # for the child. The suite exports DOCKER_HOST, and docker reports the
+    # "default" context whenever DOCKER_HOST is set, so a named result also
+    # proves the variable was cleared. The caller's currentContext in
+    # config.json is left unchanged.
+    run_e -0 rdd run docker context show
+    assert_output "${CONTEXT_NAME}"
+}
 
+@test "rdd run propagates the child exit status without a spurious error line" {
+    # A non-zero child exit returns a cliexit.Error carrying only a code; main
+    # must not log it as a bare level=error line. run -7 asserts the status and
+    # merges stderr into the output so refute_line can catch the spurious line.
+    run -7 rdd run sh -c 'exit 7'
+    refute_line --partial "level=error"
+}
+
+@test "moby engine sets currentContext when no healthy context exists" {
     # Seed a named context pointing at an unreachable socket and make it
     # current. This forces the reconciler into the probeNamedDockerContext
     # branch with a guaranteed-failing endpoint, independent of whether the
@@ -835,17 +851,16 @@ EOF
     rdd ctl wait --for=condition=ContainerEngineReady app/app --timeout=30s
 
     # The probe goroutine runs asynchronously; give it a moment.
-    try --max 6 --delay 1 -- assert_docker_context "${context_name}"
+    try --max 6 --delay 1 -- assert_docker_context "${CONTEXT_NAME}"
 
-    assert_docker_context "${context_name}"
+    assert_docker_context "${CONTEXT_NAME}"
 }
 
 @test "stopping moby engine removes Docker context and clears currentContext" {
     rdd set running=false
 
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
-    run_e -0 docker_context_dir "${context_name}"
-    local context_dir="${output}"
+    run_e -0 docker_context_dir "${CONTEXT_NAME}"
+    context_dir="${output}"
 
     # removeDockerContext runs asynchronously after the reconciler processes
     # the Running=False transition; poll until the directory is gone.
@@ -855,5 +870,5 @@ EOF
     # currentContext should either be gone or point to something else.
     run -0 cat "${DOCKER_CONFIG}/config.json"
     run -0 jq_output '.currentContext // empty'
-    refute_output "${context_name}"
+    refute_output "${CONTEXT_NAME}"
 }

--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -12,6 +12,7 @@ load '../../helpers/load'
 APP_NAME="app"
 VM_NAME="rd"
 K3S_VERSION="1.32.0"
+CONTEXT_NAME="rancher-desktop-${RDD_INSTANCE}"
 
 local_setup_file() {
     # Isolate ~/.kube/config so tests never touch the developer's real kubeconfig.
@@ -85,44 +86,63 @@ kube_current_context_is() { # <expected-context>
 }
 
 @test "kubernetes controller creates context entry in user kubeconfig" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
-    run -0 kube_context_exists "${context_name}"
+    kube_context_exists "${CONTEXT_NAME}"
 }
 
 @test "kubernetes controller creates cluster entry in user kubeconfig" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
-    run -0 kube_cluster_exists "${context_name}"
+    kube_cluster_exists "${CONTEXT_NAME}"
 }
 
 @test "kubernetes controller creates user entry in user kubeconfig" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
-    run -0 kube_user_exists "${context_name}"
+    kube_user_exists "${CONTEXT_NAME}"
 }
 
 @test "context entry points to the instance k3s API server" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
-
     # Read the server URL from the instance kubeconfig (written by k3s).
     run -0 rdd svc paths k3s_config
-    local instance_kubeconfig="${output}"
+    instance_kubeconfig="${output}"
 
     run -0 rdd kubectl --kubeconfig="${instance_kubeconfig}" \
         config view -o jsonpath='{.clusters[0].cluster.server}'
-    local expected_server="${output}"
+    expected_server="${output}"
 
     run -0 rdd kubectl config view \
-        -o jsonpath="{.clusters[?(@.name==\"${context_name}\")].cluster.server}"
+        -o jsonpath="{.clusters[?(@.name==\"${CONTEXT_NAME}\")].cluster.server}"
     assert_output "${expected_server}"
 }
 
+@test "rdd run targets the instance Kubernetes context" {
+    # rdd run points KUBECONFIG at a throwaway file whose current context
+    # is the instance, so a client talks to this cluster regardless of the
+    # user's selected context. config current-context reads the file
+    # without contacting the cluster. The user's kubeconfig is untouched.
+    run_e -0 rdd run rdd kubectl config current-context
+    assert_output "${CONTEXT_NAME}"
+}
+
+@test "rdd run prepends the instance bin directory to PATH" {
+    # The instance bin directory leads PATH so tools bundled with the
+    # instance shadow any global ones for the duration of the command.
+    run -0 rdd svc paths short_dir
+    bin_dir="${output}/bin"
+    if is_windows; then
+        # printenv is an MSYS program: its runtime rewrites the inherited
+        # PATH into POSIX form, so convert rdd's native path to match.
+        run -0 cygpath -u "${bin_dir}"
+        bin_dir="${output}"
+    fi
+
+    run_e -0 rdd run printenv PATH
+    assert_equal "${output%%:*}" "${bin_dir}"
+}
+
 @test "kubernetes controller sets current-context when no healthy context exists" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
     # The current-context probe runs in a goroutine after KubernetesReady is
     # set; poll until it resolves.
-    try --max 6 --delay 2 -- kube_current_context_is "${context_name}"
+    try --max 6 --delay 2 -- kube_current_context_is "${CONTEXT_NAME}"
 
     run -0 kube_current_context
-    assert_output "${context_name}"
+    assert_output "${CONTEXT_NAME}"
 }
 
 @test "KubernetesReady=NotApplicable when kubernetes is disabled" {
@@ -133,19 +153,17 @@ kube_current_context_is() { # <expected-context>
 }
 
 @test "kubernetes controller removes context entries when kubernetes is disabled" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
     # removeKubeContext runs synchronously in Reconcile; the context should be
     # gone by the time KubernetesReady=NotApplicable is stamped (which rdd set
     # above already waited for via Settled).
-    run -1 kube_context_exists "${context_name}"
-    run -1 kube_cluster_exists "${context_name}"
-    run -1 kube_user_exists "${context_name}"
+    run -1 kube_context_exists "${CONTEXT_NAME}"
+    run -1 kube_cluster_exists "${CONTEXT_NAME}"
+    run -1 kube_user_exists "${CONTEXT_NAME}"
 }
 
 @test "current-context is cleared when kubernetes is disabled" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
     run -0 kube_current_context
-    refute_output "${context_name}"
+    refute_output "${CONTEXT_NAME}"
 }
 
 @test "re-enable kubernetes to set up cleanup test" {
@@ -155,22 +173,19 @@ kube_current_context_is() { # <expected-context>
 }
 
 @test "current-context is set again after re-enabling kubernetes" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
-    try --max 6 --delay 2 -- kube_current_context_is "${context_name}"
+    try --max 6 --delay 2 -- kube_current_context_is "${CONTEXT_NAME}"
 }
 
 @test "stopping VM clears current-context" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
     rdd set running=false
     # removeKubeContext fires on the NotRunning reconcile; poll until done.
-    try --max 10 --delay 1 --until-fail -- kube_context_exists "${context_name}"
+    try --max 10 --delay 1 --until-fail -- kube_context_exists "${CONTEXT_NAME}"
     run -0 kube_current_context
-    refute_output "${context_name}"
+    refute_output "${CONTEXT_NAME}"
 }
 
 @test "stopping VM removes context from user kubeconfig" {
-    local context_name="rancher-desktop-${RDD_INSTANCE}"
-    run -1 kube_context_exists "${context_name}"
-    run -1 kube_cluster_exists "${context_name}"
-    run -1 kube_user_exists "${context_name}"
+    run -1 kube_context_exists "${CONTEXT_NAME}"
+    run -1 kube_cluster_exists "${CONTEXT_NAME}"
+    run -1 kube_user_exists "${CONTEXT_NAME}"
 }

--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -24,8 +24,13 @@ local_setup_file() {
     # from the drive root (C:\tmp\...) rather than MSYS2's /tmp which maps to a
     # different location. cygpath -m produces a mixed-format path (C:/msys64/...)
     # that both native Windows processes and MSYS2 agree on.
-    if is_windows; then
+    if is_msys; then
         run -0 cygpath -m "${BATS_FILE_TMPDIR}/kube/config"
+        KUBECONFIG="${output}"
+    elif is_windows; then
+        # Under WSL2 rdd is also a native binary; wslpath -m produces the
+        # Windows-format path it expects.
+        run -0 wslpath -m "${BATS_FILE_TMPDIR}/kube/config"
         KUBECONFIG="${output}"
     else
         KUBECONFIG="${BATS_FILE_TMPDIR}/kube/config"
@@ -125,10 +130,15 @@ kube_current_context_is() { # <expected-context>
     # instance shadow any global ones for the duration of the command.
     run -0 rdd svc paths short_dir
     bin_dir="${output}/bin"
-    if is_windows; then
+    if is_msys; then
         # printenv is an MSYS program: its runtime rewrites the inherited
         # PATH into POSIX form, so convert rdd's native path to match.
         run -0 cygpath -u "${bin_dir}"
+        bin_dir="${output}"
+    elif is_windows; then
+        # Under WSL2 rdd emits a Windows path; convert it to the POSIX form
+        # printenv reports.
+        run -0 wslpath -u "${bin_dir}"
         bin_dir="${output}"
     fi
 

--- a/cmd/rdd/main.go
+++ b/cmd/rdd/main.go
@@ -161,6 +161,7 @@ func main() {
 	cmd.AddCommand(
 		hostagent.NewCommand(),
 		newKubectlCommand(),
+		newRunCommand(),
 		newServiceCommand(context.Background()),
 		newSetCommand(),
 		newStartCommand(),
@@ -171,7 +172,11 @@ func main() {
 		// *cliexit.Error lets a subcommand opt into a specific exit code; everything else gets exit 1.
 		var exitErr *cliexit.Error
 		if errors.As(err, &exitErr) {
-			logrus.Error(err)
+			// A propagated child-exit code carries no message (nil Err); logging it
+			// would emit a bare level=error line, so log only when there is one.
+			if exitErr.Err != nil {
+				logrus.Error(err)
+			}
 			os.Exit(exitErr.Code)
 		}
 		logrus.Fatal(err)

--- a/cmd/rdd/run.go
+++ b/cmd/rdd/run.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	cliexit "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/exit"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/help"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+)
+
+func newRunCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "run COMMAND [ARGS...]",
+		Short: "Run a command wired to this instance's Docker and Kubernetes contexts",
+		Long: help.Doc(`
+			Run a command against this Rancher Desktop instance.
+
+			rdd run points the command at the instance without changing
+			your selected contexts: it prepends ~/.rd<instance>/bin to
+			PATH, sets the Docker context to rancher-desktop-<instance>,
+			and points KUBECONFIG at ~/.rd<instance>/kube.config, whose
+			current context is rancher-desktop-<instance>. Your selected
+			Docker context and the current context in ~/.kube/config stay
+			as they are.
+
+			Rancher Desktop starts first if it is not already running. A
+			normal startup merges the rancher-desktop-<instance> entry
+			into ~/.kube/config and creates its Docker context, but leaves
+			both selections unchanged. When the App does not exist yet and
+			the command is kubectl or helm, rdd run enables Kubernetes so
+			the command has a cluster to talk to. An existing App is only
+			started, never reconfigured.
+
+			Examples:
+			  rdd run docker run --rm hello-world
+			  rdd run kubectl get nodes
+		`),
+		Args:               cobra.MinimumNArgs(1),
+		DisableFlagParsing: true,
+		RunE:               runAction,
+	}
+	return command
+}
+
+func runAction(cmd *cobra.Command, args []string) error {
+	// Show help without starting the App. DisableFlagParsing otherwise routes
+	// --help through ensureAppRunning and on to an exec of "--help" as a command.
+	// A leading "--" still escapes it, so `rdd run -- --help` runs --help.
+	if args[0] == "-h" || args[0] == "--help" {
+		return cmd.Help()
+	}
+	// Drop a leading "--" separator, e.g. `rdd run -- docker ps`.
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		return errors.New("run requires a command to execute")
+	}
+
+	if err := ensureAppRunning(cmd.Context(), args[0]); err != nil {
+		return err
+	}
+
+	if err := setupRunEnv(); err != nil {
+		return err
+	}
+
+	return execCommand(cmd.Context(), args)
+}
+
+// ensureAppRunning starts Rancher Desktop and waits for it to settle. When the
+// App does not exist yet and command invokes a Kubernetes client, it enables
+// Kubernetes so the client has a cluster to talk to; the App defaulter then
+// picks the default Kubernetes version. An existing App is only started.
+func ensureAppRunning(ctx context.Context, command string) error {
+	c, _, err := getAppKubeClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	props := []string{"running=true"}
+	var app appv1alpha1.App
+	switch err := c.Get(ctx, client.ObjectKey{Name: "app"}, &app); {
+	case apierrors.IsNotFound(err):
+		if isKubeCommand(command) {
+			props = append(props, "kubernetes.enabled=true")
+		}
+	case err != nil:
+		return fmt.Errorf("failed to get App: %w", err)
+	}
+
+	return setAction(ctx, props, false, true, limaLongWaitTimeout)
+}
+
+// isKubeCommand reports whether name invokes kubectl or helm, ignoring any
+// directory prefix and a trailing .exe.
+func isKubeCommand(name string) bool {
+	base := strings.TrimSuffix(filepath.Base(name), ".exe")
+	return base == "kubectl" || base == "helm"
+}
+
+// setupRunEnv points this process's environment at the instance, so the child
+// command inherits it. It prepends the instance bin directory to PATH, selects
+// the instance Docker context, points KUBECONFIG at the instance kubeconfig,
+// and clears DOCKER_HOST so the Docker context takes effect.
+func setupRunEnv() error {
+	binDir := filepath.Join(instance.ShortDir(), "bin")
+	vars := []struct{ key, value string }{
+		{"PATH", binDir + string(os.PathListSeparator) + os.Getenv("PATH")},
+		{"DOCKER_CONTEXT", instance.Name()},
+		{"KUBECONFIG", instance.KubeConfig()},
+	}
+	for _, v := range vars {
+		if err := os.Setenv(v.key, v.value); err != nil {
+			return fmt.Errorf("set %s: %w", v.key, err)
+		}
+	}
+	if err := os.Unsetenv("DOCKER_HOST"); err != nil {
+		return fmt.Errorf("unset DOCKER_HOST: %w", err)
+	}
+	return nil
+}
+
+// execCommand runs args as a child process with the current environment and
+// propagates its exit status. rdd runs the command as a child, rather than
+// replacing itself, so it propagates the child's exit code the same way on
+// every platform. The child shares rdd's stdio and foreground process group,
+// so Ctrl+C reaches it directly.
+//
+// CommandContext would hard-kill the child if ctx were canceled; the cobra
+// context is never canceled today, so this matches a plain exec until
+// signal-driven cancellation is wired up.
+func execCommand(ctx context.Context, args []string) error {
+	command := exec.CommandContext(ctx, args[0], args[1:]...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+
+	err := command.Run()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return &cliexit.Error{Code: exitErr.ExitCode()}
+	}
+	if err != nil {
+		return fmt.Errorf("run %s: %w", args[0], err)
+	}
+	return nil
+}

--- a/cmd/rdd/run.go
+++ b/cmd/rdd/run.go
@@ -35,14 +35,15 @@ func newRunCommand() *cobra.Command {
 			your selected contexts: it prepends ~/.rd<instance>/bin to
 			PATH, sets the Docker context to rancher-desktop-<instance>,
 			and points KUBECONFIG at ~/.rd<instance>/kube.config, whose
-			current context is rancher-desktop-<instance>. Your selected
-			Docker context and the current context in ~/.kube/config stay
-			as they are.
+			current context is rancher-desktop-<instance>. rdd run itself
+			leaves your selected Docker context and the current context in
+			~/.kube/config unchanged.
 
 			Rancher Desktop starts first if it is not already running. A
 			normal startup merges the rancher-desktop-<instance> entry
-			into ~/.kube/config and creates its Docker context, but leaves
-			both selections unchanged. When the App does not exist yet and
+			into ~/.kube/config and creates its Docker context; it switches
+			your current Docker or kube context only when the existing one
+			is missing or not working. When the App does not exist yet and
 			the command is kubectl or helm, rdd run enables Kubernetes so
 			the command has a cluster to talk to. An existing App is only
 			started, never reconfigured.
@@ -66,7 +67,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 	// Drop a leading "--" separator, e.g. `rdd run -- docker ps`.
-	if len(args) > 0 && args[0] == "--" {
+	if args[0] == "--" {
 		args = args[1:]
 	}
 	if len(args) == 0 {
@@ -121,8 +122,18 @@ func isKubeCommand(name string) bool {
 // and clears DOCKER_HOST so the Docker context takes effect.
 func setupRunEnv() error {
 	binDir := filepath.Join(instance.ShortDir(), "bin")
+	// Append the existing PATH only when it is set; concatenating an empty
+	// value would leave a trailing separator, which POSIX reads as the
+	// current directory.
+	path := binDir
+	if existing := os.Getenv("PATH"); existing != "" {
+		path += string(os.PathListSeparator) + existing
+	}
 	vars := []struct{ key, value string }{
-		{"PATH", binDir + string(os.PathListSeparator) + os.Getenv("PATH")},
+		{"PATH", path},
+		// DOCKER_CONTEXT resolves against the child's DOCKER_CONFIG. The daemon
+		// wrote this context under its own DOCKER_CONFIG, frozen at startup, so
+		// the two must match for the lookup to succeed.
 		{"DOCKER_CONTEXT", instance.Name()},
 		{"KUBECONFIG", instance.KubeConfig()},
 	}
@@ -155,6 +166,9 @@ func execCommand(ctx context.Context, args []string) error {
 	err := command.Run()
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
+		// A signal-killed child has no exit code: ExitCode() returns -1, which
+		// os.Exit maps to 255 rather than the shell's 128+signal. Wiring up
+		// signal handling (see above) would let us propagate 128+signal.
 		return &cliexit.Error{Code: exitErr.ExitCode()}
 	}
 	if err != nil {

--- a/cmd/rdd/run_test.go
+++ b/cmd/rdd/run_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+)
+
+func TestIsKubeCommand(t *testing.T) {
+	cases := []struct {
+		command string
+		want    bool
+	}{
+		{"kubectl", true},
+		{"helm", true},
+		{"/usr/local/bin/kubectl", true},
+		{"kubectl.exe", true},
+		{"helm.exe", true},
+		{"docker", false},
+		{"kubectllike", false},
+		{"helmfile", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			assert.Equal(t, isKubeCommand(tc.command), tc.want)
+		})
+	}
+}
+
+func TestRunHelpSkipsAppStart(t *testing.T) {
+	// A help flag must print usage without starting the App. DisableFlagParsing
+	// otherwise routes it through ensureAppRunning, which creates and starts a
+	// real service, so reaching that path here would have side effects; a
+	// passing run therefore also proves the early return.
+	for _, flag := range []string{"--help", "-h"} {
+		t.Run(flag, func(t *testing.T) {
+			cmd := newRunCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetArgs([]string{flag})
+
+			assert.NilError(t, cmd.Execute())
+			assert.Assert(t, strings.Contains(out.String(), "Run a command against this Rancher Desktop instance"))
+		})
+	}
+}
+
+func TestSetupRunEnv(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("DOCKER_HOST", "tcp://stale:2375")
+	t.Setenv("DOCKER_CONTEXT", "stale")
+	t.Setenv("KUBECONFIG", "/old/kubeconfig")
+
+	assert.NilError(t, setupRunEnv())
+
+	binDir := filepath.Join(instance.ShortDir(), "bin")
+	assert.Equal(t, os.Getenv("PATH"), binDir+string(os.PathListSeparator)+"/usr/bin:/bin")
+	assert.Equal(t, os.Getenv("DOCKER_CONTEXT"), instance.Name())
+	assert.Equal(t, os.Getenv("KUBECONFIG"), instance.KubeConfig())
+
+	// DOCKER_HOST must be cleared so DOCKER_CONTEXT takes effect.
+	_, hasDockerHost := os.LookupEnv("DOCKER_HOST")
+	assert.Assert(t, !hasDockerHost)
+}

--- a/docs/design/api_app.md
+++ b/docs/design/api_app.md
@@ -40,7 +40,7 @@ When the `App` is starting it creates the Docker context and sets up the kubecon
 
 It will only change the current context if it does not exist, or is not working at the time the app is starting.
 
-The kube config is also written to `~/.rd2/kube.config` (mostly for the [`rdd run`](cmd_app.md#rdd-run) command).
+A standalone kube config holding only the `rancher-desktop-2` context is also written to `~/.rd2/kube.config`, which the [`rdd run`](cmd_app.md#rdd-run) command points `KUBECONFIG` at.
 
 Consider using `cliPluginsExtraDirs` in `~/.docker/config.json` instead of installing into `~/.docker/cli-plugins` and have a diagnostic if the plugins exist in `~/.docker/cli-plugins`? The mechanism should be compatible with whatever we do on Windows.
 

--- a/docs/design/cmd_app.md
+++ b/docs/design/cmd_app.md
@@ -72,17 +72,21 @@ rdd lima shell rd "$@"
 
 ## `rdd run`
 
-Set up `PATH` to start with `~/.rd$RDD_INSTANCE` and set the docker and kube contexts to `rancher-desktop` before running the command.
+`rdd run COMMAND [ARGS...]` runs a command against this Rancher Desktop instance without changing your selected contexts.
 
-Since there are no environment variables for the contexts, it will have to set `DOCKER_HOST` and `KUBECONFIG` instead.
+`rdd run` prepends `~/.rd2/bin` to `PATH`, sets the Docker context to `rancher-desktop-2`, and points `KUBECONFIG` at `~/.rd2/kube.config`, whose current context is `rancher-desktop-2`. It clears `DOCKER_HOST` so the Docker context takes effect. Your selected Docker context and the current context in `~/.kube/config` stay as they are; starting the App still merges the `rancher-desktop-2` entry into `~/.kube/config`, as a normal startup does.
 
-For example `rdd run docker images` will effectively execute:
+Rancher Desktop starts first if it is not already running. When the App does not exist yet and the command is `kubectl` or `helm`, `rdd run` also enables Kubernetes so the command has a cluster to talk to; the App defaulter then picks the default version. `rdd run` only starts an existing App; it never reconfigures one.
+
+For example, `rdd run docker run --rm hello-world` effectively executes:
 
 ```bash
+rdd start
 export PATH="$HOME/.rd2/bin:$PATH"
-export DOCKER_HOST="unix://$HOME/.rd2/docker.sock"
-export KUBECONFIG="$HOME/.rd2/kube.config"
-docker images
+unset DOCKER_HOST
+export DOCKER_CONTEXT=rancher-desktop-2
+export KUBECONFIG="$HOME/.rd2/kube.config"  # current context is rancher-desktop-2
+docker run --rm hello-world
 ```
 
 ## `rdd shell-profile`

--- a/docs/design/cmd_app.md
+++ b/docs/design/cmd_app.md
@@ -74,7 +74,7 @@ rdd lima shell rd "$@"
 
 `rdd run COMMAND [ARGS...]` runs a command against this Rancher Desktop instance without changing your selected contexts.
 
-`rdd run` prepends `~/.rd2/bin` to `PATH`, sets the Docker context to `rancher-desktop-2`, and points `KUBECONFIG` at `~/.rd2/kube.config`, whose current context is `rancher-desktop-2`. It clears `DOCKER_HOST` so the Docker context takes effect. Your selected Docker context and the current context in `~/.kube/config` stay as they are; starting the App still merges the `rancher-desktop-2` entry into `~/.kube/config`, as a normal startup does.
+`rdd run` prepends `~/.rd2/bin` to `PATH`, sets the Docker context to `rancher-desktop-2`, and points `KUBECONFIG` at `~/.rd2/kube.config`, whose current context is `rancher-desktop-2`. It clears `DOCKER_HOST` so the Docker context takes effect. `rdd run` itself leaves your selected Docker context and the current context in `~/.kube/config` unchanged. Starting the App still merges the `rancher-desktop-2` entry into `~/.kube/config` and creates its Docker context; as a normal startup does, it switches your current context only when the existing one is missing or not working (see [api_app.md](api_app.md)).
 
 Rancher Desktop starts first if it is not already running. When the App does not exist yet and the command is `kubectl` or `helm`, `rdd run` also enables Kubernetes so the command has a cluster to talk to; the App defaulter then picks the default version. `rdd run` only starts an existing App; it never reconfigures one.
 

--- a/pkg/controllers/app/kubernetes/controller.go
+++ b/pkg/controllers/app/kubernetes/controller.go
@@ -44,8 +44,9 @@ func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 	r := &controllers.KubernetesReconciler{
-		Client:        mgr.GetClient(),
-		K3sConfigPath: instance.K3sConfig(),
+		Client:                 mgr.GetClient(),
+		K3sConfigPath:          instance.K3sConfig(),
+		InstanceKubeConfigPath: instance.KubeConfig(),
 	}
 	return r.SetupWithManager(mgr)
 }

--- a/pkg/controllers/app/kubernetes/controllers/kube_context.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_context.go
@@ -36,23 +36,21 @@ func loadKubeConfig(path string) (*clientcmdapi.Config, error) {
 	return cfg, err
 }
 
-// createReplaceKubeContext reads the instance kubeconfig from srcPath, renames
-// its cluster/user/context entries to contextName, and merges them into
-// ~/.kube/config.
-func createReplaceKubeContext(contextName, srcPath string) error {
+// instanceClusterUser reads the k3s mirror kubeconfig at srcPath and returns its
+// single cluster and user, which k3s names "default".
+func instanceClusterUser(srcPath string) (*clientcmdapi.Cluster, *clientcmdapi.AuthInfo, error) {
 	src, err := clientcmd.LoadFromFile(srcPath)
 	if err != nil {
-		return fmt.Errorf("load instance kubeconfig: %w", err)
+		return nil, nil, fmt.Errorf("load instance kubeconfig: %w", err)
 	}
 
-	// Extract the single cluster and user (k3s names them "default").
 	var cluster *clientcmdapi.Cluster
 	for _, c := range src.Clusters {
 		cluster = c
 		break
 	}
 	if cluster == nil {
-		return errors.New("instance kubeconfig has no cluster entry")
+		return nil, nil, errors.New("instance kubeconfig has no cluster entry")
 	}
 
 	var user *clientcmdapi.AuthInfo
@@ -61,7 +59,18 @@ func createReplaceKubeContext(contextName, srcPath string) error {
 		break
 	}
 	if user == nil {
-		return errors.New("instance kubeconfig has no user entry")
+		return nil, nil, errors.New("instance kubeconfig has no user entry")
+	}
+	return cluster, user, nil
+}
+
+// createReplaceKubeContext reads the instance kubeconfig from srcPath, renames
+// its cluster/user/context entries to contextName, and merges them into
+// ~/.kube/config.
+func createReplaceKubeContext(contextName, srcPath string) error {
+	cluster, user, err := instanceClusterUser(srcPath)
+	if err != nil {
+		return err
 	}
 
 	destPath, err := kubeConfigPath()
@@ -105,6 +114,40 @@ func deleteKubeContext(contextName string) error {
 	delete(cfg.Contexts, contextName)
 
 	return clientcmd.WriteToFile(*cfg, destPath)
+}
+
+// writeInstanceKubeConfig writes a standalone kubeconfig to destPath holding
+// only contextName, set as the current context. rdd run points KUBECONFIG at
+// this file, so the instance credentials live in the instance directory rather
+// than a per-invocation temp file.
+func writeInstanceKubeConfig(contextName, srcPath, destPath string) error {
+	cluster, user, err := instanceClusterUser(srcPath)
+	if err != nil {
+		return err
+	}
+
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters[contextName] = cluster
+	cfg.AuthInfos[contextName] = user
+	cfg.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  contextName,
+		AuthInfo: contextName,
+	}
+	cfg.CurrentContext = contextName
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
+		return fmt.Errorf("create instance dir: %w", err)
+	}
+	return clientcmd.WriteToFile(*cfg, destPath)
+}
+
+// removeInstanceKubeConfig deletes the standalone instance kubeconfig at
+// destPath. No-op if the file is already absent.
+func removeInstanceKubeConfig(destPath string) error {
+	if err := os.Remove(destPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove instance kubeconfig: %w", err)
+	}
+	return nil
 }
 
 // getCurrentKubeContext returns current-context from ~/.kube/config,

--- a/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
@@ -210,3 +210,39 @@ func TestGetCurrentKubeContext(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, current, "rancher-desktop-2")
 }
+
+func TestWriteInstanceKubeConfig(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := makeSrcKubeconfig(t, dir)
+	destPath := filepath.Join(dir, "kube.config")
+
+	assert.NilError(t, writeInstanceKubeConfig("rancher-desktop-2", srcPath, destPath))
+
+	cfg := loadDest(t, destPath)
+	// Standalone file holds only the instance context, set as current.
+	assert.Equal(t, cfg.CurrentContext, "rancher-desktop-2")
+	assert.Equal(t, len(cfg.Contexts), 1)
+
+	cluster, ok := cfg.Clusters["rancher-desktop-2"]
+	assert.Assert(t, ok, "cluster rancher-desktop-2 not found")
+	assert.Equal(t, cluster.Server, "https://127.0.0.1:6443")
+
+	user, ok := cfg.AuthInfos["rancher-desktop-2"]
+	assert.Assert(t, ok, "user rancher-desktop-2 not found")
+	assert.Equal(t, user.Token, "fake-token")
+}
+
+func TestRemoveInstanceKubeConfig(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := makeSrcKubeconfig(t, dir)
+	destPath := filepath.Join(dir, "kube.config")
+
+	assert.NilError(t, writeInstanceKubeConfig("rancher-desktop-2", srcPath, destPath))
+	assert.NilError(t, removeInstanceKubeConfig(destPath))
+
+	_, err := os.Stat(destPath)
+	assert.Assert(t, os.IsNotExist(err), "instance kubeconfig should be removed")
+
+	// Removing an absent file is a no-op.
+	assert.NilError(t, removeInstanceKubeConfig(destPath))
+}

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -94,6 +94,12 @@ type KubernetesReconciler struct {
 	// inject a path under a temp directory.
 	K3sConfigPath string
 
+	// InstanceKubeConfigPath is where the standalone instance kubeconfig (only
+	// the rancher-desktop-{instance} context) is published for rdd run to
+	// consume. Production wiring sets it from instance.KubeConfig(); tests
+	// inject a path under a temp directory.
+	InstanceKubeConfigPath string
+
 	// contextMu protects contextProbeCancel and contextProbeGen.
 	contextMu sync.Mutex
 	// contextProbeCancel cancels the in-flight current-context probe goroutine.
@@ -355,6 +361,11 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) error {
 		return fmt.Errorf("create Kubernetes context %q: %w", contextName, err)
 	}
 
+	if err := writeInstanceKubeConfig(contextName, r.K3sConfigPath, r.InstanceKubeConfigPath); err != nil {
+		log.Error(err, "Failed to write instance kubeconfig", "context", contextName)
+		return fmt.Errorf("write instance kubeconfig for %q: %w", contextName, err)
+	}
+
 	r.contextMu.Lock()
 	if r.contextProbeCancel != nil {
 		r.contextProbeCancel()
@@ -510,6 +521,9 @@ func (r *KubernetesReconciler) removeKubeContext(ctx context.Context) {
 	}
 	if err := deleteKubeContext(contextName); err != nil {
 		log.Error(err, "Failed to delete Kubernetes context", "context", contextName)
+	}
+	if err := removeInstanceKubeConfig(r.InstanceKubeConfigPath); err != nil {
+		log.Error(err, "Failed to remove instance kubeconfig", "context", contextName)
 	}
 }
 

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
@@ -166,8 +166,9 @@ func Test_Reconcile_KubernetesReady_Ready(t *testing.T) {
 		Build()
 
 	r := &KubernetesReconciler{
-		Client:        c,
-		K3sConfigPath: srcPath,
+		Client:                 c,
+		K3sConfigPath:          srcPath,
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
 	}
 	// removeKubeContext cancels the in-flight current-context probe and waits
 	// for the goroutine started by manageKubeContext to finish, so it cannot
@@ -209,8 +210,9 @@ func Test_Reconcile_KubernetesReady_MergeFailed(t *testing.T) {
 		Build()
 
 	r := &KubernetesReconciler{
-		Client:        c,
-		K3sConfigPath: srcPath,
+		Client:                 c,
+		K3sConfigPath:          srcPath,
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
 	}
 
 	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
@@ -303,8 +305,9 @@ func Test_Reconcile_KubernetesReady_Probing_ProbeError(t *testing.T) {
 	// Point K3sConfigPath at a file that does not exist so probeK3sAPI
 	// returns the (false, err) "kubeconfig unreadable" path.
 	r := &KubernetesReconciler{
-		Client:        c,
-		K3sConfigPath: filepath.Join(dir, "missing-k3s.yaml"),
+		Client:                 c,
+		K3sConfigPath:          filepath.Join(dir, "missing-k3s.yaml"),
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
 	}
 
 	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
@@ -338,8 +341,9 @@ func Test_Reconcile_KubernetesReady_Probing_Unhealthy(t *testing.T) {
 		Build()
 
 	r := &KubernetesReconciler{
-		Client:        c,
-		K3sConfigPath: srcPath,
+		Client:                 c,
+		K3sConfigPath:          srcPath,
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
 	}
 
 	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
@@ -375,8 +379,9 @@ func Test_Reconcile_KubernetesReady_Unhealthy_FromReady_ImmediateFlip(t *testing
 		Build()
 
 	r := &KubernetesReconciler{
-		Client:        c,
-		K3sConfigPath: srcPath,
+		Client:                 c,
+		K3sConfigPath:          srcPath,
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
 	}
 
 	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
@@ -507,8 +512,9 @@ func Test_Reconcile_KubernetesReady_Ambiguous_HealthyResetsCounter(t *testing.T)
 	// simulate a brief slow patch followed by recovery.
 	step := 0
 	r := &KubernetesReconciler{
-		Client:        c,
-		K3sConfigPath: srcPath,
+		Client:                 c,
+		K3sConfigPath:          srcPath,
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
 	}
 	r.probeFn = func(context.Context) (probeResult, error) {
 		step++

--- a/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
+++ b/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
@@ -190,6 +190,50 @@ func Test_Reconcile_KubernetesReady_Ready(t *testing.T) {
 	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonReady)
 }
 
+func Test_Reconcile_InstanceKubeConfig_WrittenOnReady_RemovedOnDisable(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunning()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	instanceKubeConfig := filepath.Join(dir, "kube.config")
+	r := &KubernetesReconciler{
+		Client:                 c,
+		K3sConfigPath:          srcPath,
+		InstanceKubeConfigPath: instanceKubeConfig,
+	}
+	// The healthy reconcile starts a current-context probe goroutine; ensure it
+	// finishes before the test returns even if an assertion below fails.
+	t.Cleanup(func() { r.removeKubeContext(context.Background()) })
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+
+	// A healthy reconcile publishes the standalone kubeconfig that rdd run reads.
+	_, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	_, err = os.Stat(instanceKubeConfig)
+	assert.NilError(t, err, "instance kubeconfig should exist after a healthy reconcile")
+
+	// Disabling Kubernetes removes it again, leaving nothing for rdd run to find.
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+	got.Spec.Kubernetes.Enabled = false
+	assert.NilError(t, c.Update(context.Background(), got))
+
+	_, err = r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	_, err = os.Stat(instanceKubeConfig)
+	assert.Assert(t, os.IsNotExist(err),
+		"instance kubeconfig should be removed when Kubernetes is disabled")
+}
+
 func Test_Reconcile_KubernetesReady_MergeFailed(t *testing.T) {
 	dir := t.TempDir()
 	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -128,6 +128,14 @@ var LimaHome = sync.OnceValue(func() string {
 	return filepath.Join(ShortDir(), "lima")
 })
 
+// KubeConfig returns the path to the instance's standalone kubeconfig
+// (e.g., ~/.rd2/kube.config). It holds only the rancher-desktop-{instance}
+// context and is published alongside the ~/.kube/config merge, so rdd run
+// can point KUBECONFIG at the instance without copying credentials itself.
+var KubeConfig = sync.OnceValue(func() string {
+	return filepath.Join(ShortDir(), "kube.config")
+})
+
 // DockerSocket returns the path to the Docker socket for this instance
 // (e.g., ~/.rd2/docker.sock). This is the host-side socket that Lima
 // port-forwards from the guest's /var/run/docker.sock.


### PR DESCRIPTION
`rdd run COMMAND [ARGS...]` runs a command wired to this instance's Docker and Kubernetes contexts, so users need not edit their shell profile or switch their global contexts.

rdd run first ensures Rancher Desktop is running: it starts the App, and when the App is new and the command is kubectl or helm it also enables Kubernetes so the command has a cluster to talk to. It then wires the child process's environment — prepending `~/.rd<instance>/bin` to `PATH`, setting `DOCKER_CONTEXT` to `rancher-desktop-<instance>` while clearing `DOCKER_HOST`, and pointing `KUBECONFIG` at `~/.rd<instance>/kube.config`. The user's selected Docker context and the current context in `~/.kube/config` stay unchanged; starting the App still merges the `rancher-desktop-<instance>` entry into `~/.kube/config` as usual.

To back that `KUBECONFIG`, the Kubernetes controller publishes a standalone kubeconfig at `~/.rd<instance>/kube.config` holding only the `rancher-desktop-<instance>` context. It is written alongside the `~/.kube/config` merge once k3s is healthy and removed on teardown, so `rdd run` points at this file instead of copying credentials into a per-invocation temp file.

`rdd` runs the command as a child process rather than replacing itself, so it propagates the child's exit status uniformly across platforms. A help flag prints usage before the App starts, and a non-zero child exit sets `rdd`'s status without emitting a spurious error line.

Unit tests cover the kube-command classification, the standalone kubeconfig writer and remover, the environment wiring (`PATH`, Docker context, `DOCKER_HOST`, `KUBECONFIG`), and the help short-circuit. Integration tests in `engine-docker.bats` and `kube-context.bats` exercise the Docker context, Kubernetes context, `PATH` wiring, and exit-status propagation against a running instance.

Closes #386
