### PR TITLE
Silence two check-spelling warnings from the app import

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -29,6 +29,7 @@
 # Other front end files
 ^\Qpkg/rancher-desktop/assets/styles/fonts/_dots.scss\E$
 ^\Qpkg/rancher-desktop/assets/styles/fonts/_zerowidthspace.scss\E$
+^\Qpkg/rancher-desktop/assets/styles/themes/_suse.scss\E$
 ^\Qpkg/rancher-desktop/utils/processOutputInterpreters/__tests__/assets/build.txt\E$
 ^\Qpkg/rancher-desktop/utils/processOutputInterpreters/__tests__/assets/pull03.txt\E$
 ^\Qpkg/rancher-desktop/utils/processOutputInterpreters/__tests__/assets/push.txt\E$

--- a/.github/actions/spelling/expect/tools.txt
+++ b/.github/actions/spelling/expect/tools.txt
@@ -20,7 +20,6 @@ openssh
 pacman
 printenv
 pulumi
-Trivy
 
 # golangci-lint & its linter / formatter names
 bodyclose


### PR DESCRIPTION
Importing rancher-desktop-app surfaced two check-spelling warnings on every PR. This clears both.

- **noisy-file** — `pkg/rancher-desktop/assets/styles/themes/_suse.scss` is noise-only SCSS (color variables, no words), so check-spelling skips it and warns. Exclude it like its already-excluded `_dots.scss` and `_zerowidthspace.scss` siblings.
- **ignored-expect-variant** — the import's `rda.txt` added a lowercase `trivy`, whose general case shadows the `Trivy` in `tools.txt`. Drop the redundant `Trivy`.

Verified structurally: the general lowercase `trivy` still covers the `Trivy` spellings in source, and the new exclude matches the proven sibling entries. `check-spelling` does not run locally on macOS, so CI is the confirming check.