### PR TITLE
Decompress distro image in-process when no system xz is found

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,7 +60,7 @@ jobs:
       run: |
         git config --global --replace-all core.autocrlf false # spellchecker:ignore
         git config --global --replace-all core.eol lf # spellchecker:ignore
-        git config --global --replace-all core.longpath true #spellchecker:ignore
+        git config --global --replace-all core.longpaths true # spellchecker:ignore
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -79,6 +79,12 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     if: ${{ ! needs.get-pr-number.outputs.number }}
     steps:
+    - name: "Windows: Set up line endings"
+      if: runner.os == 'Windows'
+      run: |
+        git config --global --replace-all core.autocrlf false # spellchecker:ignore
+        git config --global --replace-all core.eol lf # spellchecker:ignore
+        git config --global --replace-all core.longpaths true # spellchecker:ignore
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -105,6 +111,11 @@ jobs:
     runs-on: windows-latest
     if: ${{ ! needs.get-pr-number.outputs.number }}
     steps:
+    - name: "Windows: Set up line endings"
+      run: |
+        git config --global --replace-all core.autocrlf false # spellchecker:ignore
+        git config --global --replace-all core.eol lf # spellchecker:ignore
+        git config --global --replace-all core.longpaths true # spellchecker:ignore
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -141,7 +152,7 @@ jobs:
       run: |
         git config --global --replace-all core.autocrlf false # spellchecker:ignore
         git config --global --replace-all core.eol lf # spellchecker:ignore
-        git config --global --replace-all core.longpath true #spellchecker:ignore
+        git config --global --replace-all core.longpaths true # spellchecker:ignore
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -159,7 +170,7 @@ jobs:
       run: |
         git config --global --replace-all core.autocrlf false # spellchecker:ignore
         git config --global --replace-all core.eol lf # spellchecker:ignore
-        git config --global --replace-all core.longpath true #spellchecker:ignore
+        git config --global --replace-all core.longpaths true # spellchecker:ignore
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -181,7 +192,7 @@ jobs:
       run: |
         git config --global --replace-all core.autocrlf false # spellchecker:ignore
         git config --global --replace-all core.eol lf # spellchecker:ignore
-        git config --global --replace-all core.longpath true #spellchecker:ignore
+        git config --global --replace-all core.longpaths true # spellchecker:ignore
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false

--- a/.github/workflows/rdd-bats.yaml
+++ b/.github/workflows/rdd-bats.yaml
@@ -133,7 +133,7 @@ jobs:
         # Set up git configuration
         git config --global --replace-all core.autocrlf false # spellchecker:ignore
         git config --global --replace-all core.eol lf # spellchecker:ignore
-        git config --global --replace-all core.longpath true #spellchecker:ignore
+        git config --global --replace-all core.longpaths true # spellchecker:ignore
 
     - name: "Windows: write MSYS2 wrapper script"
       if: runner.os == 'Windows'

--- a/rdd/go.mod
+++ b/rdd/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/ulikunitz/xz v0.5.15
 	go.etcd.io/etcd/api/v3 v3.6.12
 	golang.org/x/mod v0.36.0
 	golang.org/x/sync v0.20.0

