### PR TITLE
Add docker engine command BATS suite

### DIFF
--- a/.github/workflows/rdd-bats.yaml
+++ b/.github/workflows/rdd-bats.yaml
@@ -64,13 +64,14 @@ jobs:
         - macos-15-intel
         - ubuntu-latest
         - windows-latest
-        # bats-app runs on its own runner so its WSL2 VM does not collide
-        # with bats-lima's on Windows (Lima hard-codes SSH port 22 per
-        # instance), and so bats-app can grow independently of the rest
-        # of the suite.
+        # bats-app and bats-docker each run on their own runner so their VMs
+        # do not collide with bats-lima's on Windows (Lima hard-codes SSH port
+        # 22 per instance), and so each can grow independently of the rest of
+        # the suite.
         suite:
         - bats-app
         - bats-lima
+        - bats-docker
         - bats-others
     # Run on ubuntu-latest if we don't need to actually run the tests, because
     # they start faster (and are cheaper).
@@ -105,7 +106,13 @@ jobs:
       if: needs.check-paths.outputs.should-run && runner.os == 'macOS'
       working-directory: ${{ runner.temp }}
       run: |
-        brew install bash coreutils make docker
+        brew install bash coreutils make docker docker-buildx docker-compose
+
+        # The docker formula installs only the CLI; symlink the buildx and
+        # compose plugins so `docker buildx` and `docker compose` resolve.
+        mkdir -p ~/.docker/cli-plugins
+        ln -sf "$(brew --prefix)/opt/docker-buildx/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
+        ln -sf "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
 
         # Disable Spotlight indexing on all volumes. On macos-15-intel CI
         # runners, mds/mds_stores/mdworker_shared collectively consumed
@@ -233,11 +240,11 @@ jobs:
       shell: bash
       run: |
         case "${{ matrix.suite }}" in
-          bats-app|bats-lima)
+          bats-app|bats-lima|bats-docker)
             echo "BATS_TARGET=${{ matrix.suite }}" >> "$GITHUB_ENV"
             ;;
           bats-others)
-            echo "BATS_EXCLUDES=bats-app bats-lima" >> "$GITHUB_ENV"
+            echo "BATS_EXCLUDES=bats-app bats-lima bats-docker" >> "$GITHUB_ENV"
             echo "BATS_TARGET=bats-all" >> "$GITHUB_ENV"
             ;;
           *)

--- a/rdd/bats/Makefile
+++ b/rdd/bats/Makefile
@@ -81,13 +81,25 @@ bats-containers: check-bats build-rdd build-mock-controller
 	RDD_INSTANCE=bats-containers-controller $(BATS) tests/34-containers-controllers/
 .PHONY: bats-containers
 
+# Run docker engine command tests against the moby engine. RDD_KEEP_RUNNING
+# keeps the VM up between files so it boots once for the whole suite.
+bats-docker: check-bats build-rdd
+	RDD_INSTANCE=bats-docker RDD_CONTAINER_ENGINE=moby RDD_KEEP_RUNNING=1 $(BATS) tests/40-docker/
+.PHONY: bats-docker
+
+# Run the same suite against containerd/nerdctl. The nerdctl engine path is not
+# wired yet; this target exists so the tests are ready when it lands.
+bats-nerdctl: check-bats build-rdd
+	RDD_INSTANCE=bats-nerdctl RDD_CONTAINER_ENGINE=containerd RDD_KEEP_RUNNING=1 $(BATS) tests/40-docker/
+.PHONY: bats-nerdctl
+
 # Run all controller tests.
 BATS_CONTROLLERS_TARGETS := bats-builtin bats-rdd bats-app bats-lima bats-containers
 bats-controllers: $(BATS_CONTROLLERS_TARGETS)
 .PHONY: bats-controllers
 
 # Run all BATS tests.
-bats-all: $(filter-out $(BATS_EXCLUDES),bats-helpers bats-cli bats-service $(BATS_CONTROLLERS_TARGETS))
+bats-all: $(filter-out $(BATS_EXCLUDES),bats-helpers bats-cli bats-service bats-docker $(BATS_CONTROLLERS_TARGETS))
 .PHONY: bats-all
 
 # Run specific BATS test file

