### PR TITLE
Capture the guest vm-switch log on CI

### DIFF
--- a/rdd/docs/design/environment.md
+++ b/rdd/docs/design/environment.md
@@ -14,6 +14,7 @@ These variables control RDD behavior. Set them before running `rdd` commands.
 | `RDD_LOG_DIR` | Override the logging directory; usually used for tests. | unset |
 | `RDD_LOG_LEVEL` | Sets the log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`). Overridden by `--log-level` flag. When unset, defaults to `debug` in developer mode, `warn` otherwise. | unset |
 | `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
+| `RDD_TRACE_PACKETS` | Adds `--trace-packets` to the guest vm-switch network setup, logging every packet sent or received. Requires `RDD_KEEP_LOGS`, and affects throughput and timing, so use it only when diagnosing network failures. | unset |
 | `RDD_VM_CPUS` | Overrides the app VM's CPU count (the Lima template default is 2). Intended for CI, where runner sizing differs from user machines. A set-but-invalid value is an error, not a fallback. To be replaced by an App spec property. | unset |
 
 ### BATS Test Variables

--- a/rdd/pkg/controllers/app/app/controllers/app_controller.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller.go
@@ -148,6 +148,11 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesP
 	if err != nil {
 		return "", err
 	}
+	// vm-switch writes its logfile under LogDir() (passed below as VM_SWITCH_LOG)
+	// and fails to start if the directory is missing, so create it before the VM.
+	if err := os.MkdirAll(instance.LogDir(), 0o700); err != nil {
+		return "", fmt.Errorf("failed to create log directory: %w", err)
+	}
 	return strings.Join([]string{
 		baseTemplate,
 		"param:",

--- a/rdd/pkg/controllers/app/app/controllers/app_controller.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller.go
@@ -162,6 +162,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesP
 		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.K3sConfig())),
 		fmt.Sprintf("  VM_SWITCH_LOG: %q", toLinuxPath(filepath.Join(instance.LogDir(), "vm-switch.log"))),
 		fmt.Sprintf("  NETWORK_SETUP_EXTRA_ARGS: %q", networkSetupExtraArgs()),
+		fmt.Sprintf("  GUEST_LOG_DIR: %q", guestLogDir()),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
 		fmt.Sprintf("  KUBERNETES_PORT: %d", kubernetesPort),
@@ -183,6 +184,16 @@ func networkSetupExtraArgs() string {
 		args += " --trace-packets"
 	}
 	return args
+}
+
+// guestLogDir returns the guest-visible host log dir under RDD_KEEP_LOGS, empty
+// otherwise. The lima template's capture script streams guest journals and
+// lima-init.log there; empty makes it a no-op.
+func guestLogDir() string {
+	if os.Getenv("RDD_KEEP_LOGS") == "" {
+		return ""
+	}
+	return toLinuxPath(instance.LogDir())
 }
 
 // toLinuxPath converts a host path to a Linux-accessible path inside a Lima VM.

--- a/rdd/pkg/controllers/app/app/controllers/app_controller.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller.go
@@ -161,11 +161,28 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesP
 		fmt.Sprintf("  HOST_HOME_GUEST: %q", toLinuxPath(hostHome)),
 		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.K3sConfig())),
 		fmt.Sprintf("  VM_SWITCH_LOG: %q", toLinuxPath(filepath.Join(instance.LogDir(), "vm-switch.log"))),
+		fmt.Sprintf("  NETWORK_SETUP_EXTRA_ARGS: %q", networkSetupExtraArgs()),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
 		fmt.Sprintf("  KUBERNETES_PORT: %d", kubernetesPort),
 		"",
 	}, "\n"), nil
+}
+
+// networkSetupExtraArgs returns the diagnostic vm-switch logging flags under
+// RDD_KEEP_LOGS, empty otherwise. --trace-packets is gated separately behind
+// RDD_TRACE_PACKETS because it captures every packet sent or received, decodes
+// it, and writes it to the log. This significantly affects throughput and
+// timing, which in turn can change the failures it is meant to capture.
+func networkSetupExtraArgs() string {
+	if os.Getenv("RDD_KEEP_LOGS") == "" {
+		return ""
+	}
+	args := "--vm-switch-logfile-append"
+	if os.Getenv("RDD_TRACE_PACKETS") != "" {
+		args += " --trace-packets"
+	}
+	return args
 }
 
 // toLinuxPath converts a host path to a Linux-accessible path inside a Lima VM.

--- a/rdd/pkg/controllers/app/app/controllers/app_controller.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	goruntime "runtime"
 	"slices"
