### PR TITLE
rdd: bump Lima windows-plain-ci fork to 25bdf866

### DIFF
--- a/rdd/go.mod
+++ b/rdd/go.mod
@@ -468,7 +468,7 @@ require (
 replace (
 	github.com/containerd/ltag => github.com/mook-as/ltag v0.0.0-20260224191129-27fed92c7adf
 	// Lima from the windows-plain-ci fork branch, pending lima-vm/lima#4998
-	github.com/lima-vm/lima/v2 => github.com/rancher-sandbox/lima/v2 v2.1.3-0.20260615203514-88c8dcc9ce06
+	github.com/lima-vm/lima/v2 => github.com/rancher-sandbox/lima/v2 v2.1.3-0.20260619054522-25bdf86634d8
 	k8s.io/api => k8s.io/api v0.35.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.35.4

--- a/rdd/go.sum
+++ b/rdd/go.sum
@@ -696,8 +696,8 @@ github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4l
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
 github.com/raeperd/recvcheck v0.2.0 h1:GnU+NsbiCqdC2XX5+vMZzP+jAJC5fht7rcVTAhX74UI=
 github.com/raeperd/recvcheck v0.2.0/go.mod h1:n04eYkwIR0JbgD73wT8wL4JjPC3wm0nFtzBnWNocnYU=
-github.com/rancher-sandbox/lima/v2 v2.1.3-0.20260615203514-88c8dcc9ce06 h1:GDgOdPPBFS0aq3ycJX+lhkCwuqStcQ98EkAv5ylJig8=
-github.com/rancher-sandbox/lima/v2 v2.1.3-0.20260615203514-88c8dcc9ce06/go.mod h1:yHzI4V3hz8kSv5lWPD8rnhaTK6lojHJ9USIWwsob0g4=
+github.com/rancher-sandbox/lima/v2 v2.1.3-0.20260619054522-25bdf86634d8 h1:0q5Wr6dCVifkcv0Kr97iBxNbeebKoiMTCjUuEyZOQSk=
+github.com/rancher-sandbox/lima/v2 v2.1.3-0.20260619054522-25bdf86634d8/go.mod h1:yHzI4V3hz8kSv5lWPD8rnhaTK6lojHJ9USIWwsob0g4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=


### PR DESCRIPTION
Update the replace directive to the latest commit on the windows-plain-ci branch (lima-vm/lima#4998).

Ref: https://github.com/rancher-sandbox/lima/pull/157