### PR TITLE
Link bundled binaries into the instance bin directory

### DIFF
--- a/rdd/bats/tests/20-service/7-binlinks.bats
+++ b/rdd/bats/tests/20-service/7-binlinks.bats
@@ -1,0 +1,72 @@
+load '../../helpers/load'
+
+# Prove the daemon publishes the application's bundled binaries into
+# ~/.rd<instance>/bin only when rdd runs from inside the app bundle. A fake
+# bundle holds a real rdd copy at .../Resources/<os>/bin/rdd next to a couple of
+# stand-in tool files; the daemon links whatever sits beside that rdd.
+
+local_setup_file() {
+    skip_on_windows "Bundled binaries are only published on macOS and Linux."
+    # Clean up from any previous run; svc delete also removes the short dir.
+    rdd svc delete || :
+
+    # A real rdd copy at the bundle path makes the daemon's os.Executable()
+    # match the gate. The siblings are stand-ins; only their names matter.
+    fake_bin="${BATS_FILE_TMPDIR}/Rancher Desktop.app/Contents/Resources/${OS}/bin"
+    mkdir -p "${fake_bin}"
+    cp "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${fake_bin}/rdd${EXE}"
+    echo "stand-in docker" >"${fake_bin}/docker"
+    echo "stand-in helm" >"${fake_bin}/helm"
+
+    FAKE_BIN="${fake_bin}"
+    BIN_DIR="${RDD_SHORT_DIR}/bin"
+    save_var FAKE_BIN BIN_DIR
+}
+
+local_setup() {
+    is_windows && return 0
+    # Each test starts the daemon from a chosen location, so stop any daemon a
+    # previous test left running; an already-running instance rejects the start.
+    rdd svc stop || :
+}
+
+# fake_rdd runs the bundled rdd copy. It closes BATS fds 3 and 4 so the daemon
+# it spawns cannot inherit them and hang bats, matching the rdd() helper.
+fake_rdd() {
+    "${FAKE_BIN}/rdd${EXE}" "$@" 3>&- 4>&-
+}
+
+@test 'publishes bundled binaries when started from the app bundle' {
+    load_var FAKE_BIN BIN_DIR
+    fake_rdd svc start
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker" "${BIN_DIR}/docker"
+    assert_symlink_to "${FAKE_BIN}/helm" "${BIN_DIR}/helm"
+    # kubectl is not bundled; it links to rdd.
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/kubectl"
+}
+
+@test 'leaves the links untouched when started from outside the bundle' {
+    load_var FAKE_BIN BIN_DIR
+    # The standard rdd is not in a bundle, so its startup must not touch the links.
+    rdd svc start
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker" "${BIN_DIR}/docker"
+    assert_symlink_to "${FAKE_BIN}/helm" "${BIN_DIR}/helm"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/kubectl"
+}
+
+@test 'updates the links when the bundle changes and rdd runs from it again' {
+    load_var FAKE_BIN BIN_DIR
+    # Add a tool and drop one, then restart from the bundle.
+    echo "stand-in nerdctl" >"${FAKE_BIN}/nerdctl"
+    rm "${FAKE_BIN}/helm"
+    fake_rdd svc start
+    assert_symlink_to "${FAKE_BIN}/nerdctl" "${BIN_DIR}/nerdctl"
+    # The dropped tool's link is gone, proving the directory was recreated.
+    assert_link_not_exist "${BIN_DIR}/helm"
+    # Unchanged entries are still linked.
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker" "${BIN_DIR}/docker"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/kubectl"
+}

--- a/rdd/bats/tests/20-service/7-binlinks.bats
+++ b/rdd/bats/tests/20-service/7-binlinks.bats
@@ -2,29 +2,31 @@ load '../../helpers/load'
 
 # Prove the daemon publishes the application's bundled binaries into
 # ~/.rd<instance>/bin only when rdd runs from inside the app bundle. A fake