@@ -154,6 +155,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesP
 		fmt.Sprintf("  HOST_DOCKER_SOCKET: %q", instance.DockerSocket()),
 		fmt.Sprintf("  HOST_HOME_GUEST: %q", toLinuxPath(hostHome)),
 		fmt.Sprintf("  HOST_INSTANCE_CONFIG: %q", toLinuxPath(instance.K3sConfig())),
+		fmt.Sprintf("  VM_SWITCH_LOG: %q", toLinuxPath(filepath.Join(instance.LogDir(), "vm-switch.log"))),
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
 		fmt.Sprintf("  KUBERNETES_PORT: %d", kubernetesPort),

--- a/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
 // fakeDiscovery satisfies ControllerDiscovery for unit tests.
@@ -627,6 +628,17 @@ func Test_networkSetupExtraArgs(t *testing.T) {
 		t.Setenv("RDD_KEEP_LOGS", "1")
 		t.Setenv("RDD_TRACE_PACKETS", "1")
 		assert.Equal(t, networkSetupExtraArgs(), "--vm-switch-logfile-append --trace-packets")
+	})
+}
+
+func Test_guestLogDir(t *testing.T) {
+	t.Run("unset RDD_KEEP_LOGS yields no log dir", func(t *testing.T) {
+		t.Setenv("RDD_KEEP_LOGS", "")
+		assert.Equal(t, guestLogDir(), "")
+	})
+	t.Run("set RDD_KEEP_LOGS yields the instance log dir", func(t *testing.T) {
+		t.Setenv("RDD_KEEP_LOGS", "1")
+		assert.Equal(t, guestLogDir(), toLinuxPath(instance.LogDir()))
 	})
 }
 

--- a/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -619,6 +619,11 @@ func Test_networkSetupExtraArgs(t *testing.T) {
 		t.Setenv("RDD_TRACE_PACKETS", "")
 		assert.Equal(t, networkSetupExtraArgs(), "")
 	})
