### PR TITLE
Enable Kubernetes context tests on Windows

### DIFF
--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -18,7 +18,18 @@ local_setup_file() {
     # Set KUBECONFIG before starting the service so the controller process inherits
     # it; service.Start uses exec.Command without an explicit Env, so it inherits
     # the caller's environment.
-    export KUBECONFIG="${BATS_FILE_TMPDIR}/kube/config"
+    #
+    # On Windows, rdd.exe is a native binary: it interprets /tmp/... as a path
+    # from the drive root (C:\tmp\...) rather than MSYS2's /tmp which maps to a
+    # different location. cygpath -m produces a mixed-format path (C:/msys64/...)
+    # that both native Windows processes and MSYS2 agree on.
+    if is_windows; then
+        run -0 cygpath -m "${BATS_FILE_TMPDIR}/kube/config"
+        KUBECONFIG="${output}"
+    else
+        KUBECONFIG="${BATS_FILE_TMPDIR}/kube/config"
+    fi
+    export KUBECONFIG
     mkdir -p "$(dirname "${KUBECONFIG}")"
 
     rdd svc delete

--- a/bats/tests/32-app-controllers/kube-context.bats
+++ b/bats/tests/32-app-controllers/kube-context.bats
@@ -14,8 +14,6 @@ VM_NAME="rd"
 K3S_VERSION="1.32.0"
 
 local_setup_file() {
-    skip_on_windows "Kubernetes context tests require Lima"
-
     # Isolate ~/.kube/config so tests never touch the developer's real kubeconfig.
     # Set KUBECONFIG before starting the service so the controller process inherits
     # it; service.Start uses exec.Command without an explicit Env, so it inherits

--- a/pkg/controllers/app/app/lima-images-unix.yaml
+++ b/pkg/controllers/app/app/lima-images-unix.yaml
@@ -1,7 +1,7 @@
 images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.3/distro.v0.2.3.amd64.raw.xz
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.4/distro.v0.2.4.amd64.raw.xz
   arch: x86_64
-  digest: "sha256:1d4ccf4faa3b71a2d7ad1610c0917361cf53f3ec5ac52cdc5bd6432b12bd8309"
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.3/distro.v0.2.3.arm64.raw.xz
+  digest: sha256:427c162fdc6737e9a66cb4a2b3032c8548d71018eb5e3771761e1de8437550fc
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.4/distro.v0.2.4.arm64.raw.xz
   arch: aarch64
-  digest: "sha256:a92307572b161960dc0da74d3f47ed5e1c332b69ea033113ecaeee6064a14bdd"
+  digest: sha256:2d5faa07d4faaa668a37b47eb92e4fbbe94f81e62f2e2038735ce5b0a8f190ad

--- a/pkg/controllers/app/app/lima-images-wsl2.yaml
+++ b/pkg/controllers/app/app/lima-images-wsl2.yaml
@@ -1,6 +1,6 @@
 vmType: wsl2
 images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.3/distro.v0.2.3.amd64.tar.xz
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.4/distro.v0.2.4.amd64.tar.xz
   arch: x86_64
-  digest: sha256:4b06637a1609267623df04874cbaebef2a763023f01ddb079c6c9fc0472fe9f7
+  digest: sha256:274a044ac44b23ce33fa6b24afc1462610391dec577fdf544d479886813e9b95
 mountType: wsl2

--- a/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -298,6 +299,21 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Create the Lima instance
 	inst, err := limainstance.Create(ctx, limaVM.Name, []byte(templateData), false)
 	if err != nil {
+		// If the directory exists but store.Inspect returned nil above (no valid
+		// Lima metadata), the directory is stale — left behind by a previous
+		// service run whose cleanup failed (e.g. file locks from orphaned WSL2
+		// processes on Windows). removeStaleInstance handles the platform-specific
+		// cleanup (unregistering the WSL2 distro on Windows to release the VHD
+		// lock) before removing the directory, then we requeue to start fresh.
+		if strings.Contains(err.Error(), "already exists") {
+			instanceDir := filepath.Join(instance.LimaHome(), limaVM.Name)
+			logger.Info("Found stale Lima instance directory, removing it", "path", instanceDir)
+			if rmErr := removeStaleInstance(ctx, logger, limaVM.Name, instanceDir); rmErr != nil {
+				logger.Error(rmErr, "Failed to remove stale Lima instance directory; will retry")
+				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+			}
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
 		logger.Error(err, "Failed to create Lima instance")
 		r.setCondition(ctx, &limaVM, ConditionCreated, metav1.ConditionFalse, ReasonCreateFailed, err.Error())
 		if statusErr := r.Status().Update(ctx, &limaVM); statusErr != nil {

--- a/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -707,15 +707,47 @@ func stopInstanceForcibly(ctx context.Context, logger logr.Logger, inst *limatyp
 }
 
 // terminateWSL2Distro sends `wsl.exe --terminate` for the Lima distro with
-// the given instance name. Best-effort with a 10-second timeout: wsl.exe can
-// hang if the WSL subsystem is degraded.
+// the given instance name. No-op on non-Windows. Best-effort with a
+// 10-second timeout: wsl.exe can hang if the WSL subsystem is degraded.
 func terminateWSL2Distro(ctx context.Context, logger logr.Logger, instName string) {
+	if runtime.GOOS != "windows" {
+		return
+	}
 	distroName := "lima-" + instName
 	wslCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := exec.CommandContext(wslCtx, "wsl.exe", "--terminate", distroName).Run(); err != nil {
 		logger.V(1).Info("Failed to terminate WSL2 distro", "distro", distroName, "error", err)
 	}
+}
+
+// unregisterWSL2Distro sends `wsl.exe --unregister` for the Lima distro with
+// the given instance name. No-op on non-Windows. This removes the WSL2
+// registration and deletes the distro's ext4.vhdx, allowing Lima to import a
+// fresh distro on the next Prepare. Best-effort with a 30-second timeout
+// (unregister is slower than terminate and can hang if WSL2 is degraded).
+func unregisterWSL2Distro(ctx context.Context, logger logr.Logger, instName string) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	distroName := "lima-" + instName
+	wslCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(wslCtx, "wsl.exe", "--unregister", distroName).Run(); err != nil {
+		logger.V(1).Info("Failed to unregister WSL2 distro", "distro", distroName, "error", err)
+	}
+}
+
+// removeStaleInstance removes a stale Lima instance directory left behind by
+// a previous service run whose cleanup failed. On Windows, the WSL2 distro is
+// unregistered first (removing its ext4.vhdx and releasing any file locks)
+// before the remaining Lima metadata directory is deleted. On non-Windows the
+// directory is removed directly.
+func removeStaleInstance(ctx context.Context, logger logr.Logger, instName, instanceDir string) error {
+	if runtime.GOOS == "windows" {
+		unregisterWSL2Distro(ctx, logger, instName)
+	}
+	return os.RemoveAll(instanceDir)
 }
 
 // preserveInstanceLogs moves log files from the Lima instance directory to


### PR DESCRIPTION
This PR enables the previously skipped kube-context.bats tests on Windows and fixes two root causes that prevented them from passing.

- Enable kube-context tests on Windows. Removed the `skip_on_windows` guard from kube-context.bats.
- Bump opensuse distro to v0.2.4.
- Fix stale Lima instance recovery and `KUBECONFIG` path

Two bugs prevented the tests from passing on Windows:

1. Stale Lima instance on restart when RDD was force-killed, Lima's WSL2 hostagent could survive as an orphan holding `ext4.vhdx` open. On the next start, `limainstance.Create` would fail with "already exists". The fix changes this in the LimaVM reconciler and calls
  `wsl.exe --unregister` (not just --terminate) to fully remove the WSL2 registration and VHD before retrying. Using `--terminate` alone was insufficient: it left the WSL2 registration intact, causing Lima's `Prepare()` to skip `wsl.exe --import`, which meant no new VHD was created and the hostagent would crash-loop.
2. Wrong KUBECONFIG path on Windows — `BATS_FILE_TMPDIR` is a POSIX path (`/tmp/...`). The rdd.exe binary interprets this as `C:\tmp\... `(drive root) rather than MSYS2's `C:\msys64\tmp\...`, so the kubernetes controller was writing the kubeconfig to the wrong location. Fixed by using `cygpath -m` to convert the path to a mixed format that both MSYS2 and native Windows processes agree on, similar to what was already done in engine-docker.bats.

Related: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/391