### PR TITLE
Recover from orphaned WSL2 distro registrations

### DIFF
--- a/rdd/docs/design/cmd_service.md
+++ b/rdd/docs/design/cmd_service.md
@@ -116,8 +116,8 @@ directory.
 
 On Windows it also unregisters each Lima instance's WSL2 distro before removing
 the Lima home, because deleting the directory drops the distro's `ext4.vhdx` but
-leaves the `wsl --list` registration behind, which the next `rdd service create`
-would boot against a missing disk.
+leaves the `wsl --list` registration behind, which would cause the next
+`rdd service create` to boot against a missing disk.
 
 Delete always waits for the control plane to exit before removing files, because
 removing the instance directory under a live process corrupts it on Windows and

--- a/rdd/docs/design/cmd_service.md
+++ b/rdd/docs/design/cmd_service.md
@@ -114,6 +114,11 @@ Stops the control plane and removes the instance directory, the short directory
 (which contains the Lima home), and — unless `RDD_KEEP_LOGS` is set — the log
 directory.
 
+On Windows it also unregisters each Lima instance's WSL2 distro before removing
+the Lima home, because deleting the directory drops the distro's `ext4.vhdx` but
+leaves the `wsl --list` registration behind, which the next `rdd service create`
+would boot against a missing disk.
+
 Delete always waits for the control plane to exit before removing files, because
 removing the instance directory under a live process corrupts it on Windows and
 breaks PID-file mutual exclusion on Unix. Use `--timeout` to bound that wait

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,6 +32,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/logfile"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/wsl"
 )
 
 // hostSwitchRetryInterval is the minimum time between restarts of a host-switch
@@ -812,38 +812,18 @@ func stopInstanceForcibly(ctx context.Context, logger logr.Logger, inst *limatyp
 	}
 }
 
