### PR TITLE
Bump embedded distro to v0.2.6

### DIFF
--- a/rdd/pkg/controllers/app/app/lima-images-unix.yaml
+++ b/rdd/pkg/controllers/app/app/lima-images-unix.yaml
@@ -1,7 +1,7 @@
 images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.4/distro.v0.2.4.amd64.raw.xz
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.6/distro.v0.2.6.amd64.raw.xz
   arch: x86_64
-  digest: sha256:427c162fdc6737e9a66cb4a2b3032c8548d71018eb5e3771761e1de8437550fc
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.4/distro.v0.2.4.arm64.raw.xz
+  digest: sha256:d7554a6a6c599cca3619b46dfad3e40f261cf5399293c24d7c188c3224973d29
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.6/distro.v0.2.6.arm64.raw.xz
   arch: aarch64
-  digest: sha256:2d5faa07d4faaa668a37b47eb92e4fbbe94f81e62f2e2038735ce5b0a8f190ad
+  digest: sha256:01fa604435aa511def8de4d31cdfe6b95fd575d14166ba8828c19946a339e558

--- a/rdd/pkg/controllers/app/app/lima-images-wsl2.yaml
+++ b/rdd/pkg/controllers/app/app/lima-images-wsl2.yaml
@@ -1,6 +1,6 @@
 vmType: wsl2
 images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.4/distro.v0.2.4.amd64.tar.xz
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.6/distro.v0.2.6.amd64.tar.xz
   arch: x86_64
-  digest: sha256:274a044ac44b23ce33fa6b24afc1462610391dec577fdf544d479886813e9b95
+  digest: sha256:d9eb9a3889f6982c084cecc96fcaa7d39c586754f6b31bbffc5bf48bbab9e913
 mountType: wsl2


### PR DESCRIPTION
The embedded distro was two releases behind at `v0.2.4`. `v0.2.6` adds opt-in vm-switch logging to `network-setup` — the `--trace-packets` and `--vm-switch-logfile-append` flags — and a `NETWORK_SETUP_EXTRA_ARGS` hook on the `systemd` unit, so a drop-in can pass those flags without overriding the unit's ExecStart. All default off, so the image behaves as before until a drop-in opts in.