### PR TITLE
Gate KubernetesReady until a node is Ready

### DIFF
--- a/rdd/docs/design/api_app.md
+++ b/rdd/docs/design/api_app.md
@@ -114,10 +114,11 @@ status:
   | `ContainerEngineReady` | `True`    | `NotApplicable`  | Mirroring is not implemented for the current backend (e.g. `containerd`); forced `True` so `rdd set` can finish waiting |
   | `ContainerEngineReady` | `False`   | `ConnectFailed`  | Engine controller failed to connect to Docker                     |
   | `ContainerEngineReady` | `False`   | `Stopped`        | The VM is stopped; the engine watcher is not running              |
-  | `KubernetesReady`      | `True`    | `Ready`          | k3s API server is reachable; instance context merged into `~/.kube/config` |
+  | `KubernetesReady`      | `True`    | `Ready`          | API server answers, node Ready, context merged into `~/.kube/config`. Workload-level readiness (coredns, traefik) is not gated; wait for those Deployments directly when needed |
   | `KubernetesReady`      | `False`   | `NotApplicable`  | `spec.kubernetes.enabled` is false                                |
   | `KubernetesReady`      | `False`   | `NotRunning`     | VM is not running, so k3s cannot be healthy                       |
   | `KubernetesReady`      | `False`   | `Probing`        | Waiting for k3s API server to respond                             |
+  | `KubernetesReady`      | `False`   | `WaitingForNode` | API server answers but no node has reached Ready                  |
   | `KubernetesReady`      | `False`   | `MergeFailed`    | k3s is reachable but merging the instance kubeconfig failed (see `message`) |
   | `Settled`              | `True`    | `Settled`        | Reconcile chain has caught up with the current spec               |
   | `Settled`              | `False`   | `WaitingForLimaVM` | The App has no `Running` condition yet (nothing mirrored from LimaVM) |

