### PR TITLE
Allow RDD_VM_CPUS to override the VM cpu count

### DIFF
--- a/.github/workflows/rdd-bats.yaml
+++ b/.github/workflows/rdd-bats.yaml
@@ -206,6 +206,28 @@ jobs:
         output-dir: rdd/rdd-logs/_diag
       continue-on-error: true
 
+    - name: "Linux: size the app VM for the runner"
+      if: needs.check-paths.outputs.should-run && runner.os == 'Linux'
+      shell: bash
+      run: |
+        # The ubuntu runners also have 4 cores, and the host side idles at
+        # the 2-vCPU default; give the QEMU guest 3 and keep one core for
+        # the runner agent.
+        echo "RDD_VM_CPUS=3" >> "$GITHUB_ENV"
+
+    - name: "macOS: size the app VM for the runner"
+      if: needs.check-paths.outputs.should-run && runner.os == 'macOS'
+      shell: bash
+      run: |
+        # The 2-vCPU default starves the guest on the 4-core macos-15-intel
+        # runners: both vCPUs saturate during the k3s bootstrap and container
+        # creates take minutes. Give the VM all 4 cores: validation showed
+        # 4 vCPUs reaching pod-Running 2-3x faster than 3 and passing even
+        # the slowest runners, while the runner agent stayed scheduled
+        # through 0%-idle stretches. Drop to 3 if runs start losing their
+        # runner connection.
+        echo "RDD_VM_CPUS=4" >> "$GITHUB_ENV"
+
     - name: Configure BATS targets
       if: needs.check-paths.outputs.should-run
       shell: bash

--- a/rdd/docs/design/environment.md
+++ b/rdd/docs/design/environment.md
@@ -13,6 +13,7 @@ These variables control RDD behavior. Set them before running `rdd` commands.
 | `RDD_KEEP_LOGS` | Preserves logs for post-mortem debugging. See [Log Preservation](#log-preservation) for details. | unset |
 | `RDD_LOG_LEVEL` | Sets the log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`). Overridden by `--log-level` flag. When unset, defaults to `debug` in developer mode, `warn` otherwise. | unset |
 | `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
+| `RDD_VM_CPUS` | Overrides the app VM's CPU count (the Lima template default is 2). Intended for CI, where runner sizing differs from user machines. A set-but-invalid value is an error, not a fallback. To be replaced by an App spec property. | unset |
 
 ### BATS Test Variables
 

--- a/rdd/pkg/controllers/app/app/controllers/app_controller.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller.go
@@ -11,8 +11,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	goruntime "runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -112,10 +114,38 @@ func (r *AppReconciler) kubernetesEnabled(ctx context.Context) bool {
 	return slices.Contains(enabled, v1alpha1.KubernetesControllerName)
 }
 
+// vmCPUsEnv overrides the VM's cpu count from the environment. CI sets it so
+// the VM gets more cores on starved runners; regular installs keep the
+// template default. To be replaced by an App spec property.
+const vmCPUsEnv = "RDD_VM_CPUS"
+
+// applyVMCPUsOverride rewrites the template's cpus line when vmCPUsEnv is
+// set. A set-but-invalid value is an error rather than a silent fallback to
+// the template default, so a typo cannot quietly change what CI measures.
+func applyVMCPUsOverride(template string) (string, error) {
+	val := os.Getenv(vmCPUsEnv)
+	if val == "" {
+		return template, nil
+	}
+	cpus, err := strconv.Atoi(val)
+	if err != nil || cpus < 1 {
+		return "", fmt.Errorf("invalid %s value %q: want a positive integer", vmCPUsEnv, val)
+	}
+	re := regexp.MustCompile(`(?m)^cpus: \d+$`)
+	if !re.MatchString(template) {
+		return "", fmt.Errorf("%s is set but the Lima template has no cpus line to override", vmCPUsEnv)
+	}
+	return re.ReplaceAllString(template, fmt.Sprintf("cpus: %d", cpus)), nil
+}
+
 func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesPort int) (string, error) {
 	hostHome, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get host home directory: %w", err)
+	}
+	baseTemplate, err = applyVMCPUsOverride(baseTemplate)
+	if err != nil {
+		return "", err
 	}
 	return strings.Join([]string{
 		baseTemplate,

--- a/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -454,6 +454,62 @@ func Test_applySpecToTemplate(t *testing.T) {
 	}
 }
 
+// Test_applyVMCPUsOverride is not parallel: t.Setenv forbids it.
+func Test_applyVMCPUsOverride(t *testing.T) {
+	template := "cpus: 2\nmemory: \"6442450944\"\n"
+
+	tests := []struct {
+		name    string
+		env     string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "unset env leaves the template unchanged",
+			env:   "",
+			input: template,
+			want:  template,
+		},
+		{
+			name:  "env rewrites the cpus line",
+			env:   "3",
+			input: template,
+			want:  "cpus: 3\nmemory: \"6442450944\"\n",
+		},
+		{
+			name:    "non-numeric value errors",
+			env:     "many",
+			input:   template,
+			wantErr: "invalid RDD_VM_CPUS",
+		},
+		{
+			name:    "zero errors",
+			env:     "0",
+			input:   template,
+			wantErr: "invalid RDD_VM_CPUS",
+		},
+		{
+			name:    "template without a cpus line errors",
+			env:     "3",
+			input:   "memory: \"6442450944\"\n",
+			wantErr: "no cpus line",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(vmCPUsEnv, tt.env)
+			got, err := applyVMCPUsOverride(tt.input)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
 // newTestScheme returns a scheme with all types the AppReconciler touches.
 func newTestScheme(t *testing.T) *k8sruntime.Scheme {
 	t.Helper()


### PR DESCRIPTION
The Lima template ships `cpus: 2` for everyone, but the 4-core CI runners starve the guest: telemetry shows both vCPUs pegged during the k3s bootstrap while container creates queue for minutes. Let CI give its VMs more cores without changing the default users get: 4 on the macOS runners (where the starvation breaks tests), 3 on the Linux runners (their host side idles at the default), and nothing on Windows (Lima's WSL2 driver does not apply `cpus`). A set-but-invalid value is an error, not a fallback, so a typo cannot quietly change what CI measures. An App spec property will replace the variable once VM sizing becomes a real setting.

Validation on the macos-15-intel pool, normalized for runner quality by a single-thread benchmark probe:

- 3 vCPUs: 7/10 NodePort runs passed; both slowness failures hit the slowest runners; pod-Running took 1m44s–3m11s on mid-grade hosts; host idle never reached 0%.
- 4 vCPUs: 4/4 passed, including the slowest runner measured; pod-Running took 55–62s on hosts matched to the 3-vCPU runs (2–3× faster). Host idle hit 0% in a quarter of the samples, but the runner agent stayed scheduled and no run lost its connection in the ~40-run campaign. Drop macOS to 3 if disconnects appear.

Note for sequencing: this branch and #442 both touch `applySpecToTemplate` and `environment.md`; whichever merges second has a trivial conflict to resolve.