### PR TITLE
RDA: Drop `M1` build environment variable

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -33,11 +33,6 @@ runs:
     shell: powershell
     run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
 
-  - name: Flag build for M1
-    if: runner.os == 'macOS' && runner.arch == 'ARM64'
-    run: echo "M1=1" >> "${GITHUB_ENV}"
-    shell: bash
-
   - run: yarn install --immutable
     shell: bash
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -216,9 +216,6 @@ jobs:
         hash="$(security find-identity | awk "$awk_expr")"
         echo "CSC_FINGERPRINT=${hash}" >> "$GITHUB_ENV"
       timeout-minutes: 1
-    - name: Flag build for M1
-      if: matrix.arch == 'aarch64'
-      run: echo "M1=1" >> "${GITHUB_ENV}"
     - name: Sign artifact
       run: |
         for zip in Rancher\ Desktop*mac*.zip; do

--- a/README.md
+++ b/README.md
@@ -160,17 +160,6 @@ Then you can install dependencies with:
 yarn
 ```
 
-> ### ⚠️ Working on a mac with an M1 chip?
->
-> You will need to set the `M1` environment variable before installing dependencies and running any npm scripts:
->
-> ```
-> export M1=1
-> yarn
-> ```
->
-> You will want to run `git clean -fdx` to clean out any cached assets and re-downloaded with the correct arch before running `yarn` if you previously installed dependencies without setting `M1` first.
-
 ### Linux
 
 Ensure you have the following installed:

--- a/docs/development/signing.md
+++ b/docs/development/signing.md
@@ -121,8 +121,8 @@ For notarization, the following environment variables are also needed:
 
 ### Performing signing
 
-When signing for M1/aarch64, please set the `M1` environment variable ahead of
-time as usual.
+To do cross-arch signing export the `GOARCH` environment variable to the proper
+value (`amd64` or `arm64`) when running `yarn sign`.
 
 If notarization is not required, append `--skip-notarize` to the command:
 

--- a/scripts/dependencies/electron.ts
+++ b/scripts/dependencies/electron.ts
@@ -29,11 +29,10 @@ export class Electron extends GlobalDependency(VersionedDependency) {
     // has been updated but before the next rddepman run (where we update the
     // checksums).  However, we can at least check if the versions match, and if
     // yes, that the checksum is correct.
-    const arch = context.isM1 ? 'arm64' : 'x64';
     const version = await this.version;
     const { checksums: recordedChecksums, version: recordedVersion } = context.dependencies.electron;
     const baseURL = this.getBaseURL(version);
-    const archiveName = `electron-v${ version }-${ context.platform }-${ arch }.zip`;
+    const archiveName = `electron-v${ version }-${ context.platform }-${ context.arch }.zip`;
     const url = `${ baseURL }${ archiveName }`;
     const archivePath = path.join(context.hostDir, archiveName);
     const outPath = path.join(process.cwd(), 'node_modules', 'electron', 'dist');

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -34,13 +34,12 @@ export class Helm extends GlobalDependency(GitHubDependency) {
 
   async download(context: DownloadContext): Promise<void> {
     // Download Helm. It is a tar.gz file that needs to be expanded and file moved.
-    const arch = context.isM1 ? 'arm64' : 'amd64';
-    const archiveName = `helm-v${ context.dependencies.helm.version }-${ context.goPlatform }-${ arch }.tar.gz`;
+    const archiveName = `helm-v${ context.dependencies.helm.version }-${ context.goPlatform }-${ context.goArch }.tar.gz`;
     const helmURL = `https://get.helm.sh/${ archiveName }`;
 
     await downloadTarGZ(helmURL, path.join(context.binDir, exeName(context, 'helm')), {
       expectedChecksum: lookupChecksum(context, this.name, archiveName),
-      entryName:        `${ context.goPlatform }-${ arch }/${ exeName(context, 'helm') }`,
+      entryName:        `${ context.goPlatform }-${ context.goArch }/${ exeName(context, 'helm') }`,
     });
   }
 
