### PR TITLE
Recover and surface a failed host-switch

### DIFF
--- a/rdd/pkg/controllers/lima/limavm/controllers/hostswitch_other.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/hostswitch_other.go
@@ -22,7 +22,14 @@ func (hostSwitchPlatform) initHostSwitch() {}
 // startHostSwitch is a no-op on non-Windows platforms. The host-switch virtual
 // network is only needed for WSL2 instances, which require AF_VSOCK to bridge
 // networking between the Hyper-V VM and the Windows host.
-func (r *LimaVMReconciler) startHostSwitch(_ context.Context, _ string, _ *limatype.Instance) {}
+func (r *LimaVMReconciler) startHostSwitch(_ context.Context, _, _ string, _ *limatype.Instance) {}
 
 // stopHostSwitch is a no-op on non-Windows platforms.
 func (r *LimaVMReconciler) stopHostSwitch(_ string) {}
+
+// hostSwitchHealthy is a no-op on non-Windows platforms; there is no bridge to
+// monitor, so the instance is always healthy.
+func (r *LimaVMReconciler) hostSwitchHealthy(_ string) bool { return true }
+
+// restartHostSwitch is a no-op on non-Windows platforms.
+func (r *LimaVMReconciler) restartHostSwitch(_ context.Context, _ string) bool { return false }