-// terminateWSL2Distro sends `wsl.exe --terminate` for the Lima distro with
-// the given instance name. No-op on non-Windows. Best-effort with a
-// 10-second timeout: wsl.exe can hang if the WSL subsystem is degraded.
+// terminateWSL2Distro terminates the WSL2 distro backing instName, logging any
+// failure. No-op on non-Windows.
 func terminateWSL2Distro(ctx context.Context, logger logr.Logger, instName string) {
-	if runtime.GOOS != "windows" {
-		return
-	}
-	distroName := "lima-" + instName
-	wslCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	if err := exec.CommandContext(wslCtx, "wsl.exe", "--terminate", distroName).Run(); err != nil {
-		logger.V(1).Info("Failed to terminate WSL2 distro", "distro", distroName, "error", err)
+	if err := wsl.Terminate(ctx, wsl.DistroName(instName)); err != nil {
+		logger.V(1).Info("Failed to terminate WSL2 distro", "instance", instName, "error", err)
 	}
 }
 
-// unregisterWSL2Distro sends `wsl.exe --unregister` for the Lima distro with
-// the given instance name, returning nil on non-Windows. This removes the WSL2
-// registration and deletes the distro's ext4.vhdx, allowing Lima to import a
-// fresh distro on the next Prepare. It uses a 30-second timeout (unregister is
-// slower than terminate and can hang if WSL2 is degraded) and leaves the
-// failure handling to the caller.
+// unregisterWSL2Distro unregisters the WSL2 distro backing instName, returning
+// the failure for the caller to handle. No-op on non-Windows.
 func unregisterWSL2Distro(ctx context.Context, instName string) error {
-	if runtime.GOOS != "windows" {
-		return nil
-	}
-	distroName := "lima-" + instName
-	wslCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	if err := exec.CommandContext(wslCtx, "wsl.exe", "--unregister", distroName).Run(); err != nil {
-		return fmt.Errorf("unregister WSL2 distro %q: %w", distroName, err)
-	}
-	return nil
+	return wsl.Unregister(ctx, wsl.DistroName(instName))
 }
 
 // removeStaleInstance removes a stale Lima instance directory left behind by
@@ -857,7 +837,7 @@ func removeStaleInstance(ctx context.Context, logger logr.Logger, instName, inst
 	// forceStopForDeletion guards against. Both calls are no-ops off Windows.
 	terminateWSL2Distro(ctx, logger, instName)
 	if err := unregisterWSL2Distro(ctx, instName); err != nil {
-		logger.V(1).Info("Failed to unregister WSL2 distro", "instance", instName, "error", err)
+		logger.Error(err, "Failed to unregister WSL2 distro; a stale registration may remain", "instance", instName)
 	}
 	return os.RemoveAll(instanceDir)
 }

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,6 +39,10 @@ import (
 // that exited unexpectedly, and the delay before handleWatchedState re-checks
 // afterward.
 const hostSwitchRetryInterval = 15 * time.Second
+
+// wsl2RootDisk is the root-disk filename Lima's WSL2 driver creates when it
+// imports a distro with `wsl.exe --import`.
+const wsl2RootDisk = "ext4.vhdx"
 
 func (r *LimaVMReconciler) handleDeletion(ctx context.Context, limaVM *v1alpha1.LimaVM) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -344,6 +349,19 @@ func (r *LimaVMReconciler) handleRestartNeeded(ctx context.Context, limaVM *v1al
 	}
 }
 
+// wsl2RegistrationIsOrphaned reports whether inst is a WSL2 distro still
+// registered with WSL but missing its root disk — a state Lima cannot recover
+// on its own, because its WSL2 driver only re-imports a distro that is absent
+// from `wsl --list`. It arises when an instance directory is removed without
+// `wsl --unregister`. Always false off Windows, where VMType is never WSL2.
+func wsl2RegistrationIsOrphaned(inst *limatype.Instance) bool {
+	if inst.VMType != limatype.WSL2 || inst.Status == limatype.StatusUninitialized {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(inst.Dir, wsl2RootDisk))
+	return errors.Is(err, os.ErrNotExist)
+}
+
 // startInstance launches the hostagent and starts a watcher goroutine to track
 // its lifecycle. The watcher triggers reconciles as the hostagent progresses
 // through Starting → Running → Stopped, so no polling is needed.
@@ -361,6 +379,27 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	if err := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStarting, "Lima instance is starting"); err != nil {
 		logger.Error(err, "Failed to update starting condition")
 		return ctrl.Result{}, err
+	}
+
+	// Heal an orphaned WSL2 registration before the hostagent boots it (see
+	// wsl2RegistrationIsOrphaned). Unregistering makes Lima's Start (below, in
+	// the hostagent) treat the distro as uninitialized and re-import basedisk,
+	// instead of booting a missing disk into ERROR_FILE_NOT_FOUND forever.
+	if wsl2RegistrationIsOrphaned(inst) {
+		logger.Info("WSL2 distro is registered but its root disk is missing; unregistering to force re-import",
+			"instance", limaVM.Name, "disk", wsl2RootDisk)
+		// Terminate before unregistering: wsl.exe --unregister can deadlock on a
+		// distro that still holds kernel state. Both are no-ops off Windows.
+		terminateWSL2Distro(ctx, logger, limaVM.Name)
+		if err := unregisterWSL2Distro(ctx, limaVM.Name); err != nil {
+			// Booting now would hit ERROR_FILE_NOT_FOUND again, so fail the start
+			// and requeue to retry the unregister.
+			logger.Error(err, "Failed to unregister orphaned WSL2 distro", "instance", limaVM.Name)
+			if updateErr := r.updateCondition(ctx, limaVM, ConditionRunning, metav1.ConditionFalse, ReasonStartFailed, err.Error()); updateErr != nil {
+				logger.Error(updateErr, "Failed to update status after unregister failure")
+			}
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Get the path to our own executable (rdd) to use as the hostagent launcher
@@ -789,20 +828,22 @@ func terminateWSL2Distro(ctx context.Context, logger logr.Logger, instName strin
 }
 
 // unregisterWSL2Distro sends `wsl.exe --unregister` for the Lima distro with
-// the given instance name. No-op on non-Windows. This removes the WSL2
+// the given instance name, returning nil on non-Windows. This removes the WSL2
 // registration and deletes the distro's ext4.vhdx, allowing Lima to import a
-// fresh distro on the next Prepare. Best-effort with a 30-second timeout
-// (unregister is slower than terminate and can hang if WSL2 is degraded).
-func unregisterWSL2Distro(ctx context.Context, logger logr.Logger, instName string) {
+// fresh distro on the next Prepare. It uses a 30-second timeout (unregister is
+// slower than terminate and can hang if WSL2 is degraded) and leaves the
+// failure handling to the caller.
+func unregisterWSL2Distro(ctx context.Context, instName string) error {
 	if runtime.GOOS != "windows" {
-		return
+		return nil
 	}
 	distroName := "lima-" + instName
 	wslCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	if err := exec.CommandContext(wslCtx, "wsl.exe", "--unregister", distroName).Run(); err != nil {
-		logger.V(1).Info("Failed to unregister WSL2 distro", "distro", distroName, "error", err)
+		return fmt.Errorf("unregister WSL2 distro %q: %w", distroName, err)
 	}
+	return nil
 }
 
 // removeStaleInstance removes a stale Lima instance directory left behind by
@@ -815,7 +856,9 @@ func removeStaleInstance(ctx context.Context, logger logr.Logger, instName, inst
 	// deadlock on a distro that still holds kernel state, the same hazard
 	// forceStopForDeletion guards against. Both calls are no-ops off Windows.
 	terminateWSL2Distro(ctx, logger, instName)
-	unregisterWSL2Distro(ctx, logger, instName)
+	if err := unregisterWSL2Distro(ctx, instName); err != nil {
+		logger.V(1).Info("Failed to unregister WSL2 distro", "instance", instName, "error", err)
+	}
 	return os.RemoveAll(instanceDir)
 }
 

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -388,10 +388,7 @@ func (r *LimaVMReconciler) startInstance(ctx context.Context, limaVM *v1alpha1.L
 	if wsl2RegistrationIsOrphaned(inst) {
 		logger.Info("WSL2 distro is registered but its root disk is missing; unregistering to force re-import",
 			"instance", limaVM.Name, "disk", wsl2RootDisk)
-		// Terminate before unregistering: wsl.exe --unregister can deadlock on a
-		// distro that still holds kernel state. Both are no-ops off Windows.
-		terminateWSL2Distro(ctx, logger, limaVM.Name)
-		if err := unregisterWSL2Distro(ctx, limaVM.Name); err != nil {
+		if err := wsl.Unregister(ctx, wsl.DistroName(limaVM.Name)); err != nil {
 			// Booting now would hit ERROR_FILE_NOT_FOUND again, so fail the start
 			// and requeue to retry the unregister.
 			logger.Error(err, "Failed to unregister orphaned WSL2 distro", "instance", limaVM.Name)
@@ -820,12 +817,6 @@ func terminateWSL2Distro(ctx context.Context, logger logr.Logger, instName strin
 	}
 }
 
-// unregisterWSL2Distro unregisters the WSL2 distro backing instName, returning
-// the failure for the caller to handle. No-op on non-Windows.
-func unregisterWSL2Distro(ctx context.Context, instName string) error {
-	return wsl.Unregister(ctx, wsl.DistroName(instName))
-}
-
 // removeStaleInstance removes a stale Lima instance directory left behind by
 // a previous service run whose cleanup failed. On Windows, the WSL2 distro is
 // terminated and then unregistered (removing its ext4.vhdx and releasing any
@@ -836,7 +827,7 @@ func removeStaleInstance(ctx context.Context, logger logr.Logger, instName, inst
 	// deadlock on a distro that still holds kernel state, the same hazard
 	// forceStopForDeletion guards against. Both calls are no-ops off Windows.
 	terminateWSL2Distro(ctx, logger, instName)
-	if err := unregisterWSL2Distro(ctx, instName); err != nil {
+	if err := wsl.Unregister(ctx, wsl.DistroName(instName)); err != nil {
 		logger.Error(err, "Failed to unregister WSL2 distro; a stale registration may remain", "instance", instName)
 	}
 	return os.RemoveAll(instanceDir)

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle_test.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lima-vm/lima/v2/pkg/limatype"
+	"gotest.tools/v3/assert"
+)
+
+func TestWSL2RegistrationIsOrphaned(t *testing.T) {
+	// newDir returns a fresh instance directory, optionally containing the
+	// WSL2 root disk so the predicate sees a registration with its disk intact.
+	newDir := func(t *testing.T, withDisk bool) string {
+		t.Helper()
+		dir := t.TempDir()
+		if withDisk {
+			assert.NilError(t, os.WriteFile(filepath.Join(dir, wsl2RootDisk), []byte("vhdx"), 0o644))
+		}
+		return dir
+	}
+
+	t.Run("registered WSL2 distro with a missing disk is orphaned", func(t *testing.T) {
+		inst := &limatype.Instance{Dir: newDir(t, false), VMType: limatype.WSL2, Status: limatype.StatusStopped}
+		assert.Assert(t, wsl2RegistrationIsOrphaned(inst))
+	})
+
+	t.Run("registered WSL2 distro with its disk present is healthy", func(t *testing.T) {
+		inst := &limatype.Instance{Dir: newDir(t, true), VMType: limatype.WSL2, Status: limatype.StatusStopped}
+		assert.Assert(t, !wsl2RegistrationIsOrphaned(inst))
+	})
+
+	t.Run("uninitialized WSL2 distro is not orphaned (fresh import pending)", func(t *testing.T) {
+		inst := &limatype.Instance{Dir: newDir(t, false), VMType: limatype.WSL2, Status: limatype.StatusUninitialized}
+		assert.Assert(t, !wsl2RegistrationIsOrphaned(inst))
+	})
+
+	t.Run("non-WSL2 instance with a missing disk is not orphaned", func(t *testing.T) {
+		inst := &limatype.Instance{Dir: newDir(t, false), VMType: limatype.QEMU, Status: limatype.StatusStopped}
+		assert.Assert(t, !wsl2RegistrationIsOrphaned(inst))
+	})
+}

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -566,64 +566,9 @@ func Delete(ctx context.Context, timeout time.Duration) error {
 	// directory deletes the distro's ext4.vhdx but orphans the `wsl --list`
 	// registration, which the next `rdd svc create` would boot against a
 	// missing disk.
-	unregisterInstanceDistros(ctx)
+	wsl.UnregisterInstanceDistros(ctx, instance.LimaHome())
 	_ = os.RemoveAll(instance.ShortDir())
 	return os.RemoveAll(instance.Dir())
-}
-
-// unregisterInstanceDistros unregisters the WSL2 distro backing each Lima
-// instance, clearing the `wsl --list` registration before its directory is
-// removed. It terminates each distro first, because `wsl --unregister` can
-// deadlock on a distro that still holds kernel state. Both calls are best-effort
-// and time-bounded, since wsl.exe can hang when the WSL subsystem is degraded.
-// No-op on non-Windows.
-//
-// TODO: This reimplements cleanup the lima controller already owns
-// (unregisterWSL2Distro), because `svc delete` stops the daemon before
-// reaching here. Route it through the controller once the stop/delete hook
-// (rancher-desktop-2#319) exists.
-func unregisterInstanceDistros(ctx context.Context) {
-	if runtime.GOOS != "windows" {
-		return
-	}
-	for _, distroName := range instanceDistroNames(instance.LimaHome()) {
-		// Terminating is a best-effort precursor — the distro is usually already
-		// stopped — so log its failure at debug.
-		if err := wsl.Terminate(ctx, distroName); err != nil {
-			logrus.WithError(err).WithField("distro", distroName).Debug("wsl --terminate failed during delete")
-		}
-
-		// A failed unregister is the failure that matters: it leaves behind the
-		// stale registration this cleanup exists to prevent, so log it at warn.
-		// (A distro that was never imported also fails here, harmlessly.)
-		if err := wsl.Unregister(ctx, distroName); err != nil {
-			logrus.WithError(err).WithField("distro", distroName).Warn("Failed to unregister WSL2 distro; a stale registration may remain")
-		}
-	}
-}
-
-// instanceDistroNames returns the WSL2 distro name ("lima-<instance>") for each
-// Lima instance directory under limaHome. It skips Lima's reserved bookkeeping
-// directories (those prefixed with "_" or "."), which are never instances, the
-// same way Lima's own store.Instances does. It returns nil when limaHome does
-// not exist (no instances were ever created).
-func instanceDistroNames(limaHome string) []string {
-	entries, err := os.ReadDir(limaHome)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			logrus.WithError(err).Warn("Failed to read Lima instance directory for WSL2 cleanup")
-		}
-		return nil
-	}
-	var names []string
-	for _, entry := range entries {
-		name := entry.Name()
-		if !entry.IsDir() || strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
-			continue
-		}
-		names = append(names, wsl.DistroName(name))
-	}
-	return names
 }
 
 // preserveAllInstanceLogs moves .log files from each Lima instance directory

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -76,6 +76,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/service/readiness"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/logfile"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/wsl"
 )
 
 // API groups that RDD requires and enables.
@@ -588,20 +589,14 @@ func unregisterInstanceDistros(ctx context.Context) {
 	for _, distroName := range instanceDistroNames(instance.LimaHome()) {
 		// Terminating is a best-effort precursor — the distro is usually already
 		// stopped — so log its failure at debug.
-		termCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		err := exec.CommandContext(termCtx, "wsl.exe", "--terminate", distroName).Run()
-		cancel()
-		if err != nil {
+		if err := wsl.Terminate(ctx, distroName); err != nil {
 			logrus.WithError(err).WithField("distro", distroName).Debug("wsl --terminate failed during delete")
 		}
 
 		// A failed unregister is the failure that matters: it leaves behind the
 		// stale registration this cleanup exists to prevent, so log it at warn.
 		// (A distro that was never imported also fails here, harmlessly.)
-		unregCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		err = exec.CommandContext(unregCtx, "wsl.exe", "--unregister", distroName).Run()
-		cancel()
-		if err != nil {
+		if err := wsl.Unregister(ctx, distroName); err != nil {
 			logrus.WithError(err).WithField("distro", distroName).Warn("Failed to unregister WSL2 distro; a stale registration may remain")
 		}
 	}
@@ -626,7 +621,7 @@ func instanceDistroNames(limaHome string) []string {
 		if !entry.IsDir() || strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
 			continue
 		}
-		names = append(names, "lima-"+name)
+		names = append(names, wsl.DistroName(name))
 	}
 	return names
 }

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -561,8 +561,74 @@ func Delete(ctx context.Context, timeout time.Duration) error {
 	if os.Getenv("RDD_KEEP_LOGS") == "" {
 		_ = os.RemoveAll(instance.LogDir())
 	}
+	// Unregister each WSL2 distro before dropping its directory: removing the
+	// directory deletes the distro's ext4.vhdx but orphans the `wsl --list`
+	// registration, which the next `rdd svc create` would boot against a
+	// missing disk.
+	unregisterInstanceDistros(ctx)
 	_ = os.RemoveAll(instance.ShortDir())
 	return os.RemoveAll(instance.Dir())
+}
+
+// unregisterInstanceDistros unregisters the WSL2 distro backing each Lima
+// instance, clearing the `wsl --list` registration before its directory is
+// removed. It terminates each distro first, because `wsl --unregister` can
+// deadlock on a distro that still holds kernel state. Both calls are best-effort
+// and time-bounded, since wsl.exe can hang when the WSL subsystem is degraded.
+// No-op on non-Windows.
+//
+// TODO: This reimplements cleanup the lima controller already owns
+// (unregisterWSL2Distro), because `svc delete` stops the daemon before
+// reaching here. Route it through the controller once the stop/delete hook
+// (rancher-desktop-2#319) exists.
+func unregisterInstanceDistros(ctx context.Context) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	for _, distroName := range instanceDistroNames(instance.LimaHome()) {
+		// Terminating is a best-effort precursor — the distro is usually already
+		// stopped — so log its failure at debug.
+		termCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		err := exec.CommandContext(termCtx, "wsl.exe", "--terminate", distroName).Run()
+		cancel()
+		if err != nil {
+			logrus.WithError(err).WithField("distro", distroName).Debug("wsl --terminate failed during delete")
+		}
+
+		// A failed unregister is the failure that matters: it leaves behind the
+		// stale registration this cleanup exists to prevent, so log it at warn.
+		// (A distro that was never imported also fails here, harmlessly.)
+		unregCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		err = exec.CommandContext(unregCtx, "wsl.exe", "--unregister", distroName).Run()
+		cancel()
+		if err != nil {
+			logrus.WithError(err).WithField("distro", distroName).Warn("Failed to unregister WSL2 distro; a stale registration may remain")
+		}
+	}
+}
+
+// instanceDistroNames returns the WSL2 distro name ("lima-<instance>") for each
+// Lima instance directory under limaHome. It skips Lima's reserved bookkeeping
+// directories (those prefixed with "_" or "."), which are never instances, the
+// same way Lima's own store.Instances does. It returns nil when limaHome does
+// not exist (no instances were ever created).
+func instanceDistroNames(limaHome string) []string {
+	entries, err := os.ReadDir(limaHome)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logrus.WithError(err).Warn("Failed to read Lima instance directory for WSL2 cleanup")
+		}
+		return nil
+	}
+	var names []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
+			continue
+		}
+		names = append(names, "lima-"+name)
+	}
+	return names
 }
 
 // preserveAllInstanceLogs moves .log files from each Lima instance directory