--- a/rdd/pkg/controllers/lima/limavm/controllers/image_decompress_test.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/image_decompress_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestLinkWSL2BaseDisk(t *testing.T) {
+	writeImage := func(t *testing.T, dir string) string {
+		t.Helper()
+		imagePath := filepath.Join(dir, filenames.Image)
+		assert.NilError(t, os.WriteFile(imagePath, []byte("decompressed image"), 0o644))
+		return imagePath
+	}
+
+	t.Run("WSL2 hardlinks basedisk to the image", func(t *testing.T) {
+		dir := t.TempDir()
+		imagePath := writeImage(t, dir)
+		inst := &limatype.Instance{Dir: dir, VMType: limatype.WSL2}
+
+		assert.NilError(t, linkWSL2BaseDisk(inst, imagePath))
+
+		baseDisk := filepath.Join(dir, filenames.BaseDiskLegacy)
+		got, err := os.ReadFile(baseDisk)
+		assert.NilError(t, err)
+		assert.Equal(t, string(got), "decompressed image")
+		assert.Assert(t, sameFile(t, imagePath, baseDisk), "basedisk must be a hardlink to image")
+	})
+
+	t.Run("non-WSL2 leaves basedisk absent", func(t *testing.T) {
+		dir := t.TempDir()
+		imagePath := writeImage(t, dir)
+		inst := &limatype.Instance{Dir: dir, VMType: limatype.VZ}
+
+		assert.NilError(t, linkWSL2BaseDisk(inst, imagePath))
+
+		_, err := os.Stat(filepath.Join(dir, filenames.BaseDiskLegacy))
+		assert.Assert(t, cmp.ErrorIs(err, os.ErrNotExist), "basedisk must not exist for vz")
+	})
+
+	t.Run("existing basedisk is left untouched", func(t *testing.T) {
+		dir := t.TempDir()
+		imagePath := writeImage(t, dir)
+		baseDisk := filepath.Join(dir, filenames.BaseDiskLegacy)
+		assert.NilError(t, os.WriteFile(baseDisk, []byte("preexisting"), 0o644))
+		inst := &limatype.Instance{Dir: dir, VMType: limatype.WSL2}
+
+		assert.NilError(t, linkWSL2BaseDisk(inst, imagePath))
+
+		got, err := os.ReadFile(baseDisk)
+		assert.NilError(t, err)
+		assert.Equal(t, string(got), "preexisting")
+	})
+
+	t.Run("missing image is a no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		inst := &limatype.Instance{Dir: dir, VMType: limatype.WSL2}
+
+		assert.NilError(t, linkWSL2BaseDisk(inst, filepath.Join(dir, filenames.Image)))
+
+		_, err := os.Stat(filepath.Join(dir, filenames.BaseDiskLegacy))
+		assert.Assert(t, cmp.ErrorIs(err, os.ErrNotExist), "basedisk must not exist when image is absent")
+	})
+}
+
+func sameFile(t *testing.T, a, b string) bool {
+	t.Helper()
+	ai, err := os.Stat(a)
+	assert.NilError(t, err)
+	bi, err := os.Stat(b)
+	assert.NilError(t, err)
+	return os.SameFile(ai, bi)
+}

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -10,12 +10,15 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/lima-vm/lima/v2/pkg/fileutils"
 	limainstance "github.com/lima-vm/lima/v2/pkg/instance"
+	"github.com/lima-vm/lima/v2/pkg/limatype"
 	"github.com/lima-vm/lima/v2/pkg/limatype/filenames"
 	"github.com/lima-vm/lima/v2/pkg/store"
 