--- a/rdd/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
@@ -18,6 +18,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Microsoft/go-winio"
@@ -51,6 +52,18 @@ func (p *hostSwitchPlatform) initHostSwitch() {
 type hostSwitchState struct {
 	cancel context.CancelFunc
 	done   chan struct{}
+
+	// namespace of the owning LimaVM, captured so the goroutine can enqueue a
+	// reconcile when it exits unexpectedly.
+	namespace string
+
+	// failed is set when the goroutine exits on error rather than cancellation.
+	// The reconciler reads it via hostSwitchHealthy and restarts a failed bridge.
+	failed atomic.Bool
+
+	// lastRestart records when this bridge was last (re)started, so the reconciler
+	// can rate-limit recovery restarts to one per hostSwitchRetryInterval.
+	lastRestart time.Time
 }
 
 // Virtual network configuration for the host-switch. These values are a
@@ -121,25 +134,76 @@ const (
 // startHostSwitch launches the host-switch goroutine for a WSL2 instance.
 // It must be called before the hostagent starts, because the guest's
 // network-setup.service performs a vsock handshake during early boot.
-func (r *LimaVMReconciler) startHostSwitch(ctx context.Context, name string, inst *limatype.Instance) {
+func (r *LimaVMReconciler) startHostSwitch(ctx context.Context, name, namespace string, inst *limatype.Instance) {
 	if inst.VMType != limatype.WSL2 {
 		return
 	}
 
 	r.stopHostSwitch(name)
 
+	state := &hostSwitchState{namespace: namespace}
+	r.hostSwitchMu.Lock()
+	r.hostSwitchStates[name] = state
+	r.hostSwitchMu.Unlock()
+
+	r.launchHostSwitch(ctx, name, state)
+}
+
+// launchHostSwitch starts the host-switch goroutine for an existing state entry
+// and records the (re)start time. The caller holds no lock.
+func (r *LimaVMReconciler) launchHostSwitch(ctx context.Context, name string, state *hostSwitchState) {
 	hsCtx, hsCancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 
 	r.hostSwitchMu.Lock()
-	r.hostSwitchStates[name] = &hostSwitchState{
-		cancel: hsCancel,
-		done:   done,
-	}
+	state.cancel = hsCancel
+	state.done = done
+	state.failed.Store(false)
+	state.lastRestart = time.Now()
 	r.hostSwitchMu.Unlock()
 
 	logger := logr.FromContextOrDiscard(ctx).WithValues("instance", name, "component", "host-switch")
-	go r.runHostSwitch(hsCtx, logger, done)
+	go r.runHostSwitch(hsCtx, logger, name, state, done)
+}
+
+// restartHostSwitch relaunches a host-switch that exited unexpectedly while its
+// VM keeps running. Restarts are rate-limited to one per
+// hostSwitchRetryInterval. It returns true when it relaunches the bridge, false
+// when none is tracked or the retry interval has not elapsed.
+//
+// Per-object reconciles are serialized, so no concurrent stopHostSwitch removes
+// the entry between the unlock and launchHostSwitch.
+func (r *LimaVMReconciler) restartHostSwitch(ctx context.Context, name string) bool {
+	r.hostSwitchMu.Lock()
+	state, ok := r.hostSwitchStates[name]
+	if !ok || time.Since(state.lastRestart) < hostSwitchRetryInterval {
+		r.hostSwitchMu.Unlock()
+		return false
+	}
+	oldCancel, oldDone := state.cancel, state.done
+	r.hostSwitchMu.Unlock()
+
+	// Stop the dead goroutine before relaunching, mirroring stopHostSwitch's
+	// cancel-then-wait outside the lock.
+	if oldCancel != nil {
+		oldCancel()
+	}
+	if oldDone != nil {
+		<-oldDone
+	}
+
+	r.launchHostSwitch(ctx, name, state)
+	return true
+}
+
+// hostSwitchHealthy reports whether the host-switch for an instance is alive. A
+// missing entry counts as healthy: non-WSL2 instances never start a bridge, and
+// a stopping VM has had its entry removed.
+func (r *LimaVMReconciler) hostSwitchHealthy(name string) bool {
+	r.hostSwitchMu.Lock()
+	state, ok := r.hostSwitchStates[name]
+	r.hostSwitchMu.Unlock()
+	return !ok || !state.failed.Load()
 }
 
 // stopHostSwitch cancels the host-switch goroutine and waits for it to exit.
@@ -162,12 +226,10 @@ func (r *LimaVMReconciler) stopHostSwitch(name string) {
 // creates a gvisor-tap-vsock virtual network, and relays Ethernet frames
 // between the host and the WSL2 VM until the context is cancelled.
 //
-// If the goroutine exits due to an error (not context cancellation), the
-// controller is not notified: the guest loses DHCP/DNS/NAT and must be
-// restarted manually. Integrating host-switch health into the controller's
-// state machine (enqueue a reconcile on unexpected exit) would allow
-// automatic recovery but requires non-trivial plumbing.
-func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger, done chan struct{}) {
+// On an unexpected exit (an error rather than cancellation) the guest loses
+// DHCP/DNS/NAT, so the goroutine marks the bridge failed and enqueues a
+// reconcile; handleWatchedState then restarts it via restartHostSwitch.
+func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger, name string, state *hostSwitchState, done chan struct{}) {
 	defer close(done)
 
 	subnet, err := validateSubnet(defaultSubnet)
@@ -205,6 +267,10 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 	mux.Handle("/services/forwarder/expose", vn.Mux())
 	mux.Handle("/services/forwarder/unexpose", vn.Mux())
 
+	// Capture the parent context before errgroup shadows it: after g.Wait() the
+	// errgroup's derived ctx is always cancelled, so only the parent reveals
+	// whether this exit was a clean shutdown or an unexpected failure.
+	parentCtx := ctx
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Start the host-side socket bridge now that we have the VM GUID.
@@ -308,9 +374,17 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 
 	logger.Info("Host-switch running", "subnet", subnet.SubnetCIDR, "gateway", subnet.GatewayIP)
 
-	if err := g.Wait(); err != nil {
-		logger.Error(err, "Host-switch exited with error")
-	} else {
+	switch err := g.Wait(); {
+	case parentCtx.Err() != nil:
+		// Cancelled by stopHostSwitch or restartHostSwitch: a clean shutdown.
+		logger.Info("Host-switch stopped")
+	case err != nil:
+		// The bridge died on its own; the guest has no DHCP/DNS/NAT until it is
+		// restarted. Flag it and wake the reconciler to recover.
+		logger.Error(err, "Host-switch exited unexpectedly; guest networking is down until it is restarted")
+		state.failed.Store(true)
+		r.enqueueReconcile(name, state.namespace)
+	default:
 		logger.Info("Host-switch stopped")
 	}
 }
@@ -506,6 +580,7 @@ func getVMGUID(ctx context.Context, logger logr.Logger) (hvsock.GUID, error) {
 
 	// Immediate first scan, then rescan on each tick.
 	scanRegistry()
+	ticks := 0
 	for {
 		select {
 		case vmGUID := <-found:
@@ -513,6 +588,13 @@ func getVMGUID(ctx context.Context, logger logr.Logger) (hvsock.GUID, error) {
 		case <-ctx.Done():
 			return hvsock.GUIDZero, fmt.Errorf("VM GUID discovery timed out: %w", ctx.Err())
 		case <-ticker.C:
+			ticks++
+			// The dial failures inside attemptHandshake are V(1); without this
+			// a bridge stuck waiting for the VM is silent at default verbosity.
+			if ticks%30 == 0 {
+				logger.Info("Still waiting for the WSL2 VM to answer the vsock handshake",
+					"elapsed", (time.Duration(ticks) * time.Second).String())
+			}
 			scanRegistry()
 		}
 	}

--- a/rdd/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/hostswitch_windows.go
@@ -232,15 +232,30 @@ func (r *LimaVMReconciler) stopHostSwitch(name string) {
 func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger, name string, state *hostSwitchState, done chan struct{}) {
 	defer close(done)
 
+	// fail flags an unexpected setup exit so the reconciler restarts the bridge.
+	// A cancelled context is a clean shutdown, not a failure, so fail only logs it.
+	fail := func(err error, msg string, kv ...any) {
+		if ctx.Err() != nil {
+			logger.Info("Host-switch stopped")
+			return
+		}
+		logger.Error(err, msg, kv...)
+		state.failed.Store(true)
+		r.enqueueReconcile(name, state.namespace)
+	}
+
 	subnet, err := validateSubnet(defaultSubnet)
 	if err != nil {
+		// defaultSubnet is a compile-time constant, so this fails only on a bad
+		// code change, never at runtime; a restart cannot fix it. Exit without
+		// flagging for recovery, which would otherwise loop forever.
 		logger.Error(err, "Invalid subnet configuration")
 		return
 	}
 
 	ln, vmGUID, err := vsockHandshake(ctx, logger)
 	if err != nil {
-		logger.Error(err, "Vsock handshake failed")
+		fail(err, "Vsock handshake failed")
 		return
 	}
 
@@ -248,7 +263,7 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 	vn, err := virtualnetwork.New(&cfg)
 	if err != nil {
 		ln.Close()
-		logger.Error(err, "Failed to create virtual network")
+		fail(err, "Failed to create virtual network")
 		return
 	}
 	defer unexposeAllForwards(logger, vn)
@@ -259,7 +274,7 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 	vnLn, err := vn.Listen("tcp", apiAddr)
 	if err != nil {
 		ln.Close()
-		logger.Error(err, "Failed to listen on API address", "addr", apiAddr)
+		fail(err, "Failed to listen on API address", "addr", apiAddr)
 		return
 	}
 	mux := http.NewServeMux()
@@ -267,11 +282,10 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 	mux.Handle("/services/forwarder/expose", vn.Mux())
 	mux.Handle("/services/forwarder/unexpose", vn.Mux())
 
-	// Capture the parent context before errgroup shadows it: after g.Wait() the
-	// errgroup's derived ctx is always cancelled, so only the parent reveals
-	// whether this exit was a clean shutdown or an unexpected failure.
-	parentCtx := ctx
-	g, ctx := errgroup.WithContext(ctx)
+	// gctx is the errgroup's context, always cancelled by the time g.Wait()
+	// returns. Only the original ctx distinguishes a clean shutdown from a
+	// failure, so fail and the check below read ctx, not gctx.
+	g, gctx := errgroup.WithContext(ctx)
 
 	// Start the host-side socket bridge now that we have the VM GUID.
 	// It listens on the Docker named pipe and forwards each connection to
@@ -279,7 +293,7 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 	// the VM image (via rancher-desktop-opensuse) and started by systemd.
 	g.Go(func() error {
 		bridge := socketbridge.NewDockerHostBridge(vmGUID, logger)
-		if err := bridge.Run(ctx); err != nil {
+		if err := bridge.Run(gctx); err != nil {
 			logger.Error(err, "Socket bridge exited with error")
 		}
 		return nil
@@ -300,7 +314,7 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 			// intentional: each VM runs a single vm-switch process, so
 			// reconnections are serial (old connection EOF, then new accept).
 			start := time.Now()
-			err = vn.AcceptStdio(ctx, conn)
+			err = vn.AcceptStdio(gctx, conn)
 			elapsed := time.Since(start)
 			switch {
 			case err == nil:
@@ -331,12 +345,12 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 
 	// Close the vsock listener when the context is cancelled.
 	g.Go(func() error {
-		<-ctx.Done()
+		<-gctx.Done()
 		return ln.Close()
 	})
 
 	g.Go(func() error {
-		<-ctx.Done()
+		<-gctx.Done()
 		return vnLn.Close()
 	})
 	g.Go(func() error {
@@ -363,7 +377,7 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 			defer ticker.Stop()
 			for {
 				select {
-				case <-ctx.Done():
+				case <-gctx.Done():
 					return nil
 				case <-ticker.C:
 					vl.Info("Virtual network diagnostics", vnDiagnostics(vn)...)
@@ -374,17 +388,11 @@ func (r *LimaVMReconciler) runHostSwitch(ctx context.Context, logger logr.Logger
 
 	logger.Info("Host-switch running", "subnet", subnet.SubnetCIDR, "gateway", subnet.GatewayIP)
 
-	switch err := g.Wait(); {
-	case parentCtx.Err() != nil:
-		// Cancelled by stopHostSwitch or restartHostSwitch: a clean shutdown.
-		logger.Info("Host-switch stopped")
-	case err != nil:
-		// The bridge died on its own; the guest has no DHCP/DNS/NAT until it is
-		// restarted. Flag it and wake the reconciler to recover.
-		logger.Error(err, "Host-switch exited unexpectedly; guest networking is down until it is restarted")
-		state.failed.Store(true)
-		r.enqueueReconcile(name, state.namespace)
-	default:
+	if err := g.Wait(); err != nil {
+		// The bridge died on its own; the guest has no DHCP/DNS/NAT until it
+		// is restarted.
+		fail(err, "Host-switch exited unexpectedly; guest networking is down until it is restarted")
+	} else {
 		logger.Info("Host-switch stopped")
 	}
 }

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/store"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +33,11 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/logfile"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
 )
+
+// hostSwitchRetryInterval is the minimum time between restarts of a host-switch
+// that exited unexpectedly, and the delay before handleWatchedState re-checks
+// afterward.
+const hostSwitchRetryInterval = 15 * time.Second
 
 func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.LimaVM) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -176,6 +182,20 @@ func (r *LimaVMReconciler) handleWatchedState(ctx context.Context, limaVM *v1alp
 				logger.Error(err, "Failed to update running condition")
 				return ctrl.Result{}, err
 			}
+		}
+		// The host-switch (WSL2 only) can die while the hostagent keeps running,
+		// silently cutting the guest's DHCP/DNS/NAT. Restart a failed bridge and
+		// re-check on a backoff. Both calls are no-ops on other platforms and
+		// when the bridge is healthy.
+		if !r.hostSwitchHealthy(limaVM.Name) {
+			if r.restartHostSwitch(ctx, limaVM.Name) {
+				logger.Info("Restarted host-switch after unexpected exit", "instance", limaVM.Name)
+				if r.Recorder != nil {
+					r.Recorder.Eventf(limaVM, nil, corev1.EventTypeWarning, "HostSwitchRestarted", "Recovering",
+						"host-switch network exited unexpectedly; restarted it")
+				}
+			}
+			return ctrl.Result{RequeueAfter: hostSwitchRetryInterval}, nil
 		}
 		return ctrl.Result{}, nil
 
@@ -413,7 +433,7 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	// Start the host-switch virtual network for WSL2 instances. This must
 	// happen before the hostagent starts, because the guest's
 	// network-setup.service performs a vsock handshake during early boot.
-	r.startHostSwitch(ctx, limaVM.Name, inst)
+	r.startHostSwitch(ctx, limaVM.Name, limaVM.Namespace, inst)
 
 	// SetGroup makes the hostagent a new process-group leader (pgid == pid
 	// on Unix), which lets bats-with-timeout.sh attribute leaked qemu


### PR DESCRIPTION
The Windows host-switch goroutine carries the WSL2 guest's networking, but an exit on error rather than cancellation went unnoticed: the guest silently lost DHCP/DNS/NAT while the hostagent reported healthy. Mark the bridge failed on unexpected exit and enqueue a reconcile; handleWatchedState restarts it, rate-limited to one per hostSwitchRetryInterval, with a Warning Event. Also surface a stuck vsock handshake, previously silent for up to five minutes.