-# bundle holds a real rdd copy at .../Resources/<os>/bin/rdd next to a couple of
-# stand-in tool files; the daemon links whatever sits beside that rdd.
+# bundle holds a real rdd copy at .../<resources>/<os>/bin/rdd next to a couple
+# of stand-in tool files; the daemon links whatever sits beside that rdd.
 
 local_setup_file() {
     skip_on_windows "Bundled binaries are only published on macOS and Linux."
     # Clean up from any previous run; svc delete also removes the short dir.
     rdd svc delete || :
 
-    # A real rdd copy at the bundle path makes the daemon's os.Executable()
-    # match the gate. The siblings are stand-ins; only their names matter.
-    fake_bin="${BATS_FILE_TMPDIR}/Rancher Desktop.app/Contents/Resources/${OS}/bin"
+    # Mock up a packaged Rancher Desktop distribution so rdd thinks it is
+    # bundled. The siblings are stand-ins; only their names matter. macOS
+    # capitalizes Resources; Linux uses lowercase.
+    resources=Resources
+    is_linux && resources=resources
+    fake_bin="${BATS_FILE_TMPDIR}/Rancher Desktop.app/Contents/${resources}/${OS}/bin"
     mkdir -p "${fake_bin}"
     cp "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${fake_bin}/rdd${EXE}"
     echo "stand-in docker" >"${fake_bin}/docker"
     echo "stand-in helm" >"${fake_bin}/helm"
 
     FAKE_BIN="${fake_bin}"
-    BIN_DIR="${RDD_SHORT_DIR}/bin"
-    save_var FAKE_BIN BIN_DIR
+    DEST_DIR="${RDD_SHORT_DIR}/bin"
+    save_var FAKE_BIN DEST_DIR
 }
 
 local_setup() {
-    is_windows && return 0
     # Each test starts the daemon from a chosen location, so stop any daemon a
     # previous test left running; an already-running instance rejects the start.
     rdd svc stop || :
@@ -37,36 +39,36 @@ fake_rdd() {
 }
 
 @test 'publishes bundled binaries when started from the app bundle' {
-    load_var FAKE_BIN BIN_DIR
+    load_var FAKE_BIN DEST_DIR
     fake_rdd svc start
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/rdd${EXE}"
-    assert_symlink_to "${FAKE_BIN}/docker" "${BIN_DIR}/docker"
-    assert_symlink_to "${FAKE_BIN}/helm" "${BIN_DIR}/helm"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
+    assert_symlink_to "${FAKE_BIN}/helm" "${DEST_DIR}/helm"
     # kubectl is not bundled; it links to rdd.
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl"
 }
 
 @test 'leaves the links untouched when started from outside the bundle' {
-    load_var FAKE_BIN BIN_DIR
+    load_var FAKE_BIN DEST_DIR
     # The standard rdd is not in a bundle, so its startup must not touch the links.
     rdd svc start
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/rdd${EXE}"
-    assert_symlink_to "${FAKE_BIN}/docker" "${BIN_DIR}/docker"
-    assert_symlink_to "${FAKE_BIN}/helm" "${BIN_DIR}/helm"
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
+    assert_symlink_to "${FAKE_BIN}/helm" "${DEST_DIR}/helm"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl"
 }
 
 @test 'updates the links when the bundle changes and rdd runs from it again' {
-    load_var FAKE_BIN BIN_DIR
+    load_var FAKE_BIN DEST_DIR
     # Add a tool and drop one, then restart from the bundle.
     echo "stand-in nerdctl" >"${FAKE_BIN}/nerdctl"
     rm "${FAKE_BIN}/helm"
     fake_rdd svc start
-    assert_symlink_to "${FAKE_BIN}/nerdctl" "${BIN_DIR}/nerdctl"
+    assert_symlink_to "${FAKE_BIN}/nerdctl" "${DEST_DIR}/nerdctl"
     # The dropped tool's link is gone, proving the directory was recreated.
-    assert_link_not_exist "${BIN_DIR}/helm"
+    assert_link_not_exist "${DEST_DIR}/helm"
     # Unchanged entries are still linked.
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/rdd${EXE}"
-    assert_symlink_to "${FAKE_BIN}/docker" "${BIN_DIR}/docker"
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${BIN_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl"
 }

--- a/rdd/bats/tests/20-service/7-binlinks.bats
+++ b/rdd/bats/tests/20-service/7-binlinks.bats
@@ -105,6 +105,30 @@ assert_hardlink_to() { # <target> <link>
     assert_symlink_to "${FAKE_BIN}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
 }
 
+@test 'prunes dangling tool links left after an uninstall' {
+    load_var DEST_DIR
+    # Publish from a throwaway bundle, then delete it so its links dangle — the
+    # uninstall case. Driving setup through rdd gives real symlinks the daemon
+    # recognizes (MSYS2 ln -s would not).
+    resources=resources
+    is_macos && resources=Resources
+    bundle="${BATS_TEST_TMPDIR}/Gone.app/Contents/${resources}/${OS}/bin"
+    mkdir -p "${bundle}"
+    cp "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${bundle}/rdd${EXE}"
+    echo "stand-in docker" >"${bundle}/docker${EXE}"
+    "${bundle}/rdd${EXE}" svc start 3>&- 4>&-
+    "${bundle}/rdd${EXE}" svc stop 3>&- 4>&-
+    assert_symlink_to "${bundle}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
+    rm -rf "${bundle}"
+    # A standalone rdd prunes the now-dangling docker link so it cannot shadow a
+    # tool on PATH, and repairs its own rdd and kubectl links to itself.
+    rdd svc start
+    assert_link_not_exist "${DEST_DIR}/docker${EXE}"
+    standalone="${PATH_REPO_ROOT}/bin/rdd${EXE}"
+    assert_symlink_to "${standalone}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${standalone}" "${DEST_DIR}/kubectl${EXE}"
+}
+
 @test 'publishes hardlinks when symlinks are disabled' {
     load_var FAKE_BIN DEST_DIR
     # RDD_NO_SYMLINKS forces the hardlink fallback that Windows hits without

--- a/rdd/bats/tests/20-service/7-binlinks.bats
+++ b/rdd/bats/tests/20-service/7-binlinks.bats
@@ -17,7 +17,7 @@ local_setup_file() {
     is_linux && resources=resources
     fake_bin="${BATS_FILE_TMPDIR}/Rancher Desktop.app/Contents/${resources}/${OS}/bin"
     mkdir -p "${fake_bin}"
-    cp "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${fake_bin}/rdd${EXE}"
+    cp "${PATH_REPO_ROOT}/bin/rdd" "${fake_bin}/rdd"
     echo "stand-in docker" >"${fake_bin}/docker"
     echo "stand-in helm" >"${fake_bin}/helm"
 
@@ -35,17 +35,17 @@ local_setup() {
 # fake_rdd runs the bundled rdd copy. It closes BATS fds 3 and 4 so the daemon
 # it spawns cannot inherit them and hang bats, matching the rdd() helper.
 fake_rdd() {
-    "${FAKE_BIN}/rdd${EXE}" "$@" 3>&- 4>&-
+    "${FAKE_BIN}/rdd" "$@" 3>&- 4>&-
 }
 
 @test 'publishes bundled binaries when started from the app bundle' {
     load_var FAKE_BIN DEST_DIR
     fake_rdd svc start
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/rdd"
     assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
     assert_symlink_to "${FAKE_BIN}/helm" "${DEST_DIR}/helm"
     # kubectl is not bundled; it links to rdd.
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/kubectl"
 }
 
 @test 'leaves working links untouched when started standalone' {
@@ -53,10 +53,10 @@ fake_rdd() {
     # The bundle run's links still resolve, so a standalone rdd leaves its own
     # rdd and kubectl links alone and never touches docker or helm.
     rdd svc start
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/rdd"
     assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
     assert_symlink_to "${FAKE_BIN}/helm" "${DEST_DIR}/helm"
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/kubectl"
 }
 
 @test 'updates the links when the bundle changes and rdd runs from it again' {
@@ -69,21 +69,21 @@ fake_rdd() {
     # The dropped tool's link is gone, proving the directory was recreated.
     assert_link_not_exist "${DEST_DIR}/helm"
     # Unchanged entries are still linked.
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/rdd"
     assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
-    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/kubectl"
 }
 
 @test 'repairs missing or dangling rdd and kubectl links when started standalone' {
     load_var FAKE_BIN DEST_DIR
     # Simulate an instance whose app was deleted: rdd's link dangles, kubectl is
     # gone, and an unrelated tool link still resolves.
-    rm -f "${DEST_DIR}/rdd${EXE}" "${DEST_DIR}/kubectl"
-    ln -s "${DEST_DIR}/deleted/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    rm -f "${DEST_DIR}/rdd" "${DEST_DIR}/kubectl"
+    ln -s "${DEST_DIR}/deleted/rdd" "${DEST_DIR}/rdd"
     rdd svc start
     # The standalone rdd repairs its own links to point at the running binary.
-    standalone="${PATH_REPO_ROOT}/bin/rdd${EXE}"
-    assert_symlink_to "${standalone}" "${DEST_DIR}/rdd${EXE}"
+    standalone="${PATH_REPO_ROOT}/bin/rdd"
+    assert_symlink_to "${standalone}" "${DEST_DIR}/rdd"
     assert_symlink_to "${standalone}" "${DEST_DIR}/kubectl"
     # The unrelated docker link from the bundle run is left in place.
     assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"

--- a/rdd/bats/tests/20-service/7-binlinks.bats
+++ b/rdd/bats/tests/20-service/7-binlinks.bats
@@ -34,7 +34,10 @@ local_setup() {
 }
 
 # fake_rdd runs the bundled rdd copy. It closes BATS fds 3 and 4 so the daemon
-# it spawns cannot inherit them and hang bats, matching the rdd() helper.
+# it spawns cannot inherit them and hang bats, matching the rdd() helper. A
+# daemon fake_rdd starts must be stopped with fake_rdd too: on Windows rdd only
+# recognizes a control plane running its own binary, so the repo rdd in
+# local_setup cannot stop the bundled copy's daemon, and would orphan it.
 fake_rdd() {
     "${FAKE_BIN}/rdd${EXE}" "$@" 3>&- 4>&-
 }
@@ -55,6 +58,8 @@ assert_hardlink_to() { # <target> <link>
     assert_symlink_to "${FAKE_BIN}/helm${EXE}" "${DEST_DIR}/helm${EXE}"
     # kubectl is not bundled; it links to rdd.
     assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl${EXE}"
+    # Stop the bundled daemon with fake_rdd; the repo rdd cannot (see fake_rdd).
+    fake_rdd svc stop
 }
 
 @test 'leaves working links untouched when started standalone' {
@@ -81,6 +86,7 @@ assert_hardlink_to() { # <target> <link>
     assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
     assert_symlink_to "${FAKE_BIN}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
     assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl${EXE}"
+    fake_rdd svc stop
 }
 
 @test 'repairs missing or dangling rdd and kubectl links when started standalone' {
@@ -139,4 +145,5 @@ assert_hardlink_to() { # <target> <link>
     assert_hardlink_to "${FAKE_BIN}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
     # kubectl is not bundled; it hardlinks to rdd.
     assert_hardlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl${EXE}"
+    fake_rdd svc stop
 }

--- a/rdd/bats/tests/20-service/7-binlinks.bats
+++ b/rdd/bats/tests/20-service/7-binlinks.bats
@@ -4,22 +4,23 @@ load '../../helpers/load'
 # ~/.rd<instance>/bin only when rdd runs from inside the app bundle. A fake
 # bundle holds a real rdd copy at .../<resources>/<os>/bin/rdd next to a couple
 # of stand-in tool files; the daemon links whatever sits beside that rdd.
+# Symlinks need privileges on Windows, so the daemon falls back to hardlinks;
+# RDD_NO_SYMLINKS forces that fallback for the last test.
 
 local_setup_file() {
-    skip_on_windows "Bundled binaries are only published on macOS and Linux."
     # Clean up from any previous run; svc delete also removes the short dir.
     rdd svc delete || :
 
     # Mock up a packaged Rancher Desktop distribution so rdd thinks it is
     # bundled. The siblings are stand-ins; only their names matter. macOS
-    # capitalizes Resources; Linux uses lowercase.
-    resources=Resources
-    is_linux && resources=resources
+    # capitalizes Resources; Linux and Windows use lowercase.
+    resources=resources
+    is_macos && resources=Resources
     fake_bin="${BATS_FILE_TMPDIR}/Rancher Desktop.app/Contents/${resources}/${OS}/bin"
     mkdir -p "${fake_bin}"
-    cp "${PATH_REPO_ROOT}/bin/rdd" "${fake_bin}/rdd"
-    echo "stand-in docker" >"${fake_bin}/docker"
-    echo "stand-in helm" >"${fake_bin}/helm"
+    cp "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${fake_bin}/rdd${EXE}"
+    echo "stand-in docker" >"${fake_bin}/docker${EXE}"
+    echo "stand-in helm" >"${fake_bin}/helm${EXE}"
 
     FAKE_BIN="${fake_bin}"
     DEST_DIR="${RDD_SHORT_DIR}/bin"
@@ -35,17 +36,25 @@ local_setup() {
 # fake_rdd runs the bundled rdd copy. It closes BATS fds 3 and 4 so the daemon
 # it spawns cannot inherit them and hang bats, matching the rdd() helper.
 fake_rdd() {
-    "${FAKE_BIN}/rdd" "$@" 3>&- 4>&-
+    "${FAKE_BIN}/rdd${EXE}" "$@" 3>&- 4>&-
+}
+
+# assert_hardlink_to asserts that the link shares the target's file and is not a
+# symlink, as the hardlink fallback produces.
+assert_hardlink_to() { # <target> <link>
+    assert_file_exist "$2"
+    refute [ -L "$2" ]
+    assert [ "$2" -ef "$1" ]
 }
 
 @test 'publishes bundled binaries when started from the app bundle' {
     load_var FAKE_BIN DEST_DIR
     fake_rdd svc start
-    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/rdd"
-    assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
-    assert_symlink_to "${FAKE_BIN}/helm" "${DEST_DIR}/helm"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
+    assert_symlink_to "${FAKE_BIN}/helm${EXE}" "${DEST_DIR}/helm${EXE}"
     # kubectl is not bundled; it links to rdd.
-    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl${EXE}"
 }
 
 @test 'leaves working links untouched when started standalone' {
@@ -53,38 +62,57 @@ fake_rdd() {
     # The bundle run's links still resolve, so a standalone rdd leaves its own
     # rdd and kubectl links alone and never touches docker or helm.
     rdd svc start
-    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/rdd"
-    assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
-    assert_symlink_to "${FAKE_BIN}/helm" "${DEST_DIR}/helm"
-    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
+    assert_symlink_to "${FAKE_BIN}/helm${EXE}" "${DEST_DIR}/helm${EXE}"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl${EXE}"
 }
 
 @test 'updates the links when the bundle changes and rdd runs from it again' {
     load_var FAKE_BIN DEST_DIR
     # Add a tool and drop one, then restart from the bundle.
-    echo "stand-in nerdctl" >"${FAKE_BIN}/nerdctl"
-    rm "${FAKE_BIN}/helm"
+    echo "stand-in nerdctl" >"${FAKE_BIN}/nerdctl${EXE}"
+    rm "${FAKE_BIN}/helm${EXE}"
     fake_rdd svc start
-    assert_symlink_to "${FAKE_BIN}/nerdctl" "${DEST_DIR}/nerdctl"
+    assert_symlink_to "${FAKE_BIN}/nerdctl${EXE}" "${DEST_DIR}/nerdctl${EXE}"
     # The dropped tool's link is gone, proving the directory was recreated.
-    assert_link_not_exist "${DEST_DIR}/helm"
+    assert_link_not_exist "${DEST_DIR}/helm${EXE}"
     # Unchanged entries are still linked.
-    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/rdd"
-    assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
-    assert_symlink_to "${FAKE_BIN}/rdd" "${DEST_DIR}/kubectl"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${FAKE_BIN}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
+    assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl${EXE}"
 }
 
 @test 'repairs missing or dangling rdd and kubectl links when started standalone' {
     load_var FAKE_BIN DEST_DIR
-    # Simulate an instance whose app was deleted: rdd's link dangles, kubectl is
-    # gone, and an unrelated tool link still resolves.
-    rm -f "${DEST_DIR}/rdd" "${DEST_DIR}/kubectl"
-    ln -s "${DEST_DIR}/deleted/rdd" "${DEST_DIR}/rdd"
-    rdd svc start
+    # Simulate an instance whose app was deleted: an rdd run from a throwaway
+    # directory links rdd and kubectl to itself, then removing that directory
+    # leaves the links dangling. Driving this through rdd avoids depending on
+    # how the shell creates symlinks, which differs under MSYS2.
+    rm -f "${DEST_DIR}/rdd${EXE}" "${DEST_DIR}/kubectl${EXE}"
+    throwaway="${BATS_TEST_TMPDIR}/throwaway"
+    mkdir -p "${throwaway}"
+    cp "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${throwaway}/rdd${EXE}"
+    "${throwaway}/rdd${EXE}" svc start 3>&- 4>&-
+    "${throwaway}/rdd${EXE}" svc stop 3>&- 4>&-
+    rm -rf "${throwaway}"
     # The standalone rdd repairs its own links to point at the running binary.
-    standalone="${PATH_REPO_ROOT}/bin/rdd"
-    assert_symlink_to "${standalone}" "${DEST_DIR}/rdd"
-    assert_symlink_to "${standalone}" "${DEST_DIR}/kubectl"
+    rdd svc start
+    standalone="${PATH_REPO_ROOT}/bin/rdd${EXE}"
+    assert_symlink_to "${standalone}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${standalone}" "${DEST_DIR}/kubectl${EXE}"
     # The unrelated docker link from the bundle run is left in place.
-    assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
+    assert_symlink_to "${FAKE_BIN}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
+}
+
+@test 'publishes hardlinks when symlinks are disabled' {
+    load_var FAKE_BIN DEST_DIR
+    # RDD_NO_SYMLINKS forces the hardlink fallback that Windows hits without
+    # developer mode, so the same publish runs on a system that lacks symlinks.
+    export RDD_NO_SYMLINKS=1
+    fake_rdd svc start
+    assert_hardlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    assert_hardlink_to "${FAKE_BIN}/docker${EXE}" "${DEST_DIR}/docker${EXE}"
+    # kubectl is not bundled; it hardlinks to rdd.
+    assert_hardlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl${EXE}"
 }

--- a/rdd/bats/tests/20-service/7-binlinks.bats
+++ b/rdd/bats/tests/20-service/7-binlinks.bats
@@ -48,9 +48,10 @@ fake_rdd() {
     assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl"
 }
 
-@test 'leaves the links untouched when started from outside the bundle' {
+@test 'leaves working links untouched when started standalone' {
     load_var FAKE_BIN DEST_DIR
-    # The standard rdd is not in a bundle, so its startup must not touch the links.
+    # The bundle run's links still resolve, so a standalone rdd leaves its own
+    # rdd and kubectl links alone and never touches docker or helm.
     rdd svc start
     assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
     assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
@@ -71,4 +72,19 @@ fake_rdd() {
     assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
     assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
     assert_symlink_to "${FAKE_BIN}/rdd${EXE}" "${DEST_DIR}/kubectl"
+}
+
+@test 'repairs missing or dangling rdd and kubectl links when started standalone' {
+    load_var FAKE_BIN DEST_DIR
+    # Simulate an instance whose app was deleted: rdd's link dangles, kubectl is
+    # gone, and an unrelated tool link still resolves.
+    rm -f "${DEST_DIR}/rdd${EXE}" "${DEST_DIR}/kubectl"
+    ln -s "${DEST_DIR}/deleted/rdd${EXE}" "${DEST_DIR}/rdd${EXE}"
+    rdd svc start
+    # The standalone rdd repairs its own links to point at the running binary.
+    standalone="${PATH_REPO_ROOT}/bin/rdd${EXE}"
+    assert_symlink_to "${standalone}" "${DEST_DIR}/rdd${EXE}"
+    assert_symlink_to "${standalone}" "${DEST_DIR}/kubectl"
+    # The unrelated docker link from the bundle run is left in place.
+    assert_symlink_to "${FAKE_BIN}/docker" "${DEST_DIR}/docker"
 }

--- a/rdd/pkg/binlinks/binlinks.go
+++ b/rdd/pkg/binlinks/binlinks.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package binlinks publishes the binaries bundled with the Rancher Desktop
+// application into the instance bin directory (~/.rd<instance>/bin) as
+// symlinks, so a user can put that directory on PATH. It acts only when rdd
+// runs from inside the application bundle, so a standalone CLI install never
+// disturbs links the application created.
+package binlinks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+)
+
+// LinkBundledBinaries publishes the application's bundled binaries into the
+// instance bin directory as symlinks. It is a no-op unless rdd runs from inside
+// the application bundle. Publishing is best-effort: the returned error is for
+// the caller to log and must not block startup.
+func LinkBundledBinaries() error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate executable: %w", err)
+	}
+	if !inAppBundle(execPath, runtime.GOOS) {
+		return nil
+	}
+	return linkBinaries(execPath, filepath.Join(instance.ShortDir(), "bin"))
+}
+
+// inAppBundle reports whether execPath is the bundled rdd binary for the given
+// OS, as opposed to a standalone CLI install. The application stages its
+// per-platform resources under Resources/<goos>/bin/rdd. The leading separator
+// anchors the match, so an unrelated path ending in "Resources/<goos>/bin/rdd"
+// does not qualify.
+func inAppBundle(execPath, goos string) bool {
+	return strings.HasSuffix(execPath, "/Resources/"+goos+"/bin/rdd")
+}
+
+// linkBinaries recreates binDir with symlinks to the bundled binaries and a
+// kubectl link to rdd. Recreating it drops stale links from a previous install;
+// reading the source directory before removing binDir keeps the existing links
+// when the read fails.
+func linkBinaries(execPath, binDir string) error {
+	srcDir := filepath.Dir(execPath)
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("read bundle directory %q: %w", srcDir, err)
+	}
+
+	if err := os.RemoveAll(binDir); err != nil {
+		return fmt.Errorf("remove %q: %w", binDir, err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return fmt.Errorf("create %q: %w", binDir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if err := os.Symlink(filepath.Join(srcDir, name), filepath.Join(binDir, name)); err != nil {
+			return fmt.Errorf("link %q: %w", name, err)
+		}
+	}
+
+	// No separate kubectl binary is bundled; rdd provides it. Link kubectl to
+	// rdd so kubectl on PATH reaches rdd.
+	if err := os.Symlink(execPath, filepath.Join(binDir, "kubectl")); err != nil {
+		return fmt.Errorf("link kubectl: %w", err)
+	}
+	return nil
+}

--- a/rdd/pkg/binlinks/binlinks.go
+++ b/rdd/pkg/binlinks/binlinks.go
@@ -7,10 +7,10 @@
 // can put that directory on PATH. Each entry is a symlink, or a hardlink where
 // symlinks need privileges that are absent (Windows without developer mode).
 // Inside the application bundle rdd owns the directory and recreates it to
-// mirror the bundled binaries. Standalone, rdd repairs only its own rdd and
-// kubectl links, and only when they are missing or dangling, so links the
-// application installed survive and a CLI-only install still gets a usable rdd
-// and kubectl.
+// mirror the bundled binaries. Standalone, rdd repairs its own rdd and kubectl
+// links and prunes any symlink left dangling by an uninstalled application, so a
+// stale link cannot shadow a tool the user later installs on PATH; working links
+// and non-symlink entries survive.
 package binlinks
 
 import (
@@ -125,17 +125,48 @@ func link(target, linkPath string, useSymlink bool) error {
 	return os.Link(target, linkPath)
 }
 
-// ensureSelfLinks points the rdd and kubectl links in binDir at a standalone
-// rdd, so the instance bin directory stays usable when no application bundle
-// has published them. It repairs each link only when it is missing or dangling
-// and leaves every other entry, including a working link, untouched.
+// ensureSelfLinks keeps the instance bin directory usable when no application
+// bundle has published it. It first prunes symlinks left dangling by an
+// uninstalled application, then points the rdd and kubectl links at a standalone
+// rdd. Working links and non-symlink entries survive.
 func ensureSelfLinks(execPath, binDir, exe string, useSymlink bool) error {
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		return fmt.Errorf("create %q: %w", binDir, err)
 	}
+	if err := pruneDanglingLinks(binDir); err != nil {
+		return err
+	}
 	for _, name := range []string{"rdd" + exe, "kubectl" + exe} {
 		if err := ensureSelfLink(filepath.Join(binDir, name), execPath, useSymlink); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// pruneDanglingLinks removes symlinks in binDir whose target no longer resolves,
+// so a link left dangling by an uninstalled application cannot shadow a tool the
+// user later installs elsewhere on PATH; zsh stops at the broken link instead of
+// searching on. Working links and non-symlink entries stay. A hardlink from an
+// uninstalled application is not dangling and survives, so it still shadows;
+// detecting that needs the app install location (see #448).
+func pruneDanglingLinks(binDir string) error {
+	entries, err := os.ReadDir(binDir)
+	if err != nil {
+		return fmt.Errorf("read %q: %w", binDir, err)
+	}
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+		linkPath := filepath.Join(binDir, entry.Name())
+		if _, err := os.Stat(linkPath); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat %q: %w", linkPath, err)
+		}
+		if err := os.Remove(linkPath); err != nil {
+			return fmt.Errorf("remove dangling link %q: %w", linkPath, err)
 		}
 	}
 	return nil

--- a/rdd/pkg/binlinks/binlinks.go
+++ b/rdd/pkg/binlinks/binlinks.go
@@ -36,11 +36,16 @@ func LinkBundledBinaries() error {
 
 // inAppBundle reports whether execPath is the bundled rdd binary for the given
 // OS, as opposed to a standalone CLI install. The application stages its
-// per-platform resources under Resources/<goos>/bin/rdd. The leading separator
-// anchors the match, so an unrelated path ending in "Resources/<goos>/bin/rdd"
-// does not qualify.
+// per-platform resources under <resources>/<goos>/bin/rdd, where the directory
+// is "Resources" on macOS (the .app bundle convention) and lowercase
+// "resources" elsewhere. The leading separator anchors the match, so
+// an unrelated path ending in the same tail does not qualify.
 func inAppBundle(execPath, goos string) bool {
-	return strings.HasSuffix(execPath, "/Resources/"+goos+"/bin/rdd")
+	resources := "resources"
+	if goos == "darwin" {
+		resources = "Resources"
+	}
+	return strings.HasSuffix(execPath, "/"+resources+"/"+goos+"/bin/rdd")
 }
 
 // linkBinaries recreates binDir with symlinks to the bundled binaries and a

--- a/rdd/pkg/binlinks/binlinks.go
+++ b/rdd/pkg/binlinks/binlinks.go
@@ -3,12 +3,14 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
 // Package binlinks publishes the binaries bundled with the Rancher Desktop
-// application into the instance bin directory (~/.rd<instance>/bin) as
-// symlinks, so a user can put that directory on PATH. Inside the application
-// bundle rdd owns the directory and recreates it to mirror the bundled
-// binaries. Standalone, rdd repairs only its own rdd and kubectl links, and
-// only when they are missing or dangling, so links the application installed
-// survive and a CLI-only install still gets a usable rdd and kubectl.
+// application into the instance bin directory (~/.rd<instance>/bin), so a user
+// can put that directory on PATH. Each entry is a symlink, or a hardlink where
+// symlinks need privileges that are absent (Windows without developer mode).
+// Inside the application bundle rdd owns the directory and recreates it to
+// mirror the bundled binaries. Standalone, rdd repairs only its own rdd and
+// kubectl links, and only when they are missing or dangling, so links the
+// application installed survive and a CLI-only install still gets a usable rdd
+// and kubectl.
 package binlinks
 
 import (
@@ -21,42 +23,62 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
-// LinkBundledBinaries publishes rdd's binaries into the instance bin directory
-// as symlinks. Inside the application bundle it recreates the directory to
-// mirror every bundled binary; standalone it repairs only its own rdd and
-// kubectl links. Publishing is best-effort: the returned error is for the
-// caller to log and must not block startup.
+// LinkBundledBinaries publishes rdd's binaries into the instance bin directory.
+// Inside the application bundle it recreates the directory to mirror every
+// bundled binary; standalone it repairs only its own rdd and kubectl links.
+// Publishing is best-effort: the returned error is for the caller to log and
+// must not block startup.
 func LinkBundledBinaries() error {
 	execPath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("locate executable: %w", err)
 	}
 	binDir := filepath.Join(instance.ShortDir(), "bin")
+	exe := exeSuffix(runtime.GOOS)
+	// RDD_NO_SYMLINKS forces hardlinks, so tests can exercise the fallback that
+	// real systems hit when symlinks need absent privileges.
+	useSymlink := os.Getenv("RDD_NO_SYMLINKS") == ""
 	if inAppBundle(execPath, runtime.GOOS) {
-		return linkBinaries(execPath, binDir)
+		return linkBinaries(execPath, binDir, exe, useSymlink)
 	}
-	return ensureSelfLinks(execPath, binDir)
+	return ensureSelfLinks(execPath, binDir, exe, useSymlink)
+}
+
+// exeSuffix is the executable extension for goos: ".exe" on Windows, empty
+// elsewhere. Bundled binaries carry it in their own names; only the links rdd
+// invents (kubectl, and the standalone rdd and kubectl) need it appended.
+func exeSuffix(goos string) string {
+	if goos == "windows" {
+		return ".exe"
+	}
+	return ""
 }
 
 // inAppBundle reports whether execPath is the bundled rdd binary for the given
 // OS, as opposed to a standalone CLI install. The application stages its
 // per-platform resources under <resources>/<goos>/bin/rdd, where the directory
 // is "Resources" on macOS (the .app bundle convention) and lowercase
-// "resources" elsewhere. The leading separator anchors the match, so
-// an unrelated path ending in the same tail does not qualify.
+// "resources" elsewhere, the separator is a backslash on Windows, and the
+// binary carries a .exe suffix there. The leading separator anchors the match,
+// so an unrelated path ending in the same tail does not qualify.
 func inAppBundle(execPath, goos string) bool {
 	resources := "resources"
-	if goos == "darwin" {
+	sep := "/"
+	switch goos {
+	case "darwin":
 		resources = "Resources"
+	case "windows":
+		sep = `\`
 	}
-	return strings.HasSuffix(execPath, "/"+resources+"/"+goos+"/bin/rdd")
+	tail := strings.Join([]string{resources, goos, "bin", "rdd" + exeSuffix(goos)}, sep)
+	return strings.HasSuffix(execPath, sep+tail)
 }
 
-// linkBinaries recreates binDir with symlinks to the bundled binaries and a
-// kubectl link to rdd. Recreating it drops stale links from a previous install;
-// reading the source directory before removing binDir keeps the existing links
-// when the read fails.
-func linkBinaries(execPath, binDir string) error {
+// linkBinaries recreates binDir with links to the bundled binaries and a kubectl
+// link to rdd. Recreating it drops stale links from a previous install; reading
+// the source directory before removing binDir keeps the existing links when the
+// read fails.
+func linkBinaries(execPath, binDir, exe string, useSymlink bool) error {
 	srcDir := filepath.Dir(execPath)
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
@@ -75,29 +97,44 @@ func linkBinaries(execPath, binDir string) error {
 			continue
 		}
 		name := entry.Name()
-		if err := os.Symlink(filepath.Join(srcDir, name), filepath.Join(binDir, name)); err != nil {
+		if err := link(filepath.Join(srcDir, name), filepath.Join(binDir, name), useSymlink); err != nil {
 			return fmt.Errorf("link %q: %w", name, err)
 		}
 	}
 
 	// No separate kubectl binary is bundled; rdd provides it. Link kubectl to
 	// rdd so kubectl on PATH reaches rdd.
-	if err := os.Symlink(execPath, filepath.Join(binDir, "kubectl")); err != nil {
+	if err := link(execPath, filepath.Join(binDir, "kubectl"+exe), useSymlink); err != nil {
 		return fmt.Errorf("link kubectl: %w", err)
 	}
 	return nil
+}
+
+// link points linkPath at target, preferring a symlink for its self-documenting
+// target and falling back to a hardlink where symlinks need absent privileges
+// (Windows without developer mode). useSymlink false skips straight to a
+// hardlink. A hardlink stays current across app updates because rdd recreates
+// these links on every start; it works only within one volume, so the
+// cross-volume copy fallback is deferred (see #448).
+func link(target, linkPath string, useSymlink bool) error {
+	if useSymlink {
+		if err := os.Symlink(target, linkPath); err == nil {
+			return nil
+		}
+	}
+	return os.Link(target, linkPath)
 }
 
 // ensureSelfLinks points the rdd and kubectl links in binDir at a standalone
 // rdd, so the instance bin directory stays usable when no application bundle
 // has published them. It repairs each link only when it is missing or dangling
 // and leaves every other entry, including a working link, untouched.
-func ensureSelfLinks(execPath, binDir string) error {
+func ensureSelfLinks(execPath, binDir, exe string, useSymlink bool) error {
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		return fmt.Errorf("create %q: %w", binDir, err)
 	}
-	for _, name := range []string{"rdd", "kubectl"} {
-		if err := ensureSelfLink(filepath.Join(binDir, name), execPath); err != nil {
+	for _, name := range []string{"rdd" + exe, "kubectl" + exe} {
+		if err := ensureSelfLink(filepath.Join(binDir, name), execPath, useSymlink); err != nil {
 			return err
 		}
 	}
@@ -108,17 +145,22 @@ func ensureSelfLinks(execPath, binDir string) error {
 // existing file. A missing or dangling link is recreated; a working link
 // survives, so a link the application installed to a still-present binary is
 // left in place.
-func ensureSelfLink(linkPath, target string) error {
+//
+// This detects an uninstalled app only for symlinks: a symlink dangles once its
+// target is removed, while a hardlink keeps the inode alive and stays a valid
+// file, so an orphaned hardlink survives and leaves the user on the old binary.
+// Detecting that needs the app install location, not the link alone (see #448).
+func ensureSelfLink(linkPath, target string, useSymlink bool) error {
 	if _, err := os.Stat(linkPath); err == nil {
 		return nil
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("stat %q: %w", linkPath, err)
 	}
-	// Symlink fails when the path already exists, so drop a dangling link first.
+	// Linking fails when the path already exists, so drop a dangling link first.
 	if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove %q: %w", linkPath, err)
 	}
-	if err := os.Symlink(target, linkPath); err != nil {
+	if err := link(target, linkPath, useSymlink); err != nil {
 		return fmt.Errorf("link %q: %w", linkPath, err)
 	}
 	return nil

--- a/rdd/pkg/binlinks/binlinks.go
+++ b/rdd/pkg/binlinks/binlinks.go
@@ -20,14 +20,18 @@ import (
 	"runtime"
 	"strings"
 
+	"k8s.io/klog/v2"
+
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
 // LinkBundledBinaries publishes rdd's binaries into the instance bin directory.
 // Inside the application bundle it recreates the directory to mirror every
 // bundled binary; standalone it repairs only its own rdd and kubectl links.
-// Publishing is best-effort: the returned error is for the caller to log and
-// must not block startup.
+// Publishing is best-effort and must not block startup. A per-binary link
+// failure is logged and skipped; only a whole-operation failure — an unreadable
+// bundle directory or an unwritable bin directory — is returned for the caller
+// to log.
 func LinkBundledBinaries() error {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -98,14 +102,14 @@ func linkBinaries(execPath, binDir, exe string, useSymlink bool) error {
 		}
 		name := entry.Name()
 		if err := link(filepath.Join(srcDir, name), filepath.Join(binDir, name), useSymlink); err != nil {
-			return fmt.Errorf("link %q: %w", name, err)
+			klog.Warningf("Failed to link bundled binary %q, skipping: %v", name, err)
 		}
 	}
 
 	// No separate kubectl binary is bundled; rdd provides it. Link kubectl to
 	// rdd so kubectl on PATH reaches rdd.
 	if err := link(execPath, filepath.Join(binDir, "kubectl"+exe), useSymlink); err != nil {
-		return fmt.Errorf("link kubectl: %w", err)
+		klog.Warningf("Failed to link kubectl to rdd: %v", err)
 	}
 	return nil
 }
@@ -118,9 +122,13 @@ func linkBinaries(execPath, binDir, exe string, useSymlink bool) error {
 // cross-volume copy fallback is deferred (see #448).
 func link(target, linkPath string, useSymlink bool) error {
 	if useSymlink {
-		if err := os.Symlink(target, linkPath); err == nil {
+		err := os.Symlink(target, linkPath)
+		if err == nil {
 			return nil
 		}
+		// Falling back is expected where symlinks need absent privileges, so log
+		// the cause at a verbose level instead of warning on every such link.
+		klog.V(1).Infof("symlink %q -> %q failed, falling back to a hardlink: %v", linkPath, target, err)
 	}
 	return os.Link(target, linkPath)
 }
@@ -138,7 +146,7 @@ func ensureSelfLinks(execPath, binDir, exe string, useSymlink bool) error {
 	}
 	for _, name := range []string{"rdd" + exe, "kubectl" + exe} {
 		if err := ensureSelfLink(filepath.Join(binDir, name), execPath, useSymlink); err != nil {
-			return err
+			klog.Warningf("Failed to repair the %q link: %v", name, err)
 		}
 	}
 	return nil
@@ -150,6 +158,9 @@ func ensureSelfLinks(execPath, binDir, exe string, useSymlink bool) error {
 // searching on. Working links and non-symlink entries stay. A hardlink from an
 // uninstalled application is not dangling and survives, so it still shadows;
 // detecting that needs the app install location (see #448).
+//
+// An entry it cannot stat or remove is logged and skipped, so one failure does
+// not abort pruning the rest.
 func pruneDanglingLinks(binDir string) error {
 	entries, err := os.ReadDir(binDir)
 	if err != nil {
@@ -163,10 +174,11 @@ func pruneDanglingLinks(binDir string) error {
 		if _, err := os.Stat(linkPath); err == nil {
 			continue
 		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("stat %q: %w", linkPath, err)
+			klog.Warningf("Cannot stat %q while pruning dangling links, skipping: %v", linkPath, err)
+			continue
 		}
 		if err := os.Remove(linkPath); err != nil {
-			return fmt.Errorf("remove dangling link %q: %w", linkPath, err)
+			klog.Warningf("Failed to remove dangling link %q: %v", linkPath, err)
 		}
 	}
 	return nil

--- a/rdd/pkg/binlinks/binlinks.go
+++ b/rdd/pkg/binlinks/binlinks.go
@@ -4,9 +4,11 @@
 
 // Package binlinks publishes the binaries bundled with the Rancher Desktop
 // application into the instance bin directory (~/.rd<instance>/bin) as
-// symlinks, so a user can put that directory on PATH. It acts only when rdd
-// runs from inside the application bundle, so a standalone CLI install never
-// disturbs links the application created.
+// symlinks, so a user can put that directory on PATH. Inside the application
+// bundle rdd owns the directory and recreates it to mirror the bundled
+// binaries. Standalone, rdd repairs only its own rdd and kubectl links, and
+// only when they are missing or dangling, so links the application installed
+// survive and a CLI-only install still gets a usable rdd and kubectl.
 package binlinks
 
 import (
@@ -19,19 +21,21 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
-// LinkBundledBinaries publishes the application's bundled binaries into the
-// instance bin directory as symlinks. It is a no-op unless rdd runs from inside
-// the application bundle. Publishing is best-effort: the returned error is for
-// the caller to log and must not block startup.
+// LinkBundledBinaries publishes rdd's binaries into the instance bin directory
+// as symlinks. Inside the application bundle it recreates the directory to
+// mirror every bundled binary; standalone it repairs only its own rdd and
+// kubectl links. Publishing is best-effort: the returned error is for the
+// caller to log and must not block startup.
 func LinkBundledBinaries() error {
 	execPath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("locate executable: %w", err)
 	}
-	if !inAppBundle(execPath, runtime.GOOS) {
-		return nil
+	binDir := filepath.Join(instance.ShortDir(), "bin")
+	if inAppBundle(execPath, runtime.GOOS) {
+		return linkBinaries(execPath, binDir)
 	}
-	return linkBinaries(execPath, filepath.Join(instance.ShortDir(), "bin"))
+	return ensureSelfLinks(execPath, binDir)
 }
 
 // inAppBundle reports whether execPath is the bundled rdd binary for the given
@@ -80,6 +84,42 @@ func linkBinaries(execPath, binDir string) error {
 	// rdd so kubectl on PATH reaches rdd.
 	if err := os.Symlink(execPath, filepath.Join(binDir, "kubectl")); err != nil {
 		return fmt.Errorf("link kubectl: %w", err)
+	}
+	return nil
+}
+
+// ensureSelfLinks points the rdd and kubectl links in binDir at a standalone
+// rdd, so the instance bin directory stays usable when no application bundle
+// has published them. It repairs each link only when it is missing or dangling
+// and leaves every other entry, including a working link, untouched.
+func ensureSelfLinks(execPath, binDir string) error {
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return fmt.Errorf("create %q: %w", binDir, err)
+	}
+	for _, name := range []string{"rdd", "kubectl"} {
+		if err := ensureSelfLink(filepath.Join(binDir, name), execPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureSelfLink points linkPath at target unless it already resolves to an
+// existing file. A missing or dangling link is recreated; a working link
+// survives, so a link the application installed to a still-present binary is
+// left in place.
+func ensureSelfLink(linkPath, target string) error {
+	if _, err := os.Stat(linkPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %q: %w", linkPath, err)
+	}
+	// Symlink fails when the path already exists, so drop a dangling link first.
+	if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %q: %w", linkPath, err)
+	}
+	if err := os.Symlink(target, linkPath); err != nil {
+		return fmt.Errorf("link %q: %w", linkPath, err)
 	}
 	return nil
 }

--- a/rdd/pkg/binlinks/binlinks_test.go
+++ b/rdd/pkg/binlinks/binlinks_test.go
@@ -28,9 +28,21 @@ func TestInAppBundle(t *testing.T) {
 		},
 		{
 			name:     "Linux app bundle",
-			execPath: "/opt/rancher-desktop/Resources/linux/bin/rdd",
+			execPath: "/opt/rancher-desktop-2/resources/linux/bin/rdd",
 			goos:     "linux",
 			want:     true,
+		},
+		{
+			name:     "Linux path with macOS casing",
+			execPath: "/opt/rancher-desktop-2/Resources/linux/bin/rdd",
+			goos:     "linux",
+			want:     false,
+		},
+		{
+			name:     "macOS path with Linux casing",
+			execPath: "/Applications/Rancher Desktop.app/Contents/resources/darwin/bin/rdd",
+			goos:     "darwin",
+			want:     false,
 		},
 		{
 			name:     "standalone CLI install",
@@ -105,7 +117,8 @@ func TestLinkBinaries(t *testing.T) {
 
 // TestLinkBundledBinariesNoopWhenStandalone checks that LinkBundledBinaries is
 // a no-op outside the application bundle: the test binary's path never ends in
-// Resources/<goos>/bin/rdd, so the instance bin directory is never touched.
+// the bundled <resources>/<goos>/bin/rdd tail, so the instance bin directory is
+// never touched.
 func TestLinkBundledBinariesNoopWhenStandalone(t *testing.T) {
 	assert.NilError(t, LinkBundledBinaries())
 }

--- a/rdd/pkg/binlinks/binlinks_test.go
+++ b/rdd/pkg/binlinks/binlinks_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package binlinks
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestInAppBundle(t *testing.T) {
+	cases := []struct {
+		name     string
+		execPath string
+		goos     string
+		want     bool
+	}{
+		{
+			name:     "macOS app bundle",
+			execPath: "/Applications/Rancher Desktop.app/Contents/Resources/darwin/bin/rdd",
+			goos:     "darwin",
+			want:     true,
+		},
+		{
+			name:     "Linux app bundle",
+			execPath: "/opt/rancher-desktop/Resources/linux/bin/rdd",
+			goos:     "linux",
+			want:     true,
+		},
+		{
+			name:     "standalone CLI install",
+			execPath: "/usr/local/bin/rdd",
+			goos:     "darwin",
+			want:     false,
+		},
+		{
+			name:     "bundle path but goos mismatch",
+			execPath: "/Applications/Rancher Desktop.app/Contents/Resources/darwin/bin/rdd",
+			goos:     "linux",
+			want:     false,
+		},
+		{
+			name:     "unanchored suffix does not match",
+			execPath: "/home/user/fooResources/darwin/bin/rdd",
+			goos:     "darwin",
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, inAppBundle(tc.execPath, tc.goos), tc.want)
+		})
+	}
+}
+
+func TestLinkBinaries(t *testing.T) {
+	srcDir := t.TempDir()
+	bundled := []string{"rdd", "docker", "helm"}
+	for _, name := range bundled {
+		assert.NilError(t, os.WriteFile(filepath.Join(srcDir, name), []byte("binary"), 0o755), "write %q", name)
+	}
+	// A subdirectory beside the executable must not be linked.
+	assert.NilError(t, os.Mkdir(filepath.Join(srcDir, "subdir"), 0o755))
+	execPath := filepath.Join(srcDir, "rdd")
+
+	// Pre-populate binDir with a stale entry so the wipe can be verified.
+	binDir := filepath.Join(t.TempDir(), "bin")
+	assert.NilError(t, os.MkdirAll(binDir, 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(binDir, "stale"), []byte("old"), 0o644))
+
+	assert.NilError(t, linkBinaries(execPath, binDir))
+
+	// The stale entry from the previous install is gone.
+	_, err := os.Lstat(filepath.Join(binDir, "stale"))
+	assert.Assert(t, os.IsNotExist(err), "stale entry survived the wipe: %v", err)
+
+	// Every bundled file is linked to its source under the same name.
+	for _, name := range bundled {
+		assertSymlink(t, filepath.Join(binDir, name), filepath.Join(srcDir, name))
+	}
+
+	// kubectl is linked to the rdd executable.
+	assertSymlink(t, filepath.Join(binDir, "kubectl"), execPath)
+
+	// The subdirectory is not linked.
+	_, err = os.Lstat(filepath.Join(binDir, "subdir"))
+	assert.Assert(t, os.IsNotExist(err), "subdir was linked: %v", err)
+
+	// Only the bundled files plus kubectl are present.
+	entries, err := os.ReadDir(binDir)
+	assert.NilError(t, err)
+	var got []string
+	for _, e := range entries {
+		got = append(got, e.Name())
+	}
+	slices.Sort(got)
+	want := []string{"docker", "helm", "kubectl", "rdd"}
+	assert.Assert(t, slices.Equal(got, want), "binDir contents = %v, want %v", got, want)
+}
+
+// TestLinkBundledBinariesNoopWhenStandalone checks that LinkBundledBinaries is
+// a no-op outside the application bundle: the test binary's path never ends in
+// Resources/<goos>/bin/rdd, so the instance bin directory is never touched.
+func TestLinkBundledBinariesNoopWhenStandalone(t *testing.T) {
+	assert.NilError(t, LinkBundledBinaries())
+}
+
+// assertSymlink fails unless path is a symlink that points at want.
+func assertSymlink(t *testing.T, path, want string) {
+	t.Helper()
+	info, err := os.Lstat(path)
+	assert.NilError(t, err, "lstat %q", path)
+	assert.Assert(t, info.Mode()&os.ModeSymlink != 0, "%q is not a symlink", path)
+	target, err := os.Readlink(path)
+	assert.NilError(t, err, "readlink %q", path)
+	assert.Equal(t, target, want)
+}

--- a/rdd/pkg/binlinks/binlinks_test.go
+++ b/rdd/pkg/binlinks/binlinks_test.go
@@ -62,6 +62,30 @@ func TestInAppBundle(t *testing.T) {
 			goos:     "darwin",
 			want:     false,
 		},
+		{
+			name:     "Windows app bundle",
+			execPath: `C:\Program Files\Rancher Desktop\resources\windows\bin\rdd.exe`,
+			goos:     "windows",
+			want:     true,
+		},
+		{
+			name:     "Windows path without .exe suffix",
+			execPath: `C:\Program Files\Rancher Desktop\resources\windows\bin\rdd`,
+			goos:     "windows",
+			want:     false,
+		},
+		{
+			name:     "Windows path with forward slashes",
+			execPath: "C:/Program Files/Rancher Desktop/resources/windows/bin/rdd.exe",
+			goos:     "windows",
+			want:     false,
+		},
+		{
+			name:     "Windows standalone CLI install",
+			execPath: `C:\Users\me\bin\rdd.exe`,
+			goos:     "windows",
+			want:     false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -70,49 +94,67 @@ func TestInAppBundle(t *testing.T) {
 	}
 }
 
+// linkModes exercises both link kinds (symlink and the hardlink fallback) under
+// both name conventions (bare, and the .exe suffix Windows uses).
+var linkModes = []struct {
+	name       string
+	exe        string
+	useSymlink bool
+}{
+	{"symlinks", "", true},
+	{"hardlinks", "", false},
+	{"symlinks with exe suffix", ".exe", true},
+	{"hardlinks with exe suffix", ".exe", false},
+}
+
 func TestLinkBinaries(t *testing.T) {
-	srcDir := t.TempDir()
-	bundled := []string{"rdd", "docker", "helm"}
-	for _, name := range bundled {
-		assert.NilError(t, os.WriteFile(filepath.Join(srcDir, name), []byte("binary"), 0o755), "write %q", name)
+	for _, tc := range linkModes {
+		t.Run(tc.name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			bundled := []string{"rdd" + tc.exe, "docker" + tc.exe, "helm" + tc.exe}
+			for _, name := range bundled {
+				assert.NilError(t, os.WriteFile(filepath.Join(srcDir, name), []byte("binary"), 0o755), "write %q", name)
+			}
+			// A subdirectory beside the executable must not be linked.
+			assert.NilError(t, os.Mkdir(filepath.Join(srcDir, "subdir"), 0o755))
+			execPath := filepath.Join(srcDir, "rdd"+tc.exe)
+
+			// Pre-populate binDir with a stale entry so the wipe can be verified.
+			binDir := filepath.Join(t.TempDir(), "bin")
+			assert.NilError(t, os.MkdirAll(binDir, 0o755))
+			assert.NilError(t, os.WriteFile(filepath.Join(binDir, "stale"), []byte("old"), 0o644))
+
+			assert.NilError(t, linkBinaries(execPath, binDir, tc.exe, tc.useSymlink))
+
+			// The stale entry from the previous install is gone.
+			_, err := os.Lstat(filepath.Join(binDir, "stale"))
+			assert.Assert(t, os.IsNotExist(err), "stale entry survived the wipe: %v", err)
+
+			// Every bundled file is linked to its source under the same name.
+			for _, name := range bundled {
+				assertLink(t, filepath.Join(binDir, name), filepath.Join(srcDir, name), tc.useSymlink)
+			}
+
+			// kubectl is linked to the rdd executable.
+			assertLink(t, filepath.Join(binDir, "kubectl"+tc.exe), execPath, tc.useSymlink)
+
+			// The subdirectory is not linked.
+			_, err = os.Lstat(filepath.Join(binDir, "subdir"))
+			assert.Assert(t, os.IsNotExist(err), "subdir was linked: %v", err)
+
+			// Only the bundled files plus kubectl are present.
+			entries, err := os.ReadDir(binDir)
+			assert.NilError(t, err)
+			var got []string
+			for _, e := range entries {
+				got = append(got, e.Name())
+			}
+			slices.Sort(got)
+			want := append([]string{"kubectl" + tc.exe}, bundled...)
+			slices.Sort(want)
+			assert.Assert(t, slices.Equal(got, want), "binDir contents = %v, want %v", got, want)
+		})
 	}
-	// A subdirectory beside the executable must not be linked.
-	assert.NilError(t, os.Mkdir(filepath.Join(srcDir, "subdir"), 0o755))
-	execPath := filepath.Join(srcDir, "rdd")
-
-	// Pre-populate binDir with a stale entry so the wipe can be verified.
-	binDir := filepath.Join(t.TempDir(), "bin")
-	assert.NilError(t, os.MkdirAll(binDir, 0o755))
-	assert.NilError(t, os.WriteFile(filepath.Join(binDir, "stale"), []byte("old"), 0o644))
-
-	assert.NilError(t, linkBinaries(execPath, binDir))
-
-	// The stale entry from the previous install is gone.
-	_, err := os.Lstat(filepath.Join(binDir, "stale"))
-	assert.Assert(t, os.IsNotExist(err), "stale entry survived the wipe: %v", err)
-
-	// Every bundled file is linked to its source under the same name.
-	for _, name := range bundled {
-		assertSymlink(t, filepath.Join(binDir, name), filepath.Join(srcDir, name))
-	}
-
-	// kubectl is linked to the rdd executable.
-	assertSymlink(t, filepath.Join(binDir, "kubectl"), execPath)
-
-	// The subdirectory is not linked.
-	_, err = os.Lstat(filepath.Join(binDir, "subdir"))
-	assert.Assert(t, os.IsNotExist(err), "subdir was linked: %v", err)
-
-	// Only the bundled files plus kubectl are present.
-	entries, err := os.ReadDir(binDir)
-	assert.NilError(t, err)
-	var got []string
-	for _, e := range entries {
-		got = append(got, e.Name())
-	}
-	slices.Sort(got)
-	want := []string{"docker", "helm", "kubectl", "rdd"}
-	assert.Assert(t, slices.Equal(got, want), "binDir contents = %v, want %v", got, want)
 }
 
 // TestEnsureSelfLinks checks the standalone path: a missing or dangling rdd or
@@ -138,7 +180,7 @@ func TestEnsureSelfLinks(t *testing.T) {
 	docker := filepath.Join(binDir, "docker")
 	assert.NilError(t, os.Symlink(filepath.Join(srcDir, "docker"), docker))
 
-	assert.NilError(t, ensureSelfLinks(execPath, binDir))
+	assert.NilError(t, ensureSelfLinks(execPath, binDir, "", true))
 
 	// The working rdd link is preserved, still pointing at the app binary.
 	assertSymlink(t, filepath.Join(binDir, "rdd"), appRdd)
@@ -152,15 +194,30 @@ func TestEnsureSelfLinks(t *testing.T) {
 // the app was never installed — gets one with rdd and kubectl linked to the
 // running rdd.
 func TestEnsureSelfLinksCreatesDir(t *testing.T) {
-	srcDir := t.TempDir()
-	execPath := filepath.Join(srcDir, "rdd")
-	assert.NilError(t, os.WriteFile(execPath, []byte("binary"), 0o755))
+	for _, tc := range linkModes {
+		t.Run(tc.name, func(t *testing.T) {
+			srcDir := t.TempDir()
+			execPath := filepath.Join(srcDir, "rdd"+tc.exe)
+			assert.NilError(t, os.WriteFile(execPath, []byte("binary"), 0o755))
 
-	binDir := filepath.Join(t.TempDir(), "bin")
-	assert.NilError(t, ensureSelfLinks(execPath, binDir))
+			binDir := filepath.Join(t.TempDir(), "bin")
+			assert.NilError(t, ensureSelfLinks(execPath, binDir, tc.exe, tc.useSymlink))
 
-	assertSymlink(t, filepath.Join(binDir, "rdd"), execPath)
-	assertSymlink(t, filepath.Join(binDir, "kubectl"), execPath)
+			assertLink(t, filepath.Join(binDir, "rdd"+tc.exe), execPath, tc.useSymlink)
+			assertLink(t, filepath.Join(binDir, "kubectl"+tc.exe), execPath, tc.useSymlink)
+		})
+	}
+}
+
+// assertLink fails unless path is the kind of link to want that link() creates
+// for useSymlink: a symlink pointing at want, or a hardlink sharing its file.
+func assertLink(t *testing.T, path, want string, useSymlink bool) {
+	t.Helper()
+	if useSymlink {
+		assertSymlink(t, path, want)
+		return
+	}
+	assertHardlink(t, path, want)
 }
 
 // assertSymlink fails unless path is a symlink that points at want.
@@ -172,4 +229,18 @@ func assertSymlink(t *testing.T, path, want string) {
 	target, err := os.Readlink(path)
 	assert.NilError(t, err, "readlink %q", path)
 	assert.Equal(t, target, want)
+}
+
+// assertHardlink fails unless path is a hardlink to want: not a symlink, and
+// sharing want's file identity.
+func assertHardlink(t *testing.T, path, want string) {
+	t.Helper()
+	link, err := os.Lstat(path)
+	assert.NilError(t, err, "lstat %q", path)
+	assert.Assert(t, link.Mode()&os.ModeSymlink == 0, "%q is a symlink, want a hardlink", path)
+	pathInfo, err := os.Stat(path)
+	assert.NilError(t, err, "stat %q", path)
+	wantInfo, err := os.Stat(want)
+	assert.NilError(t, err, "stat %q", want)
+	assert.Assert(t, os.SameFile(pathInfo, wantInfo), "%q is not a hardlink to %q", path, want)
 }

--- a/rdd/pkg/binlinks/binlinks_test.go
+++ b/rdd/pkg/binlinks/binlinks_test.go
@@ -176,9 +176,11 @@ func TestEnsureSelfLinks(t *testing.T) {
 	// A dangling kubectl link must be replaced.
 	assert.NilError(t, os.Symlink(filepath.Join(srcDir, "gone"), filepath.Join(binDir, "kubectl")))
 
-	// An unrelated entry must be left untouched.
+	// An unrelated working link must be left untouched.
+	dockerTarget := filepath.Join(srcDir, "docker")
+	assert.NilError(t, os.WriteFile(dockerTarget, []byte("binary"), 0o755))
 	docker := filepath.Join(binDir, "docker")
-	assert.NilError(t, os.Symlink(filepath.Join(srcDir, "docker"), docker))
+	assert.NilError(t, os.Symlink(dockerTarget, docker))
 
 	assert.NilError(t, ensureSelfLinks(execPath, binDir, "", true))
 
@@ -186,8 +188,8 @@ func TestEnsureSelfLinks(t *testing.T) {
 	assertSymlink(t, filepath.Join(binDir, "rdd"), appRdd)
 	// The dangling kubectl link now points at the running executable.
 	assertSymlink(t, filepath.Join(binDir, "kubectl"), execPath)
-	// The unrelated link is left as it was.
-	assertSymlink(t, docker, filepath.Join(srcDir, "docker"))
+	// The unrelated working link is left as it was.
+	assertSymlink(t, docker, dockerTarget)
 }
 
 // TestEnsureSelfLinksCreatesDir checks that an instance with no bin directory —
@@ -207,6 +209,41 @@ func TestEnsureSelfLinksCreatesDir(t *testing.T) {
 			assertLink(t, filepath.Join(binDir, "kubectl"+tc.exe), execPath, tc.useSymlink)
 		})
 	}
+}
+
+// TestEnsureSelfLinksPrunesDangling checks the uninstall path: a standalone rdd
+// removes symlinks left dangling by a removed app so they cannot shadow a tool
+// on PATH, while repairing its own rdd and kubectl links and leaving a working
+// link and a plain file alone.
+func TestEnsureSelfLinksPrunesDangling(t *testing.T) {
+	srcDir := t.TempDir()
+	execPath := filepath.Join(srcDir, "rdd")
+	assert.NilError(t, os.WriteFile(execPath, []byte("binary"), 0o755))
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	assert.NilError(t, os.MkdirAll(binDir, 0o755))
+
+	// A removed app leaves docker dangling, and rdd's own link dangling too.
+	assert.NilError(t, os.Symlink(filepath.Join(srcDir, "gone"), filepath.Join(binDir, "docker")))
+	assert.NilError(t, os.Symlink(filepath.Join(srcDir, "gone"), filepath.Join(binDir, "rdd")))
+	// A working tool link and a plain file must survive.
+	tool := filepath.Join(srcDir, "helm-real")
+	assert.NilError(t, os.WriteFile(tool, []byte("binary"), 0o755))
+	assert.NilError(t, os.Symlink(tool, filepath.Join(binDir, "helm")))
+	assert.NilError(t, os.WriteFile(filepath.Join(binDir, "notes"), []byte("keep"), 0o644))
+
+	assert.NilError(t, ensureSelfLinks(execPath, binDir, "", true))
+
+	// The dangling docker link is pruned, not repaired: rdd does not provide it.
+	_, err := os.Lstat(filepath.Join(binDir, "docker"))
+	assert.Assert(t, os.IsNotExist(err), "dangling docker link survived: %v", err)
+	// rdd and kubectl are repaired to the running standalone rdd.
+	assertSymlink(t, filepath.Join(binDir, "rdd"), execPath)
+	assertSymlink(t, filepath.Join(binDir, "kubectl"), execPath)
+	// The working link and the plain file survive.
+	assertSymlink(t, filepath.Join(binDir, "helm"), tool)
+	_, err = os.Lstat(filepath.Join(binDir, "notes"))
+	assert.NilError(t, err, "plain file was removed")
 }
 
 // assertLink fails unless path is the kind of link to want that link() creates

--- a/rdd/pkg/binlinks/binlinks_test.go
+++ b/rdd/pkg/binlinks/binlinks_test.go
@@ -115,12 +115,52 @@ func TestLinkBinaries(t *testing.T) {
 	assert.Assert(t, slices.Equal(got, want), "binDir contents = %v, want %v", got, want)
 }
 
-// TestLinkBundledBinariesNoopWhenStandalone checks that LinkBundledBinaries is
-// a no-op outside the application bundle: the test binary's path never ends in
-// the bundled <resources>/<goos>/bin/rdd tail, so the instance bin directory is
-// never touched.
-func TestLinkBundledBinariesNoopWhenStandalone(t *testing.T) {
-	assert.NilError(t, LinkBundledBinaries())
+// TestEnsureSelfLinks checks the standalone path: a missing or dangling rdd or
+// kubectl link is repaired to point at the running executable, while a working
+// link and any unrelated entry are left untouched.
+func TestEnsureSelfLinks(t *testing.T) {
+	srcDir := t.TempDir()
+	execPath := filepath.Join(srcDir, "rdd")
+	assert.NilError(t, os.WriteFile(execPath, []byte("binary"), 0o755))
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	assert.NilError(t, os.MkdirAll(binDir, 0o755))
+
+	// A working rdd link to a still-present binary must survive.
+	appRdd := filepath.Join(srcDir, "app-rdd")
+	assert.NilError(t, os.WriteFile(appRdd, []byte("binary"), 0o755))
+	assert.NilError(t, os.Symlink(appRdd, filepath.Join(binDir, "rdd")))
+
+	// A dangling kubectl link must be replaced.
+	assert.NilError(t, os.Symlink(filepath.Join(srcDir, "gone"), filepath.Join(binDir, "kubectl")))
+
+	// An unrelated entry must be left untouched.
+	docker := filepath.Join(binDir, "docker")
+	assert.NilError(t, os.Symlink(filepath.Join(srcDir, "docker"), docker))
+
+	assert.NilError(t, ensureSelfLinks(execPath, binDir))
+
+	// The working rdd link is preserved, still pointing at the app binary.
+	assertSymlink(t, filepath.Join(binDir, "rdd"), appRdd)
+	// The dangling kubectl link now points at the running executable.
+	assertSymlink(t, filepath.Join(binDir, "kubectl"), execPath)
+	// The unrelated link is left as it was.
+	assertSymlink(t, docker, filepath.Join(srcDir, "docker"))
+}
+
+// TestEnsureSelfLinksCreatesDir checks that an instance with no bin directory —
+// the app was never installed — gets one with rdd and kubectl linked to the
+// running rdd.
+func TestEnsureSelfLinksCreatesDir(t *testing.T) {
+	srcDir := t.TempDir()
+	execPath := filepath.Join(srcDir, "rdd")
+	assert.NilError(t, os.WriteFile(execPath, []byte("binary"), 0o755))
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	assert.NilError(t, ensureSelfLinks(execPath, binDir))
+
+	assertSymlink(t, filepath.Join(binDir, "rdd"), execPath)
+	assertSymlink(t, filepath.Join(binDir, "kubectl"), execPath)
 }
 
 // assertSymlink fails unless path is a symlink that points at want.

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -718,9 +718,9 @@ func NewServeCommand(ctx context.Context) *cobra.Command {
 			cliflag.PrintFlags(fs)
 
 			// Publish the application's bundled binaries to the instance bin
-			// directory. Only macOS and Linux do this. Best-effort: a failure
-			// must not block the control plane.
-			if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+			// directory. Every platform except Windows does this. Best-effort: a
+			// failure must not block the control plane.
+			if runtime.GOOS != "windows" {
 				if err := binlinks.LinkBundledBinaries(); err != nil {
 					klog.Warningf("Failed to link bundled binaries: %v", err)
 				}

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -53,6 +53,7 @@ import (
 	// Justify blank import.
 	_ "k8s.io/kubernetes/pkg/features"
 
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/binlinks"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/help"
 	// Import controller packages to trigger init() functions for embedded mode.
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/app"
@@ -715,6 +716,15 @@ func NewServeCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 			cliflag.PrintFlags(fs)
+
+			// Publish the application's bundled binaries to the instance bin
+			// directory. Only macOS and Linux do this. Best-effort: a failure
+			// must not block the control plane.
+			if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+				if err := binlinks.LinkBundledBinaries(); err != nil {
+					klog.Warningf("Failed to link bundled binaries: %v", err)
+				}
+			}
 
 			completedOptions, err := s.Complete(cmd.Context())
 			if err != nil {

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -718,12 +718,9 @@ func NewServeCommand(ctx context.Context) *cobra.Command {
 			cliflag.PrintFlags(fs)
 
 			// Publish the application's bundled binaries to the instance bin
-			// directory. Every platform except Windows does this. Best-effort: a
-			// failure must not block the control plane.
-			if runtime.GOOS != "windows" {
-				if err := binlinks.LinkBundledBinaries(); err != nil {
-					klog.Warningf("Failed to link bundled binaries: %v", err)
-				}
+			// directory. Best-effort: a failure must not block the control plane.
+			if err := binlinks.LinkBundledBinaries(); err != nil {
+				klog.Warningf("Failed to link bundled binaries: %v", err)
 			}
 
 			completedOptions, err := s.Complete(cmd.Context())


### PR DESCRIPTION
When rdd runs from inside the Rancher Desktop application bundle, publish the bundled binaries into `~/.rd<instance>/bin` as symlinks so a user can put that directory on `PATH`. The new `pkg/binlinks` recreates the directory on each daemon startup and links every file beside the `rdd` executable under the same name, plus a `kubectl` link to `rdd`.

A standalone CLI install makes no change, so it never removes links the application created. Publishing is best-effort: on failure the daemon logs a warning and startup continues.

A BATS test drives a fake app bundle through the daemon to confirm the links are created from the bundle, survive a start from outside it, and update when the bundle changes.

Refs #385