@@ -38,6 +41,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/xz"
 )
 
 const (
@@ -337,6 +341,20 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
+	// When no system xz is on PATH, decompress the image in-process; Prepare
+	// then finds the ready image and skips its own xz shell-out.
+	if err := ensureImageDecompressed(ctx, inst); err != nil {
+		logger.Error(err, "Failed to decompress instance image")
+		if delErr := limainstance.Delete(ctx, inst, true); delErr != nil {
+			logger.Error(delErr, "Failed to clean up instance after decompression failure")
+		}
+		r.setCondition(ctx, &limaVM, ConditionCreated, metav1.ConditionFalse, ReasonCreateFailed, err.Error())
+		if statusErr := r.Status().Update(ctx, &limaVM); statusErr != nil {
+			logger.Error(statusErr, "Failed to update status after image decompression failure")
+		}
+		return ctrl.Result{}, err
+	}
+
 	// Prepare the instance: download images and create disks.
 	// The guestAgent path is a placeholder during Prepare (only stored for later);
 	// limactl start will look up the real path when called.
@@ -376,6 +394,85 @@ func (r *LimaVMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Return and let the next reconcile handle running state (one mutation per reconcile)
 	return ctrl.Result{}, nil
+}
+
+// ensureImageDecompressed pre-produces the decompressed distro image with the
+// in-process xz decoder when no system xz is on PATH, so provisioning works on a
+// host without xz (base macOS, a clean Windows). When xz is present rdd leaves
+// the image alone and Lima uses xz, whose threaded decode is faster.
+//
+// Lima reads the image under two names: the vz/qemu path (Prepare) reads
+// <inst.Dir>/image, while the WSL2 driver (EnsureFs) reads <inst.Dir>/basedisk.
+// rdd writes image and, for WSL2, hardlinks basedisk to it, so Lima finds each
+// ready and skips its own download-and-decompress.
+func ensureImageDecompressed(ctx context.Context, inst *limatype.Instance) error {
+	imagePath := filepath.Join(inst.Dir, filenames.Image)
+	diskPath := filepath.Join(inst.Dir, filenames.Disk)
+	if _, err := os.Stat(diskPath); err == nil {
+		return nil
+	}
+	if _, err := exec.LookPath("xz"); err == nil {
+		return nil
+	}
+
+	if _, err := os.Stat(imagePath); err != nil {
+		if err := decompressImage(ctx, inst, imagePath); err != nil {
+			return err
+		}
+	}
+	return linkWSL2BaseDisk(inst, imagePath)
+}
+
+// decompressImage downloads the arch-matching xz image through Lima's verified
+// downloader and decompresses it to imagePath. It returns nil without writing
+// imagePath when no xz image matches the host arch, leaving Prepare to handle
+// that case with its own decompressor.
+func decompressImage(ctx context.Context, inst *limatype.Instance, imagePath string) error {
+	logger := log.FromContext(ctx)
+	arch := *inst.Config.Arch
+	for _, img := range inst.Config.Images {
+		if img.File.Arch != arch {
+			continue
+		}
+		// rdd's templates point at .xz images. A location without an .xz
+		// suffix falls through to Prepare, which runs its own decompressor.
+		if !strings.HasSuffix(img.File.Location, ".xz") {
+			return nil
+		}
+		cached, err := fileutils.DownloadFile(ctx, "", img.File, false, "the image", arch)
+		if err != nil {
+			return fmt.Errorf("caching image for in-process decompression: %w", err)
+		}
+		logger.Info("Decompressing image with in-process xz decoder (no system xz found)",
+			"location", img.File.Location)
+		// rdd's templates list one .xz image per arch; this skips Prepare's
+		// mirror fallback and kernel/initrd sidecars, which no current template
+		// needs.
+		return xz.DecompressFile(ctx, cached, imagePath)
+	}
+	// No image matched this arch; let Prepare surface its usual error.
+	return nil
+}
+
+// linkWSL2BaseDisk hardlinks <inst.Dir>/basedisk to imagePath for WSL2
+// instances, so the WSL2 driver's EnsureFs reuses the decompressed image
+// instead of shelling out to xz. It is a no-op for other VM types, when the
+// image was left for Prepare, or when basedisk already exists.
+func linkWSL2BaseDisk(inst *limatype.Instance, imagePath string) error {
+	if inst.VMType != limatype.WSL2 {
+		return nil
+	}
+	if _, err := os.Stat(imagePath); err != nil {
+		return nil
+	}
+	baseDiskPath := filepath.Join(inst.Dir, filenames.BaseDiskLegacy)
+	if _, err := os.Stat(baseDiskPath); err == nil {
+		return nil
+	}
+	if err := os.Link(imagePath, baseDiskPath); err != nil {
+		return fmt.Errorf("linking basedisk for WSL2: %w", err)
+	}
+	return nil
 }
 
 // handleTemplateUpdate detects and applies changes to the template ConfigMap.

--- a/rdd/pkg/xz/xz.go
+++ b/rdd/pkg/xz/xz.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package xz decompresses xz streams in-process with a pure-Go decoder, so rdd
+// can provision a VM image without a system xz binary on the host.
+package xz
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	ulikunitz "github.com/ulikunitz/xz"
+)
+
+// bufSize is the input read buffer size. ulikunitz/xz issues many small reads;
+// without a large buffer wrapping the source it spends most of its time in
+// syscalls (roughly 5x slower decoding a multi-hundred-megabyte image).
+const bufSize = 4 << 20
+
+// Decompress streams xz-compressed data from in to out, aborting with the
+// context error if ctx is cancelled mid-decode.
+func Decompress(ctx context.Context, in io.Reader, out io.Writer) error {
+	r, err := ulikunitz.NewReader(bufio.NewReaderSize(in, bufSize))
+	if err != nil {
+		return fmt.Errorf("initializing xz reader: %w", err)
+	}
+	if _, err := io.Copy(out, &ctxReader{ctx: ctx, r: r}); err != nil {
+		return fmt.Errorf("decompressing xz stream: %w", err)
+	}
+	return nil
+}
+
+// ctxReader makes the otherwise-uninterruptible decode cancellable: each Read
+// returns the context error once ctx is cancelled, which unwinds io.Copy. The
+// decode is single-threaded and can run for tens of seconds on a large image,
+// so this is what lets a service shutdown propagate instead of blocking on it.
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *ctxReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
+}
+
+// DecompressFile decompresses the xz file at src to dst. It decodes into a
+// temporary file in dst's directory and renames it into place, so an
+// interrupted decode never leaves a partial dst that downstream code would
+// mistake for a complete image.
+func DecompressFile(ctx context.Context, src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err = Decompress(ctx, in, tmp); err != nil {
+		return err
+	}
+	// os.CreateTemp creates the file 0o600. Match Lima's 0o644 for decompressed
+	// images so the result stays readable beyond its owner.
+	if err = tmp.Chmod(0o644); err != nil {
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, dst)
+}

