### PR TITLE
Add CI telemetry collectors and a probe analyzer

### DIFF
--- a/.github/actions/macos-telemetry-sampler/action.yaml
+++ b/.github/actions/macos-telemetry-sampler/action.yaml
@@ -1,0 +1,46 @@
+name: macOS Telemetry Sampler
+description: >-
+  Low-overhead host sampling on macOS runners. Every ~15s capture a
+  timestamp, iostat disk throughput, a two-sample top (per-process %CPU
+  needs the second sample), a ps listing, and vm_stat counters. The log
+  attributes runner-side CPU and disk pressure when a Lima VM misbehaves.
+
+inputs:
+  command:
+    description: '"start" to launch the sampler, "stop" to terminate it.'
+    required: true
+  output-dir:
+    description: Directory for host-probe.log and the sampler pid file.
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Start sampler
+    if: runner.os == 'macOS' && inputs.command == 'start'
+    shell: bash
+    run: |
+      mkdir -p "${{ inputs.output-dir }}"
+      nohup bash -c 'while true; do
+          date -u +%FT%TZ
+          iostat -d -w 1 -c 2
+          top -l 2 -n 8 -stats pid,command,cpu,state -o cpu | tail -n 20
+          ps -Ao pid,pcpu,state,comm -r | head -n 12
+          vm_stat | head -n 8
+          sleep 15
+      done' >> "${{ inputs.output-dir }}/host-probe.log" 2>&1 &
+      echo $! > "${{ inputs.output-dir }}/host-probe.pid"
+      echo "host sampler started, pid=$(cat "${{ inputs.output-dir }}/host-probe.pid")"
+
+  - name: Stop sampler
+    if: runner.os == 'macOS' && inputs.command == 'stop'
+    shell: bash
+    run: |
+      pidfile="${{ inputs.output-dir }}/host-probe.pid"
+      if [[ -f "${pidfile}" ]]; then
+        kill "$(cat "${pidfile}")" 2>/dev/null || true
+        rm -f "${pidfile}"
+      fi
+      if [[ -f "${{ inputs.output-dir }}/host-probe.log" ]]; then
+        wc -l "${{ inputs.output-dir }}/host-probe.log"
+      fi

--- a/.github/workflows/rdd-bats.yaml
+++ b/.github/workflows/rdd-bats.yaml
@@ -206,6 +206,14 @@ jobs:
         output-dir: rdd/rdd-logs/_diag
       continue-on-error: true
 
+    - name: "macOS: start host telemetry sampler"
+      if: needs.check-paths.outputs.should-run && runner.os == 'macOS'
+      uses: ./.github/actions/macos-telemetry-sampler
+      with:
+        command: start
+        output-dir: rdd/rdd-logs/_diag
+      continue-on-error: true
+
     - name: Configure BATS targets
       if: needs.check-paths.outputs.should-run
       shell: bash
@@ -231,6 +239,17 @@ jobs:
       env:
         RDD_TRACE: true
         RDD_LOG_LEVEL: trace
+        # Run the in-guest telemetry sampler on every platform; the serial
+        # console captures it under QEMU and VZ (WSL2 capture is a follow-up).
+        RDD_VM_TELEMETRY: "1"
+
+    - name: "macOS: stop host telemetry sampler"
+      if: always() && needs.check-paths.outputs.should-run && runner.os == 'macOS'
+      uses: ./.github/actions/macos-telemetry-sampler
+      with:
+        command: stop
+        output-dir: rdd/rdd-logs/_diag
+      continue-on-error: true
 
     - name: "Windows: stop typeperf sampler"
       if: always() && needs.check-paths.outputs.should-run && runner.os == 'Windows'