--- a/rdd/bats/helpers/defaults.bash
+++ b/rdd/bats/helpers/defaults.bash
@@ -7,6 +7,18 @@ export RDD_INSTANCE
 : "${RDD_KEEP_LOGS:=1}"
 export RDD_KEEP_LOGS
 
+# Container engine under test. moby selects the Docker engine (and the docker
+# CLI); containerd selects nerdctl. ctrctl() in commands.bash dispatches on it.
+: "${RDD_CONTAINER_ENGINE:=moby}"
+
+using_containerd() {
+    [[ "${RDD_CONTAINER_ENGINE}" == containerd ]]
+}
+
+using_docker() {
+    ! using_containerd
+}
+
 using_windows_exe() {
     # MSYS2 always uses Windows executables; there is no Linux alternative.
     if is_msys; then

--- a/rdd/bats/helpers/docker.bash
+++ b/rdd/bats/helpers/docker.bash
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+# Helpers for the docker-command suite (tests/40-docker). Tests drive the engine
+# through ctrctl() (commands.bash) so the suite can later run against nerdctl.
+
+# Test image, pinned to a tag. TODO: pin by digest and mirror to ghcr.io to
+# avoid Docker Hub pull limits, as the rancher-desktop suite does.
+IMAGE_BUSYBOX=busybox:1.36
+
+# Bring up the moby engine and point the docker CLI at it via DOCKER_HOST. Boots
+# the VM on a run's first file and reuses it after (marker in BATS_RUN_TMPDIR).
+start_docker_engine() {
+    if ! load_var DOCKER_ENGINE_BOOTED; then
+        rdd svc delete
+        DOCKER_ENGINE_BOOTED=1
+        save_var DOCKER_ENGINE_BOOTED
+    fi
+    # Creates and starts the instance on the first call; a fast no-op afterward.
+    rdd set running=true
+    if is_windows; then
+        DOCKER_HOST="npipe:////./pipe/docker_engine"
+    else
+        run -0 rdd svc paths docker_socket
+        DOCKER_HOST="unix://${output}"
+    fi
+    export DOCKER_HOST
+}
+
+# skip_unless_docker skips a docker-only command when the engine is containerd.
+# nerdctl has no equivalent, so the gap is by design.
+skip_unless_docker() { # [reason]
+    using_docker || skip "${1:-not applicable to the containerd/nerdctl engine}"
+}
+
+# docker_has_compose reports whether the docker CLI has a working compose plugin.
+docker_has_compose() {
+    docker compose version >/dev/null 2>&1
+}
+
+# docker_has_build reports whether the docker CLI has the buildx plugin that
+# docker build needs.
+docker_has_build() {
+    docker buildx version >/dev/null 2>&1
+}

--- a/rdd/bats/helpers/load.bash
+++ b/rdd/bats/helpers/load.bash
@@ -61,6 +61,9 @@ source "${PATH_BATS_HELPERS}/paths.bash"
 # and PATH_* variables from paths.bash
 source "${PATH_BATS_HELPERS}/commands.bash"
 
+# docker.bash depends on defaults.bash, os.bash, and utils.bash, sourced above.
+source "${PATH_BATS_HELPERS}/docker.bash"
+
 # Add repo-root/bin directory to the PATH. This is where the Makefile puts all compiled programs.
 export PATH="${PATH_BATS_ROOT}/../bin:${PATH}"
 
@@ -86,9 +89,12 @@ setup_file() {
 }
 
 teardown_file() {
-    # Stop the control plane but don't delete it, to preserve logs for debugging.
-    # The next test run's setup will clean up and create a fresh instance.
-    rdd svc stop || true
+    # Stop the control plane between files so logs survive for debugging; the
+    # next run's setup creates a fresh instance. RDD_KEEP_RUNNING=1 keeps the
+    # engine up across files so a VM-booting suite boots once.
+    if [[ "${RDD_KEEP_RUNNING:-}" != 1 ]]; then
+        rdd svc stop || true
+    fi
 
     call_local_function
 }

--- a/rdd/bats/helpers/paths.bash
+++ b/rdd/bats/helpers/paths.bash
@@ -19,6 +19,16 @@ win_to_posix_exports() {
     done
 }
 
+# Convert a path to the form the native Windows docker CLI needs (cygpath -m);
+# MSYS_NO_PATHCONV (load.bash) suppresses the automatic conversion. No-op elsewhere.
+host_path() { # <path>
+    if is_windows; then
+        cygpath -m "$1"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
 # Get instance paths from rdd (single source of truth).
 # shellcheck disable=SC1090
 if is_windows; then

--- a/rdd/bats/tests/33-lima-controllers/limavm-instance.bats
+++ b/rdd/bats/tests/33-lima-controllers/limavm-instance.bats
@@ -76,8 +76,11 @@ lima_instance_exists() {
 }
 
 @test "wait for Created condition to be True" {
+    # This is the first instance creation in the suite, so it must download
+    # and decompress the distro image. A throttled GitHub release CDN can
+    # stretch the download past two minutes.
     rdd ctl wait --for=condition=Created=True \
-        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=120s
+        "limavm/${VM_NAME}" --namespace "${NAMESPACE}" --timeout=180s
 }
 
 @test "verify Lima instance directory exists" {

--- a/rdd/bats/tests/40-docker/build.bats
+++ b/rdd/bats/tests/40-docker/build.bats
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# Build commands against the rdd Docker engine. docker build needs the host
+# buildx plugin; tests skip when it is absent.
+
+local_setup_file() {
+    start_docker_engine
+    if docker_has_build; then
+        ctrctl pull --quiet "${IMAGE_BUSYBOX}"
+    fi
+}
+
+local_setup() {
+    docker_has_build || skip "docker buildx plugin is not installed"
+}
+
+@test "build creates an image from a Dockerfile" {
+    cat >"${BATS_TEST_TMPDIR}/Dockerfile" <<EOF
+FROM ${IMAGE_BUSYBOX}
+RUN echo built >/built.txt
+EOF
+    run -0 host_path "${BATS_TEST_TMPDIR}"
+    ctrctl build --tag rdd-build:v1 "${output}"
+    run -0 ctrctl run --rm rdd-build:v1 cat /built.txt
+    assert_output built
+    ctrctl rmi rdd-build:v1
+}
+
+@test "build --build-arg passes a value into the build" {
+    cat >"${BATS_TEST_TMPDIR}/Dockerfile" <<EOF
+FROM ${IMAGE_BUSYBOX}
+ARG GREETING
+RUN echo "\${GREETING}" >/greeting.txt
+EOF
+    run -0 host_path "${BATS_TEST_TMPDIR}"
+    ctrctl build --build-arg GREETING=hi --tag rdd-build-arg:v1 "${output}"
+    run -0 ctrctl run --rm rdd-build-arg:v1 cat /greeting.txt
+    assert_output hi
+    ctrctl rmi rdd-build-arg:v1
+}

--- a/rdd/bats/tests/40-docker/compose.bats
+++ b/rdd/bats/tests/40-docker/compose.bats
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# Compose commands against the rdd Docker engine: up, ps, logs, down. Compose is
+# a docker CLI plugin; tests skip when it is absent.
+
+local_setup_file() {
+    start_docker_engine
+    if using_docker && docker_has_compose; then
+        ctrctl pull --quiet "${IMAGE_BUSYBOX}"
+    fi
+}
+
+local_setup() {
+    using_docker || skip "compose is driven through the docker CLI plugin"
+    docker_has_compose || skip "docker compose plugin is not installed"
+}
+
+@test "compose up starts a project that ps lists" {
+    cat >"${BATS_TEST_TMPDIR}/compose.yaml" <<EOF
+services:
+  app:
+    image: ${IMAGE_BUSYBOX}
+    command: sleep 300
+EOF
+    run -0 host_path "${BATS_TEST_TMPDIR}/compose.yaml"
+    compose_file=${output}
+    docker compose --file "${compose_file}" --project-name rdd-compose up --detach
+    run -0 docker compose --file "${compose_file}" --project-name rdd-compose ps --format "{{.State}}"
+    assert_output "running"
+    docker compose --file "${compose_file}" --project-name rdd-compose down
+}
+
+@test "compose logs returns service output" {
+    cat >"${BATS_TEST_TMPDIR}/compose.yaml" <<EOF
+services:
+  app:
+    image: ${IMAGE_BUSYBOX}
+    command: echo composed
+EOF
+    run -0 host_path "${BATS_TEST_TMPDIR}/compose.yaml"
+    compose_file=${output}
+    docker compose --file "${compose_file}" --project-name rdd-compose-logs up --detach
+    run -0 docker compose --file "${compose_file}" --project-name rdd-compose-logs logs
+    assert_output --partial composed
+    docker compose --file "${compose_file}" --project-name rdd-compose-logs down
+}

--- a/rdd/bats/tests/40-docker/compose.bats
+++ b/rdd/bats/tests/40-docker/compose.bats
@@ -43,7 +43,9 @@ services:
 EOF
     run -0 host_path "${BATS_TEST_TMPDIR}/compose.yaml"
     compose_file=${output}
-    docker compose --file "${compose_file}" --project-name rdd-compose-logs up --detach
+    # Run in the foreground so the service finishes before logs is read.
+    # --abort-on-container-exit makes a foreground `up` return once the container exits.
+    docker compose --file "${compose_file}" --project-name rdd-compose-logs up --abort-on-container-exit
     run -0 docker compose --file "${compose_file}" --project-name rdd-compose-logs logs
     assert_output --partial composed
     docker compose --file "${compose_file}" --project-name rdd-compose-logs down

--- a/rdd/bats/tests/40-docker/container.bats
+++ b/rdd/bats/tests/40-docker/container.bats
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# Container lifecycle commands against the rdd Docker engine.
+
+local_setup_file() {
+    start_docker_engine
+    # Pull once so each test times the command under test, not an image pull.
+    ctrctl pull --quiet "${IMAGE_BUSYBOX}"
+}
+
+@test "run executes a command and streams its output" {
+    run -0 ctrctl run --rm "${IMAGE_BUSYBOX}" echo hello
+    assert_output hello
+}
+
+@test "run --detach starts a container that ps lists" {
+    run_e -0 ctrctl run --detach --name rdd-run "${IMAGE_BUSYBOX}" sleep 300
+    cid=${output}
+
+    # ps prints the 12-character short ID, a prefix of the full ID from run.
+    run -0 ctrctl ps --quiet --filter name=rdd-run
+    assert_output "${cid:0:12}"
+
+    ctrctl rm --force rdd-run
+}
+
+@test "exec runs a command inside a running container" {
+    ctrctl run --detach --name rdd-exec "${IMAGE_BUSYBOX}" sleep 300
+    run -0 ctrctl exec rdd-exec echo inside
+    assert_output inside
+    ctrctl rm --force rdd-exec
+}
+
+@test "logs returns a container's stdout" {
+    # Run in the foreground so the container finishes before logs is read.
+    ctrctl run --name rdd-logs "${IMAGE_BUSYBOX}" sh -c 'echo one; echo two'
+    run -0 ctrctl logs rdd-logs
+    assert_line --index 0 one
+    assert_line --index 1 two
+    ctrctl rm --force rdd-logs
+}
+
+@test "inspect reports container state" {
+    ctrctl run --detach --name rdd-inspect "${IMAGE_BUSYBOX}" sleep 300
+    run -0 ctrctl inspect --format '{{.State.Status}}' rdd-inspect
+    assert_output running
+    ctrctl rm --force rdd-inspect
+}
+
+@test "cp copies files between host and container" {
+    ctrctl run --detach --name rdd-cp "${IMAGE_BUSYBOX}" sleep 300
+
+    echo marker >"${BATS_TEST_TMPDIR}/in.txt"
+    run -0 host_path "${BATS_TEST_TMPDIR}/in.txt"
+    in_host=${output}
+    run -0 host_path "${BATS_TEST_TMPDIR}/out.txt"
+    out_host=${output}
+
+    ctrctl cp "${in_host}" rdd-cp:/in.txt
+    run -0 ctrctl exec rdd-cp cat /in.txt
+    assert_output marker
+
+    ctrctl cp rdd-cp:/in.txt "${out_host}"
+    run -0 cat "${BATS_TEST_TMPDIR}/out.txt"
+    assert_output marker
+
+    ctrctl rm --force rdd-cp
+}
+
+@test "stop, start, and restart move a container through its states" {
+    ctrctl run --detach --name rdd-lifecycle "${IMAGE_BUSYBOX}" sleep 300
+
+    ctrctl stop --time 1 rdd-lifecycle
+    run -0 ctrctl inspect --format '{{.State.Status}}' rdd-lifecycle
+    assert_output exited
+
+    ctrctl start rdd-lifecycle
+    run -0 ctrctl inspect --format '{{.State.Status}}' rdd-lifecycle
+    assert_output running
+
+    ctrctl restart --time 1 rdd-lifecycle
+    run -0 ctrctl inspect --format '{{.State.Status}}' rdd-lifecycle
+    assert_output running
+
+    ctrctl rm --force rdd-lifecycle
+}
+
+@test "pause and unpause freeze and resume a container" {
+    ctrctl run --detach --name rdd-pause "${IMAGE_BUSYBOX}" sleep 300
+
+    ctrctl pause rdd-pause
+    run -0 ctrctl inspect --format '{{.State.Status}}' rdd-pause
+    assert_output paused
+
+    ctrctl unpause rdd-pause
+    run -0 ctrctl inspect --format '{{.State.Status}}' rdd-pause
+    assert_output running
+
+    ctrctl rm --force rdd-pause
+}
+
+@test "kill stops a running container" {
+    ctrctl run --detach --name rdd-kill "${IMAGE_BUSYBOX}" sleep 300
+    ctrctl kill rdd-kill
+    run -0 ctrctl inspect --format '{{.State.Status}}' rdd-kill
+    assert_output exited
+    ctrctl rm --force rdd-kill
+}
+
+@test "wait blocks until a container exits and reports its code" {
+    ctrctl run --detach --name rdd-wait "${IMAGE_BUSYBOX}" sh -c 'exit 3'
+    run -0 ctrctl wait rdd-wait
+    assert_output 3
+    ctrctl rm --force rdd-wait
+}
+
+@test "rename changes a container's name" {
+    ctrctl run --detach --name rdd-old "${IMAGE_BUSYBOX}" sleep 300
+    ctrctl rename rdd-old rdd-new
+
+    run -0 ctrctl ps --quiet --filter name=rdd-new
+    assert_output
+    run -0 ctrctl ps --quiet --filter name=rdd-old
+    refute_output
+
+    ctrctl rm --force rdd-new
+}
+
+@test "stats reports a running container without streaming" {
+    ctrctl run --detach --name rdd-stats "${IMAGE_BUSYBOX}" sleep 300
+    run -0 ctrctl stats --no-stream --format '{{.Name}}' rdd-stats
+    assert_output rdd-stats
+    ctrctl rm --force rdd-stats
+}
+
+@test "port lists a container's published port mappings" {
+    ctrctl run --detach --name rdd-port --publish 127.0.0.1::80 "${IMAGE_BUSYBOX}" sleep 300
+    run -0 ctrctl port rdd-port 80
+    assert_output --partial 127.0.0.1:
+    ctrctl rm --force rdd-port
+}
+
+@test "exec on a stopped container fails" {
+    ctrctl run --detach --name rdd-stopped "${IMAGE_BUSYBOX}" sh -c 'exit 0'
+    ctrctl wait rdd-stopped
+    run ctrctl exec rdd-stopped true
+    assert_failure
+    ctrctl rm --force rdd-stopped
+}

--- a/rdd/bats/tests/40-docker/image.bats
+++ b/rdd/bats/tests/40-docker/image.bats
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# Image commands against the rdd Docker engine: pull, images, tag, inspect,
+# history, save/load, rmi, prune.
+
+local_setup_file() {
+    start_docker_engine
+    ctrctl pull --quiet "${IMAGE_BUSYBOX}"
+}
+
+@test "images lists a pulled image" {
+    run -0 ctrctl images --quiet "${IMAGE_BUSYBOX}"
+    assert_output
+}
+
+@test "tag adds a second reference to an image" {
+    ctrctl tag "${IMAGE_BUSYBOX}" rdd-tag:v1
+    run -0 ctrctl images --quiet rdd-tag:v1
+    assert_output
+    ctrctl rmi rdd-tag:v1
+}
+
+@test "image inspect reports image fields" {
+    run -0 ctrctl image inspect --format '{{.Os}}' "${IMAGE_BUSYBOX}"
+    assert_output linux
+}
+
+@test "history lists an image's layers" {
+    run -0 ctrctl history --quiet "${IMAGE_BUSYBOX}"
+    assert_output
+}
+
+@test "save and load round-trip an image" {
+    run -0 host_path "${BATS_TEST_TMPDIR}/image.tar"
+    image_tar=${output}
+
+    ctrctl tag "${IMAGE_BUSYBOX}" rdd-save:v1
+    ctrctl save --output "${image_tar}" rdd-save:v1
+    ctrctl rmi rdd-save:v1
+    run -0 ctrctl images --quiet rdd-save:v1
+    refute_output
+
+    ctrctl load --input "${image_tar}"
+    run -0 ctrctl images --quiet rdd-save:v1
+    assert_output
+
+    ctrctl rmi rdd-save:v1
+}
+
+@test "rmi removes an image tag" {
+    ctrctl tag "${IMAGE_BUSYBOX}" rdd-rmi:v1
+    ctrctl rmi rdd-rmi:v1
+    run -0 ctrctl images --quiet rdd-rmi:v1
+    refute_output
+}
+
+@test "image prune runs against the engine" {
+    # With no dangling images this removes nothing, but the command must work.
+    ctrctl image prune --force
+}
+
+@test "rmi of an unknown image fails" {
+    run ctrctl rmi rdd-no-such-image:nope
+    assert_failure
+}

--- a/rdd/bats/tests/40-docker/network.bats
+++ b/rdd/bats/tests/40-docker/network.bats
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# Network commands against the rdd Docker engine: create, ls, inspect, rm,
+# prune, connect/disconnect, and name-based DNS on a user-defined network.
+
+local_setup_file() {
+    start_docker_engine
+    ctrctl pull --quiet "${IMAGE_BUSYBOX}"
+}
+
+@test "create and ls show a user-defined network" {
+    ctrctl network create rdd-net
+    run -0 ctrctl network ls --quiet --filter name=rdd-net
+    assert_output
+    ctrctl network rm rdd-net
+}
+
+@test "network inspect reports the bridge driver" {
+    ctrctl network create rdd-net-inspect
+    run -0 ctrctl network inspect --format '{{.Driver}}' rdd-net-inspect
+    assert_output bridge
+    ctrctl network rm rdd-net-inspect
+}
+
+@test "containers resolve each other by name on a user-defined network" {
+    ctrctl network create rdd-net-dns
+    ctrctl run --detach --name rdd-net-server --network rdd-net-dns "${IMAGE_BUSYBOX}" sleep 300
+    run -0 ctrctl run --rm --network rdd-net-dns "${IMAGE_BUSYBOX}" ping -c 1 rdd-net-server
+    assert_output --partial '1 packets received'
+    ctrctl rm --force rdd-net-server
+    ctrctl network rm rdd-net-dns
+}
+
+@test "connect and disconnect attach a container to a network" {
+    skip_unless_docker "nerdctl has no network connect/disconnect"
+    ctrctl network create rdd-net-conn
+    ctrctl run --detach --name rdd-net-attach "${IMAGE_BUSYBOX}" sleep 300
+
+    ctrctl network connect rdd-net-conn rdd-net-attach
+    run -0 ctrctl inspect --format '{{json .NetworkSettings.Networks}}' rdd-net-attach
+    assert_output --partial rdd-net-conn
+
+    ctrctl network disconnect rdd-net-conn rdd-net-attach
+    run -0 ctrctl inspect --format '{{json .NetworkSettings.Networks}}' rdd-net-attach
+    refute_output --partial rdd-net-conn
+
+    ctrctl rm --force rdd-net-attach
+    ctrctl network rm rdd-net-conn
+}
+
+@test "network prune removes unused networks" {
+    ctrctl network create rdd-net-prune
+    ctrctl network prune --force
+    run -0 ctrctl network ls --quiet --filter name=rdd-net-prune
+    refute_output
+}
+
+@test "network inspect of an unknown network fails" {
+    run ctrctl network inspect rdd-no-such-network
+    assert_failure
+}

--- a/rdd/bats/tests/40-docker/system.bats
+++ b/rdd/bats/tests/40-docker/system.bats
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# System commands against the rdd Docker engine: version, info, events, df,
+# prune.
+
+local_setup_file() {
+    start_docker_engine
+    ctrctl pull --quiet "${IMAGE_BUSYBOX}"
+}
+
+@test "version reports the server version" {
+    run -0 ctrctl version --format '{{.Server.Version}}'
+    assert_output
+}
+
+@test "info reports the OS type" {
+    run -0 ctrctl info --format '{{.OSType}}'
+    assert_output linux
+}
+
+@test "events reports container activity in a time window" {
+    since=$(date +%s)
+    ctrctl run --rm "${IMAGE_BUSYBOX}" true
+    until=$(($(date +%s) + 1))
+    run -0 ctrctl events --since "${since}" --until "${until}"
+    assert_output --partial create
+}
+
+@test "system df reports disk usage" {
+    skip_unless_docker "nerdctl has no system df"
+    run -0 ctrctl system df
+    assert_output --partial Images
+}
+
+@test "system prune runs against the engine" {
+    ctrctl system prune --force
+}

--- a/rdd/bats/tests/40-docker/volume.bats
+++ b/rdd/bats/tests/40-docker/volume.bats
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+load '../../helpers/load'
+
+# Volume commands against the rdd Docker engine: create, ls, inspect, rm,
+# prune, and data persistence across containers.
+
+local_setup_file() {
+    start_docker_engine
+    ctrctl pull --quiet "${IMAGE_BUSYBOX}"
+}
+
+@test "create and ls show a named volume" {
+    ctrctl volume create rdd-vol
+    run -0 ctrctl volume ls --quiet --filter name=rdd-vol
+    assert_output rdd-vol
+    ctrctl volume rm rdd-vol
+}
+
+@test "volume inspect reports the volume name" {
+    ctrctl volume create rdd-vol-inspect
+    run -0 ctrctl volume inspect --format '{{.Name}}' rdd-vol-inspect
+    assert_output rdd-vol-inspect
+    ctrctl volume rm rdd-vol-inspect
+}
+
+@test "a volume persists data across containers" {
+    ctrctl volume create rdd-vol-data
+    ctrctl run --rm --volume rdd-vol-data:/data "${IMAGE_BUSYBOX}" sh -c 'echo persisted >/data/file'
+    run -0 ctrctl run --rm --volume rdd-vol-data:/data "${IMAGE_BUSYBOX}" cat /data/file
+    assert_output persisted
+    ctrctl volume rm rdd-vol-data
+}
+
+@test "rm removes a volume" {
+    ctrctl volume create rdd-vol-rm
+    ctrctl volume rm rdd-vol-rm
+    run -0 ctrctl volume ls --quiet --filter name=rdd-vol-rm
+    refute_output
+}
+
+@test "volume prune removes unused volumes" {
+    # --all removes named volumes too; the default only prunes anonymous ones.
+    ctrctl volume create rdd-vol-prune
+    ctrctl volume prune --all --force
+    run -0 ctrctl volume ls --quiet --filter name=rdd-vol-prune
+    refute_output
+}
+
+@test "volume inspect of an unknown volume fails" {
+    run ctrctl volume inspect rdd-no-such-volume
+    assert_failure
+}

--- a/rdd/docs/design/environment.md
+++ b/rdd/docs/design/environment.md
@@ -26,6 +26,8 @@ These variables configure the BATS test framework. They have no effect on `rdd` 
 | `RDD_TRACE` | Enables verbose trace output in BATS tests. | `false` |
 | `RDD_NAMESPACE` | Default Kubernetes namespace for BATS controller tests. | `rdd-bats` |
 | `RDD_VM_TYPE` | Lima VM type for tests that boot a VM (`qemu` or `vz`). Useful for reproducing QEMU-specific failures on macOS. | Lima's default (`vz` on macOS, `qemu` on Linux) |
+| `RDD_CONTAINER_ENGINE` | Container engine the docker test suite drives (`moby` or `containerd`). | `moby` |
+| `RDD_KEEP_RUNNING` | Keeps the control plane running between test files instead of stopping it in `teardown_file`, so a VM-booting suite boots once per run. | unset |
 
 ## Path Variables
 


### PR DESCRIPTION
Adds `tests/40-docker`, a BATS suite that exercises the docker command surface against the rdd moby engine: container lifecycle, images, volumes, networks, build, compose, and system. Run via `make bats-docker`.

`engine-docker.bats` covers the controller that mirrors docker objects into `Container`/`Image`/`Volume` resources, not the docker command surface itself. This suite exercises the commands users run.
