### PR TITLE
CI: cache Go modules from the rdd/ subdirectory

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,6 +43,7 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: rdd/go.mod
+        cache-dependency-path: rdd/go.sum
     - run: make verify-generate
       working-directory: rdd
   lint-rdd:
@@ -66,6 +67,7 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: rdd/go.mod
+        cache-dependency-path: rdd/go.sum
     - run: make lint-rdd
       working-directory: rdd
   test:
@@ -83,6 +85,7 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: rdd/go.mod
+        cache-dependency-path: rdd/go.sum
     - run: make test
       working-directory: rdd
   lint-bats:

--- a/.github/workflows/rdd-bats.yaml
+++ b/.github/workflows/rdd-bats.yaml
@@ -153,6 +153,7 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: rdd/go.mod
+        cache-dependency-path: rdd/go.sum
 
     - name: "Windows: disable Compatibility Telemetry"
       if: runner.os == 'Windows'


### PR DESCRIPTION
## Problem

The rdd/ reorg (#398) moved `go.mod` to `rdd/go.mod`. `actions/setup-go` looks for the dependency file at the repo root for its module cache, so every cacheable CI job now logs:

```
Restore cache failed: Dependencies file is not found in ... Supported file pattern: go.mod
```

The module cache never restores. Each build re-downloads every Go module, which slows CI and widens the window for the recurring macos-15-intel `proxy.golang.org` timeout flake (seen most recently on #395's `bats-others` job).

## Fix

Set `cache-dependency-path: rdd/go.sum` on the four setup-go steps that cache modules: the BATS job and lint's `verify-generate`, `lint-rdd`, and `test` jobs. The `lint-bats`, `spelling`, and `ltag` steps already opt out with `cache: false`.