### PR TITLE
Turn rdd into a multi-call binary

### DIFF
--- a/rdd/bats/tests/10-cli/7-multicall.bats
+++ b/rdd/bats/tests/10-cli/7-multicall.bats
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-FileCopyrightText: The Rancher Desktop Authors
+# SPDX-FileCopyrightText: Copyright The Lima Authors
+
+# The symlink mechanism is adapted from
+# https://github.com/lima-vm/lima/blob/master/hack/bats/tests/yq.bats
+
+load '../../helpers/load'
+
+# link_rdd_as symlinks the rdd binary under <name> in the per-test temp dir, so
+# invoking "${BATS_TEST_TMPDIR}/<name>" runs rdd as a multi-call binary.
+link_rdd_as() { # <name>
+    ln -sf "${PATH_REPO_ROOT}/bin/rdd${EXE}" "${BATS_TEST_TMPDIR}/$1"
+}
+
+@test 'a kubectl symlink runs the embedded kubectl' {
+    link_rdd_as "kubectl${EXE}"
+    run -0 "${BATS_TEST_TMPDIR}/kubectl${EXE}" version --client
+    assert_line --partial "Client Version"
+}
+
+@test 'a yq symlink runs the embedded yq' {
+    link_rdd_as "yq${EXE}"
+    run -0 "${BATS_TEST_TMPDIR}/yq${EXE}" --version
+    assert_output --regexp '^yq .*mikefarah.* version v'
+}
+
+@test 'multi-call detection strips all extensions' {
+    # A name like yq.rdd or yq.rdd.exe still dispatches to yq.
+    link_rdd_as "yq.rdd${EXE}"
+    run -0 "${BATS_TEST_TMPDIR}/yq.rdd${EXE}" -n .foo=42
+    assert_output 'foo: 42'
+}
+
+@test 'an unrecognized name runs rdd normally' {
+    link_rdd_as "notacommand${EXE}"
+    run -0 "${BATS_TEST_TMPDIR}/notacommand${EXE}" version
+    # Matches a git version tag or a commit hash, like 1-version.bats.
+    assert_output --regexp '^(v[0-9]+\.[0-9]+\.[0-9]+|[a-f0-9]{7,})'
+}

--- a/rdd/bats/tests/10-cli/7-multicall.bats
+++ b/rdd/bats/tests/10-cli/7-multicall.bats
@@ -16,8 +16,8 @@ link_rdd_as() { # <name>
 
 @test 'a kubectl symlink runs the embedded kubectl' {
     link_rdd_as "kubectl${EXE}"
-    run -0 "${BATS_TEST_TMPDIR}/kubectl${EXE}" version --client
-    assert_line --partial "Client Version"
+    run -0 "${BATS_TEST_TMPDIR}/kubectl${EXE}" --help
+    assert_line --partial 'kubectl controls the Kubernetes cluster manager.'
 }
 
 @test 'a yq symlink runs the embedded yq' {
@@ -35,7 +35,6 @@ link_rdd_as() { # <name>
 
 @test 'an unrecognized name runs rdd normally' {
     link_rdd_as "notacommand${EXE}"
-    run -0 "${BATS_TEST_TMPDIR}/notacommand${EXE}" version
-    # Matches a git version tag or a commit hash, like 1-version.bats.
-    assert_output --regexp '^(v[0-9]+\.[0-9]+\.[0-9]+|[a-f0-9]{7,})'
+    run -0 "${BATS_TEST_TMPDIR}/notacommand${EXE}" --help
+    assert_line --partial 'RDD manages the Rancher Desktop 2 background services.'
 }

--- a/rdd/cmd/rdd/main.go
+++ b/rdd/cmd/rdd/main.go
@@ -120,6 +120,7 @@ func newVersionCommand() *cobra.Command {
 }
 
 func main() {
+	os.Args = multiCallArgs(os.Args)
 	parseInstanceFlag()
 
 	cmd := &cobra.Command{

--- a/rdd/cmd/rdd/multicall.go
+++ b/rdd/cmd/rdd/multicall.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+// SPDX-FileCopyrightText: Copyright The Lima Authors
+
+// The name detection here is adapted from MaybeRunYQ in
+// https://github.com/lima-vm/lima/blob/master/cmd/yq/yq.go
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// multiCallArgs lets rdd run as an embedded command (kubectl, yq) when invoked
+// under that name via a symlink or rename, inserting the matching subcommand
+// for Cobra to dispatch. The name is argv[0]'s basename minus extensions;
+// os.Executable() would resolve symlinks back to rdd on Linux.
+func multiCallArgs(args []string) []string {
+	name := filepath.Base(args[0])
+	name, _, _ = strings.Cut(name, ".")
+	switch name {
+	case "kubectl", "yq":
+		return append([]string{args[0], name}, args[1:]...)
+	}
+	return args
+}

--- a/rdd/cmd/rdd/multicall_test.go
+++ b/rdd/cmd/rdd/multicall_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMultiCallArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{"rdd runs normally", []string{"rdd", "start"}, []string{"rdd", "start"}},
+		{"rdd.exe runs normally", []string{"rdd.exe", "start"}, []string{"rdd.exe", "start"}},
+		{"kubectl symlink", []string{"kubectl", "get", "pods"}, []string{"kubectl", "kubectl", "get", "pods"}},
+		{"kubectl with path", []string{"/usr/local/bin/kubectl", "get"}, []string{"/usr/local/bin/kubectl", "kubectl", "get"}},
+		{"kubectl.exe", []string{"kubectl.exe", "version"}, []string{"kubectl.exe", "kubectl", "version"}},
+		{"kubectl no args", []string{"kubectl"}, []string{"kubectl", "kubectl"}},
+		{"yq symlink", []string{"yq", ".foo"}, []string{"yq", "yq", ".foo"}},
+		{"yq with extra extensions", []string{"yq.rdd.exe", ".foo"}, []string{"yq.rdd.exe", "yq", ".foo"}},
+		{"name only contains kubectl", []string{"kubectllike", "get"}, []string{"kubectllike", "get"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.DeepEqual(t, multiCallArgs(tc.args), tc.want)
+		})
+	}
+}

--- a/rdd/cmd/rdd/multicall_test.go
+++ b/rdd/cmd/rdd/multicall_test.go
@@ -18,6 +18,7 @@ func TestMultiCallArgs(t *testing.T) {
 	}{
 		{"rdd runs normally", []string{"rdd", "start"}, []string{"rdd", "start"}},
 		{"rdd.exe runs normally", []string{"rdd.exe", "start"}, []string{"rdd.exe", "start"}},
+		{"rdd with a multi-call subcommand", []string{"rdd", "kubectl", "cluster-info"}, []string{"rdd", "kubectl", "cluster-info"}},
 		{"kubectl symlink", []string{"kubectl", "get", "pods"}, []string{"kubectl", "kubectl", "get", "pods"}},
 		{"kubectl with path", []string{"/usr/local/bin/kubectl", "get"}, []string{"/usr/local/bin/kubectl", "kubectl", "get"}},
 		{"kubectl.exe", []string{"kubectl.exe", "version"}, []string{"kubectl.exe", "kubectl", "version"}},


### PR DESCRIPTION
Dispatch to the embedded `kubectl` and `yq` subcommands when `rdd` is invoked under their name via a symlink or rename. Use `argv[0]`'s basename, not `os.Executable()`, which resolves symlinks back to `rdd` on Linux.

Implements #439.