--- a/rdd/docs/design/environment.md
+++ b/rdd/docs/design/environment.md
@@ -13,6 +13,7 @@ These variables control RDD behavior. Set them before running `rdd` commands.
 | `RDD_KEEP_LOGS` | Preserves logs for post-mortem debugging. See [Log Preservation](#log-preservation) for details. | unset |
 | `RDD_LOG_LEVEL` | Sets the log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`). Overridden by `--log-level` flag. When unset, defaults to `debug` in developer mode, `warn` otherwise. | unset |
 | `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
+| `RDD_VM_TELEMETRY` | When set, the app VM runs a telemetry sampler that logs substrate probes (load, PSI, CPU split, per-process top, single-thread speed, disk latency) to the serial console every 15s. CI enables it so artifacts and support bundles carry measurements; analyze captures with `scripts/probe-analyze.go`. | unset |
 
 ### BATS Test Variables
 

--- a/rdd/pkg/controllers/app/app/controllers/app_controller.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller.go
@@ -112,6 +112,11 @@ func (r *AppReconciler) kubernetesEnabled(ctx context.Context) bool {
 	return slices.Contains(enabled, v1alpha1.KubernetesControllerName)
 }
 
+// vmTelemetryEnv enables the guest telemetry sampler in the Lima template.
+// CI sets it so the guest logs substrate probes to the serial console;
+// user VMs keep the sampler off.
+const vmTelemetryEnv = "RDD_VM_TELEMETRY"
+
 func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesPort int) (string, error) {
 	hostHome, err := os.UserHomeDir()
 	if err != nil {
@@ -127,6 +132,7 @@ func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesP
 		fmt.Sprintf("  KUBERNETES_ENABLED: %v", spec.Kubernetes.Enabled),
 		fmt.Sprintf("  KUBERNETES_VERSION: %s", spec.Kubernetes.Version),
 		fmt.Sprintf("  KUBERNETES_PORT: %d", kubernetesPort),
+		fmt.Sprintf("  VM_TELEMETRY: %v", os.Getenv(vmTelemetryEnv) != ""),
 		"",
 	}, "\n"), nil
 }

--- a/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -454,6 +454,23 @@ func Test_applySpecToTemplate(t *testing.T) {
 	}
 }
 
