### PR TITLE
Repair Windows console after wsl.exe breaks newline auto-return

### DIFF
--- a/rdd/cmd/rdd/main.go
+++ b/rdd/cmd/rdd/main.go
@@ -23,6 +23,7 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 	_ "k8s.io/component-base/metrics/prometheus/version"
 
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/console"
 	cliexit "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/exit"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/help"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/developer"
@@ -85,6 +86,9 @@ func setLogOptions(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("invalid log format: %q", logFormat)
 		}
 	}
+	// Route log output through RepairingWriter so a child corrupting the shared
+	// console's newline mode doesn't make our lines "staircase" (see pkg/cli/console).
+	logrus.SetOutput(console.RepairingWriter(os.Stderr))
 	logLevel, err := cmd.Root().Flags().GetString("log-level")
 	if err != nil {
 		return err

--- a/rdd/cmd/rdd/run.go
+++ b/rdd/cmd/rdd/run.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/console"
 	cliexit "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/exit"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/help"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
@@ -162,6 +163,10 @@ func execCommand(ctx context.Context, args []string) error {
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
+
+	// Booting the App's VM runs wsl.exe, which corrupts the shared console's
+	// newline mode; repair it before the child inherits the console.
+	console.Repair()
 
 	err := command.Run()
 	var exitErr *exec.ExitError

--- a/rdd/pkg/cli/console/console_other.go
+++ b/rdd/pkg/cli/console/console_other.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build !windows
+
+// Package console repairs the controlling console after a child process leaves
+// it in a broken output mode.
+package console
+
+import "io"
+
+// Repair is a no-op: non-Windows consoles have no newline-auto-return bit.
+func Repair() {}
+
+// RepairingWriter returns w unchanged on non-Windows.
+func RepairingWriter(w io.Writer) io.Writer { return w }

--- a/rdd/pkg/cli/console/console_windows.go
+++ b/rdd/pkg/cli/console/console_windows.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package console repairs the controlling console after a child process leaves
+// it in a broken output mode.
+package console
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// disableNewlineAutoReturn (DISABLE_NEWLINE_AUTO_RETURN) suppresses the implicit
+// carriage return on a line feed. wsl.exe — Lima's WSL2 driver — sets it, with
+// virtual-terminal processing, on the console it shares with us and never
+// restores it, so every later '\n' moves down without returning to column 0:
+// the "staircase".
+const disableNewlineAutoReturn = 0x0008
+
+// Repair clears DISABLE_NEWLINE_AUTO_RETURN on the controlling console, undoing
+// the staircase a child leaves behind while preserving virtual-terminal
+// processing (ANSI colors). Best-effort: a no-op when the console is redirected.
+func Repair() {
+	for _, f := range []*os.File{os.Stdout, os.Stderr} {
+		h := windows.Handle(f.Fd())
+		var mode uint32
+		if windows.GetConsoleMode(h, &mode) != nil {
+			continue // not a console handle (redirected)
+		}
+		if mode&disableNewlineAutoReturn != 0 {
+			_ = windows.SetConsoleMode(h, mode&^disableNewlineAutoReturn)
+		}
+		return // stdout and stderr share one console buffer; one repair suffices
+	}
+}
+
+// RepairingWriter wraps w so each Write first repairs the console mode, keeping
+// logged lines from staircasing after a child corrupts the console.
+func RepairingWriter(w io.Writer) io.Writer { return repairingWriter{w} }
+
+type repairingWriter struct{ w io.Writer }
+
+func (rw repairingWriter) Write(p []byte) (int, error) {
+	Repair()
+	return rw.w.Write(p)
+}


### PR DESCRIPTION
`wsl.exe` (Lima's WSL2 driver) boots the VM in the console it shares with rdd and leaves it in `DISABLE_NEWLINE_AUTO_RETURN` mode, so our later output "staircases" down the terminal.

Detaching the hostagent isn't an option: graceful shutdown sends `CTRL_BREAK`, which only reaches a process sharing our console. So we clear the bit ourselves, before each log write and before running a child command.

The tempting fix - detach the hostagent from the console `DETACHED_PROCESS`/`CREATE_NO_WINDOW`) - would break graceful shutdown. The hostagent is stopped with `GenerateConsoleCtrlEvent(CTRL_BREAK)` (`process.Interrupt`), and that signal only reaches a process that shares the caller's console.