### PR TITLE
CI: Run darwin/x86_64 packaging on arm

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -1,6 +1,10 @@
 name: Yarn Install
 description: >-
   This is a composite action that does everything needed to do `yarn install`.
+inputs:
+  GOARCH:
+    description: Target architecture
+    default: amd64
 
 runs:
   using: composite
@@ -37,9 +41,13 @@ runs:
     shell: bash
     run: make build-rdd
     working-directory: rdd
+    env:
+      GOARCH: ${{ inputs.GOARCH }}
 
   - run: yarn install --immutable
     shell: bash
+    env:
+      GOARCH: ${{ inputs.GOARCH }}
 
   - name: Fix electron sandbox
     if: runner.os == 'Linux'

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -40,7 +40,7 @@ jobs:
         include:
         - platform: mac
           arch: x86_64
-          runs-on: macos-15-intel
+          runs-on: macos-latest
         - platform: mac
           arch: aarch64
           runs-on: macos-latest
@@ -50,12 +50,21 @@ jobs:
           runs-on: ubuntu-22.04
     runs-on: ${{ matrix.runs-on }}
     steps:
+    - name: Set GOARCH
+      run: |
+        case '${{ matrix.arch }}' in
+          'aarch64') echo "GOARCH=arm64" >> "${GITHUB_ENV}" ;;
+          'x86_64')  echo "GOARCH=amd64" >> "${GITHUB_ENV}" ;;
+          *)         echo "GOARCH=amd64" >> "${GITHUB_ENV}" ;;
+        esac
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
         # Needed to run `git describe` to get full version info
         fetch-depth: 0
     - uses: ./.github/actions/yarn-install
+      with:
+        GOARCH: ${{ env.GOARCH }}
     - run: yarn build
     - run: yarn package
     - name: Upload mac disk image

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -24,6 +24,8 @@ jobs:
         # Needed to run `git describe` to get full version info
         fetch-depth: 0
     - uses: ./.github/actions/yarn-install
+      with:
+        GOARCH: ${{ case(matrix.arch == 'aarch64', 'arm64', 'amd64') }}
     - run: yarn build
     - run: yarn package
     - name: Upload Windows installer


### PR DESCRIPTION
Since the arm runners are much faster and available at this point, we can run the package step there even for x86_64 builds, because it does not require running the build artifacts.

~Please test the built result on a real macOS x86_64 machine to make sure it still works fine.  Inspecting the built binaries says all the Mach-O files are x86_64.~ Tested pm a x86_64 mac, it seems to start with no complaints.