### PR TITLE
Linux packaging: LLM-suggested fixes

### DIFF
--- a/packaging/linux/rancher-desktop.appdata.xml
+++ b/packaging/linux/rancher-desktop.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>rancher-desktop</id>
+  <id>io.rancherdesktop.app2</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>
   <name>Rancher Desktop</name>

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -46,7 +46,11 @@ BuildRequires:  ImageMagick
 
 %if 0%{?debian}
 Requires: qemu-utils
+%ifarch aarch64
+Requires: qemu-system-arm
+%else
 Requires: qemu-system-x86
+%endif
 Requires: pass
 Requires: openssh-client
 # To enumerate system certificates
@@ -65,7 +69,6 @@ Requires: libgbm1
 Requires: libgcc1
 Requires: libgdk-pixbuf-2.0-0
 Requires: libglib2.0-0
-Requires: libglib2.0-dev
 Requires: libgtk-3-0
 Requires: libnspr4
 Requires: libnss3
@@ -178,6 +181,7 @@ mv resources/linux/rancher-desktop.appdata.xml share/metainfo/rancher-desktop.ap
 mkdir -p "%{buildroot}%{_prefix}/bin" "%{buildroot}/opt/%{name}"
 
 cp -ra ./share "%{buildroot}%{_prefix}"
+rm -rf ./share
 cp -ra ./* "%{buildroot}/opt/%{name}"
 
 # Link to the binary
@@ -192,6 +196,7 @@ true
 %defattr(-,root,root,-)
 %dir /opt/%{name}
 /opt/%{name}*
+%exclude /opt/%{name}/chrome-sandbox
 %attr(4755,root,root) /opt/%{name}/chrome-sandbox
 %{_bindir}/rancher-desktop
 %{_prefix}/share/applications/rancher-desktop.desktop


### PR DESCRIPTION
This is a few LLM-suggested fixes for Linux packaging.

- appdata.xml: Provide a more proper application ID
- spec: Provide correct qemu dependency in Debian/arm64
- spec: Drop libglib2.0-dev dependency in Debian
- spec: Avoid shipping unneeded `/opt/rancher-desktop/share/`
- spec: Avoid including `chrome-sandbox` twice