--- a/rdd/pkg/xz/xz_test.go
+++ b/rdd/pkg/xz/xz_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+package xz
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// samplePlaintext is the content the tests compress and decode back. It is built
+// from \n literals so the expectation does not depend on how git checks out line
+// endings, and it is large enough to drive the decode loop over many reads.
+func samplePlaintext() []byte {
+	const block = "rancher-desktop-daemon in-process xz decoder fixture.\n" +
+		"The quick brown fox jumps over the lazy dog.\n"
+	return bytes.Repeat([]byte(block), 100_000)
+}
+
+// xzCompress compresses data with the system xz CLI, so the tests exercise the
+// decoder against real xz output rather than our own encoder. It skips when no
+// xz is installed: the decoder runs without xz, but producing its test input
+// needs one.
+func xzCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	if _, err := exec.LookPath("xz"); err != nil {
+		t.Skip("xz not found in PATH")
+	}
+	cmd := exec.CommandContext(t.Context(), "xz", "--compress", "--stdout")
+	cmd.Stdin = bytes.NewReader(data)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	assert.NilError(t, cmd.Run(), "xz failed: %s", stderr.String())
+	return out.Bytes()
+}
+
+func TestDecompress(t *testing.T) {
+	want := samplePlaintext()
+	compressed := xzCompress(t, want)
+
+	var got bytes.Buffer
+	assert.NilError(t, Decompress(t.Context(), bytes.NewReader(compressed), &got))
+	assert.Assert(t, bytes.Equal(got.Bytes(), want))
+}
+
+func TestDecompressTruncated(t *testing.T) {
+	compressed := xzCompress(t, samplePlaintext())
+
+	var got bytes.Buffer
+	err := Decompress(t.Context(), bytes.NewReader(compressed[:len(compressed)/2]), &got)
+	assert.Assert(t, err != nil, "truncated xz stream must fail")
+}
+
+func TestDecompressFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "sample.xz")
+	want := samplePlaintext()
+	assert.NilError(t, os.WriteFile(src, xzCompress(t, want), 0o644))
+
+	dst := filepath.Join(dir, "image")
+	assert.NilError(t, DecompressFile(t.Context(), src, dst))
+
+	got, err := os.ReadFile(dst)
+	assert.NilError(t, err)
+	assert.Assert(t, bytes.Equal(got, want))
+	assertNoTempFiles(t, dir)
+}
+
+func TestDecompressFileLeavesNoPartialOutput(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "truncated.xz")
+	compressed := xzCompress(t, samplePlaintext())
+	assert.NilError(t, os.WriteFile(src, compressed[:len(compressed)/2], 0o644))
+
+	dst := filepath.Join(dir, "image")
+	assert.Assert(t, DecompressFile(t.Context(), src, dst) != nil)
+
+	_, err := os.Stat(dst)
+	assert.Assert(t, os.IsNotExist(err), "dst must not exist after a failed decode")
+	assertNoTempFiles(t, dir)
+}
+
+// A canceled context must abort the decode and leave neither a partial output
+// nor a leftover temp file behind.
+func TestDecompressFileCanceledContext(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "sample.xz")
+	assert.NilError(t, os.WriteFile(src, xzCompress(t, samplePlaintext()), 0o644))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	dst := filepath.Join(dir, "image")
+	err := DecompressFile(ctx, src, dst)
+	assert.Assert(t, errors.Is(err, context.Canceled), "want context.Canceled, got %v", err)
+
+	_, statErr := os.Stat(dst)
+	assert.Assert(t, os.IsNotExist(statErr), "dst must not exist after a canceled decode")
+	assertNoTempFiles(t, dir)
+}
+
+func assertNoTempFiles(t *testing.T, dir string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.tmp-*"))
+	assert.NilError(t, err)
+	assert.Assert(t, len(matches) == 0, "leftover temp files: %v", matches)
+}


