### PR TITLE
Allow overriding log directory

### DIFF
--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -81,7 +81,7 @@ jobs:
       env:
         EXEC_COMMAND: ${{ env.EXEC_COMMAND }}
         RD_ENV_SCREENSHOT_SLEEP: 5000
-        RD_LOGS_DIR: logs
+        RDD_LOG_DIR: logs
     - name: Upload screenshots
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -143,7 +143,7 @@ jobs:
       shell: bash
       # Use node here to do path manipulation to get correct Windows paths.
       run: >-
-        node --eval='console.log("RD_LOGS_DIR=" + require("path").join(process.cwd(), "logs"));'
+        node --eval='console.log("RDD_LOG_DIR=" + require("path").join(process.cwd(), "logs"));'
         >> "$GITHUB_ENV"
 
     - name: Download artifacts
@@ -188,10 +188,10 @@ jobs:
       run: |
         useradd --create-home --user-group ci-user
         export LOGS_DIR=$PWD/logs
-        export RD_LOGS_DIR=$LOGS_DIR/rd
+        export RDD_LOG_DIR=$LOGS_DIR/rd
         echo "LOGS_DIR=$LOGS_DIR" >> "$GITHUB_ENV"
-        echo "RD_LOGS_DIR=$RD_LOGS_DIR" >> "$GITHUB_ENV"
-        mkdir -p $RD_LOGS_DIR
+        echo "RDD_LOG_DIR=$RDD_LOG_DIR" >> "$GITHUB_ENV"
+        mkdir -p $RDD_LOG_DIR
         chown --recursive ci-user "$LOGS_DIR"
     - uses: ./.github/actions/setup-environment
     - name: Install Rancher Desktop from package
@@ -215,7 +215,7 @@ jobs:
         )
         sudo --user=ci-user --login --set-home --non-interactive \
           /usr/bin/env --chdir=$PWD \
-            RD_DEBUG_ENABLED=1 RD_TEST=smoke RD_SKIP_INSTALL=true RD_LOGS_DIR=$RD_LOGS_DIR \
+            RD_DEBUG_ENABLED=1 RD_TEST=smoke RD_SKIP_INSTALL=true RDD_LOG_DIR=$RDD_LOG_DIR \
           script \
             --log-out $LOGS_DIR/repo-${{ matrix.id }}.log \
             --return --command "${inner_command[*]@Q}"
@@ -268,10 +268,10 @@ jobs:
       run: |
         useradd --create-home --user-group ci-user
         export LOGS_DIR=$PWD/logs
-        export RD_LOGS_DIR=$LOGS_DIR/rd
+        export RDD_LOG_DIR=$LOGS_DIR/rd
         echo "LOGS_DIR=$LOGS_DIR" >> "$GITHUB_ENV"
-        echo "RD_LOGS_DIR=$RD_LOGS_DIR" >> "$GITHUB_ENV"
-        mkdir -p $RD_LOGS_DIR
+        echo "RDD_LOG_DIR=$RDD_LOG_DIR" >> "$GITHUB_ENV"
+        mkdir -p $RDD_LOG_DIR
         chown --recursive ci-user "$LOGS_DIR"
     - uses: ./.github/actions/setup-environment
       with:
@@ -292,7 +292,7 @@ jobs:
         )
         sudo --user=ci-user --login --set-home --non-interactive \
           /usr/bin/env --chdir=$PWD \
-            RD_DEBUG_ENABLED=1 RD_TEST=smoke RD_LOGS_DIR=$RD_LOGS_DIR \
+            RD_DEBUG_ENABLED=1 RD_TEST=smoke RDD_LOG_DIR=$RDD_LOG_DIR \
           script \
             --log-out $LOGS_DIR/appimage-${{ matrix.id }}.log \
             --return --command "${inner_command[*]@Q}" \