+	t.Run("RDD_TRACE_PACKETS without RDD_KEEP_LOGS yields no extra args", func(t *testing.T) {
+		t.Setenv("RDD_KEEP_LOGS", "")
+		t.Setenv("RDD_TRACE_PACKETS", "1")
+		assert.Equal(t, networkSetupExtraArgs(), "")
+	})
 	t.Run("RDD_KEEP_LOGS without tracing yields append only", func(t *testing.T) {
 		t.Setenv("RDD_KEEP_LOGS", "1")
 		t.Setenv("RDD_TRACE_PACKETS", "")
@@ -680,14 +685,15 @@ func Test_limaTemplate_networkSetupExtraArgsDropin(t *testing.T) {
 
 	// Empty param renders the distro's own default (an empty value).
 	blank := renderProvisionContent(t, content, map[string]string{"NETWORK_SETUP_EXTRA_ARGS": ""})
-	assert.Assert(t, strings.Contains(blank, `Environment=NETWORK_SETUP_EXTRA_ARGS=""`),
+	assert.Assert(t, strings.Contains(blank, `Environment="NETWORK_SETUP_EXTRA_ARGS="`),
 		"got:\n%s", blank)
 
-	// Quoted as a whole so the space stays one env var; the unit's unquoted
-	// $NETWORK_SETUP_EXTRA_ARGS splits it back into args.
+	// The value is a single env var. network-setup.service's ExecStart references
+	// it unbraced as $NETWORK_SETUP_EXTRA_ARGS, which systemd word-splits into
+	// separate arguments; braced ${...} would pass it as one argument.
 	got := renderProvisionContent(t, content,
 		map[string]string{"NETWORK_SETUP_EXTRA_ARGS": "--vm-switch-logfile-append --trace-packets"})
 	assert.Assert(t, strings.Contains(got,
-		`Environment=NETWORK_SETUP_EXTRA_ARGS="--vm-switch-logfile-append --trace-packets"`),
+		`Environment="NETWORK_SETUP_EXTRA_ARGS=--vm-switch-logfile-append --trace-packets"`),
 		"got:\n%s", got)
 }

--- a/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -5,10 +5,13 @@
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
+	"text/template"
 
 	"gotest.tools/v3/assert"
 
@@ -18,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	limav1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/lima/v1alpha1"
@@ -606,4 +610,72 @@ func Test_Reconcile_clearsKubernetesPortOnDisable(t *testing.T) {
 	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, result))
 	assert.Equal(t, result.Status.KubernetesPort, 0,
 		"expected Status.KubernetesPort to be cleared when Kubernetes is disabled")
+}
+
+func Test_networkSetupExtraArgs(t *testing.T) {
+	t.Run("unset RDD_KEEP_LOGS yields no extra args", func(t *testing.T) {
+		t.Setenv("RDD_KEEP_LOGS", "")
+		t.Setenv("RDD_TRACE_PACKETS", "")
+		assert.Equal(t, networkSetupExtraArgs(), "")
+	})
+	t.Run("RDD_KEEP_LOGS without tracing yields append only", func(t *testing.T) {
+		t.Setenv("RDD_KEEP_LOGS", "1")
+		t.Setenv("RDD_TRACE_PACKETS", "")
+		assert.Equal(t, networkSetupExtraArgs(), "--vm-switch-logfile-append")
+	})
+	t.Run("RDD_TRACE_PACKETS adds the trace flag", func(t *testing.T) {
+		t.Setenv("RDD_KEEP_LOGS", "1")
+		t.Setenv("RDD_TRACE_PACKETS", "1")
+		assert.Equal(t, networkSetupExtraArgs(), "--vm-switch-logfile-append --trace-packets")
+	})
+}
+
+// renderProvisionContent mirrors Lima's executeGuestTemplate: it runs the guest
+// template engine over a provision file's content with the given Param map, the
+// only datum the network-setup drop-in references.
+func renderProvisionContent(t *testing.T, content string, param map[string]string) string {
+	t.Helper()
+	tmpl, err := template.New("").Parse(content)
+	assert.NilError(t, err)
+	var out bytes.Buffer
+	assert.NilError(t, tmpl.Execute(&out, map[string]any{"Param": param}))
+	return out.String()
+}
+
+func Test_limaTemplate_networkSetupExtraArgsDropin(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../lima-template.yaml")
+	assert.NilError(t, err)
+
+	var doc struct {
+		Provision []struct {
+			Path    string `json:"path"`
+			Content string `json:"content"`
+		} `json:"provision"`
+	}
+	assert.NilError(t, yaml.Unmarshal(data, &doc))
+
+	const dropinPath = "/etc/systemd/system/network-setup.service.d/extra-args.conf"
+	var content string
+	for _, p := range doc.Provision {
+		if p.Path == dropinPath {
+			content = p.Content
+			break
+		}
+	}
+	assert.Assert(t, content != "", "no provision entry writes %s", dropinPath)
+
+	// Empty param renders the distro's own default (an empty value).
+	blank := renderProvisionContent(t, content, map[string]string{"NETWORK_SETUP_EXTRA_ARGS": ""})
+	assert.Assert(t, strings.Contains(blank, `Environment=NETWORK_SETUP_EXTRA_ARGS=""`),
+		"got:\n%s", blank)
+
+	// Quoted as a whole so the space stays one env var; the unit's unquoted
+	// $NETWORK_SETUP_EXTRA_ARGS splits it back into args.
+	got := renderProvisionContent(t, content,
+		map[string]string{"NETWORK_SETUP_EXTRA_ARGS": "--vm-switch-logfile-append --trace-packets"})
+	assert.Assert(t, strings.Contains(got,
+		`Environment=NETWORK_SETUP_EXTRA_ARGS="--vm-switch-logfile-append --trace-packets"`),
+		"got:\n%s", got)
 }

--- a/rdd/pkg/controllers/app/app/lima-template.yaml
+++ b/rdd/pkg/controllers/app/app/lima-template.yaml
@@ -60,6 +60,27 @@ provision:
   content: |
     [Service]
     Environment=NETWORK_SETUP_EXTRA_ARGS={{printf "%q" .Param.NETWORK_SETUP_EXTRA_ARGS}}
+# Stream guest journals and lima-init.log (which die with the VM) to the host
+# log dir so CI artifacts carry them. Empty GUEST_LOG_DIR (no RDD_KEEP_LOGS)
+# makes this a no-op. The capture units are transient, restarted each boot.
+- mode: system
+  script: |
+    #!/bin/bash
+
+    set -o errexit -o nounset -o pipefail -o xtrace
+
+    if [[ -z $PARAM_GUEST_LOG_DIR ]]; then
+        exit 0
+    fi
+
+    if ! systemctl is-active --quiet rdd-journal-capture.service; then
+        systemd-run --collect --unit=rdd-journal-capture /bin/sh -c \
+            "journalctl --follow --no-tail --output=short-iso --unit=lima-init.service --unit=network-setup.service --unit=rancher-desktop-guest-agent.service --unit=rdd-guest.service --unit=wsl-proxy.service >> \"$PARAM_GUEST_LOG_DIR/guest-journal.log\""
+    fi
+    if ! systemctl is-active --quiet rdd-lima-init-capture.service; then
+        systemd-run --collect --unit=rdd-lima-init-capture /bin/sh -c \
+            "tail -c +0 -F /var/log/lima-init.log >> \"$PARAM_GUEST_LOG_DIR/lima-init.log\""
+    fi
 - mode: system
   script: |
     #!/bin/bash

