### PR TITLE
Bump embedded distro to v0.2.8

### DIFF
--- a/rdd/pkg/controllers/app/app/lima-images-unix.yaml
+++ b/rdd/pkg/controllers/app/app/lima-images-unix.yaml
@@ -1,7 +1,7 @@
 images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.6/distro.v0.2.6.amd64.raw.xz
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.8/distro.v0.2.8.amd64.raw.xz
   arch: x86_64
-  digest: sha256:d7554a6a6c599cca3619b46dfad3e40f261cf5399293c24d7c188c3224973d29
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.6/distro.v0.2.6.arm64.raw.xz
+  digest: sha256:a589e020df983d6b971fbbe73d1b378fb3dfaaa6c0a6056ac48a168f646e9007
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.8/distro.v0.2.8.arm64.raw.xz
   arch: aarch64
-  digest: sha256:01fa604435aa511def8de4d31cdfe6b95fd575d14166ba8828c19946a339e558
+  digest: sha256:64136a49ecebdf09e88d5026e942595e0c8b5c92d21f9d4e5e6bdfa85c2673dd

--- a/rdd/pkg/controllers/app/app/lima-images-wsl2.yaml
+++ b/rdd/pkg/controllers/app/app/lima-images-wsl2.yaml
@@ -1,6 +1,6 @@
 vmType: wsl2
 images:
-- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.6/distro.v0.2.6.amd64.tar.xz
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.8/distro.v0.2.8.amd64.tar.xz
   arch: x86_64
-  digest: sha256:d9eb9a3889f6982c084cecc96fcaa7d39c586754f6b31bbffc5bf48bbab9e913
+  digest: sha256:3d356fc196a5b929de075d132a3f46688fd881fadad16219172bde392a3a82e0
 mountType: wsl2


### PR DESCRIPTION
v0.2.8 makes k3s and the guest agent use the configured Kubernetes port when k3s runs in a network namespace (WSL), and raises the Virtualization:containers repo priority above the primary Leap repo so its packages win.

This is a replay of #477 (using the same head commit).