--- a/rdd/pkg/apis/app/v1alpha1/app_types.go
+++ b/rdd/pkg/apis/app/v1alpha1/app_types.go
@@ -41,11 +41,13 @@ const (
 	// from a fresh one.
 	AppConditionContainerEngineReady = "ContainerEngineReady"
 
-	// AppConditionKubernetesReady goes True once the Kubernetes controller has
-	// confirmed that the k3s API server is reachable and has merged the
-	// rancher-desktop-{instance} context into ~/.kube/config. It is only
-	// meaningful when spec.kubernetes.enabled is true; when Kubernetes is
-	// disabled the condition is absent or False with reason NotApplicable.
+	// AppConditionKubernetesReady goes True once the k3s API server answers,
+	// the node is Ready, and the rancher-desktop-{instance} context is
+	// merged into ~/.kube/config. Workload-level readiness (coredns,
+	// traefik) is not gated; consumers that need it wait for those
+	// Deployments themselves. The condition is only meaningful when
+	// spec.kubernetes.enabled is true; when Kubernetes is disabled the
+	// condition is absent or False with reason NotApplicable.
 	AppConditionKubernetesReady = "KubernetesReady"
 
 	// AppConditionSettled reports whether the reconcile chain has
@@ -90,8 +92,8 @@ const (
 
 // Reasons for the KubernetesReady condition.
 const (
-	// AppKubernetesReasonReady means the k3s API server is reachable and the
-	// kubeconfig context has been merged into ~/.kube/config.
+	// AppKubernetesReasonReady means the API server answers, the node is
+	// Ready, and the kubeconfig context is merged into ~/.kube/config.
 	AppKubernetesReasonReady = "Ready"
 
 	// AppKubernetesReasonNotApplicable means spec.kubernetes.enabled is false;
@@ -106,6 +108,10 @@ const (
 	// AppKubernetesReasonProbing means the controller is still waiting for
 	// the k3s API server to respond.
 	AppKubernetesReasonProbing = "Probing"
+
+	// AppKubernetesReasonWaitingForNode means the API server answers but no
+	// node has reached Ready, so the cluster cannot schedule a workload.
+	AppKubernetesReasonWaitingForNode = "WaitingForNode"
 
 	// AppKubernetesReasonMergeFailed means the k3s API server is reachable
 	// but merging the instance kubeconfig into ~/.kube/config failed.

--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -17,9 +17,11 @@ import (
 	"syscall"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -120,6 +122,11 @@ type KubernetesReconciler struct {
 	// probeFn lets tests inject probe results without making real HTTP calls.
 	// Production wiring leaves it nil; Reconcile then calls probeK3sAPI.
 	probeFn func(ctx context.Context) (probeResult, error)
+
+	// clientsetFn lets tests inject a fake typed client so the node check
+	// runs against in-memory objects. Production wiring leaves it nil;
+	// checkNodeReady then builds a client from the instance kubeconfig.
+	clientsetFn func() (kubernetes.Interface, error)
 }
 
 // probe dispatches to probeFn if injected (tests) or probeK3sAPI otherwise.
@@ -128,6 +135,68 @@ func (r *KubernetesReconciler) probe(ctx context.Context) (probeResult, error) {
 		return r.probeFn(ctx)
 	}
 	return r.probeK3sAPI(ctx)
+}
+
+// checkNodeReady reports whether a node has reached Ready, so a scheduled
+// workload has somewhere to run. It returns (ready, reason, message); reason
+// and message describe the blocking gate only when ready is false.
+// Workload-level readiness (coredns, traefik) is deliberately NOT gated here:
+// it would delay Ready for every user, and consumers that need it can wait
+// for those Deployments themselves.
+func (r *KubernetesReconciler) checkNodeReady(ctx context.Context) (ready bool, reason, message string) {
+	cs, err := r.getClientset()
+	if err != nil {
+		return false, appv1alpha1.AppKubernetesReasonWaitingForNode,
+			fmt.Sprintf("Cannot reach cluster: %v", err)
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, kubeProbeTimeout)
+	defer cancel()
+
+	nodes, err := cs.CoreV1().Nodes().List(checkCtx, metav1.ListOptions{})
+	if err != nil {
+		return false, appv1alpha1.AppKubernetesReasonWaitingForNode,
+			fmt.Sprintf("Cannot list nodes: %v", err)
+	}
+	if len(nodes.Items) == 0 {
+		return false, appv1alpha1.AppKubernetesReasonWaitingForNode, "No node has registered yet"
+	}
+	for i := range nodes.Items {
+		if !nodeReady(&nodes.Items[i]) {
+			return false, appv1alpha1.AppKubernetesReasonWaitingForNode,
+				fmt.Sprintf("Node %q is not Ready", nodes.Items[i].Name)
+		}
+	}
+
+	return true, "", ""
+}
+
+// getClientset returns the injected fake client in tests or a real client
+// built from the instance kubeconfig in production.
+func (r *KubernetesReconciler) getClientset() (kubernetes.Interface, error) {
+	if r.clientsetFn != nil {
+		return r.clientsetFn()
+	}
+	data, err := os.ReadFile(r.K3sConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("read instance kubeconfig: %w", err)
+	}
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse instance kubeconfig: %w", err)
+	}
+	cfg.Timeout = kubeProbeTimeout
+	return kubernetes.NewForConfig(cfg)
+}
+
+// nodeReady reports whether node carries a Ready condition set to True.
+func nodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // Reconcile drives the KubernetesReady condition and ~/.kube/config lifecycle.
@@ -249,6 +318,23 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
 	}
 
+	// /healthz answers before the node registers, so reporting Ready here
+	// would let `rdd set` return while `kubectl run` still sits Pending.
+	// Gate the first Ready on node Ready. Once Ready, API-server liveness
+	// alone keeps the condition True, so a transient node blip does not
+	// flap Settled.
+	if !apimeta.IsStatusConditionTrue(app.Status.Conditions, appv1alpha1.AppConditionKubernetesReady) {
+		ready, reason, message := r.checkNodeReady(ctx)
+		if !ready {
+			log.V(1).Info("k3s API healthy but cluster not yet usable",
+				"reason", reason, "message", message)
+			if condErr := r.setKubeCondition(ctx, &app, metav1.ConditionFalse, reason, message); condErr != nil {
+				return ctrl.Result{}, condErr
+			}
+			return ctrl.Result{RequeueAfter: kubeProbeRequeue}, nil
+		}
+	}
+
 	// Requeue periodically so a later k3s death surfaces even if no other
 	// controller writes to App in the meantime. Without this, setKubeCondition
 	// is a no-op when Ready→Ready and there is nothing else to trigger a
@@ -256,7 +342,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 	return ctrl.Result{RequeueAfter: kubeHealthyRequeue}, r.setKubeCondition(ctx, &app,
 		metav1.ConditionTrue,
 		appv1alpha1.AppKubernetesReasonReady,
-		"Kubernetes API server is ready",
+		"Kubernetes cluster is ready",
 	)
 }
 

--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -137,7 +137,7 @@ func (r *KubernetesReconciler) probe(ctx context.Context) (probeResult, error) {
 	return r.probeK3sAPI(ctx)
 }
 
-// checkNodeReady reports whether a node has reached Ready, so a scheduled
+// checkNodeReady reports whether any node has reached Ready, so a scheduled
 // workload has somewhere to run. It returns (ready, reason, message); reason
 // and message describe the blocking gate only when ready is false.
 // Workload-level readiness (coredns, traefik) is deliberately NOT gated here:
@@ -162,17 +162,18 @@ func (r *KubernetesReconciler) checkNodeReady(ctx context.Context) (ready bool, 
 		return false, appv1alpha1.AppKubernetesReasonWaitingForNode, "No node has registered yet"
 	}
 	for i := range nodes.Items {
-		if !nodeReady(&nodes.Items[i]) {
-			return false, appv1alpha1.AppKubernetesReasonWaitingForNode,
-				fmt.Sprintf("Node %q is not Ready", nodes.Items[i].Name)
+		if nodeReady(&nodes.Items[i]) {
+			return true, "", ""
 		}
 	}
 
-	return true, "", ""
+	return false, appv1alpha1.AppKubernetesReasonWaitingForNode, "No node is Ready yet"
 }
 
-// getClientset returns the injected fake client in tests or a real client
-// built from the instance kubeconfig in production.
+// getClientset returns a typed client for the k3s cluster inside the VM.
+// r.Client is no substitute: it talks to rdd's embedded control plane,
+// which hosts the App resource but no Nodes. Tests inject a fake via
+// clientsetFn.
 func (r *KubernetesReconciler) getClientset() (kubernetes.Interface, error) {
 	if r.clientsetFn != nil {
 		return r.clientsetFn()
@@ -320,9 +321,8 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (c
 
 	// /healthz answers before the node registers, so reporting Ready here
 	// would let `rdd set` return while `kubectl run` still sits Pending.
-	// Gate the first Ready on node Ready. Once Ready, API-server liveness
-	// alone keeps the condition True, so a transient node blip does not
-	// flap Settled.
+	// Gate the first Ready on node Ready. Once Ready, ignore the status of
+	// the node, so a transient node blip does not flap Settled.
 	if !apimeta.IsStatusConditionTrue(app.Status.Conditions, appv1alpha1.AppConditionKubernetesReady) {
 		ready, reason, message := r.checkNodeReady(ctx)
 		if !ready {

--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
@@ -20,9 +20,12 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -131,6 +134,31 @@ func newAppNotRunning() *appv1alpha1.App {
 	return app
 }
 
+// readyNode returns a Node carrying a Ready condition set to True.
+func readyNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "lima-rd"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+// notReadyNode returns a registered Node whose Ready condition is False.
+func notReadyNode() *corev1.Node {
+	node := readyNode()
+	node.Status.Conditions[0].Status = corev1.ConditionFalse
+	return node
+}
+
+// fakeClientset returns a clientsetFn that serves objs from an in-memory
+// client, letting the node check run without a real cluster.
+func fakeClientset(objs ...k8sruntime.Object) func() (kubernetes.Interface, error) {
+	return func() (kubernetes.Interface, error) {
+		return k8sfake.NewSimpleClientset(objs...), nil
+	}
+}
+
 // isolateKubeconfig points HOME and KUBECONFIG at dir so the reconciler's
 // kubeconfig writes cannot touch the developer's real ~/.kube/config even
 // if a future refactor changes KUBECONFIG-precedence handling.
@@ -169,6 +197,7 @@ func Test_Reconcile_KubernetesReady_Ready(t *testing.T) {
 		Client:                 c,
 		K3sConfigPath:          srcPath,
 		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
+		clientsetFn:            fakeClientset(readyNode()),
 	}
 	// removeKubeContext cancels the in-flight current-context probe and waits
 	// for the goroutine started by manageKubeContext to finish, so it cannot
@@ -190,6 +219,107 @@ func Test_Reconcile_KubernetesReady_Ready(t *testing.T) {
 	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonReady)
 }
 
+// Test_Reconcile_KubernetesReady_GatedUntilNodeReady checks that a healthy
+// API server does not promote KubernetesReady to True until the node is
+// Ready, so `rdd set` cannot return while a scheduled pod would have no
+// node to run on.
+func Test_Reconcile_KubernetesReady_GatedUntilNodeReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []k8sruntime.Object
+		wantReason string
+	}{
+		{
+			name:       "node not Ready",
+			objects:    []k8sruntime.Object{notReadyNode()},
+			wantReason: appv1alpha1.AppKubernetesReasonWaitingForNode,
+		},
+		{
+			name:       "no node registered",
+			objects:    []k8sruntime.Object{},
+			wantReason: appv1alpha1.AppKubernetesReasonWaitingForNode,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)
+			isolateKubeconfig(t, dir)
+
+			scheme := newKubeScheme(t)
+			app := newAppRunning()
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(app).
+				WithStatusSubresource(app).
+				Build()
+
+			r := &KubernetesReconciler{
+				Client:                 c,
+				K3sConfigPath:          srcPath,
+				InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
+				clientsetFn:            fakeClientset(tc.objects...),
+			}
+			t.Cleanup(func() { r.removeKubeContext(context.Background()) })
+
+			req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+			result, err := r.Reconcile(context.Background(), req)
+			assert.NilError(t, err)
+			assert.Equal(t, result.RequeueAfter, kubeProbeRequeue,
+				"a not-yet-usable cluster should requeue after kubeProbeRequeue")
+
+			got := &appv1alpha1.App{}
+			assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+			cond := findKubeReady(got)
+			assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+			assert.Equal(t, cond.Status, metav1.ConditionFalse,
+				"KubernetesReady must stay False until a node is Ready")
+			assert.Equal(t, cond.Reason, tc.wantReason)
+		})
+	}
+}
+
+// Test_Reconcile_KubernetesReady_StaysReadyDespiteNodeBlip checks that the
+// node gate runs only on the path to the first Ready. Once Ready,
+// API-server liveness alone keeps the condition True, so a transient node
+// blip cannot flap Settled.
+func Test_Reconcile_KubernetesReady_StaysReadyDespiteNodeBlip(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunningKubeReady()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	r := &KubernetesReconciler{
+		Client:                 c,
+		K3sConfigPath:          srcPath,
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
+		// No Ready node: if the gate ran here it would flip the
+		// condition to False, so leaving it True proves the gate is skipped.
+		clientsetFn: fakeClientset(),
+	}
+	t.Cleanup(func() { r.removeKubeContext(context.Background()) })
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, kubeHealthyRequeue)
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionTrue,
+		"already-Ready condition must not flap on a node blip")
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonReady)
+}
+
 func Test_Reconcile_InstanceKubeConfig_WrittenOnReady_RemovedOnDisable(t *testing.T) {
 	dir := t.TempDir()
 	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)