--- a/rdd/pkg/controllers/app/app/lima-template.yaml
+++ b/rdd/pkg/controllers/app/app/lima-template.yaml
@@ -44,6 +44,15 @@ provision:
     KUBERNETES_ENABLED={{.Param.KUBERNETES_ENABLED}}
     KUBERNETES_VERSION={{.Param.KUBERNETES_VERSION}}
     KUBERNETES_PORT={{.Param.KUBERNETES_PORT}}
+# Redirect vm-switch's log to a host-mounted file (under the service log dir) so
+# it survives VM teardown and is collected with the other instance logs. The
+# distro's network-setup.service defaults VM_SWITCH_LOG to an in-guest path; this
+# drop-in overrides it and is written before systemd loads the unit.
+- mode: data
+  path: /etc/systemd/system/network-setup.service.d/log-path.conf
+  content: |
+    [Service]
+    Environment=VM_SWITCH_LOG={{printf "%q" .Param.VM_SWITCH_LOG}}
 - mode: system
   script: |
     #!/bin/bash

--- a/rdd/pkg/controllers/app/app/lima-template.yaml
+++ b/rdd/pkg/controllers/app/app/lima-template.yaml
@@ -47,19 +47,21 @@ provision:
 # Redirect vm-switch's log to a host-mounted file (under the service log dir) so
 # it survives VM teardown and is collected with the other instance logs. The
 # distro's network-setup.service defaults VM_SWITCH_LOG to an in-guest path; this
-# drop-in overrides it and is written before systemd loads the unit.
+# drop-in overrides it. The unit runs only under WSL (ConditionVirtualization=wsl);
+# elsewhere this file is unused. Quote the whole assignment per systemd.exec so a
+# path with spaces stays one env var; quoting only the value would not.
 - mode: data
   path: /etc/systemd/system/network-setup.service.d/log-path.conf
   content: |
     [Service]
-    Environment=VM_SWITCH_LOG={{printf "%q" .Param.VM_SWITCH_LOG}}
+    Environment="VM_SWITCH_LOG={{.Param.VM_SWITCH_LOG}}"
 # Diagnostic vm-switch logging flags from networkSetupExtraArgs(); empty
-# (the distro default) outside RDD_KEEP_LOGS.
+# (the distro default) when RDD_KEEP_LOGS is not set.
 - mode: data
   path: /etc/systemd/system/network-setup.service.d/extra-args.conf
   content: |
     [Service]
-    Environment=NETWORK_SETUP_EXTRA_ARGS={{printf "%q" .Param.NETWORK_SETUP_EXTRA_ARGS}}
+    Environment="NETWORK_SETUP_EXTRA_ARGS={{.Param.NETWORK_SETUP_EXTRA_ARGS}}"
 # Stream guest journals and lima-init.log (which die with the VM) to the host
 # log dir so CI artifacts carry them. Empty GUEST_LOG_DIR (no RDD_KEEP_LOGS)
 # makes this a no-op. The capture units are transient, restarted each boot.

--- a/rdd/pkg/controllers/app/app/lima-template.yaml
+++ b/rdd/pkg/controllers/app/app/lima-template.yaml
@@ -53,6 +53,13 @@ provision:
   content: |
     [Service]
     Environment=VM_SWITCH_LOG={{printf "%q" .Param.VM_SWITCH_LOG}}
+# Diagnostic vm-switch logging flags from networkSetupExtraArgs(); empty
+# (the distro default) outside RDD_KEEP_LOGS.
+- mode: data
+  path: /etc/systemd/system/network-setup.service.d/extra-args.conf
+  content: |
+    [Service]
+    Environment=NETWORK_SETUP_EXTRA_ARGS={{printf "%q" .Param.NETWORK_SETUP_EXTRA_ARGS}}
 - mode: system
   script: |
     #!/bin/bash


### PR DESCRIPTION
Capture vm-switch diagnostics on CI under `RDD_KEEP_LOGS` so WSL2 networking failures stay debuggable after teardown: redirect the vm-switch relay log to the collected log dir (appended across restarts, with optional packet tracing under `RDD_TRACE_PACKETS` via v0.2.6's `NETWORK_SETUP_EXTRA_ARGS` hook), and stream the guest networking journals and `lima-init.log` there too.