+// Test_applySpecToTemplate_VMTelemetry is not parallel: t.Setenv forbids it.
+func Test_applySpecToTemplate_VMTelemetry(t *testing.T) {
+	spec := v1alpha1.AppSpec{Kubernetes: v1alpha1.KubernetesSpec{Enabled: false}}
+
+	t.Setenv(vmTelemetryEnv, "")
+	got, err := applySpecToTemplate("", spec, 0)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(got, "  VM_TELEMETRY: false"),
+		"unset env must disable the sampler, got:\n%s", got)
+
+	t.Setenv(vmTelemetryEnv, "1")
+	got, err = applySpecToTemplate("", spec, 0)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(got, "  VM_TELEMETRY: true"),
+		"set env must enable the sampler, got:\n%s", got)
+}
+
 // newTestScheme returns a scheme with all types the AppReconciler touches.
 func newTestScheme(t *testing.T) *k8sruntime.Scheme {
 	t.Helper()

--- a/rdd/pkg/controllers/app/app/lima-template.yaml
+++ b/rdd/pkg/controllers/app/app/lima-template.yaml
@@ -44,6 +44,65 @@ provision:
     KUBERNETES_ENABLED={{.Param.KUBERNETES_ENABLED}}
     KUBERNETES_VERSION={{.Param.KUBERNETES_VERSION}}
     KUBERNETES_PORT={{.Param.KUBERNETES_PORT}}
+# Substrate telemetry sampler, enabled host-side via RDD_VM_TELEMETRY (CI
+# sets it; user VMs skip the block). Every 15s it logs scheduling and I/O
+# health to the serial console, so CI artifacts and support bundles carry
+# measurements of the guest substrate: load, PSI when the kernel offers it,
+# raw /proc/stat for user/system/iowait deltas, a busybox-top process
+# listing (second iteration — the first has no deltas), a single-threaded
+# hash as the vCPU-count-independent speed probe, and disk-latency probes
+# when the VM has a virtio disk (WSL2 has none). Runs before the main
+# provision script to cover the k3s install phase. Analyze captures with
+# scripts/probe-analyze.go.
+- mode: system
+  script: |
+    #!/bin/bash
+
+    [[ ${PARAM_VM_TELEMETRY:-false} == "true" ]] || exit 0
+
+    (
+        exec >/dev/console 2>&1
+        echo "PROBE start kernel=$(uname -r)"
+        blocks_4k=0
+        if [[ -b /dev/vda ]]; then
+            blocks_4k=$(($(blockdev --getsz /dev/vda) / 8))
+        fi
+        # Fixed blob for the single-thread probe; after the first pass it
+        # reads from the page cache, so the hash time measures one core's
+        # effective speed (host core speed + steal) independent of the
+        # vCPU count.
+        dd if=/dev/zero of=/var/tmp/.probe-blob bs=1M count=64 status=none
+        while true; do
+            echo "PROBE tick $(date -u +%H:%M:%S) load $(cat /proc/loadavg)"
+            for f in io cpu memory; do
+                if [[ -r /proc/pressure/$f ]]; then
+                    echo "PROBE psi-$f $(tr '\n' ';' </proc/pressure/$f)"
+                else
+                    echo "PROBE psi-$f absent"
+                fi
+            done
+            echo "PROBE cpustat $(head -1 /proc/stat)"
+            if command -v busybox >/dev/null; then
+                busybox top -b -n 2 -d 1 2>/dev/null | awk '/^Mem:/{i++} i==2' \
+                    | head -22 | sed 's/^/PROBE ptop /'
+            fi
+            t0=$(date +%s%N)
+            sha256sum /var/tmp/.probe-blob >/dev/null 2>&1 || true
+            echo "PROBE st-hash-ms $((($(date +%s%N) - t0) / 1000000))"
+            t0=$(date +%s%N)
+            dd if=/dev/zero of=/var/tmp/.probe bs=4096 count=8 conv=fsync status=none || true
+            echo "PROBE syncwrite-us $((($(date +%s%N) - t0) / 1000))"
+            if ((blocks_4k > 16)); then
+                echo "PROBE diskstats $(grep ' vda ' /proc/diskstats || true)"
+                t0=$(date +%s%N)
+                dd if=/dev/vda of=/dev/null bs=4096 count=16 iflag=direct \
+                    skip=$((RANDOM % (blocks_4k - 16))) status=none || true
+                echo "PROBE directread-us $((($(date +%s%N) - t0) / 1000))"
+            fi
+            sleep 15
+        done
+    ) &
+    disown
 - mode: system
   script: |
     #!/bin/bash

--- a/rdd/scripts/probe-analyze.go
+++ b/rdd/scripts/probe-analyze.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Probe-analyze tabulates the PROBE telemetry lines that the guest sampler
+// (enabled via RDD_VM_TELEMETRY, see lima-template.yaml) writes to the
+// serial console. It reads a serial log and emits one TSV row per sampler
+// tick: wall time, load1, CPU split (user/system/iowait/idle percent,
+// computed from /proc/stat deltas), PSI io avg10 when the kernel offers
+// PSI, per-interval vda IOPS with average ms per I/O and io_ticks, the
+// single-thread hash time (the vCPU-count-independent substrate speed),
+// and the synced-write and O_DIRECT-read latency probes.
+//
+// Usage: go run scripts/probe-analyze.go <serial-log> [...]
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	tickRE     = regexp.MustCompile(`PROBE tick (\S+) load (\S+)`)
+	psiRE      = regexp.MustCompile(`PROBE psi-(\w+) (.*)`)
+	diskRE     = regexp.MustCompile(`PROBE diskstats\s+\d+\s+\d+\s+vda\s+(.*)`)
+	cpustatRE  = regexp.MustCompile(`PROBE cpustat cpu\s+(.*)`)
+	stHashRE   = regexp.MustCompile(`PROBE st-hash-ms (\d+)`)
+	syncwRE    = regexp.MustCompile(`PROBE syncwrite-us (\d+)`)
+	dreadRE    = regexp.MustCompile(`PROBE directread-us (\d+)`)
+	psiAvg10RE = regexp.MustCompile(`avg10=([0-9.]+)`)
+)
+
+// row collects one sampler tick. Fields stay strings so absent probes
+// render as empty TSV cells.
+type row struct {
+	t, load1, cpu, psiIO, iops, msPerIO, utilTicks, stHash, syncw, dread string
+}
+
+func ints(fields string) []int64 {
+	parts := strings.Fields(fields)
+	out := make([]int64, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.ParseInt(p, 10, 64)
+		if err != nil {
+			return nil
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+func analyze(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var rows []*row
+	var cur *row
+	var prevDisk, prevCPU []int64
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case tickRE.MatchString(line):
+			m := tickRE.FindStringSubmatch(line)
+			cur = &row{t: m[1], load1: strings.SplitN(m[2], "/", 2)[0]}
+			rows = append(rows, cur)
+		case cur == nil:
+			// Ignore lines before the first tick.
+		case psiRE.MatchString(line):
+			m := psiRE.FindStringSubmatch(line)
+			if m[1] != "io" {
+				break
+			}
+			if strings.Contains(m[2], "absent") {
+				cur.psiIO = "absent"
+			} else if a := psiAvg10RE.FindStringSubmatch(m[2]); a != nil {
+				cur.psiIO = a[1]
+			}
+		case diskRE.MatchString(line):
+			// Fields: reads merged sectors read_ms writes merged sectors
+			// write_ms inflight io_ticks weighted [...]
+			f := ints(diskRE.FindStringSubmatch(line)[1])
+			if prevDisk != nil && len(f) > 9 && len(prevDisk) > 9 {
+				dio := (f[0] - prevDisk[0]) + (f[4] - prevDisk[4])
+				dms := (f[3] - prevDisk[3]) + (f[7] - prevDisk[7])
+				cur.iops = strconv.FormatInt(dio, 10)
+				if dio > 0 {
+					cur.msPerIO = fmt.Sprintf("%.1f", float64(dms)/float64(dio))
+				}
+				cur.utilTicks = strconv.FormatInt(f[9]-prevDisk[9], 10)
+			}
+			if len(f) > 9 {
+				prevDisk = f
+			}
+		case cpustatRE.MatchString(line):
+			// Fields: user nice system idle iowait irq softirq steal [...]
+			f := ints(cpustatRE.FindStringSubmatch(line)[1])
+			if prevCPU != nil && len(f) > 7 && len(prevCPU) > 7 {
+				var total int64
+				d := make([]int64, len(f))
+				for i := range f {
+					d[i] = f[i] - prevCPU[i]
+					total += d[i]
+				}
+				if total > 0 {
+					cur.cpu = fmt.Sprintf("%d/%d/%d/%d",
+						d[0]*100/total, d[2]*100/total, d[4]*100/total, d[3]*100/total)
+				}
+			}
+			if len(f) > 7 {
+				prevCPU = f
+			}
+		case stHashRE.MatchString(line):
+			cur.stHash = stHashRE.FindStringSubmatch(line)[1]
+		case syncwRE.MatchString(line):
+			us, _ := strconv.ParseInt(syncwRE.FindStringSubmatch(line)[1], 10, 64)
+			cur.syncw = fmt.Sprintf("%.1f", float64(us)/1000)
+		case dreadRE.MatchString(line):
+			us, _ := strconv.ParseInt(dreadRE.FindStringSubmatch(line)[1], 10, 64)
+			cur.dread = fmt.Sprintf("%.1f", float64(us)/1000)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	w := bufio.NewWriter(os.Stdout)
+	defer w.Flush()
+	fmt.Fprintln(w, "t\tload1\tcpu%us/sy/io/id\tpsi_io\tiops\tms_per_io\tutil_ticks_ms\tst_hash_ms\tsyncw_ms\tdread_ms")
+	for _, r := range rows {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.t, r.load1, r.cpu, r.psiIO, r.iops, r.msPerIO, r.utilTicks, r.stHash, r.syncw, r.dread)
+	}
+	return w.Flush()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run scripts/probe-analyze.go <serial-log> [...]")
+		os.Exit(2)
+	}
+	for _, path := range os.Args[1:] {
+		if len(os.Args) > 2 {
+			fmt.Fprintf(os.Stdout, "== %s\n", path)
+		}
+		if err := analyze(path); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
The NodePort flake investigation needed substrate measurements the existing logs could not provide: whether the guest starves on CPU or disk, which processes burn it, and how the host fares alongside. Make those collectors permanent: a macOS host sampler as a composite action mirroring the Windows typeperf sampler, and an in-guest sampler in the Lima template, gated by `RDD_VM_TELEMETRY` so CI captures substrate probes on every platform while user VMs stay silent. The serial console carries the guest probes under QEMU and VZ; WSL2 capture is a follow-up.

Analyze captures with:

```
go run scripts/probe-analyze.go <serial-log>
```

Note for sequencing: this branch and the upcoming `RDD_VM_CPUS` branch both touch `applySpecToTemplate` and `environment.md`; whichever merges second has a trivial conflict to resolve.