### PR TITLE
Fix Smoke Tests

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -15,6 +15,18 @@ on:
           Download artifacts from release with this tag, rather than picking the
           first draft release.
         type: string
+      obs-project:
+        description: >
+          OpenSUSE Build Service project to download AppImage from, in the form
+          of "home:username:projectname". The default is the devel project used
+          in final pre-release smoke tests.
+        type: string
+        default: "isv:Rancher:dev"
+      skip-signing-checks:
+        description: >
+          Skip signature checks on downloaded artifacts (fails the tests).
+        type: boolean
+        default: false
 
 jobs:
   download-artifacts:
@@ -58,6 +70,8 @@ jobs:
 
     - name: Download AppImage
       run: |
+        # The OBS project needs to have a slash added after each colon.
+        OBS_DOWNLOAD_URL=https://download.opensuse.org/download/repositories/${OBS_PROJECT//:/:/}/AppImage/
         branch=$(cut -d. -f1,2 <<< "${RELEASE_TAG#v}")
         read -r artifact_name < <(
           curl "${OBS_DOWNLOAD_URL}?jsontable" \
@@ -68,7 +82,7 @@ jobs:
         sha512sum rancher-desktop.AppImage > rancher-desktop.AppImage.sha512sum
         chmod a+x rancher-desktop.AppImage
       env:
-        OBS_DOWNLOAD_URL: https://download.opensuse.org/download/repositories/isv:/Rancher:/dev/AppImage/
+        OBS_PROJECT: ${{ inputs.obs-project }}
 
     - name: Upload macOS aarch-64 artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -152,6 +166,8 @@ jobs:
         name: application-${{ matrix.platform }}.zip
     - run: ${{ env.EXEC_COMMAND }} .github/workflows/smoke-test/smoke-test.sh
       shell: bash
+      env:
+        RD_SKIP_SIGNING_CHECKS: ${{ inputs.skip-signing-checks }}
     - name: Upload logs
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
@@ -199,6 +215,7 @@ jobs:
       run: .github/workflows/smoke-test/install-from-repo.sh
       env:
         RD_VERSION: ${{ needs.download-artifacts.outputs.release-tag }}
+        OBS_PROJECT: ${{ inputs.obs-project }}
     - name: "openSUSE Workaround for #9145"
       if: contains(matrix.id, 'opensuse')
       run: >-
@@ -323,3 +340,13 @@ jobs:
         name: logs-appimage-${{ matrix.id }}.zip
         path: ${{ github.workspace }}/logs
         if-no-files-found: warn
+
+  flag-skipped-signing-checks:
+    name: Flag that signing checks were skipped
+    needs: [smoke-test,repository-smoke-test,appimage-smoke-test]
+    runs-on: ubuntu-latest
+    if: inputs.skip-signing-checks
+    steps:
+    - run: |
+        echo "Force failing smoke tests because signature checks were skipped." >&2
+        exit 1

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -164,8 +164,12 @@ jobs:
       shell: bash
       # Use node here to do path manipulation to get correct Windows paths.
       run: >-
-        node --eval='console.log("RDD_LOG_DIR=" + require("path").join(process.cwd(), "logs"));'
-        >> "$GITHUB_ENV"
+        node --eval='
+        var join = require("path").join;
+        var l = join(process.cwd(), "logs");
+        console.log("LOGS_DIR=" + l);
+        console.log("RDD_LOG_DIR=" + join(l, "rd"));
+        ' >> "$GITHUB_ENV"
 
     - name: Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -175,6 +179,24 @@ jobs:
       shell: bash
       env:
         RD_SKIP_SIGNING_CHECKS: ${{ inputs.skip-signing-checks }}
+        RDD_KEEP_LOGS: '1'
+    - name: Collect Lima Logs
+      if: always()
+      shell: bash
+      run: |
+        # Lima should output its logs to the RD log directory, but it currently
+        # doesn't; collect them manually here.
+        set +o errexit
+        shopt -s nullglob
+        mkdir -p "${LOGS_DIR}/lima"
+        case "$(uname -o | tr 'A-Z' 'a-z')" in
+          msys)
+            # On Windows/MSYS, the home directory is USERPROFILE.
+            HOME="$(cygpath -u "$USERPROFILE")";;
+        esac
+        for file in "${HOME}"/.rd2/lima/rd/*.log; do
+          cp -v "$file" "$LOGS_DIR/lima/$(basename "$file")"
+        done
     - name: Upload logs
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
@@ -242,7 +264,8 @@ jobs:
         )
         sudo --user=ci-user --login --set-home --non-interactive \
           /usr/bin/env --chdir=$PWD \
-            RD_DEBUG_ENABLED=1 RD_TEST=smoke RD_SKIP_INSTALL=true RDD_LOG_DIR=$RDD_LOG_DIR \
+            RD_DEBUG_ENABLED=1 RD_TEST=smoke RD_SKIP_INSTALL=true \
+            RDD_LOG_DIR=$RDD_LOG_DIR RDD_KEEP_LOGS=1 \
           script \
             --log-out $LOGS_DIR/repo-${{ matrix.id }}.log \
             --return --command "${inner_command[*]@Q}"
@@ -266,6 +289,18 @@ jobs:
         export MAGICK_DEBUG=All # spellcheck-ignore-line
         gm import -window root -verbose $LOGS_DIR/screenshot-${{ matrix.id }}.png
 
+    - name: Collect Lima Logs
+      if: always()
+      shell: bash
+      run: |
+        # Lima should output its logs to the RD log directory, but it currently
+        # doesn't; collect them manually here.
+        set +o errexit
+        shopt -s nullglob
+        mkdir -p "${LOGS_DIR}/lima"
+        for file in ~ci-user/.rd2/lima/rd/*.log; do
+          cp --verbose "$file" "$LOGS_DIR/lima/$(basename "$file")"
+        done
     - name: Upload logs
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
@@ -345,7 +380,8 @@ jobs:
         )
         sudo --user=ci-user --login --set-home --non-interactive \
           /usr/bin/env --chdir=$PWD \
-            RD_DEBUG_ENABLED=1 RD_TEST=smoke RDD_LOG_DIR=$RDD_LOG_DIR \
+            RD_DEBUG_ENABLED=1 RD_TEST=smoke \
+            RDD_LOG_DIR=$RDD_LOG_DIR RDD_KEEP_LOGS=1 \
           script \
             --log-out $LOGS_DIR/appimage-${{ matrix.id }}.log \
             --return --command "${inner_command[*]@Q}" \
@@ -369,6 +405,18 @@ jobs:
         export MAGICK_DEBUG=All # spellcheck-ignore-line
         gm import -window root -verbose $LOGS_DIR/screenshot-${{ matrix.id }}.png
 
+    - name: Collect Lima Logs
+      if: always()
+      shell: bash
+      run: |
+        # Lima should output its logs to the RD log directory, but it currently
+        # doesn't; collect them manually here.
+        set +o errexit
+        shopt -s nullglob
+        mkdir -p "${LOGS_DIR}/lima"
+        for file in ~ci-user/.rd2/lima/rd/*.log; do
+          cp --verbose "$file" "$LOGS_DIR/lima/$(basename "$file")"
+        done
     - name: Upload logs
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -152,6 +152,13 @@ jobs:
         EXEC_COMMAND: >-
           exec xvfb-run --auto-servernum
           --server-args='-screen 0 1280x960x24'
+    - name: "Linux: Install Extra Packages"
+      if: runner.os == 'Linux'
+      run: |
+        set -o xtrace
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends \
+          ovmf qemu-system qemu-utils
 
     - name: Set log directory
       shell: bash
@@ -192,6 +199,14 @@ jobs:
       image: ${{ matrix.image }}
       options: --privileged
     steps:
+    - name: Disable AppArmor User Namespace Restrictions
+      run: |
+        # This is needed because even though we run in a container for a
+        # different distribution, we're still running the Ubuntu kernel in the
+        # runner VM.  Filed as
+        # https://github.com/rancher-sandbox/rancher-desktop-2/issues/459
+        set +o errexit
+        echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns
     - name: Install basic tools
       if: contains(matrix.id, 'opensuse')
       run: >-
@@ -216,11 +231,6 @@ jobs:
       env:
         RD_VERSION: ${{ needs.download-artifacts.outputs.release-tag }}
         OBS_PROJECT: ${{ inputs.obs-project }}
-    - name: "openSUSE Workaround for #9145"
-      if: contains(matrix.id, 'opensuse')
-      run: >-
-        zypper --non-interactive install
-        qemu-img qemu-hw-display-virtio-gpu
     - name: Run smoke test
       shell: bash
       run: |
@@ -293,6 +303,32 @@ jobs:
     - uses: ./.github/actions/setup-environment
       with:
         user: ci-user
+
+    - name: Install qemu
+      run: |
+        source /etc/os-release
+        for id in $ID $ID_LIKE; do
+          case $id in
+            suse|opensuse)
+              zypper --non-interactive install qemu-headless
+              exit 0;;
+            rocky|rhel|centos|fedora)
+              dnf install --assumeyes qemu-kvm
+              # On RHEL/CentOS, the qemu exectuable is not actually exposed;
+              # make a symlink to qemu-kvm, even though it's unsupported.
+              if ! command -v qemu-system-x86_64; then
+                ln -sf /usr/libexec/qemu-kvm /usr/local/bin/qemu-system-x86_64
+              fi
+              qemu-system-x86_64 --version
+              exit 0;;
+            debian|ubuntu)
+              apt-get update
+              apt-get install --yes ovmf qemu-system qemu-utils
+              exit 0;;
+          esac
+        done
+        printf "Could not find known distribution in [%s %s]\n" "$ID" "$ID_LIKE" >&2
+        exit 1
 
     - name: Download AppImage
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/smoke-test/install-from-repo.sh
+++ b/.github/workflows/smoke-test/install-from-repo.sh
@@ -5,6 +5,8 @@
 # Expected environment variables:
 #   RD_VERSION
 #      Rancher Desktop version; either major.minor (`1.20`) or the tag (`v1.20.0`).
+#   OBS_PROJECT
+#      The openSUSE Build Service project to use, in the form `isv:Rancher:dev`.
 
 set -o errexit -o nounset
 
@@ -20,10 +22,10 @@ install_linux_debian() {
 
     apt-get update
     apt-get install -y gnupg
-    curl -s https://download.opensuse.org/repositories/isv:/Rancher:/dev/deb/Release.key \
+    curl -s https://download.opensuse.org/repositories/${OBS_PROJECT//:/:/}/deb/Release.key \
         | gpg --dearmor \
         > "${keyLocation}/keyrings/isv-rancher-dev-archive-keyring.gpg"
-    echo "deb [signed-by=${keyLocation}/keyrings/isv-rancher-dev-archive-keyring.gpg] https://download.opensuse.org/repositories/isv:/Rancher:/dev/deb/ ./"\
+    echo "deb [signed-by=${keyLocation}/keyrings/isv-rancher-dev-archive-keyring.gpg] https://download.opensuse.org/repositories/${OBS_PROJECT//:/:/}/deb/ ./"\
         > /etc/apt/sources.list.d/isv-rancher-dev.list
     apt-get update
     version=$(apt-cache show --quiet "${PACKAGE_NAME}" \
@@ -38,7 +40,7 @@ install_linux_debian() {
 
 # shellcheck disable=2329 # The function is invoked dynamically
 install_linux_opensuse() {
-    zypper --non-interactive addrepo https://download.opensuse.org/repositories/isv:/Rancher:/dev/rpm/isv:Rancher:dev.repo
+    zypper --non-interactive addrepo https://download.opensuse.org/repositories/${OBS_PROJECT//:/:/}/rpm/${OBS_PROJECT}.repo
     zypper --non-interactive --gpg-auto-import-keys install libxml2-tools
     local version
     version=$(zypper --xmlout --non-interactive search --details --match-exact "${PACKAGE_NAME}" \
@@ -53,7 +55,7 @@ install_linux_opensuse() {
 
 # shellcheck disable=2329 # The function is invoked dynamically
 install_linux_fedora() {
-    dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/isv:/Rancher:/dev/fedora/isv:Rancher:dev.repo
+    dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/${OBS_PROJECT//:/:/}/fedora/${OBS_PROJECT}.repo
     local version
     version=$(dnf --quiet info --showduplicates "${PACKAGE_NAME}.$(uname -m)" \
         | awk -F: "\$1 ~ /Version/ && \$2 ~ /0\.release${RD_VERSION//./\\.}/ { print \$2 }" \

--- a/.github/workflows/smoke-test/install-from-repo.sh
+++ b/.github/workflows/smoke-test/install-from-repo.sh
@@ -8,6 +8,8 @@
 
 set -o errexit -o nounset
 
+PACKAGE_NAME="rancher-desktop-2"
+
 # shellcheck disable=2329 # The function is invoked dynamically
 install_linux_debian() {
     local keyLocation=/usr/share version
@@ -24,13 +26,14 @@ install_linux_debian() {
     echo "deb [signed-by=${keyLocation}/keyrings/isv-rancher-dev-archive-keyring.gpg] https://download.opensuse.org/repositories/isv:/Rancher:/dev/deb/ ./"\
         > /etc/apt/sources.list.d/isv-rancher-dev.list
     apt-get update
-    version=$(apt-cache show --quiet rancher-desktop \
+    version=$(apt-cache show --quiet "${PACKAGE_NAME}" \
         | awk -F': ' "/^Version: 0\.release${RD_VERSION//./\\.}\./ { print \$2 }")
     if [[ -z "${version}" ]]; then
-        echo "Could not find any versions of rancher-desktop" >&2
+        echo "Could not find any versions of ${PACKAGE_NAME}" >&2
+        apt-cache show --quiet "${PACKAGE_NAME}" | sed 's@^@    @' >&2
         exit 1
     fi
-    apt-get install -y "rancher-desktop=${version}"
+    apt-get install -y "${PACKAGE_NAME}=${version}"
 }
 
 # shellcheck disable=2329 # The function is invoked dynamically
@@ -38,19 +41,29 @@ install_linux_opensuse() {
     zypper --non-interactive addrepo https://download.opensuse.org/repositories/isv:/Rancher:/dev/rpm/isv:Rancher:dev.repo
     zypper --non-interactive --gpg-auto-import-keys install libxml2-tools
     local version
-    version=$(zypper --xmlout --non-interactive search --details --match-exact rancher-desktop \
+    version=$(zypper --xmlout --non-interactive search --details --match-exact "${PACKAGE_NAME}" \
         | xmllint --xpath "string(//solvable[@kind='package']/@edition[contains(., '0.release${RD_VERSION}.')])" -)
-    zypper --non-interactive install "rancher-desktop=${version}"
+    if [[ -z "${version}" ]]; then
+        echo "Could not find any versions of ${PACKAGE_NAME}" >&2
+        zypper --non-interactive search --details --match-exact "${PACKAGE_NAME}" | sed 's@^@    @' >&2
+        exit 1
+    fi
+    zypper --non-interactive install "${PACKAGE_NAME}=${version}"
 }
 
 # shellcheck disable=2329 # The function is invoked dynamically
 install_linux_fedora() {
     dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/isv:/Rancher:/dev/fedora/isv:Rancher:dev.repo
     local version
-    version=$(dnf --quiet info --showduplicates rancher-desktop.x86_64 \
+    version=$(dnf --quiet info --showduplicates "${PACKAGE_NAME}.$(uname -m)" \
         | awk -F: "\$1 ~ /Version/ && \$2 ~ /0\.release${RD_VERSION//./\\.}/ { print \$2 }" \
         | tr -d '[:space:]')
-    dnf --assumeyes install "rancher-desktop-${version}"
+    if [[ -z "${version}" ]]; then
+        echo "Could not find any versions of ${PACKAGE_NAME}" >&2
+        dnf --quiet info --showduplicates "${PACKAGE_NAME}.$(uname -m)" | sed 's@^@    @' >&2
+        exit 1
+    fi
+    dnf --assumeyes install "${PACKAGE_NAME}-${version}"
 }
 
 main() {

--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -216,8 +216,8 @@ install_win32() {
     local archiveName=$1
 
     win32_verify "$archiveName"
-    mkdir -p "$(cygpath --unix "${RDD_LOG_DIR}")"
-    msiexec.exe '/lv*x' "${RDD_LOG_DIR}\\install.log" \
+    mkdir -p "$(cygpath --unix "${LOGS_DIR}")"
+    msiexec.exe '/lv*x' "${LOGS_DIR}\\install.log" \
         /i "$(cygpath --windows "$archiveName")" /passive ALLUSERS=1
     # msiexec returns immediately and runs in the background; wait for that
     # process to exit before continuing.

--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -8,6 +8,8 @@
 # Environment variables as inputs:
 #   RD_SKIP_INSTALL (Linux)
 #     Skip installing Rancher Desktop, and assume it was installed from the repo.
+#   RD_SKIP_SIGNING_CHECKS (macOS / Windows)
+#     Skip signature checks on downloaded artifacts.
 
 # Required tools:
 # - jq
@@ -90,7 +92,11 @@ install_darwin() {
     mountpoint=$(mktemp -d -t rd-dmg-)
     cleanups+=("rm -rf '$mountpoint'")
 
-    codesign --verify --deep --strict --verbose=2 --check-notarization "$archiveName"
+    if [[ "${RD_SKIP_SIGNING_CHECKS:-}" != "true" ]]; then
+        codesign --verify --deep --strict --verbose=2 --check-notarization "$archiveName"
+    else
+        echo "Skipping signature checks on archive." >&2
+    fi
     xattr -d -r -s -v com.apple.quarantine "$archiveName"
     hdiutil attach "$archiveName" -mountpoint "$mountpoint"
     cleanups+=("hdiutil detach '$mountpoint'")
@@ -103,7 +109,11 @@ install_darwin() {
     fi
     destApp="/Applications/$(basename "$srcApp")"
 
-    codesign --verify --deep --strict --verbose=2 --check-notarization "$srcApp"
+    if [[ "${RD_SKIP_SIGNING_CHECKS:-}" != "true" ]]; then
+        codesign --verify --deep --strict --verbose=2 --check-notarization "$srcApp"
+    else
+        echo "Skipping signature checks on app." >&2
+    fi
     mkdir -p "$destApp"
     cleanups+=("rm -rf '$destApp'")
 
@@ -177,6 +187,12 @@ install_linux() {
 win32_verify() {
     local path
     path="$(cygpath --windows "$1")"
+
+    if [[ "${RD_SKIP_SIGNING_CHECKS:-}" == "true" ]]; then
+        echo "Skipping signature checks on $path." >&2
+        return
+    fi
+
     # When running GitHub actions, using `powershell.exe` here causes issues
     # with loading the `Microsoft.PowerShell.Security` module; using `pwsh.exe`
     # seems to be fine.  This is probably because the default shell is pwsh, and

--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -15,12 +15,16 @@
 
 # Note that, on Windows, this is run via msys bash (installed wit git).
 
+# The `install_*` functions are expected start Rancher Desktop.  Other than the
+# AppImage implementation on Linux, they should also set `RDD`.
+
 set -o errexit -o nounset
 shopt -s nullglob
 
 export MSYS2_ARG_CONV_EXCL='*'
-RDCTL= # Path to rdctl
+RDD= # Path to rdd
 APPIMAGE_PID= # PID of AppImage process; not used if not using AppImage.
+RDD_VM_CPUS= # To allow the RDD VM to use more CPUs during the test.
 
 # All commands in the cleanups array will be run on exit.  They must be plain
 # strings that will be passed to eval
@@ -78,20 +82,26 @@ get_platform() {
 }
 
 # Assume the first argument given is a path to the Rancher Desktop .dmg disk
-# image; install it, and set the global variable RDCTL to the path of the rdctl
+# image; install it, and set the global variable RDD to the path of the rdd
 # executable.
 install_darwin() {
     local archiveName=$1
-    local mountpoint
+    local mountpoint srcApp destApp
     mountpoint=$(mktemp -d -t rd-dmg-)
     cleanups+=("rm -rf '$mountpoint'")
 
-    local srcApp="${mountpoint}/Rancher Desktop.app"
-    local destApp="/Applications/Rancher Desktop.app"
-
     codesign --verify --deep --strict --verbose=2 --check-notarization "$archiveName"
+    xattr -d -r -s -v com.apple.quarantine "$archiveName"
     hdiutil attach "$archiveName" -mountpoint "$mountpoint"
     cleanups+=("hdiutil detach '$mountpoint'")
+
+    srcApp=$(echo "${mountpoint}"/*.app)
+    if [[ ! -d "$srcApp" ]]; then
+        echo "Failed to find app in mounted image." >&2
+        ls -l "$mountpoint"
+        exit 1
+    fi
+    destApp="/Applications/$(basename "$srcApp")"
 
     codesign --verify --deep --strict --verbose=2 --check-notarization "$srcApp"
     mkdir -p "$destApp"
@@ -119,11 +129,17 @@ install_darwin() {
         exit 0
     fi
 
-    RDCTL="$destApp/Contents/Resources/resources/darwin/bin/rdctl"
+    # Use as many CPUs as possible.
+    RDD_VM_CPUS=$(sysctl -n hw.ncpu)
+    RDD="$destApp/Contents/Resources/darwin/bin/rdd"
+
+    export RDD_VM_CPUS
+    # `open` wouldn't pick up `RDD_VM_CPUS`, so run the executable directly.
+    "$destApp/Contents/MacOS/Rancher Desktop 2" &
 }
 
 # Assume the first argument given is a path to the Rancher Desktop zip file;
-# install it, and set the global variable RDCTL to the path of the rdctl
+# install it, and set the global variable RDD to the path of the rdd
 # executable.  If the archive is an AppImage file instead, then this function
 # instead sets APPIMAGE_PID.
 install_linux() {
@@ -138,19 +154,22 @@ install_linux() {
         if [[ "$archiveName" =~ .*\.AppImage$ ]]; then
             sudo chmod a+x "$archiveName"
             "$archiveName" \
-                --no-sandbox --enable-logging=stderr --v=1 \
-                --no-modal-dialogs --kubernetes.enabled \
-                --application.updater.enabled=false&
+                --no-sandbox --enable-logging=stderr --v=1 &
             APPIMAGE_PID=$!
             return
         else
-            sudo mkdir -p /opt/rancher-desktop
-            sudo unzip -d /opt/rancher-desktop "$archiveName"
-            sudo chmod 4755 /opt/rancher-desktop/chrome-sandbox
+            sudo mkdir -p /opt/rancher-desktop-2
+            sudo unzip -d /opt/rancher-desktop-2 "$archiveName"
+            sudo chmod 4755 /opt/rancher-desktop-2/chrome-sandbox
         fi
     fi
 
-    RDCTL="/opt/rancher-desktop/resources/resources/linux/bin/rdctl"
+    # Use as many CPUs as possible, but leave one for GitHub runner use.
+    RDD_VM_CPUS=$(($(nproc) - 1))
+    RDD="/opt/rancher-desktop-2/resources/linux/bin/rdd"
+    export RDD_VM_CPUS
+
+    /opt/rancher-desktop-2/rancher-desktop &
 }
 
 # Helper function on Windows to verify the signature of a file (provided as the
@@ -175,7 +194,7 @@ win32_verify() {
 }
 
 # Assume the first argument given is a path to the Rancher Desktop installer;
-# install it, and set the global variable RDCTL to the path of the rdctl
+# install it, and set the global variable RDD to the path of the rdd
 # executable.
 install_win32() {
     local archiveName=$1
@@ -202,8 +221,8 @@ install_win32() {
         exit 1
     fi
     local installDirectory
-    installDirectory=$(cygpath --unix 'C:\Program Files\Rancher Desktop')
-    local rdctl="$installDirectory/resources/resources/win32/bin/rdctl.exe"
+    installDirectory=$(cygpath --unix 'C:\Program Files\Rancher Desktop 2')
+    local rdd="$installDirectory/resources/win32/bin/rdd.exe"
 
     local -a keys
     mapfile -t keys < <(yq.exe 'keys | .[]' < build/signing-config-win.yaml)
@@ -221,45 +240,48 @@ install_win32() {
         done
     done
 
-    # Verify that rdctl exists
-    win32_verify "$rdctl"
-    RDCTL=$rdctl
+    # Verify that rdd exists
+    win32_verify "$rdd"
+    RDD=$rdd
+
+    "$installDirectory/Rancher Desktop 2.exe" &
 }
 
-# Wait for the backend to be alive.  $RDCTL must be set (from the install_*
+# Wait for the backend to be alive.  $RDD must be set (from the install_*
 # functions).  If $APPIMAGE_PID is set, assume we're running AppImage instead.
 wait_for_backend() {
-    local deadline state deadline_date platform rd_pid
+    local deadline deadline_date platform
     deadline=$(( $(date +%s) + 10 * 60 ))
     deadline_date=$({ date --date="@$deadline" || date -j -f %s "$deadline"; } 2>/dev/null)
     platform=$(get_platform)
 
     while [[ $(date +%s) -lt $deadline ]]; do
-        if [[ -n "${APPIMAGE_PID:-}" ]] && [[ -z "${RDCTL:-}" ]]; then
+        if [[ -n "${APPIMAGE_PID:-}" ]] && [[ -z "${RDD:-}" ]]; then
+            local rd_pid
             rd_pid=$(pidof --separator $'\n' rancher-desktop | sort -n | head -n 1 || echo missing)
-            if [[ -e /proc/$rd_pid/exe ]]; then
-                RDCTL=$(dirname "$(readlink /proc/$rd_pid/exe)")/resources/resources/linux/bin/rdctl
+            if [[ -e "/proc/$rd_pid/exe" ]]; then
+                # The AppImage initialization is complete, we can locate rdd and poll for status.
+                RDD=$(dirname "$(readlink "/proc/$rd_pid/exe")")/resources/linux/bin/rdd
                 continue
             fi
-            state=NOT_RUNNING
-        elif [[ $platform == linux ]] && [[ ! -e $HOME/.local/share/rancher-desktop/rd-engine.json ]]; then
-            state=NO_SERVER_CONFIG
+            printf "Waiting for AppImage to start: %s (deadline: %s)\n" "$(date)" "$deadline_date"
         else
-            state=$("$RDCTL" api /v1/backend_state || echo '{"vmState": "NO_RESPONSE"}')
-            state=$(jq --raw-output .vmState <<< "$state")
+            if "$RDD" service status 2>&1 | grep --quiet 'control plane has been started: true'; then
+                # RDD is running; check for the app; note that the app may not exist yet.
+                status=$("$RDD" ctl get app -o jsonpath='{.items[].status.conditions[?(@.type=="Settled")]}' 2>/dev/null || echo '{}')
+                if [[ "$(jq --raw-output .status <<< "${status}")" == "True" ]]; then
+                    # App is settled; waiting is done.
+                    "$RDD" ctl describe app
+                    return
+                fi
+                printf "Waiting for app to settle: (%s) %s (deadline: %s)\n" \
+                    "$(jq --raw-output .message <<< "${status}")" "$(date)" "$deadline_date"
+            else
+                "$RDD" service status
+            fi
         fi
-        case "$state" in
-            ERROR)
-                echo "Backend reached error state." >&2
-                exit 1 ;;
-            STARTED|DISABLED)
-                return ;;
-            *)
-                printf "Backend state: %s\n" "$state";;
-        esac
 
         # if we get here, either we failed to get state or it's starting.
-        printf "Waiting for backend: (%s) %s/%s\n" "$state" "$(date)" "$deadline_date"
         sleep 10
     done
 
@@ -274,12 +296,11 @@ main() {
     platform=$(get_platform)
     archive=$(get_archive)
 
+    # Start the app, and wait for it to settle.
     eval "install_${platform}" "$archive"
-    if [[ -z "${APPIMAGE_PID:-}" ]]; then
-        "$RDCTL" start --no-modal-dialogs \
-            --kubernetes.enabled --application.updater.enabled=false
-        cleanups+=("'$RDCTL' shutdown")
-    fi
+    wait_for_backend
+    # Enable Kubernetes, and wait for it to settle.
+    "$RDD" set --wait=false running=true kubernetes.enabled=true
     wait_for_backend
     echo "Smoke test passed."
 }

--- a/packaging/linux/appimage.yml
+++ b/packaging/linux/appimage.yml
@@ -8,7 +8,7 @@ build:
 
 script:
   - rm -rf $BUILD_APPDIR/* && mkdir -p $BUILD_APPDIR/opt/rancher-desktop $BUILD_APPDIR/usr/share/metainfo $BUILD_APPDIR/usr/bin $BUILD_APPDIR/usr/lib64
-  - unzip $BUILD_SOURCE_DIR/rancher-desktop.zip -d $BUILD_APPDIR/opt/rancher-desktop
+  - unzip $BUILD_SOURCE_DIR/rancher-desktop*.zip -d $BUILD_APPDIR/opt/rancher-desktop
   - chmod 04755 $BUILD_APPDIR/opt/rancher-desktop/chrome-sandbox
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/linux/rancher-desktop.desktop $BUILD_APPDIR
   - convert -resize 512x512 $BUILD_APPDIR/opt/rancher-desktop/resources/icons/logo-square-512.png $BUILD_APPDIR/rancher-desktop.png

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -16,7 +16,7 @@
 #
 
 
-Name:       rancher-desktop
+Name:       rancher-desktop-2
 Version:    0
 Release:    0
 Summary:    Kubernetes and container management on the desktop

--- a/pkg/rancher-desktop/utils/logging.ts
+++ b/pkg/rancher-desktop/utils/logging.ts
@@ -202,6 +202,9 @@ export function clearLoggingDirectory(): void {
   if ((process.env.RD_TEST ?? '').includes('e2e') || process.type !== 'browser') {
     return;
   }
+  if (process.env.RDD_KEEP_LOGS) {
+    return;
+  }
 
   const entries = fs.readdirSync(paths.log_dir, { withFileTypes: true });
 


### PR DESCRIPTION
This is a bunch of stuff aimed at fixing the smoke tests:

- Rename the Linux package to `rancher-desktop-2`
- Make the smoke tests use RDD
- Install qemu (because we don't do that in AppImage, zip)

There's also some debugging related stuff like collecting the Lima logs in smoke tests.