### PR TITLE
CI: Skip bats when RDD not modified

### DIFF
--- a/.github/workflows/rdd-bats.yaml
+++ b/.github/workflows/rdd-bats.yaml
@@ -9,6 +9,26 @@ permissions:
   contents: read
 
 jobs:
+  check-paths:
+    name: Check for relevant changes
+    # Due to required status checks, these still need to run even if there are
+    # no relevant changes.
+    outputs:
+      should-run: ${{ steps.check.outputs.result }}
+    runs-on: ubuntu-latest
+    steps:
+    - id: check
+      continue-on-error: true
+      run: |
+        set -o errexit -o pipefail -o xtrace
+        if test "${{ github.event_name }}" != 'pull_request'; then
+          echo "result=true" >> "$GITHUB_OUTPUT"
+        elif gh pr diff --name-only "${{ github.event.pull_request.html_url }}" | grep -E '^rdd/'; then
+          echo "result=true" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        GH_TOKEN: ${{ github.token }}
+
   get-pr-number:
     name: Lookup Pull Request
     outputs:
@@ -34,7 +54,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
   bats:
     name: BATS
-    needs: get-pr-number
+    needs: [get-pr-number, check-paths]
     if: ${{ ! needs.get-pr-number.outputs.number }}
     strategy:
       fail-fast: false
@@ -52,10 +72,12 @@ jobs:
         - bats-app
         - bats-lima
         - bats-others
-    runs-on: ${{ matrix.runs-on }}
+    # Run on ubuntu-latest if we don't need to actually run the tests, because
+    # they start faster (and are cheaper).
+    runs-on: ${{ case(needs.check-paths.outputs.should-run == 'true', matrix.runs-on, 'ubuntu-latest') }}
     steps:
     - name: "Linux: Install prerequisites"
-      if: runner.os == 'Linux'
+      if: needs.check-paths.outputs.should-run && runner.os == 'Linux'
       working-directory: ${{ runner.temp }}
       run: |
         # Enable KVM access
@@ -80,7 +102,7 @@ jobs:
         chmod a+x bin/jq
 
     - name: "macOS: Install prerequisites"
-      if: runner.os == 'macOS'
+      if: needs.check-paths.outputs.should-run && runner.os == 'macOS'
       working-directory: ${{ runner.temp }}
       run: |
         brew install bash coreutils make docker
@@ -101,7 +123,7 @@ jobs:
         echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
 
     - name: "Windows: install prerequisites"
-      if: runner.os == 'Windows'
+      if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
       shell: pwsh
       working-directory: ${{ runner.temp }}
       run: |
@@ -136,7 +158,7 @@ jobs:
         git config --global --replace-all core.longpath true #spellchecker:ignore
 
     - name: "Windows: write MSYS2 wrapper script"
-      if: runner.os == 'Windows'
+      if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
       shell: cmd /c copy {0} run-in-shell.cmd
       working-directory: ${{ runner.temp }}/bin
       run: |
@@ -147,20 +169,22 @@ jobs:
         EXIT %ERRORLEVEL%
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      if: needs.check-paths.outputs.should-run
       with:
         persist-credentials: false
         submodules: recursive
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      if: needs.check-paths.outputs.should-run
       with:
         go-version-file: rdd/go.mod
         cache-dependency-path: rdd/go.sum
 
     - name: "Windows: disable Compatibility Telemetry"
-      if: runner.os == 'Windows'
+      if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
       uses: ./.github/actions/disable-compat-telemetry
 
     - name: "Windows: WSL debugging"
-      if: runner.os == 'Windows'
+      if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
       shell: pwsh
       run: |
         wsl --list --verbose
@@ -168,14 +192,14 @@ jobs:
       continue-on-error: true
 
     - name: "Windows: capture machine info"
-      if: runner.os == 'Windows'
+      if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
       uses: ./.github/actions/windows-machine-info
       with:
         output-path: rdd/rdd-logs/_diag/machine-info.txt
       continue-on-error: true
 
     - name: "Windows: start typeperf sampler"
-      if: runner.os == 'Windows'
+      if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
       uses: ./.github/actions/windows-typeperf-sampler
       with:
         command: start
@@ -183,6 +207,7 @@ jobs:
       continue-on-error: true
 
     - name: Configure BATS targets
+      if: needs.check-paths.outputs.should-run
       shell: bash
       run: |
         case "${{ matrix.suite }}" in
@@ -200,6 +225,7 @@ jobs:
         esac
 
     - run: make -C bats ${{ env.BATS_TARGET }} --keep-going
+      if: needs.check-paths.outputs.should-run
       working-directory: rdd
       shell: run-in-shell {0}
       env:
@@ -207,7 +233,7 @@ jobs:
         RDD_LOG_LEVEL: trace
 
     - name: "Windows: stop typeperf sampler"
-      if: always() && runner.os == 'Windows'
+      if: always() && needs.check-paths.outputs.should-run && runner.os == 'Windows'
       uses: ./.github/actions/windows-typeperf-sampler
       with:
         command: stop
@@ -215,13 +241,13 @@ jobs:
       continue-on-error: true
 
     - name: Collect RDD logs
-      if: always()
+      if: always() && needs.check-paths.outputs.should-run
       shell: run-in-shell {0}
       working-directory: rdd
       run: scripts/collect-bats-logs.sh rdd-logs
 
     - name: Upload RDD service logs
-      if: always()
+      if: always() && needs.check-paths.outputs.should-run
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: rdd-logs-${{ matrix.runs-on }}-${{ matrix.suite }}


### PR DESCRIPTION
This should save some CI time; there is no need to run BATS when its inputs solely depend on the RDD part of the tree.

We couldn't use [paths-ignore](https://github.com/rancher-sandbox/rancher-desktop-daemon/blob/b87f0253e2196a3bf85a059e538c4f30bfbe3adb/.github/workflows/paths-ignore.yaml) because that ignores files, instead of only allowing them.