### PR TITLE
Set up release packaging

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -58,6 +58,14 @@ jobs:
     - uses: ./.github/actions/yarn-install
     - run: yarn build
     - run: yarn package
+    - name: Upload RDD
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: RDD.${{ matrix.platform }}${{ case(matrix.arch != '', format('.{0}', matrix.arch), '') }}.zip
+        path: |
+          rdd/bin/rdd
+          rdd/bin/rdd.exe
+        if-no-files-found: error
     - name: Upload mac disk image
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: matrix.platform == 'mac'

--- a/build/signing-config-mac.yaml
+++ b/build/signing-config-mac.yaml
@@ -8,7 +8,9 @@ entitlements:
 
   # Entitlement overrides.  This is a list of overrides, each with a "paths"
   # key describing which paths to override, and an "entitlements" key for the
-  # overriding entitlements.
+  # overriding entitlements.  The "entitlements" key can be either a list of
+  # entitlements, or missing to use entitlements already in the file.  App
+  # bundles (directories) do not support the latter.
   overrides:
   - paths:
     - '' # This is the main application
@@ -24,6 +26,8 @@ entitlements:
     entitlements:
     - com.apple.security.cs.allow-unsigned-executable-memory
     - com.apple.security.cs.disable-library-validation
+  - paths:
+    - Contents/Resources/darwin/bin/rdd
 
 # List of launch constraints.
 # This is similar to entitlements, but has no default: it's just a list of

--- a/build/signing-config-win.yaml
+++ b/build/signing-config-win.yaml
@@ -14,3 +14,12 @@
 - '!vulkan-1.dll'       # spellcheck-ignore-line
 resources/internal:
 - steve.exe
+resources/win32/bin:
+- docker-credential-ecr-login.exe
+- docker-credential-wincred.exe
+- docker.exe
+- helm.exe
+- rdd.exe
+resources/win32/docker-cli-plugins:
+- docker-buildx.exe
+- docker-compose.exe

--- a/scripts/lib/sign-macos.ts
+++ b/scripts/lib/sign-macos.ts
@@ -22,8 +22,9 @@ interface SigningConfig {
   entitlements: {
     default:   string[];
     overrides: {
-      paths:        string[];
-      entitlements: string[];
+      paths:         string[];
+      // Entitlements; if missing, use the existing entitlements.
+      entitlements?: string[];
     }[];
   }
   constraints: {
@@ -83,7 +84,23 @@ export async function sign(workDir: string): Promise<string[]> {
 
     if (entitlementsOverride) {
       entitlementName = fileHash;
-      entitlements = entitlementsOverride.entitlements;
+      if (Array.isArray(entitlementsOverride.entitlements)) {
+        entitlements = entitlementsOverride.entitlements;
+      } else {
+        // Use existing entitlements
+        const { stdout } = await spawnFile(
+          'codesign', ['--display', '--entitlements', '-', '--xml', filePath], { stdio: ['ignore', 'pipe', 'inherit'] });
+        const xml = stdout.split(/\r?\n/).find(line => line.startsWith('<?xml'));
+        if (!xml) {
+          throw new Error(`Could not read existing entitlements from ${ relPath }`);
+        }
+        const parsed = plist.parse(xml);
+        if (parsed && [null, Object.prototype].includes(Object.getPrototypeOf(parsed))) {
+          entitlements = Object.keys(parsed);
+        } else {
+          throw new Error(`Could not parse existing entitlements from ${ relPath }: got ${ JSON.stringify(parsed) }`);
+        }
+      }
     }
     const entitlementFile = path.join(plistsDir, `${ entitlementName }-entitlement.plist`);
 
@@ -188,7 +205,11 @@ export async function sign(workDir: string): Promise<string[]> {
     return spawnFile('codesign', ['--sign', certFingerprint, '--timestamp', f], { stdio: 'inherit' });
   }));
 
-  return Object.values([dmgRenamedFile, zipFile]);
+  const rddSource = path.join(appDir, 'Contents/Resources/darwin/bin/rdd');
+  const rddTarget = path.join(process.cwd(), 'dist', `rdd.${ config.extraMetadata.version }.${ process.platform }.${ productArch }`);
+  await fs.promises.copyFile(rddSource, rddTarget, fs.constants.COPYFILE_FICLONE);
+
+  return [dmgRenamedFile, zipFile, rddTarget];
 }
 
 /**

--- a/scripts/lib/sign-win32.ts
+++ b/scripts/lib/sign-win32.ts
@@ -111,8 +111,13 @@ export async function sign(workDir: string, outDir: string): Promise<string[]> {
   }
 
   await signFn(...filesToSign);
+  const signedInstaller = await buildWiX(workDir, unpackedDir, outDir, signFn);
 
-  return [await buildWiX(workDir, unpackedDir, outDir, signFn)];
+  const rddSource = path.join(unpackedDir, 'resources', 'win32', 'bin', 'rdd.exe');
+  const rddDest = path.join(outDir, 'rdd.exe');
+  await fs.promises.copyFile(rddSource, rddDest, fs.constants.COPYFILE_FICLONE);
+
+  return [signedInstaller, rddDest];
 }
 
 /**


### PR DESCRIPTION
This updates the signing workflow to also produce signed rdd binaries for macOS & Windows (by grabbing them out of `…/resources/…/bin`).  This needs to go on top of #411, as that starts shipping RDD in the installers.