--- a/rdd/pkg/service/cmd/service_test.go
+++ b/rdd/pkg/service/cmd/service_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestInstanceDistroNames(t *testing.T) {
+	t.Run("maps instance directories to distro names and skips reserved dirs and files", func(t *testing.T) {
+		limaHome := t.TempDir()
+		for _, name := range []string{"rd", "other"} {
+			assert.NilError(t, os.Mkdir(filepath.Join(limaHome, name), 0o755))
+		}
+		// Lima's reserved bookkeeping directories (e.g. _config, _disks) are
+		// not instances and must be skipped.
+		assert.NilError(t, os.Mkdir(filepath.Join(limaHome, "_config"), 0o755))
+		// A stray file must not be treated as an instance either.
+		assert.NilError(t, os.WriteFile(filepath.Join(limaHome, "stray"), nil, 0o644))
+
+		// os.ReadDir returns entries sorted by name; "_config" and "stray" drop out.
+		assert.DeepEqual(t, instanceDistroNames(limaHome), []string{"lima-other", "lima-rd"})
+	})
+
+	t.Run("returns nil when the Lima home does not exist", func(t *testing.T) {
+		assert.Assert(t, instanceDistroNames(filepath.Join(t.TempDir(), "missing")) == nil)
+	})
+}

--- a/rdd/pkg/util/wsl/wsl.go
+++ b/rdd/pkg/util/wsl/wsl.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package wsl wraps the wsl.exe commands rdd uses to manage the WSL2 distros
+// that back Lima instances on Windows. Every command is a no-op off Windows,
+// where Lima creates no WSL2 distros.
+package wsl
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// wsl.exe can hang when the WSL subsystem is degraded, so each call is
+// time-bounded. --unregister is slower than --terminate.
+const (
+	terminateTimeout  = 10 * time.Second
+	unregisterTimeout = 30 * time.Second
+)
+
+// DistroName returns the WSL2 distro name Lima registers for instName. Lima's
+// WSL2 driver names each distro "lima-<instance>".
+func DistroName(instName string) string {
+	return "lima-" + instName
+}
+
+// Terminate runs `wsl.exe --terminate` to shut the distro down, releasing the
+// kernel state that can make a following --unregister deadlock. No-op off
+// Windows.
+func Terminate(ctx context.Context, distroName string) error {
+	return run(ctx, terminateTimeout, "--terminate", distroName)
+}
+
+// Unregister runs `wsl.exe --unregister`, dropping the WSL2 registration and
+// the distro's ext4.vhdx so Lima imports a fresh distro on the next start.
+// Terminate the distro first. No-op off Windows.
+func Unregister(ctx context.Context, distroName string) error {
+	return run(ctx, unregisterTimeout, "--unregister", distroName)
+}
+
+func run(ctx context.Context, timeout time.Duration, verb, distroName string) error {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	wslCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := exec.CommandContext(wslCtx, "wsl.exe", verb, distroName).Run(); err != nil {
+		return fmt.Errorf("wsl.exe %s %q: %w", verb, distroName, err)
+	}
+	return nil
+}

