### PR TITLE
RDA: Report error on incompatible control plane

### DIFF
--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -126,17 +126,16 @@ interface MainEventNames {
   'dialog-info'(args: Record<string, string>): void;
 
   /**
-   * Get the KubeConfig used for Rancher Desktop Daemon.  This may synchronously
-   * trigger `rdd/kube-config-ready` before returning.
+   * Get the KubeConfig used for Rancher Desktop Daemon.
+   * @note This will block until `rdd/certificate-callback` has been called at
+   * least once.
    */
   'rdd/kube-config'(): Promise<string>;
 
   /**
-   * Emitted when the KubeConfig used for Rancher Desktop Daemon has been
-   * fetched.  This should only be handled by the networking code.
-   * @param kubeConfig The KubeConfig string.
+   * Register a callback that will be called when the KubeConfig is ready.
    */
-  'rdd/kube-config-ready'(kubeConfig: string): Promise<void>;
+  'rdd/certificate-callback'(callback: (kubeConfig: string) => void): void;
 }
 
 /**

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -126,9 +126,17 @@ interface MainEventNames {
   'dialog-info'(args: Record<string, string>): void;
 
   /**
-   * Get the KubeConfig used for Rancher Desktop Daemon.
+   * Get the KubeConfig used for Rancher Desktop Daemon.  This may synchronously
+   * trigger `rdd/kube-config-ready` before returning.
    */
   'rdd/kube-config'(): Promise<string>;