@@ -208,6 +338,7 @@ func Test_Reconcile_InstanceKubeConfig_WrittenOnReady_RemovedOnDisable(t *testin
 		Client:                 c,
 		K3sConfigPath:          srcPath,
 		InstanceKubeConfigPath: instanceKubeConfig,
+		clientsetFn:            fakeClientset(readyNode()),
 	}
 	// The healthy reconcile starts a current-context probe goroutine; ensure it
 	// finishes before the test returns even if an assertion below fails.

--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
@@ -279,6 +279,46 @@ func Test_Reconcile_KubernetesReady_GatedUntilNodeReady(t *testing.T) {
 	}
 }
 
+// Test_Reconcile_KubernetesReady_AnyReadyNodeSuffices checks that one Ready
+// node promotes the condition even while another node is not Ready: a
+// scheduled workload has somewhere to run as soon as any node is Ready.
+func Test_Reconcile_KubernetesReady_AnyReadyNodeSuffices(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := fakeK3sServer(t, filepath.Join(dir, "k3s.yaml"), http.StatusOK)
+	isolateKubeconfig(t, dir)
+
+	scheme := newKubeScheme(t)
+	app := newAppRunning()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(app).
+		WithStatusSubresource(app).
+		Build()
+
+	secondNode := notReadyNode()
+	secondNode.Name = "lima-rd-2"
+	r := &KubernetesReconciler{
+		Client:                 c,
+		K3sConfigPath:          srcPath,
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
+		clientsetFn:            fakeClientset(readyNode(), secondNode),
+	}
+	t.Cleanup(func() { r.removeKubeContext(context.Background()) })
+
+	req := ctrl.Request{NamespacedName: client.ObjectKey{Name: appName}}
+	result, err := r.Reconcile(context.Background(), req)
+	assert.NilError(t, err)
+	assert.Equal(t, result.RequeueAfter, kubeHealthyRequeue)
+
+	got := &appv1alpha1.App{}
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, got))
+	cond := findKubeReady(got)
+	assert.Assert(t, cond != nil, "KubernetesReady condition missing")
+	assert.Equal(t, cond.Status, metav1.ConditionTrue,
+		"one Ready node should be enough; a not-Ready sibling must not block")
+	assert.Equal(t, cond.Reason, appv1alpha1.AppKubernetesReasonReady)
+}
+
 // Test_Reconcile_KubernetesReady_StaysReadyDespiteNodeBlip checks that the
 // node gate runs only on the path to the first Ready. Once Ready,
 // API-server liveness alone keeps the condition True, so a transient node


### PR DESCRIPTION
`KubernetesReady` went `True` as soon as the k3s API server answered `/healthz`. The API server answers before the node registers, so `rdd set` returned `Settled` while a scheduled pod had no node to run on.

Gate the first `Ready` on the node being `Ready`; once `Ready`, API-server liveness alone keeps the condition `True`, so a transient node blip does not flap `Settled`. The new reason `WaitingForNode` reports the blocking gate.

Workload-level readiness (coredns, traefik) is deliberately not gated: it would slow startup for every user, and consumers that need it can wait for those Deployments themselves. The BATS tests will gain explicit coredns/traefik waits separately.