### PR TITLE
RDA: locate RDD

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -33,6 +33,11 @@ runs:
     shell: powershell
     run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
 
+  - name: Build RDD
+    shell: bash
+    run: make build-rdd
+    working-directory: rdd
+
   - run: yarn install --immutable
     shell: bash
 

--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -16,6 +16,11 @@ extraResources:
   - '!**/*.tgz'
   - '!**/*.xz'
   - '!**/*.zip'
+- from: rdd/bin
+  to: ${platform}/bin/
+  filter:
+  - rdd
+  - rdd.exe
 files:
 - dist/app/**/*
 - '!**/node_modules/*/prebuilds/!(${platform}*)/*.node'

--- a/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
@@ -35,7 +35,7 @@ describe('getRDDPath', () => {
   beforeAll(async() => {
     resourcesPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'r-d-a-paths-'));
     packagedPath = path.join(resourcesPath, process.platform, 'bin', exeName);
-    relativePath = path.join(process.cwd(), 'resources', process.platform, 'bin', exeName);
+    relativePath = path.join(process.cwd(), 'rdd', 'bin', exeName);
     environmentPath = path.join(resourcesPath, exeName);
   });
   afterAll(async() => {
@@ -63,6 +63,7 @@ describe('getRDDPath', () => {
   describe('when not packaged', () => {
     beforeEach(() => {
       jest.replaceProperty(modules.electron.app, 'isPackaged', false);
+      modules.fs.accessSync.mockClear();
     });
     it('should return relative path if it exists', () => {
       const actual = getRDDPath(false);

--- a/pkg/rancher-desktop/utils/paths.ts
+++ b/pkg/rancher-desktop/utils/paths.ts
@@ -77,8 +77,9 @@ export function getRDDPath(useCached = true): string {
       } catch { /* ignore */ }
     }
 
+    // For unpackaged builds, look into the RDD directory.
     const relativePath = path.join(
-      process.cwd(), 'resources', process.platform, 'bin', exeName);
+      process.cwd(), 'rdd', 'bin', exeName);
     try {
       fs.accessSync(relativePath, fs.constants.X_OK);
       return relativePath;

--- a/scripts/dependencies/rdd.ts
+++ b/scripts/dependencies/rdd.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+
+import { Dependency, DownloadContext } from '@/scripts/lib/dependencies';
+import { simpleSpawn } from '@/scripts/simple_process';
+
+export class RDD implements Dependency {
+  readonly name = 'rdd';
+  async download(context: DownloadContext): Promise<void> {
+    const importDir = import.meta.dirname;
+    const rddDir = path.join(importDir, '..', '..', 'rdd');
+
+    await simpleSpawn('make', ['build-rdd'], {
+      cwd: rddDir,
+      env: {
+        ...process.env,
+        GOOS:   context.goPlatform,
+        GOARCH: context.goArch,
+      },
+    });
+  }
+}

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -2,6 +2,7 @@ import os from 'os';
 import path from 'path';
 
 import { Electron } from '@/scripts/dependencies/electron';
+import { RDD } from '@/scripts/dependencies/rdd';
 import * as tools from '@/scripts/dependencies/tools';
 import { Wix } from '@/scripts/dependencies/wix';
 import buildUtils from '@/scripts/lib/build-utils';
@@ -56,6 +57,7 @@ const vmDependencies: Dependency[] = [];
 const hostDependencies = [
   new tools.Steve(),
   new Electron(),
+  new RDD(),
 ];
 
 async function downloadDependencies(items: DependencyWithContext[]): Promise<void> {


### PR DESCRIPTION
- On postinstall, run `make -C rdd build-rdd` to ensure RDD is built.
- In `yarn dev`, locate the RDD artifact built from the above.
- When packaging, package the same RDD artifact.

This should mean a fresh checkout plus `yarn && yarn dev` should still work fine without needing any manual steps to build RDD.