+
+  /**
+   * Emitted when the KubeConfig used for Rancher Desktop Daemon has been
+   * fetched.  This should only be handled by the networking code.
+   * @param kubeConfig The KubeConfig string.
+   */
+  'rdd/kube-config-ready'(kubeConfig: string): Promise<void>;
 }
 
 /**

--- a/pkg/rancher-desktop/main/networking/index.ts
+++ b/pkg/rancher-desktop/main/networking/index.ts
@@ -41,7 +41,7 @@ export default async function setupNetworking() {
   http.globalAgent = proxyAgent;
   https.globalAgent = proxyAgent;
 
-  mainEvents.handle('rdd/kube-config-ready', (kubeConfigStr) => {
+  mainEvents.emit('rdd/certificate-callback', (kubeConfigStr) => {
     const kubeConfig = new KubeConfig();
     kubeConfig.loadFromString(kubeConfigStr);
     configureRDDAuthentication(kubeConfig);
@@ -61,10 +61,10 @@ export default async function setupNetworking() {
       verifyCertificate.bind(null, kubeCerts, getSystemCertificates));
 
     mainEvents.emit('network-ready');
-
-    return Promise.resolve();
   });
-  // Trigger RDD config loading, ignoring the result.
+  // Trigger RDD config loading, ignoring the result.  This lets us move the
+  // certificate handling setup outside of a potential hot path.  If this has
+  // already occurred, it would just ignore the cached result.
   mainEvents.invoke('rdd/kube-config').catch(console.error);
 }
 

--- a/pkg/rancher-desktop/main/networking/index.ts
+++ b/pkg/rancher-desktop/main/networking/index.ts
@@ -41,25 +41,31 @@ export default async function setupNetworking() {
   http.globalAgent = proxyAgent;
   https.globalAgent = proxyAgent;
 
-  const kubeConfig = new KubeConfig();
-  kubeConfig.loadFromString(await mainEvents.invoke('rdd/kube-config'));
-  configureRDDAuthentication(kubeConfig);
-  const kubeCerts =
-    Buffer.from(kubeConfig.getCurrentCluster()?.caData ?? '', 'base64')
-      .toString('utf-8')
-      .split(/(?=-----BEGIN CERTIFICATE-----)/g)
-      .map(cleanupCert)
-      .filter(x => x);
+  mainEvents.handle('rdd/kube-config-ready', (kubeConfigStr) => {
+    const kubeConfig = new KubeConfig();
+    kubeConfig.loadFromString(kubeConfigStr);
+    configureRDDAuthentication(kubeConfig);
+    const kubeCerts =
+      Buffer.from(kubeConfig.getCurrentCluster()?.caData ?? '', 'base64')
+        .toString('utf-8')
+        .split(/(?=-----BEGIN CERTIFICATE-----)/g)
+        .map(cleanupCert)
+        .filter(x => x);
 
-  // Set up certificate handling for specific hosts; we ignore the certificate
-  // completely on these, but limit them to specific ports.
-  Electron.app.on('certificate-error', handleCertificateError.bind(null, kubeCerts));
-  // Set up certificate handling for system certificates, as well as handling
-  // custom certificate authorities for RDD.
-  Electron.session.defaultSession.setCertificateVerifyProc(
-    verifyCertificate.bind(null, kubeCerts, getSystemCertificates));
+    // Set up certificate handling for specific hosts; we ignore the certificate
+    // completely on these, but limit them to specific ports.
+    Electron.app.on('certificate-error', handleCertificateError.bind(null, kubeCerts));
+    // Set up certificate handling for system certificates, as well as handling
+    // custom certificate authorities for RDD.
+    Electron.session.defaultSession.setCertificateVerifyProc(
+      verifyCertificate.bind(null, kubeCerts, getSystemCertificates));
 
-  mainEvents.emit('network-ready');
+    mainEvents.emit('network-ready');
+
+    return Promise.resolve();
+  });
+  // Trigger RDD config loading, ignoring the result.
+  mainEvents.invoke('rdd/kube-config').catch(console.error);
 }
 
 /**

--- a/pkg/rancher-desktop/main/rdd-ctl.ts
+++ b/pkg/rancher-desktop/main/rdd-ctl.ts
@@ -4,16 +4,19 @@ import stream from 'node:stream';
 import Electron from 'electron';
 
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
-import mainEvents, { NoMainEventsHandlerError } from '@pkg/main/mainEvents';
+import mainEvents from '@pkg/main/mainEvents';
 import { spawnFile, SpawnError } from '@pkg/utils/childProcess';
+import Latch from '@pkg/utils/latch';
 import Logging from '@pkg/utils/logging';
 import { getRDDPath } from '@pkg/utils/paths';
 
 const console = Logging.rdd;
 const CodeIncompatibleServer = 5;
 
+const certificateCallback = Latch<(kubeConfig: string) => void>();
 let fetchConfigPromise: Promise<string> | undefined;
-let missingReadyCallback = false;
+
+mainEvents.on('rdd/certificate-callback', certificateCallback.resolve);
 
 /**
  * fetchConfig returns the kubeconfig for accessing RDD.
@@ -26,7 +29,7 @@ async function fetchConfigWithoutCache(): Promise<string> {
 
   // Loop until the control plane is ready.
   while (true) {
-    // stderr friom the `service config` command, in case there is a JSON error
+    // stderr from the `service config` command, in case there is a JSON error
     // message we can parse.
     let stderr = '';
     let lastStderrLine = '';
@@ -69,17 +72,15 @@ async function fetchConfigWithoutCache(): Promise<string> {
       // control the output, that should be safe.
       if (stdout.includes('apiVersion')) {
         // Notify the networking code that the kubeconfig is ready, to configure
-        // the certificate handling.
+        // the certificate handling.  This must happen before we return so that
+        // the caller will not get certificate errors when making requests.
         try {
-          await mainEvents.invoke('rdd/kube-config-ready', stdout);
+          (await certificateCallback)(stdout);
         } catch (err) {
-          if (err instanceof NoMainEventsHandlerError) {
-            // The callback hasn't been registered yet.
-            missingReadyCallback = true;
-          } else {
-            // Retrying to get the config will not help.
-            console.error('Error processing new RDD configuration', err);
-          }
+          // Retrying to get the config will not help; just log the error so we
+          // can debug it later.  The user will see other errors and need to
+          // restart.
+          console.error('Error processing new RDD configuration', err);
         }
 
         // Log the RDD version for debugging purposes; no need to do that
@@ -133,17 +134,6 @@ async function fetchConfigWithoutCache(): Promise<string> {
  */
 function fetchConfig(): Promise<string> {
   fetchConfigPromise ??= fetchConfigWithoutCache();
-
-  if (missingReadyCallback) {
-    // The callback for `rdd/kube-config-ready` was not registered by the time
-    // the initial `fetchConfig` call was made.  Call that now (because the
-    // kube config must have been ready for that flag to be set).
-    fetchConfigPromise.then(kubeConfigStr => {
-      mainEvents.invoke('rdd/kube-config-ready', kubeConfigStr)
-        .catch(err => console.error('Error processing new RDD configuration', err));
-    });
-    missingReadyCallback = false;
-  }
 
   return fetchConfigPromise;
 }

