### PR TITLE
Test reaching a container from the host

### DIFF
--- a/rdd/bats/helpers/commands.bash
+++ b/rdd/bats/helpers/commands.bash
@@ -24,6 +24,16 @@ curl() {
     command "curl${EXE}" "$@"
 }
 
+# Fetch a URL and run assert_output against the response body, forwarding any
+# assert_output flags. Pair it with try() to poll an endpoint that comes up
+# asynchronously.
+assert_http_body() { # <url> [assert_output args...]
+    local url=$1
+    shift
+    run -0 curl --silent --show-error --fail --connect-timeout 5 --max-time 10 "${url}"
+    assert_output "$@"
+}
+
 # Check if curl supports WebSockets; some tests may require it.
 curl_has_websocket_support() {
     if ! command -v "curl${EXE}" >/dev/null 2>&1; then

--- a/rdd/bats/tests/32-app-controllers/engine-docker.bats
+++ b/rdd/bats/tests/32-app-controllers/engine-docker.bats
@@ -245,6 +245,32 @@ assert_single_mirror() { # <image-id> <expected-tag>
     docker rm --force test-exposed test-published
 }
 
+# --- Host connectivity ---
+
+@test "published container port is reachable from the host" {
+    # Run nginx with a published port and reach it from the host. The
+    # container listens on 0.0.0.0 inside the VM; the Lima template forwards
+    # each guest 0.0.0.0 port to the host, so localhost:<port> reaches the
+    # containerized application.
+    #
+    # Pull nginx up front (quietly), mirroring the Kubernetes NodePort test;
+    # docker run would otherwise pull it inline.
+    docker pull --quiet nginx
+    host_port=18080
+    run_e -0 docker run --detach --name test-connect --publish "${host_port}:80" nginx
+    cid=${output}
+
+    rdd ctl wait --for=jsonpath='{.status.status}'=running \
+        --namespace="${RDD_NAMESPACE}" container/"${cid}" --timeout=30s
+
+    # The port forward is established asynchronously once the container
+    # starts listening, so poll until nginx answers.
+    try --max 30 --delay 2 -- \
+        assert_http_body "http://localhost:${host_port}" --partial "Welcome to nginx"
+
+    docker rm --force test-connect
+}
+
 # --- Container logs ---
 
 @test "docker logs for container with tty" {

--- a/rdd/bats/tests/32-app-controllers/kube-context.bats
+++ b/rdd/bats/tests/32-app-controllers/kube-context.bats
@@ -10,7 +10,6 @@ load '../../helpers/load'
 # KubernetesReady condition on the App resource.
 
 APP_NAME="app"
-VM_NAME="rd"
 K3S_VERSION="1.32.0"
 CONTEXT_NAME="rancher-desktop-${RDD_INSTANCE}"
 
@@ -153,6 +152,37 @@ kube_current_context_is() { # <expected-context>
 
     run -0 kube_current_context
     assert_output "${CONTEXT_NAME}"
+}
+
+# --- Host connectivity ---
+
+@test "NodePort service is reachable from the host" {
+    # Deploy nginx behind a NodePort service and reach it from the host. k3s
+    # opens the NodePort on the node's 0.0.0.0; the Lima template forwards
+    # that port to the host, so localhost:<nodePort> reaches the application.
+
+    # Warm the image cache so the cold nginx pull stays off the rollout's clock
+    # on a slow CI runner. With the default moby backend k3s pulls through
+    # cri-dockerd from dockerd, so warm it with rdd run, which points docker at
+    # the VM's engine.
+    rdd run docker pull --quiet nginx
+
+    rdd kubectl --context "${CONTEXT_NAME}" create deployment test-connect --image=nginx
+    rdd kubectl --context "${CONTEXT_NAME}" expose deployment test-connect \
+        --name=test-connect --port=80 --type=NodePort
+    rdd kubectl --context "${CONTEXT_NAME}" rollout status deployment/test-connect --timeout=240s
+
+    run -0 rdd kubectl --context "${CONTEXT_NAME}" get service test-connect \
+        -o jsonpath='{.spec.ports[0].nodePort}'
+    node_port=${output}
+
+    # The pod must become an endpoint, kube-proxy must program the NodePort,
+    # and Lima must forward it to the host; poll until nginx answers.
+    try --max 40 --delay 3 -- \
+        assert_http_body "http://localhost:${node_port}" --partial "Welcome to nginx"
+
+    rdd kubectl --context "${CONTEXT_NAME}" delete service test-connect
+    rdd kubectl --context "${CONTEXT_NAME}" delete deployment test-connect
 }
 
 @test "KubernetesReady=NotApplicable when kubernetes is disabled" {

--- a/rdd/bats/tests/32-app-controllers/kube-context.bats
+++ b/rdd/bats/tests/32-app-controllers/kube-context.bats
@@ -116,10 +116,10 @@ kube_current_context_is() { # <expected-context>
 }
 
 @test "rdd run targets the instance Kubernetes context" {
-    # rdd run points KUBECONFIG at a throwaway file whose current context
-    # is the instance, so a client talks to this cluster regardless of the
-    # user's selected context. config current-context reads the file
-    # without contacting the cluster. The user's kubeconfig is untouched.
+    # rdd run points KUBECONFIG at a separate kubeconfig it maintains, whose
+    # current context is the instance, so a client talks to this cluster
+    # regardless of the user's selected context. config current-context reads
+    # the file without contacting the cluster. The user's kubeconfig is untouched.
     run_e -0 rdd run rdd kubectl config current-context
     assert_output "${CONTEXT_NAME}"
 }
@@ -176,10 +176,10 @@ kube_current_context_is() { # <expected-context>
     # opens the NodePort on the node's 0.0.0.0; the Lima template forwards
     # that port to the host, so localhost:<nodePort> reaches the application.
 
-    # Warm the image cache so the cold nginx pull stays off the rollout's clock
-    # on a slow CI runner. With the default moby backend k3s pulls through
-    # cri-dockerd from dockerd, so warm it with rdd run, which points docker at
-    # the VM's engine.
+    # Pull nginx ahead of the rollout so the cold pull doesn't count against its
+    # --timeout; this helps on slow CI runners. With the default moby backend
+    # k3s pulls through cri-dockerd from dockerd; use rdd run docker to ensure we
+    # are using the correct docker context.
     rdd run docker pull --quiet nginx
 
     rdd kubectl --context "${CONTEXT_NAME}" create deployment test-connect --image=nginx

--- a/rdd/bats/tests/32-app-controllers/kube-context.bats
+++ b/rdd/bats/tests/32-app-controllers/kube-context.bats
@@ -124,6 +124,21 @@ kube_current_context_is() { # <expected-context>
     assert_output "${CONTEXT_NAME}"
 }
 
+@test "rdd run kubectl reaches the instance cluster" {
+    # current-context (above) proves the maintained kubeconfig names the
+    # instance, not that it reaches the right cluster. The kube-system
+    # namespace UID is a stable per-cluster identity: read it through the
+    # known-good shared context and through rdd run's maintained config, and
+    # require the two to match.
+    run -0 rdd kubectl --context "${CONTEXT_NAME}" \
+        get namespace kube-system -o jsonpath='{.metadata.uid}'
+    expected_uid=${output}
+
+    run_e -0 rdd run rdd kubectl get namespace kube-system \
+        -o jsonpath='{.metadata.uid}'
+    assert_output "${expected_uid}"
+}
+
 @test "rdd run prepends the instance bin directory to PATH" {
     # The instance bin directory leads PATH so tools bundled with the
     # instance shadow any global ones for the duration of the command.


### PR DESCRIPTION
Two end-to-end bats tests for #393: run a containerized nginx and reach it from the host, one per container path:

- `engine-docker.bats` publishes a Docker port (`-p 18080:80`) and curls `localhost:18080`.
- `kube-context.bats` exposes a Kubernetes NodePort and curls `localhost:<nodePort>`.

Both ride the VM their suite already boots, so they add no VM startup.

Closes #393