### PR DESCRIPTION
## Problem

Lima's `Prepare` decompresses the distro image by shelling out to `xz -d`. Base macOS and a clean Windows ship no `xz`, so provisioning there fails unless the user installs one. rdd should depend only on what the OS ships.

## Change

When no `xz` is on `PATH`, the LimaVM controller decompresses the image in-process with a pure-Go decoder (`github.com/ulikunitz/xz`):

- Download and verify the image through Lima's own downloader, reusing its digest check and cache.
- Decompress to `<instance>/image`. `Prepare` then finds the ready image and skips its `xz` shell-out, because Lima skips a download whose destination already exists.
- When `xz` is present, rdd leaves the image alone so Lima keeps using it; its threaded decode is faster.

One integration point covers both the macOS/Linux `.raw.xz` and the Windows/WSL2 `.tar.xz` paths, which share `Prepare`.

## Why pure-Go (no CGO/liblzma)

`ulikunitz/xz` is already in the module graph (via `diskfs/go-diskfs`) and the decoder is pure Go, so this adds no build dependency and leaves `CGO_ENABLED` unchanged on every platform — no liblzma, no mingw, no Makefile changes.

The decoder buffers both sides. Unbuffered, `ulikunitz/xz` issues tiny reads and spends most of its time in syscalls. On the real 1.4 GB arm64 distro image (8-core M-series), byte-exact decode times:

| Decoder | Time |
|---|---|
| system `xz --threads=0` (threaded) | 5.6s |
| system `xz --threads=1` | 10.2s |
| `ulikunitz/xz`, 4 MB buffered | 18.9s |
| `ulikunitz/xz`, unbuffered | 95.3s |

The fallback is single-threaded, so a slow host without `xz` pays more — a one-time cost behind an already-multi-minute download. `DecompressFile` writes to a temp file and renames it into place, so an interrupted decode leaves no partial image.

## CI

The new `pkg/xz` test compares decoded bytes against an LF fixture, which exposed two Windows CI gaps:

- `test-rdd` and `test-wix-helper` never set `core.autocrlf=false` and `core.eol=lf` before checkout, unlike the lint jobs, so Windows checked the fixture out as CRLF and the byte comparison failed. Both jobs now run the same line-ending step.
- The Windows long-path setup used `core.longpath` (singular), which git silently ignores. The lint and bats workflows now use the real key, `core.longpaths`.

## Testing

- `pkg/xz` unit tests: decode an `xz`-CLI-produced fixture (verifies real-xz compatibility), a larger-than-buffer round-trip, a truncated-input error, and temp-file cleanup on both success and failure.
- `make build-rdd`, `go vet`, `golangci-lint` (0 issues), and the existing `limavm` controller tests pass.
- Manual end-to-end with `xz` removed from `PATH` is not yet run — flagging for review.

## Follow-up

This is shaped to lift into upstream Lima: the decoder is standalone, and the fallback mirrors what Lima's `decompressLocal` could do itself (`exec.LookPath("xz")`, else decode in-process). The rdd hook retires if Lima adopts it.