@@ -68,9 +67,8 @@ export class DockerCLI extends GlobalDependency(GitHubDependency) {
 
   async download(context: DownloadContext): Promise<void> {
     const dockerPlatform = context.dependencyPlatform === 'wsl' ? 'wsl' : context.goPlatform;
-    const arch = context.isM1 ? 'arm64' : 'amd64';
     const baseURL = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ context.dependencies.dockerCLI.version }`;
-    const executableName = exeName(context, `docker-${ dockerPlatform }-${ arch }`);
+    const executableName = exeName(context, `docker-${ dockerPlatform }-${ context.goArch }`);
     const dockerURL = `${ baseURL }/${ executableName }`;
     const destPath = path.join(context.binDir, exeName(context, 'docker'));
     const expectedChecksum = lookupChecksum(context, this.name, executableName);
@@ -102,9 +100,8 @@ export class DockerBuildx extends GlobalDependency(GitHubDependency) {
 
   async download(context: DownloadContext): Promise<void> {
     // Download the Docker-Buildx Plug-In
-    const arch = context.isM1 ? 'arm64' : 'amd64';
     const baseURL = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ context.dependencies.dockerBuildx.version }`;
-    const executableName = exeName(context, `buildx-v${ context.dependencies.dockerBuildx.version }.${ context.goPlatform }-${ arch }`);
+    const executableName = exeName(context, `buildx-v${ context.dependencies.dockerBuildx.version }.${ context.goPlatform }-${ context.goArch }`);
     const dockerBuildxURL = `${ baseURL }/${ executableName }`;
     const dockerBuildxPath = path.join(context.dockerPluginsDir, exeName(context, 'docker-buildx'));
     const expectedChecksum = lookupChecksum(context, this.name, executableName);
@@ -138,7 +135,7 @@ export class DockerCompose extends GlobalDependency(GitHubDependency) {
 
   async download(context: DownloadContext): Promise<void> {
     const baseUrl = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ context.dependencies.dockerCompose.version }`;
-    const arch = context.isM1 ? 'aarch64' : 'x86_64';
+    const arch = context.arch === 'arm64' ? 'aarch64' : 'x86_64';
     const executableName = exeName(context, `docker-compose-${ context.goPlatform }-${ arch }`);
     const url = `${ baseUrl }/${ executableName }`;
     const destPath = path.join(context.dockerPluginsDir, exeName(context, 'docker-compose'));
@@ -203,8 +200,7 @@ export class Steve extends GlobalDependency(GitHubDependency) {
 
   async download(context: DownloadContext): Promise<void> {
     const steveURLBase = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ context.dependencies.steve.version }`;
-    const arch = context.isM1 ? 'arm64' : 'amd64';
-    const archiveName = `steve-${ context.goPlatform }-${ arch }.tar.gz`;
+    const archiveName = `steve-${ context.goPlatform }-${ context.goArch }.tar.gz`;
     const steveURL = `${ steveURLBase }/${ archiveName }`;
     const stevePath = path.join(context.internalDir, exeName(context, 'steve'));
     const expectedChecksum = lookupChecksum(context, this.name, archiveName);
@@ -238,7 +234,6 @@ export class DockerProvidedCredHelpers extends GlobalDependency(GitHubDependency
   readonly githubRepo = 'docker-credential-helpers';
 
   async download(context: DownloadContext): Promise<void> {
-    const arch = context.isM1 ? 'arm64' : 'amd64';
     const version = context.dependencies.dockerProvidedCredentialHelpers.version;
     const credHelperNames = {
       linux:  ['docker-credential-secretservice', 'docker-credential-pass'],
@@ -249,7 +244,7 @@ export class DockerProvidedCredHelpers extends GlobalDependency(GitHubDependency
     const baseURL = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ version }`;
 
     for (const baseName of credHelperNames) {
-      const fullBaseName = `${ baseName }-v${ version }.${ context.goPlatform }-${ arch }`;
+      const fullBaseName = `${ baseName }-v${ version }.${ context.goPlatform }-${ context.goArch }`;
       const fullBinName = exeName(context, fullBaseName);
       const sourceURL = `${ baseURL }/${ fullBinName }`;
       const expectedChecksum = lookupChecksum(context, this.name, fullBinName);
@@ -298,14 +293,13 @@ export class ECRCredHelper extends GlobalDependency(GitHubDependency) {
   readonly githubRepo = 'amazon-ecr-credential-helper';
 
   async download(context: DownloadContext): Promise<void> {
-    const arch = context.isM1 ? 'arm64' : 'amd64';
     const ecrLoginPlatform = context.platform.startsWith('win') ? 'windows' : context.platform;
     const baseName = 'docker-credential-ecr-login';
     const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
     const binName = exeName(context, baseName);
-    const sourceUrl = `${ baseUrl }/${ context.dependencies.ECRCredentialHelper.version }/${ ecrLoginPlatform }-${ arch }/${ binName }`;
+    const sourceUrl = `${ baseUrl }/${ context.dependencies.ECRCredentialHelper.version }/${ ecrLoginPlatform }-${ context.goArch }/${ binName }`;
     const destPath = path.join(context.binDir, binName);
-    const expectedChecksum = lookupChecksum(context, this.name, `${ ecrLoginPlatform }-${ arch }/${ binName }`);
+    const expectedChecksum = lookupChecksum(context, this.name, `${ ecrLoginPlatform }-${ context.goArch }/${ binName }`);
 
     return await download(sourceUrl, destPath, { expectedChecksum });
   }

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -337,8 +337,19 @@ export default {
     });
   },
 
-  get arch(): NodeJS.Architecture {
-    return process.env.M1 ? 'arm64' : process.arch;
+  get arch(): 'x64' | 'arm64' {
+    const archMap = {
+      amd64: 'x64',
+      arm64: 'arm64',
+    } as const;
+
+    if (process.env.GOARCH) {
+      if (process.env.GOARCH in archMap) {
+        return archMap[process.env.GOARCH as keyof typeof archMap];
+      }
+      console.warn(`\x1b[0;1;33m[WARNING]\x1b[0m Unknown GOARCH ${ process.env.GOARCH }, defaulting to ${ process.arch }`);
+    }
+    return process.arch === 'arm64' ? 'arm64' : 'x64';
   },
 
   /**

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -12,14 +12,17 @@ import { download, getResource, hashFile } from './download';
 export type DependencyPlatform = 'wsl' | 'linux' | 'darwin' | 'win32';
 export type Platform = 'linux' | 'darwin' | 'win32';
 export type GoPlatform = 'linux' | 'darwin' | 'windows';
+export type Arch = 'x64' | 'arm64';
+export type GoArch = 'amd64' | 'arm64';
 
 export interface DownloadContext {
   dependencies:       DependencyManifest;
   dependencyPlatform: DependencyPlatform;
   platform:           Platform;
+  arch:               Arch;
+  // goPlatform / goArch is the go name for platform/arch.
   goPlatform:         GoPlatform;
-  // whether we are running on M1
-  isM1:               boolean;
+  goArch:             GoArch;
   // resourcesDir is the directory that external dependencies and the like go into
   resourcesDir:       string;
   // binDir is for binaries that the user will execute

--- a/scripts/lib/sign-macos.ts
+++ b/scripts/lib/sign-macos.ts
@@ -15,6 +15,7 @@ import _ from 'lodash';
 import * as plist from 'plist';
 import yaml from 'yaml';
 
+import buildUtils from '@/scripts/lib/build-utils';
 import { spawnFile } from '@pkg/utils/childProcess';
 
 interface SigningConfig {
@@ -142,9 +143,9 @@ export async function sign(workDir: string): Promise<string[]> {
   }
 
   log.info('Building disk image and update archive...');
-  const arch = process.env.M1 ? Arch.arm64 : Arch.x64;
+  const arch = buildUtils.arch === 'arm64' ? Arch.arm64 : Arch.x64;
   const productFileName = config.productName?.replace(/\s*\d+$/, '')?.replace(/\s+/g, '.');
-  const productArch = process.env.M1 ? 'aarch64' : 'x86_64';
+  const productArch = arch === Arch.arm64 ? 'aarch64' : 'x86_64';
   const artifactName = `${ productFileName }-\${version}-mac.${ productArch }.\${ext}`;
   const formats = ['dmg', 'zip'];
 

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { Electron } from '@/scripts/dependencies/electron';
 import * as tools from '@/scripts/dependencies/tools';
 import { Wix } from '@/scripts/dependencies/wix';
+import buildUtils from '@/scripts/lib/build-utils';
 import {
   Dependency,
   DependencyManifest,
@@ -180,13 +181,16 @@ async function runScripts(): Promise<void> {
 
 function buildDownloadContextFor(rawPlatform: DependencyPlatform, manifest: DependencyManifest): Promise<DownloadContext> {
   const platform = rawPlatform === 'wsl' ? 'linux' : rawPlatform;
+  const arch = buildUtils.arch;
+  const goArch = arch === 'arm64' ? 'arm64' : 'amd64';
   const resourcesDir = path.join(process.cwd(), 'resources');
   return Promise.resolve({
     dependencies:       manifest,
     dependencyPlatform: rawPlatform,
     platform,
+    arch,
     goPlatform:         platform === 'win32' ? 'windows' : platform,
-    isM1:               !!process.env.M1,
+    goArch,
     resourcesDir,
     binDir:             path.join(resourcesDir, platform, 'bin'),
     internalDir:        path.join(resourcesDir, 'internal'),


### PR DESCRIPTION
The architecture of the built artifact is now based on the `GOARCH` environment variable, and if not provided, the host architecture.