--- a/pkg/rancher-desktop/main/rdd-ctl.ts
+++ b/pkg/rancher-desktop/main/rdd-ctl.ts
@@ -1,7 +1,11 @@
 // This file contains handlers to let the front end use `rdd ctl`.
+import stream from 'node:stream';
+
+import Electron from 'electron';
+
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import mainEvents from '@pkg/main/mainEvents';
-import { spawnFile } from '@pkg/utils/childProcess';
+import { spawnFile, SpawnError } from '@pkg/utils/childProcess';
 import Logging from '@pkg/utils/logging';
 import { getRDDPath } from '@pkg/utils/paths';
 
@@ -24,20 +28,83 @@ async function fetchConfig(): Promise<string> {
 
   // Loop until the control plane is ready.
   while (true) {
+    // stderr friom the `service config` command, in case there is a JSON error
+    // message we can parse.
+    let stderr = '';
+    let lastStderrLine = '';
+    // stderrWritable is a Writable that logs to the `stderr` variable, and also
+    // dumps the value to the console.
+    const stderrWritable = new stream.Writable({
+      write(chunk, encoding, callback) {
+        let error: Error | null = null;
+        try {
+          stderr += chunk.toString();
+          const lines = (lastStderrLine + chunk.toString()).split('\n');
+          lastStderrLine = lines.pop() ?? '';
+          for (const line of lines) {
+            console.error(line);
+          }
+        } catch (err) {
+          error = err as Error;
+        }
+        callback(error);
+      },
+      final(callback) {
+        let error: Error | null = null;
+        try {
+          if (lastStderrLine) {
+            console.error(lastStderrLine);
+          }
+        } catch (err) {
+          error = err as Error;
+        }
+        callback(error);
+      },
+    });
     try {
       const { stdout } = await spawnFile(
         rddPath,
-        ['service', 'config'],
-        { stdio: ['ignore', 'pipe', console] });
+        ['service', 'config', '--log-format=json'],
+        { stdio: ['ignore', 'pipe', stderrWritable], encoding: 'utf-8' });
 
-      // Assume error messages do not contain `apiVersion`; as we control the
-      // output, that should be safe.
+      // Assume all other error messages do not contain `apiVersion`; as we
+      // control the output, that should be safe.
       if (stdout.includes('apiVersion')) {
         lastKubeConfig = stdout;
+        // Notify the networking code that the kubeconfig is ready, to configure
+        // the certificate handling.
+        try {
+          await mainEvents.invoke('rdd/kube-config-ready', stdout);
+        } catch (err) {
+          // Retrying to get the config will not help.
+          console.error('Error processing new RDD configuration', err);
+        }
+
+        // Log the RDD version for debugging purposes; no need to do that
+        // synchronously, though.
+        spawnFile(rddPath, ['--version=raw'], { stdio: ['ignore', 'pipe', console] })
+          .then(({ stdout }) => console.log('RDD version:', stdout))
+          .catch(err => console.error('Error fetching RDD version:', err));
 
         return stdout;
       }
     } catch (err) {
+      if (err instanceof SpawnError && err.code === 5) {
+        // Fatal: the server is using an incompatible backend.
+        let message = 'Unsupported RDD service version';
+        try {
+          message = JSON.parse(stderr).msg ?? message;
+        } catch { /* ignore, use fallback message */ }
+        console.error(message);
+        Electron.dialog.showErrorBox('Incompatible RDD Service', message);
+        Electron.app.quit();
+        // We cannot recover (the user needs to restart the application), so
+        // `fetchConfig` caching the error is fine.  However, do not use the
+        // original error; the user seeing this does not need to see the command
+        // line that caused the issue.
+        // eslint-disable-next-line preserve-caught-error
+        throw new Error(message);
+      }
       console.error('Error fetching kube config, retrying', err);
     }
 

--- a/pkg/rancher-desktop/main/rdd-ctl.ts
+++ b/pkg/rancher-desktop/main/rdd-ctl.ts
@@ -11,19 +11,15 @@ import { getRDDPath } from '@pkg/utils/paths';
 
 const console = Logging.rdd;
 
-let lastKubeConfig = '';
+let fetchConfigPromise: Promise<string> | undefined;
 
 /**
- * fetchConfig returns the kubeconfig for accessing RDD.  If it has previously
- * been fetched, it returns the cached version.
+ * fetchConfig returns the kubeconfig for accessing RDD.
+ * @note Using fetchConfig is preferred.
  * @note If we fail to fetch the configuration, we just wait more instead of
  * throwing.
  */
-async function fetchConfig(): Promise<string> {
-  if (lastKubeConfig) {
-    // Return any existing kubeconfig that is available.
-    return lastKubeConfig;
-  }
+async function fetchConfigWithoutCache(): Promise<string> {
   const rddPath = getRDDPath();
 
   // Loop until the control plane is ready.
@@ -70,7 +66,6 @@ async function fetchConfig(): Promise<string> {
       // Assume all other error messages do not contain `apiVersion`; as we
       // control the output, that should be safe.
       if (stdout.includes('apiVersion')) {
-        lastKubeConfig = stdout;
         // Notify the networking code that the kubeconfig is ready, to configure
         // the certificate handling.
         try {
@@ -110,6 +105,18 @@ async function fetchConfig(): Promise<string> {
 
     await new Promise(resolve => setTimeout(resolve, 1_000));
   }
+}
+
+/**
+ * fetchConfig returns the kubeconfig for accessing RDD.  If it has previously
+ * been fetched, it returns the cached version.
+ * @note If we fail to fetch the configuration, we just wait more instead of
+ * throwing.
+ */
+function fetchConfig(): Promise<string> {
+  fetchConfigPromise ??= fetchConfigWithoutCache();
+
+  return fetchConfigPromise;
 }
 
 getIpcMainProxy(console).handle('rdd/kube-config', () => fetchConfig());

--- a/pkg/rancher-desktop/main/rdd-ctl.ts
+++ b/pkg/rancher-desktop/main/rdd-ctl.ts
@@ -4,14 +4,16 @@ import stream from 'node:stream';
 import Electron from 'electron';
 
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
-import mainEvents from '@pkg/main/mainEvents';
+import mainEvents, { NoMainEventsHandlerError } from '@pkg/main/mainEvents';
 import { spawnFile, SpawnError } from '@pkg/utils/childProcess';
 import Logging from '@pkg/utils/logging';
 import { getRDDPath } from '@pkg/utils/paths';
 
 const console = Logging.rdd;
+const CodeIncompatibleServer = 5;
 
 let fetchConfigPromise: Promise<string> | undefined;
+let missingReadyCallback = false;
 
 /**
  * fetchConfig returns the kubeconfig for accessing RDD.
@@ -71,8 +73,13 @@ async function fetchConfigWithoutCache(): Promise<string> {
         try {
           await mainEvents.invoke('rdd/kube-config-ready', stdout);
         } catch (err) {
-          // Retrying to get the config will not help.
-          console.error('Error processing new RDD configuration', err);
+          if (err instanceof NoMainEventsHandlerError) {
+            // The callback hasn't been registered yet.
+            missingReadyCallback = true;
+          } else {
+            // Retrying to get the config will not help.
+            console.error('Error processing new RDD configuration', err);
+          }
         }
 
         // Log the RDD version for debugging purposes; no need to do that
@@ -84,12 +91,23 @@ async function fetchConfigWithoutCache(): Promise<string> {
         return stdout;
       }
     } catch (err) {
-      if (err instanceof SpawnError && err.code === 5) {
-        // Fatal: the server is using an incompatible backend.
+      if (err instanceof SpawnError && err.code === CodeIncompatibleServer) {
+        // Fatal: the server is using an incompatible backend.  `stderr` is in
+        // JSONL (i.e. JSON objects on separate lines); try to get the error
+        // message out of them.
         let message = 'Unsupported RDD service version';
-        try {
-          message = JSON.parse(stderr).msg ?? message;
-        } catch { /* ignore, use fallback message */ }
+        for (const line of stderr.split(/\r?\n/)) {
+          try {
+            const error: { 'exit-code'?: number; msg?: string } = JSON.parse(line);
+            if (error?.['exit-code'] !== CodeIncompatibleServer) {
+              continue;
+            }
+            if (typeof error?.msg === 'string' && error.msg && error.msg !== '<nil>') {
+              message = error.msg;
+              break;
+            }
+          } catch { /* ignore; try next line, or use fallback message */ }
+        }
         console.error(message);
         Electron.dialog.showErrorBox('Incompatible RDD Service', message);
         Electron.app.quit();
@@ -115,6 +133,17 @@ async function fetchConfigWithoutCache(): Promise<string> {
  */
 function fetchConfig(): Promise<string> {
   fetchConfigPromise ??= fetchConfigWithoutCache();
+
+  if (missingReadyCallback) {
+    // The callback for `rdd/kube-config-ready` was not registered by the time
+    // the initial `fetchConfig` call was made.  Call that now (because the
+    // kube config must have been ready for that flag to be set).
+    fetchConfigPromise.then(kubeConfigStr => {
+      mainEvents.invoke('rdd/kube-config-ready', kubeConfigStr)
+        .catch(err => console.error('Error processing new RDD configuration', err));
+    });
+    missingReadyCallback = false;
+  }
 
   return fetchConfigPromise;
 }

--- a/pkg/rancher-desktop/utils/childProcess.ts
+++ b/pkg/rancher-desktop/utils/childProcess.ts
@@ -28,7 +28,7 @@ interface SpawnOptionsEncoding {
   encoding?: { stdout?: BufferEncoding, stderr?: BufferEncoding } | BufferEncoding
 }
 
-class SpawnError extends Error {
+export class SpawnError extends Error {
   constructor(command: string[], options: { code: number | null, signal: NodeJS.Signals | null, stdout?: string, stderr?: string }) {
     const executable = command[0];
     let message = `${ executable } exited with code ${ options.code }`;

--- a/rdd/cmd/rdd/main.go
+++ b/rdd/cmd/rdd/main.go
@@ -177,9 +177,12 @@ func main() {
 		// *cliexit.Error lets a subcommand opt into a specific exit code; everything else gets exit 1.
 		var exitErr *cliexit.Error
 		if errors.As(err, &exitErr) {
-			// A propagated child-exit code carries no message (nil Err); logging it
-			// would emit a bare level=error line, so log only when there is one.
-			if exitErr.Err != nil {
+			if _, ok := logrus.StandardLogger().Formatter.(*logrus.JSONFormatter); ok {
+				// If we're logging to JSON, include the exit code.
+				logrus.WithField("exit-code", exitErr.Code).Error(err)
+			} else if exitErr.Err != nil {
+				// A propagated child-exit code carries no message (nil Err); logging it
+				// would emit a bare level=error line, so log only when there is one.
 				logrus.Error(err)
 			}
 			os.Exit(exitErr.Code)

--- a/rdd/docs/design/cmd_app.md
+++ b/rdd/docs/design/cmd_app.md
@@ -38,8 +38,9 @@ rdd set --wait=false running=true
 | `1` | Generic / internal error. |
 | `3` | The API server's admission controller rejected the request. |
 | `4` | The wait deadline expired before the desired state was reached. |
+| `5` | The running Rancher Desktop Daemon is not compatible with the invoked client. |
 
-`2` is reserved for cobra usage errors. Other rdd commands will adopt the same scheme as they grow `--wait` semantics; the codes are defined in `pkg/cli/exit`.
+`2` is reserved for cobra usage errors. Other rdd commands will adopt the same scheme as they grow `--wait` semantics; the codes are defined in [`pkg/cli/exit`](/rdd/pkg/cli/exit/exit.go).
 
 ## `rdd start`
 

--- a/rdd/pkg/cli/exit/exit.go
+++ b/rdd/pkg/cli/exit/exit.go
@@ -15,10 +15,13 @@ import (
 // reserved for cobra usage errors, so named codes start at 3.
 const (
 	// CodeRejected indicates the API server's admission controller rejected the request.
-	CodeRejected = 3
+	CodeRejected = iota + 3
 
 	// CodeTimeout indicates the wait deadline expired before the desired state was reached.
-	CodeTimeout = 4
+	CodeTimeout
+
+	// CodeIncompatibleServer indicates the server is incompatible with the client.
+	CodeIncompatibleServer
 )
 
 // Error is an error that carries a process exit code for main to return.

--- a/rdd/pkg/cli/exit/exit.go
+++ b/rdd/pkg/cli/exit/exit.go
@@ -12,16 +12,17 @@ import (
 )
 
 // Predefined exit codes. 0 and 1 are the defaults handled by main; 2 is
-// reserved for cobra usage errors, so named codes start at 3.
+// reserved for cobra usage errors, so named codes start at 3.  This list should
+// use explicit values, as this is a public API; see `cmd_app.md`.
 const (
 	// CodeRejected indicates the API server's admission controller rejected the request.
-	CodeRejected = iota + 3
+	CodeRejected = 3
 
 	// CodeTimeout indicates the wait deadline expired before the desired state was reached.
-	CodeTimeout
+	CodeTimeout = 4
 
 	// CodeIncompatibleServer indicates the server is incompatible with the client.
-	CodeIncompatibleServer
+	CodeIncompatibleServer = 5
 )
 
 // Error is an error that carries a process exit code for main to return.

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -52,6 +52,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/features"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/binlinks"
+	cliexit "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/exit"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/cli/help"
 	// Import controller packages to trigger init() functions for embedded mode.
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/app"
@@ -195,14 +196,6 @@ func Create(args []string) error {
 	return os.WriteFile(instance.ArgsFile(), data, 0o600)
 }
 
-// errorServerVersionUnsupported indicates the control plane is running an
-// unsupported version.
-type errorServerVersionUnsupported struct{ message string }
-
-func (e errorServerVersionUnsupported) Error() string {
-	return e.message
-}
-
 // checkSupportedVersion checks if the control plane is running a version that
 // is compatible with this client.
 func checkSupportedVersion(config *rest.Config) error {
@@ -225,10 +218,11 @@ func checkSupportedVersion(config *rest.Config) error {
 	// Currently, we only support the version that is the exact version of the
 	// client.
 	if serverVersion.GitVersion != version.Get().GitVersion {
-		message := fmt.Sprintf(
-			"Unsupported server version %s (expected %s)",
-			serverVersion.GitVersion, version.Get().GitVersion)
-		return errorServerVersionUnsupported{message: message}
+		return &cliexit.Error{
+			Code: cliexit.CodeIncompatibleServer,
+			Err: fmt.Errorf("unsupported server version %s (expected %s)",
+				serverVersion.GitVersion, version.Get().GitVersion),
+		}
 	}
 	return nil
 }
@@ -419,7 +413,9 @@ func Wait(ctx context.Context) error {
 			err := checkReadiness(ctx, reportPhase)
 			if err == nil {
 				return nil
-			} else if errors.As(err, &errorServerVersionUnsupported{}) {
+			}
+			var cliError *cliexit.Error
+			if errors.As(err, &cliError) && cliError.Code == cliexit.CodeIncompatibleServer {
 				// The error will never recover; stop waiting.
 				return err
 			}


### PR DESCRIPTION
This updates the UI so that if there is an incompatible control plane, we show a brief error instead of just waiting forever to start.

<img width="372" height="378" alt="image" src="https://github.com/user-attachments/assets/8319be3e-51a8-4e31-99fb-2c21e9e7981e" />

To test:
- Run `rdd service start` etc. on a different branch.
- Run `RDD_DEVELOPER_MODE=false yarn dev` on this branch.

See also: #463 — the second commit in the series makes the initial config fetch asynchronous, so we can show the window earlier.  (Note that we still need `rdd service paths` to finish, thogh.)