--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -181,8 +181,8 @@ install_win32() {
     local archiveName=$1
 
     win32_verify "$archiveName"
-    mkdir -p "$(cygpath --unix "${RD_LOGS_DIR}")"
-    msiexec.exe '/lv*x' "${RD_LOGS_DIR}\\install.log" \
+    mkdir -p "$(cygpath --unix "${RDD_LOG_DIR}")"
+    msiexec.exe '/lv*x' "${RDD_LOG_DIR}\\install.log" \
         /i "$(cygpath --windows "$archiveName")" /passive ALLUSERS=1
     # msiexec returns immediately and runs in the background; wait for that
     # process to exit before continuing.

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -370,7 +370,7 @@ export async function startRancherDesktop(testInfo: TestInfo, options: startRanc
     env: {
       ...process.env,
       ...options?.env ?? {},
-      RD_LOGS_DIR: logsDir,
+      RDD_LOG_DIR: logsDir,
       ...options?.mock ?? true ? { RD_MOCK_BACKEND: '1' } : {},
     },
   };

--- a/rdd/docs/design/environment.md
+++ b/rdd/docs/design/environment.md
@@ -11,6 +11,7 @@ These variables control RDD behavior. Set them before running `rdd` commands.
 | `RDD_INSTANCE` | Instance identifier. Determines which control plane and directories to use. Also settable via `rdd --instance`. | `2` |
 | `RDD_DEVELOPER_MODE` | Enables developer mode: exposes hidden CLI flags, detects source tree for local builds. | unset |
 | `RDD_KEEP_LOGS` | Preserves logs for post-mortem debugging. See [Log Preservation](#log-preservation) for details. | unset |
+| `RDD_LOG_DIR` | Override the logging directory; usually used for tests. | unset |
 | `RDD_LOG_LEVEL` | Sets the log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`). Overridden by `--log-level` flag. When unset, defaults to `debug` in developer mode, `warn` otherwise. | unset |
 | `RDD_LOG_TITLE` | When set, writes this string as the first line of each new log file. Useful for identifying log files from specific test runs or sessions. | unset |
 
@@ -26,7 +27,7 @@ These variables configure the BATS test framework. They have no effect on `rdd` 
 
 ## Path Variables
 
-`rdd svc paths --output=shell` exports these variables. They reflect the paths RDD uses for the current instance; setting them has no effect on RDD's behavior.
+`rdd svc paths --output=shell` exports these variables. They reflect the paths RDD uses for the current instance; setting them has no effect on RDD's behavior, other than `RDD_LOG_DIR` as listed above.
 
 ```shell
 source <(rdd svc paths --output=shell)

--- a/rdd/pkg/instance/instance.go
+++ b/rdd/pkg/instance/instance.go
@@ -65,6 +65,9 @@ var Dir = sync.OnceValue(func() string {
 // Logs are stored separately from instance data so they can be preserved
 // independently (e.g., when deleting an instance but keeping logs for debugging).
 var LogDir = sync.OnceValue(func() string {
+	if override := os.Getenv("RDD_LOG_DIR"); override != "" {
+		return override
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		panic(fmt.Errorf("could not get home directory: %w", err))

--- a/rdd/pkg/instance/instance_test.go
+++ b/rdd/pkg/instance/instance_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package instance
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// The instance implementation uses a lot of `sync.OnceValue`; when testing the
+// various cases, we need to simulate resetting that state.  We do this by
+// running the test in a subprocess with a clean environment.
+func runTestProcess(t *testing.T, testFunc func(*testing.T), variables ...string) {
+	t.Helper()
+
+	const subprocessMarker = "RDD_INSTANCE_TEST_IS_SUBPROCESS"
+	if os.Getenv(subprocessMarker) == subprocessMarker {
+		// We are already in the subprocess, so just run the test.
+		testFunc(t)
+		return
+	}
+
+	// Copy the environment, but exclude relevant variables.
+	excludes := []string{
+		"RDD_INSTANCE=",
+		"RDD_LOG_DIR=",
+	}
+	env := []string{subprocessMarker + "=" + subprocessMarker}
+	for _, v := range os.Environ() {
+		if !slices.ContainsFunc(excludes,
+			func(s string) bool { return strings.HasPrefix(v, s) },
+		) {
+			env = append(env, v)
+		}
+	}
+	env = append(env, variables...)
+
+	args := append(slices.Clone(os.Args[1:]),
+		fmt.Sprintf("-test.run=^%s$", regexp.QuoteMeta(t.Name())))
+	cmd := exec.CommandContext(t.Context(), os.Args[0], args...)
+	cmd.Env = env
+	cmd.Stdout = t.Output()
+	cmd.Stderr = t.Output()
+	assert.NilError(t, cmd.Run())
+}
+
+func TestSuffix(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			assert.Equal(t, "2", Suffix())
+		})
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			assert.Equal(t, "test", Suffix())
+		}, "RDD_INSTANCE=test")
+	})
+}
+
+func TestIndex(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			assert.Equal(t, 2, Index())
+		})
+	})
+	t.Run("custom numeric", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			assert.Equal(t, 42, Index())
+		}, "RDD_INSTANCE=42")
+	})
+	t.Run("custom non-numeric", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			assert.Equal(t, 198, Index())
+		}, "RDD_INSTANCE=cc") // 'c' = 99
+	})
+}
+
+func TestName(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			assert.Equal(t, "rancher-desktop-2", Name())
+		})
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			assert.Equal(t, "rancher-desktop-test", Name())
+		}, "RDD_INSTANCE=test")
+	})
+}
+
+func TestDir(t *testing.T) {
+	cases := []string{"", "test"}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("instance=%q", c), func(t *testing.T) {
+			runTestProcess(t, func(t *testing.T) {
+				home := t.TempDir()
+				t.Setenv("HOME", home)
+				t.Setenv("USERPROFILE", home) // For Windows
+				name := "rancher-desktop-2"
+				if c != "" {
+					t.Setenv("RDD_INSTANCE", c)
+					name = fmt.Sprintf("rancher-desktop-%s", c)
+				}
+				expected := map[string]string{
+					"windows": filepath.Join(home, "AppData", "Local", name),
+					"linux":   filepath.Join(home, ".local", "share", name),
+					"darwin":  filepath.Join(home, "Library", "Application Support", name),
+				}[runtime.GOOS]
+				assert.Equal(t, expected, Dir())
+			})
+		})
+	}
+}
+
+func TestLogDir(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home) // For Windows
+			expected := map[string]string{
+				"windows": filepath.Join(home, "AppData", "Local", "rancher-desktop-2-logs"),
+				"linux":   filepath.Join(home, ".local", "state", "rancher-desktop-2"),
+				"darwin":  filepath.Join(home, "Library", "Logs", "rancher-desktop-2"),
+			}[runtime.GOOS]
+			assert.Equal(t, expected, LogDir())
+		})
+	})
+
+	t.Run("override", func(t *testing.T) {
+		runTestProcess(t, func(t *testing.T) {
+			expected := t.TempDir()
+			t.Setenv("RDD_LOG_DIR", expected)
+			assert.Equal(t, expected, LogDir())
+		})
+	})
+}
+
+func TestDockerEndpoint(t *testing.T) {
+	runTestProcess(t, func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			assert.Equal(t, "npipe:////./pipe/docker_engine", DockerEndpoint())
+		} else {
+			assert.Equal(t, fmt.Sprintf("unix://%s/docker.sock", ShortDir()), DockerEndpoint())
+		}
+	})
+}


### PR DESCRIPTION
This adds the ability to override the log directory (by setting `RDD_LOG_DIR`), analogous to the feature in Rancher Desktop (1).  This is meant to be used for tests to be easier to find logs.

This also adds unit tests for `rdd/pkg/instance`, implemented by spawning subprocesses to reset the various `sync.Once…` things.