--- a/rdd/pkg/util/wsl/wsl.go
+++ b/rdd/pkg/util/wsl/wsl.go
@@ -10,9 +10,13 @@ package wsl
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // wsl.exe can hang when the WSL subsystem is degraded, so each call is
@@ -48,8 +52,68 @@ func run(ctx context.Context, timeout time.Duration, verb, distroName string) er
 	}
 	wslCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if err := exec.CommandContext(wslCtx, "wsl.exe", verb, distroName).Run(); err != nil {
+	cmd := exec.CommandContext(wslCtx, "wsl.exe", verb, distroName)
+	cmd.Env = append(os.Environ(), "WSL_UTF8=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if out := strings.TrimSpace(string(output)); out != "" {
+			return fmt.Errorf("wsl.exe %s %q: %w: %s", verb, distroName, err, out)
+		}
 		return fmt.Errorf("wsl.exe %s %q: %w", verb, distroName, err)
 	}
 	return nil
+}
+
+// UnregisterInstanceDistros unregisters the WSL2 distro backing each Lima
+// instance under limaHome, clearing the `wsl --list` registration before its
+// directory is removed. It terminates each distro first, because `wsl
+// --unregister` can deadlock on a distro that still holds kernel state. Both
+// calls are best-effort and time-bounded, since wsl.exe can hang when the WSL
+// subsystem is degraded. No-op on non-Windows.
+//
+// TODO: This reimplements cleanup the lima controller already owns, because
+// `svc delete` stops the daemon before reaching here. Route it through the
+// controller once the stop/delete hook (rancher-desktop-2#319) exists.
+func UnregisterInstanceDistros(ctx context.Context, limaHome string) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	for _, distroName := range instanceDistroNames(limaHome) {
+		// Terminating is a best-effort precursor — the distro is usually already
+		// stopped — so log its failure at debug.
+		if err := Terminate(ctx, distroName); err != nil {
+			logrus.WithError(err).WithField("distro", distroName).Debug("wsl --terminate failed during delete")
+		}
+
+		// A failed unregister is the failure that matters: it leaves behind the
+		// stale registration this cleanup exists to prevent, so log it at warn.
+		// (A distro that was never imported also fails here, harmlessly.)
+		if err := Unregister(ctx, distroName); err != nil {
+			logrus.WithError(err).WithField("distro", distroName).Warn("Failed to unregister WSL2 distro; a stale registration may remain")
+		}
+	}
+}
+
+// instanceDistroNames returns the WSL2 distro name ("lima-<instance>") for each
+// Lima instance directory under limaHome. It skips Lima's reserved bookkeeping
+// directories (those prefixed with "_" or "."), which are never instances, the
+// same way Lima's own store.Instances does. It returns nil when limaHome does
+// not exist (no instances were ever created).
+func instanceDistroNames(limaHome string) []string {
+	entries, err := os.ReadDir(limaHome)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logrus.WithError(err).Warn("Failed to read Lima instance directory for WSL2 cleanup")
+		}
+		return nil
+	}
+	var names []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || strings.HasPrefix(name, "_") || strings.HasPrefix(name, ".") {
+			continue
+		}
+		names = append(names, DistroName(name))
+	}
+	return names
 }

--- a/rdd/pkg/util/wsl/wsl_test.go
+++ b/rdd/pkg/util/wsl/wsl_test.go
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
-package service
+package wsl
 
 import (
 	"os"


### PR DESCRIPTION
A WSL2 distro can stay registered with WSL after its `ext4.vhdx` is gone: `rdd svc delete` removed each instance directory but left the `wsl --list` registration behind. Lima's WSL2 driver only re-imports a distro that is absent from `wsl --list`, so the next start booted that diskless registration into `ERROR_FILE_NOT_FOUND` on every attempt and the reconciler looped forever.

Two commits — recovery, then prevention:

- **lima: re-import an orphaned WSL2 distro on start** — `startInstance` detects a distro that is registered but missing its disk and unregisters it, so the hostagent re-imports a fresh `ext4.vhdx`. This heals orphans left by older builds or a failed unregister.
- **service: unregister WSL2 distros on delete** — `rdd svc delete` now unregisters each instance's distro before removing its directory, so it stops minting orphans in the first place.

Both paths are Windows-only and no-ops elsewhere.

Routing `svc delete` cleanup through the lima controller — rather than the duplicate unregister that currently lives in the service layer — is tracked by #319.
