### PR TITLE
Replace Windows console-event interrupt with a role-keyed named event

### DIFF
--- a/rdd/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
@@ -197,11 +197,9 @@ func (r *LimaVMReconciler) waitForProcessExit(ctx context.Context, name string) 
 	}
 }
 
-// signalHostagent sends a graceful shutdown signal to the hostagent process.
-// Uses process.Interrupt, which sends SIGINT on Unix and signals the hostagent's
-// named interrupt event on Windows (keyed by instance and PID).
-// Returns false if no watcher exists, the process has already been reaped (its
-// PID may be reused on Windows), or the signal could not be delivered.
+// signalHostagent sends a graceful shutdown signal (process.Interrupt) to the
+// hostagent process. Returns false if no watcher exists, the process has already
+// been reaped, or the signal could not be delivered.
 func (r *LimaVMReconciler) signalHostagent(name string) bool {
 	r.instanceStatesMu.RLock()
 	state, ok := r.instanceStates[name]
@@ -209,10 +207,9 @@ func (r *LimaVMReconciler) signalHostagent(name string) bool {
 	if !ok || state.cmd == nil || state.cmd.Process == nil {
 		return false
 	}
-	// Skip a process that has already been reaped: once procExited is closed,
-	// cmd.Wait() has released the OS handle and the PID may be reused. The named
-	// interrupt event makes a reused PID harmless — a recycled process has no such
-	// event, so Interrupt simply fails — but there is nothing to signal here.
+	// Skip a process that has already been reaped. Once procExited is closed,
+	// cmd.Wait() has released the OS handle and the PID may be reused, so there is
+	// nothing safe to signal here.
 	select {
 	case <-state.procExited:
 		return false

--- a/rdd/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/hostagent_watcher.go
@@ -198,8 +198,8 @@ func (r *LimaVMReconciler) waitForProcessExit(ctx context.Context, name string) 
 }
 
 // signalHostagent sends a graceful shutdown signal to the hostagent process.
-// Uses process.Interrupt which sends SIGINT on Unix and CTRL_BREAK on Windows
-// (targeted at the hostagent's process group, not the parent).
+// Uses process.Interrupt, which sends SIGINT on Unix and signals the hostagent's
+// named interrupt event on Windows (keyed by instance and PID).
 // Returns false if no watcher exists, the process has already been reaped (its
 // PID may be reused on Windows), or the signal could not be delivered.
 func (r *LimaVMReconciler) signalHostagent(name string) bool {
@@ -209,17 +209,16 @@ func (r *LimaVMReconciler) signalHostagent(name string) bool {
 	if !ok || state.cmd == nil || state.cmd.Process == nil {
 		return false
 	}
-	// Once procExited is closed, cmd.Wait() has released the OS process handle
-	// and the PID may be reused; signalling it could deliver CTRL_BREAK to an
-	// unrelated console process on Windows. While it is open the handle is
-	// normally still held; cmd.Wait() releases it just before closing the
-	// channel, leaving a brief window.
+	// Skip a process that has already been reaped: once procExited is closed,
+	// cmd.Wait() has released the OS handle and the PID may be reused. The named
+	// interrupt event makes a reused PID harmless — a recycled process has no such
+	// event, so Interrupt simply fails — but there is nothing to signal here.
 	select {
 	case <-state.procExited:
 		return false
 	default:
 	}
-	return process.Interrupt(state.cmd.Process.Pid) == nil
+	return process.Interrupt(process.HostagentInterruptKey(name), state.cmd.Process.Pid) == nil
 }
 
 // enqueueReconcile sends a GenericEvent to trigger a reconcile for the named VM.

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -633,12 +633,10 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 		return
 	}
 
-	// Send graceful shutdown signal to all hostagents in parallel. Skip any whose
-	// process has already been reaped: once cmd.Wait() closes procExited it has
-	// released the OS process handle, freeing the PID for reuse. The named
-	// interrupt event keyed by instance and PID makes a recycled PID harmless (it
-	// has no such event, so Interrupt fails), but there is nothing to signal once
-	// the process is reaped.
+	// Send a graceful shutdown signal to all hostagents in parallel. Skip any whose
+	// process has already been reaped; once cmd.Wait() closes procExited it has
+	// released the OS handle and the PID may be reused, so there is nothing to
+	// signal.
 	for name, state := range states {
 		if state.cmd == nil || state.cmd.Process == nil {
 			continue

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_controller.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_controller.go
@@ -635,12 +635,11 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 
 	// Send graceful shutdown signal to all hostagents in parallel. Skip any whose
 	// process has already been reaped: once cmd.Wait() closes procExited it has
-	// released the OS process handle, freeing the PID for reuse. On Windows a
-	// CTRL_BREAK to a recycled PID escapes to the console and kills the service
-	// and terminal. While procExited is open the handle is normally still held,
-	// so the PID is still ours; cmd.Wait() releases it just before closing the
-	// channel, leaving a brief window.
-	for _, state := range states {
+	// released the OS process handle, freeing the PID for reuse. The named
+	// interrupt event keyed by instance and PID makes a recycled PID harmless (it
+	// has no such event, so Interrupt fails), but there is nothing to signal once
+	// the process is reaped.
+	for name, state := range states {
 		if state.cmd == nil || state.cmd.Process == nil {
 			continue
 		}
@@ -649,7 +648,7 @@ func (r *LimaVMReconciler) shutdownAllHostagents() {
 			continue
 		default:
 		}
-		_ = process.Interrupt(state.cmd.Process.Pid)
+		_ = process.Interrupt(process.HostagentInterruptKey(name), state.cmd.Process.Pid)
 	}
 
 	// Wait for each hostagent process to exit. The watcher goroutine may finish

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -634,7 +634,7 @@ func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *lima
 	// confirms it is still our hostagent; stopInstanceForcibly re-screens before
 	// the forced stop below, because the PID can be recycled during the graceful
 	// wait.
-	if inst.HostAgentPID > 0 && process.IsOurProcess(process.HostagentInterruptKey(inst.Name), inst.HostAgentPID) {
+	if process.IsOurProcess(process.HostagentInterruptKey(inst.Name), inst.HostAgentPID) {
 		if err := process.Interrupt(process.HostagentInterruptKey(inst.Name), inst.HostAgentPID); err != nil {
 			logger.V(1).Info("Could not signal orphaned hostagent", "pid", inst.HostAgentPID, "error", err)
 		} else {
@@ -675,17 +675,13 @@ func waitForInstanceStopped(ctx context.Context, name string) bool {
 
 // clearRecycledHostAgentPID zeroes inst.HostAgentPID unless it still names our
 // live hostagent, so a force-stop's taskkill cannot reach an unrelated process
-// that recycled the PID. The stored PID comes from on-disk state a previous
-// service wrote, which Windows may have reassigned after the hostagent exited;
-// on other platforms IsOurProcess is a no-op, so the PID is kept. DriverPID is
-// not screened here — IsOurProcess matches our registered interrupt event, which
-// the qemu/wsl driver never creates — so a recycled DriverPID is still
-// taskkilled by the caller.
+// that recycled the PID. DriverPID is not screened — the qemu/wsl driver
+// registers no interrupt event — so a recycled DriverPID is still taskkilled.
 //
 // TODO: track the hostagent and driver in a Windows Job Object so termination
-// no longer trusts a stored DriverPID that the OS may have recycled.
+// no longer trusts a stored DriverPID the OS may have recycled.
 func clearRecycledHostAgentPID(inst *limatype.Instance) {
-	if inst.HostAgentPID > 0 && !process.IsOurProcess(process.HostagentInterruptKey(inst.Name), inst.HostAgentPID) {
+	if !process.IsOurProcess(process.HostagentInterruptKey(inst.Name), inst.HostAgentPID) {
 		inst.HostAgentPID = 0
 	}
 }

--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -634,8 +634,8 @@ func (r *LimaVMReconciler) killOrphanedHostagent(ctx context.Context, inst *lima
 	// confirms it is still our hostagent; stopInstanceForcibly re-screens before
 	// the forced stop below, because the PID can be recycled during the graceful
 	// wait.
-	if inst.HostAgentPID > 0 && process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
-		if err := process.Interrupt(inst.HostAgentPID); err != nil {
+	if inst.HostAgentPID > 0 && process.IsOurProcess(process.HostagentInterruptKey(inst.Name), inst.HostAgentPID) {
+		if err := process.Interrupt(process.HostagentInterruptKey(inst.Name), inst.HostAgentPID); err != nil {
 			logger.V(1).Info("Could not signal orphaned hostagent", "pid", inst.HostAgentPID, "error", err)
 		} else {
 			stopCtx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
@@ -673,27 +673,19 @@ func waitForInstanceStopped(ctx context.Context, name string) bool {
 	}
 }
 
-// hostAgentPIDFile returns the --pidfile path passed when starting inst's
-// hostagent. It is an unambiguous per-instance discriminator for
-// process.IsOurProcess: an instance name alone can be a prefix of another
-// (e.g. "vm" and "vm2"), but the pidfile path is bounded by the instance
-// directory, so it cannot match a sibling instance's command line.
-func hostAgentPIDFile(inst *limatype.Instance) string {
-	return filepath.Join(inst.Dir, filenames.HostAgentPID)
-}
-
 // clearRecycledHostAgentPID zeroes inst.HostAgentPID unless it still names our
 // live hostagent, so a force-stop's taskkill cannot reach an unrelated process
 // that recycled the PID. The stored PID comes from on-disk state a previous
 // service wrote, which Windows may have reassigned after the hostagent exited;
 // on other platforms IsOurProcess is a no-op, so the PID is kept. DriverPID is
-// not screened here — IsOurProcess matches the rdd image, not the qemu/wsl
-// driver — so a recycled DriverPID is still taskkilled by the caller.
+// not screened here — IsOurProcess matches our registered interrupt event, which
+// the qemu/wsl driver never creates — so a recycled DriverPID is still
+// taskkilled by the caller.
 //
 // TODO: track the hostagent and driver in a Windows Job Object so termination
 // no longer trusts a stored DriverPID that the OS may have recycled.
 func clearRecycledHostAgentPID(inst *limatype.Instance) {
-	if inst.HostAgentPID > 0 && !process.IsOurProcess(inst.HostAgentPID, "hostagent", hostAgentPIDFile(inst)) {
+	if inst.HostAgentPID > 0 && !process.IsOurProcess(process.HostagentInterruptKey(inst.Name), inst.HostAgentPID) {
 		inst.HostAgentPID = 0
 	}
 }

--- a/rdd/pkg/hostagent/command.go
+++ b/rdd/pkg/hostagent/command.go
@@ -58,18 +58,20 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 
 	// Register the interrupt event before writing the PID file so a peer can
-	// confirm our identity (IsOurProcess) as soon as the file exists. The
-	// closure forwards the event as os.Interrupt; no-op on Unix.
-	if releaseInterrupt, err := process.RegisterInterruptHandler(process.HostagentInterruptKey(instName), func() {
+	// confirm our identity (IsOurProcess) as soon as the file exists. On failure,
+	// return before the PID file exists rather than run a hostagent the control
+	// plane cannot signal; the lima reconciler retries the launch with backoff.
+	// The closure forwards the event as os.Interrupt; no-op on Unix.
+	releaseInterrupt, err := process.RegisterInterruptHandler(process.HostagentInterruptKey(instName), func() {
 		select {
 		case signalCh <- os.Interrupt:
 		default:
 		}
-	}); err != nil {
-		logrus.Warnf("Failed to register interrupt handler: %v", err)
-	} else {
-		defer releaseInterrupt()
+	})
+	if err != nil {
+		return fmt.Errorf("failed to register interrupt handler: %w", err)
 	}
+	defer releaseInterrupt()
 
 	if pidfile != "" {
 		if existingPID, err := store.ReadPIDFile(pidfile); existingPID != 0 {

--- a/rdd/pkg/hostagent/command.go
+++ b/rdd/pkg/hostagent/command.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/guestagent"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/process"
 )
 
 // NewCommand creates a new hostagent cobra command.
@@ -51,6 +52,25 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	instName := args[0]
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+	// Register the interrupt event before writing the PID file so a peer can
+	// confirm our identity (IsOurProcess) as soon as the file exists. The
+	// closure forwards the event as os.Interrupt; no-op on Unix.
+	if releaseInterrupt, err := process.RegisterInterruptHandler(process.HostagentInterruptKey(instName), func() {
+		select {
+		case signalCh <- os.Interrupt:
+		default:
+		}
+	}); err != nil {
+		logrus.Warnf("Failed to register interrupt handler: %v", err)
+	} else {
+		defer releaseInterrupt()
+	}
+
 	if pidfile != "" {
 		if existingPID, err := store.ReadPIDFile(pidfile); existingPID != 0 {
 			return fmt.Errorf("another hostagent may already be running with pid %d (pidfile %q)", existingPID, pidfile)
@@ -70,8 +90,6 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 		return errors.New("socket must be specified")
 	}
 
-	instName := args[0]
-
 	runGUI, err := cmd.Flags().GetBool("run-gui")
 	if err != nil {
 		return err
@@ -81,9 +99,6 @@ func hostagentAction(cmd *cobra.Command, args []string) error {
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 	}
-
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 
 	debug, _ := cmd.Flags().GetBool("debug")
 	if debug {

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -139,7 +139,7 @@ const PIDNotFound = 0
 
 // PID returns the process ID of the running service, or PIDNotFound if it is
 // not running. On Windows it confirms the PID via the daemon's interrupt event
-// (process.IsOurProcess), a cheap OpenEvent that callers may poll in a loop.
+// (process.IsOurProcess); on Unix it checks the PID is live.
 func PID() int {
 	pidStr, err := os.ReadFile(instance.PIDFile())
 	if err != nil {
@@ -147,27 +147,14 @@ func PID() int {
 	}
 	pid, err := strconv.Atoi(string(pidStr))
 	if err != nil {
-		// Unparseable content: the file is unusable, so drop it.
+		// Unusable pidfile; drop it.
 		_ = os.Remove(instance.PIDFile())
 		return PIDNotFound
 	}
-	// Self-heal a genuinely stale file: if no process exists under the recorded
-	// PID, remove it. If a process is alive but not our control plane — a
-	// recycled PID, or (on Windows) a daemon that never registered its interrupt
-	// event — leave the file: it is never acted on while unconfirmed and the next
-	// Start overwrites it, whereas deleting it could strip a live daemon's record
-	// and orphan it (the failure that left state.db locked and undeletable).
-	if !process.IsAlive(pid) {
-		_ = os.Remove(instance.PIDFile())
-		return PIDNotFound
-	}
-	// Confirm the live PID is our control plane via the interrupt event the
-	// daemon registers at startup; a recycled PID running something else has no
-	// such event. ServeInterruptKey carries no instance, so a PID recycled to a
-	// *different* instance's control plane would pass — that needs concurrent
-	// instances (dev/test only). IsOurProcess is a no-op (true) on non-Windows,
-	// where IsAlive above is the liveness check.
+	// Drop the file unless it names our live control plane. A dead, recycled, or
+	// unrelated PID is not running, and the next Start writes a fresh file.
 	if !process.IsOurProcess(process.ServeInterruptKey, pid) {
+		_ = os.Remove(instance.PIDFile())
 		return PIDNotFound
 	}
 	return pid
@@ -455,19 +442,10 @@ func StopWithWait(ctx context.Context, wait bool, timeout time.Duration) error {
 		return fmt.Errorf("%q control plane is not running", instance.Name())
 	}
 
-	// Try graceful shutdown first. Interrupt asks the daemon to run its orderly
-	// shutdown (drain the controller manager, which stops the hostagents): on
-	// Unix via SIGINT, on Windows by signalling the daemon's named interrupt
-	// event (process.RegisterInterruptHandler), which reaches the daemon even
-	// when the CLI runs in a different console, e.g. a daemon the GUI app started.
-	//
-	// Kill (SIGTERM on Unix, TerminateProcess on Windows) is the fallback when
-	// Interrupt fails. On Unix it rarely does, since SIGINT succeeds for any live
-	// PID. On Windows a failure means the target has no interrupt event — it is
-	// gone, recycled, or not ours — so terminating its single PID cannot reach an
-	// unrelated process. A hard kill skips the controller-manager drain, so
-	// hostagents survive in their own process groups and self-heal on the next
-	// service start via killOrphanedHostagent.
+	// Try graceful shutdown first; Interrupt asks the daemon to run its orderly
+	// shutdown. Kill is the fallback when Interrupt fails. A hard kill skips the
+	// controller-manager drain, so hostagents survive in their own process groups
+	// and self-heal on the next service start via killOrphanedHostagent.
 	if err := process.Interrupt(process.ServeInterruptKey, pid); err != nil {
 		if err := process.Kill(pid); err != nil {
 			return fmt.Errorf("failed to stop %q control plane with pid %d: %w", instance.Name(), pid, err)
@@ -543,10 +521,8 @@ func Delete(ctx context.Context, timeout time.Duration) error {
 	// Probe the datastore lock before anything destructive. state.db is the file a
 	// still-running control plane holds open; remove it alone first, so a lock
 	// error aborts the delete before os.RemoveAll could strip the -wal/-shm
-	// sidecars or rdd.pid out from under a live daemon and orphan it — the exact
-	// failure this guards against. (os.RemoveAll records the first error but keeps
-	// deleting siblings, so it cannot be the probe.) Once state.db is gone the
-	// daemon is confirmed stopped, so clearing the rest is safe.
+	// sidecars or rdd.pid out from under a live daemon and orphan it. Once state.db
+	// is gone the daemon is confirmed stopped, so clearing the rest is safe.
 	dbDir := filepath.Join(instance.Dir(), "db")
 	if err := os.Remove(filepath.Join(dbDir, "state.db")); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove datastore for %q; the control plane may still be running: %w", instance.Name(), err)
@@ -704,8 +680,8 @@ func NewServeCommand(ctx context.Context) *cobra.Command {
 			}
 
 			// Register the interrupt event before writing the PID file so a peer can
-			// confirm our identity (IsOurProcess) as soon as the file exists. On
-			// failure, bail before the PID file exists rather than run a daemon that
+			// confirm our identity (`process.IsOurProcess`) as soon as the file exists.
+			// On failure, bail before the PID file exists rather than run a daemon that
 			// `rdd svc stop` cannot find. The daemon's shutdown runs when the event
 			// fires; no-op on Unix.
 			ctx := genericapiserver.SetupSignalContext()

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -14,12 +14,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -140,55 +138,36 @@ func Exists() bool {
 const PIDNotFound = 0
 
 // PID returns the process ID of the running service, or PIDNotFound if it is
-// not running. On Windows it walks the candidate process's PEB to read its
-// command line (see process.IsOurProcessWithArg), so callers that poll it in a
-// tight loop pay a cross-process read each call.
+// not running. On Windows it confirms the PID via the daemon's interrupt event
+// (process.IsOurProcess), a cheap OpenEvent that callers may poll in a loop.
 func PID() int {
 	pidStr, err := os.ReadFile(instance.PIDFile())
 	if err != nil {
 		return PIDNotFound
 	}
 	pid, err := strconv.Atoi(string(pidStr))
-	if err == nil {
-		var proc *os.Process
-		proc, err = os.FindProcess(pid)
-		if err == nil {
-			// on non-Windows, FindProcess may return without the process being
-			// alive; on Windows, the result encapsulates a valid handle.
-			if runtime.GOOS != "windows" {
-				err = proc.Signal(syscall.Signal(0))
-			}
-			_ = proc.Release()
-		}
-		// On Windows, FindProcess succeeds for any live PID, including one the
-		// OS recycled after a crash left our PID file behind. Confirm the PID
-		// still runs our control plane, so a recycled PID reads as not-running.
-		// IsOurProcessWithArg is a no-op (true) on other platforms.
-		//
-		// Match "serve" as a whole command-line argument, not a substring: the
-		// daemon runs as `service serve` (the canonical self-spawn) or `svc serve`
-		// (the alias), so "serve" is always an argument and no other rdd subcommand
-		// is. Whole-argument matching ignores argv[0], so an install path that
-		// happens to contain "serve" cannot make an unrelated rdd process — a CLI
-		// command or a hostagent — read as the control plane.
-		//
-		// "serve" carries no instance name, so this confirms the PID runs a
-		// control plane, not specifically this instance's. A PID recycled to a
-		// *different* instance's control plane would pass. That needs concurrent
-		// instances (dev/test only); a lone instance never recycles a PID into
-		// another control plane.
-		//
-		// IsOurProcessWithArg returns false for any state it cannot confirm — a
-		// denied OpenProcess or a short PEB read on a live control plane included.
-		// Such a false negative reads as not-running and removes the PID file
-		// below; we accept that as the cost of the guard, which needs only the low
-		// query rights a same-user process always grants.
-		if err == nil && !process.IsOurProcessWithArg(pid, "serve") {
-			err = fmt.Errorf("pid %d is not our control plane", pid)
-		}
-	}
 	if err != nil {
+		// Unparseable content: the file is unusable, so drop it.
 		_ = os.Remove(instance.PIDFile())
+		return PIDNotFound
+	}
+	// Self-heal a genuinely stale file: if no process exists under the recorded
+	// PID, remove it. If a process is alive but not our control plane — a
+	// recycled PID, or (on Windows) a daemon that never registered its interrupt
+	// event — leave the file: it is never acted on while unconfirmed and the next
+	// Start overwrites it, whereas deleting it could strip a live daemon's record
+	// and orphan it (the failure that left state.db locked and undeletable).
+	if !process.IsAlive(pid) {
+		_ = os.Remove(instance.PIDFile())
+		return PIDNotFound
+	}
+	// Confirm the live PID is our control plane via the interrupt event the
+	// daemon registers at startup; a recycled PID running something else has no
+	// such event. ServeInterruptKey carries no instance, so a PID recycled to a
+	// *different* instance's control plane would pass — that needs concurrent
+	// instances (dev/test only). IsOurProcess is a no-op (true) on non-Windows,
+	// where IsAlive above is the liveness check.
+	if !process.IsOurProcess(process.ServeInterruptKey, pid) {
 		return PIDNotFound
 	}
 	return pid
@@ -466,28 +445,30 @@ func Wait(ctx context.Context) error {
 // timeout 0 to wait indefinitely (bounded only by ctx).
 func StopWithWait(ctx context.Context, wait bool, timeout time.Duration) error {
 	// Read the PID once and reject PIDNotFound before signalling. A second PID()
-	// call (the old Running()-then-PID() pattern) can return PIDNotFound when the
-	// daemon exits, a concurrent stop removes the file, or the identity check
-	// transiently fails between the two reads; signalling 0 then broadcasts —
-	// GenerateConsoleCtrlEvent(CTRL_BREAK, 0) reaches every process sharing the
-	// console on Windows, and kill(0) the caller's whole process group on Unix.
+	// call can return PIDNotFound when the daemon exits, a concurrent stop removes
+	// the file, or the identity check fails between the two reads; signalling 0
+	// would then misfire — kill(0) hits the caller's whole process group on Unix.
+	// (On Windows Interrupt(0) only fails to open a per-PID event, but reading
+	// once is still the simpler contract.)
 	pid := PID()
 	if pid == PIDNotFound {
 		return fmt.Errorf("%q control plane is not running", instance.Name())
 	}
 
-	// Try graceful shutdown first. On Unix, Kill already sends SIGTERM which
-	// triggers the Go signal handler. On Windows, Kill uses TerminateProcess
-	// which bypasses all handlers, so we send Interrupt (CTRL_BREAK_EVENT)
-	// first to let the service run its shutdown path (shutdownAllHostagents).
+	// Try graceful shutdown first. Interrupt asks the daemon to run its orderly
+	// shutdown (drain the controller manager, which stops the hostagents): on
+	// Unix via SIGINT, on Windows by signalling the daemon's named interrupt
+	// event (process.RegisterInterruptHandler), which reaches the daemon even
+	// when the CLI runs in a different console, e.g. a daemon the GUI app started.
 	//
-	// On Unix, Interrupt (SIGINT) always succeeds for a valid PID, so the
-	// Kill fallback never fires. On Windows, Interrupt uses
-	// GenerateConsoleCtrlEvent, which fails when caller and target lack a
-	// shared console; Kill (TerminateProcess) then bypasses graceful shutdown.
-	// Hostagents survive in their own process groups and self-heal on the
-	// next service start via killOrphanedHostagent.
-	if err := process.Interrupt(pid); err != nil {
+	// Kill (SIGTERM on Unix, TerminateProcess on Windows) is the fallback when
+	// Interrupt fails. On Unix it rarely does, since SIGINT succeeds for any live
+	// PID. On Windows a failure means the target has no interrupt event — it is
+	// gone, recycled, or not ours — so terminating its single PID cannot reach an
+	// unrelated process. A hard kill skips the controller-manager drain, so
+	// hostagents survive in their own process groups and self-heal on the next
+	// service start via killOrphanedHostagent.
+	if err := process.Interrupt(process.ServeInterruptKey, pid); err != nil {
 		if err := process.Kill(pid); err != nil {
 			return fmt.Errorf("failed to stop %q control plane with pid %d: %w", instance.Name(), pid, err)
 		}
@@ -537,7 +518,7 @@ func StopWithWait(ctx context.Context, wait bool, timeout time.Duration) error {
 // Delete removes all instance data. Callers must verify Exists() first; Delete
 // assumes the instance exists. If the service is running, Delete waits up to
 // timeout for it to exit before removing files; removing instance.Dir() while
-// the serve process holds rdd.pid, rdd.sqlite3, and log files corrupts the
+// the serve process holds rdd.pid, db/state.db, and log files corrupts the
 // directory on Windows and breaks PID-file mutual exclusion on Unix.
 // Pass timeout 0 to wait indefinitely (bounded only by ctx).
 func Delete(ctx context.Context, timeout time.Duration) error {
@@ -558,6 +539,17 @@ func Delete(ctx context.Context, timeout time.Duration) error {
 			}
 		}
 	}
+
+	// Drop the datastore first, before anything destructive. It is the file a
+	// still-running control plane holds open; if RemoveAll fails because it is
+	// locked, a daemon is alive and we could not stop it, so abort before
+	// deleting the rest of the directory — in particular rdd.pid. A half-finished
+	// delete that strips rdd.pid would orphan that daemon (it becomes unfindable)
+	// and leave state.db behind: the exact failure this guards against.
+	if err := os.RemoveAll(filepath.Join(instance.Dir(), "db")); err != nil {
+		return fmt.Errorf("failed to remove datastore for %q; the control plane may still be running: %w", instance.Name(), err)
+	}
+
 	preserveAllInstanceLogs()
 	if os.Getenv("RDD_KEEP_LOGS") == "" {
 		_ = os.RemoveAll(instance.LogDir())
@@ -708,6 +700,18 @@ func NewServeCommand(ctx context.Context) *cobra.Command {
 				}
 			}
 
+			// Register the interrupt event before writing the PID file so a peer can
+			// confirm our identity (IsOurProcess) as soon as the file exists. The
+			// daemon's shutdown runs when the event fires; no-op on Unix.
+			ctx := genericapiserver.SetupSignalContext()
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			if releaseInterrupt, err := process.RegisterInterruptHandler(process.ServeInterruptKey, cancel); err != nil {
+				klog.Warningf("Failed to register interrupt handler: %v", err)
+			} else {
+				defer releaseInterrupt()
+			}
+
 			pid := []byte(strconv.Itoa(os.Getpid()))
 			if err := os.WriteFile(instance.PIDFile(), pid, 0o600); err != nil {
 				return fmt.Errorf("failed to write %q: %w", instance.PIDFile(), err)
@@ -740,7 +744,6 @@ func NewServeCommand(ctx context.Context) *cobra.Command {
 
 			// add feature enablement metrics
 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
-			ctx := genericapiserver.SetupSignalContext()
 
 			// change into instance dir because kine will create the db relative to the current dir
 			if err := os.Chdir(instance.Dir()); err != nil {

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -540,15 +540,18 @@ func Delete(ctx context.Context, timeout time.Duration) error {
 		}
 	}
 
-	// Drop the datastore first, before anything destructive. It is the file a
-	// still-running control plane holds open; if RemoveAll fails because it is
-	// locked, a daemon is alive and we could not stop it, so abort before
-	// deleting the rest of the directory — in particular rdd.pid. A half-finished
-	// delete that strips rdd.pid would orphan that daemon (it becomes unfindable)
-	// and leave state.db behind: the exact failure this guards against.
-	if err := os.RemoveAll(filepath.Join(instance.Dir(), "db")); err != nil {
+	// Probe the datastore lock before anything destructive. state.db is the file a
+	// still-running control plane holds open; remove it alone first, so a lock
+	// error aborts the delete before os.RemoveAll could strip the -wal/-shm
+	// sidecars or rdd.pid out from under a live daemon and orphan it — the exact
+	// failure this guards against. (os.RemoveAll records the first error but keeps
+	// deleting siblings, so it cannot be the probe.) Once state.db is gone the
+	// daemon is confirmed stopped, so clearing the rest is safe.
+	dbDir := filepath.Join(instance.Dir(), "db")
+	if err := os.Remove(filepath.Join(dbDir, "state.db")); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove datastore for %q; the control plane may still be running: %w", instance.Name(), err)
 	}
+	_ = os.RemoveAll(dbDir)
 
 	preserveAllInstanceLogs()
 	if os.Getenv("RDD_KEEP_LOGS") == "" {
@@ -701,16 +704,18 @@ func NewServeCommand(ctx context.Context) *cobra.Command {
 			}
 
 			// Register the interrupt event before writing the PID file so a peer can
-			// confirm our identity (IsOurProcess) as soon as the file exists. The
-			// daemon's shutdown runs when the event fires; no-op on Unix.
+			// confirm our identity (IsOurProcess) as soon as the file exists. On
+			// failure, bail before the PID file exists rather than run a daemon that
+			// `rdd svc stop` cannot find. The daemon's shutdown runs when the event
+			// fires; no-op on Unix.
 			ctx := genericapiserver.SetupSignalContext()
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			if releaseInterrupt, err := process.RegisterInterruptHandler(process.ServeInterruptKey, cancel); err != nil {
-				klog.Warningf("Failed to register interrupt handler: %v", err)
-			} else {
-				defer releaseInterrupt()
+			releaseInterrupt, err := process.RegisterInterruptHandler(process.ServeInterruptKey, cancel)
+			if err != nil {
+				return fmt.Errorf("failed to register interrupt handler: %w", err)
 			}
+			defer releaseInterrupt()
 
 			pid := []byte(strconv.Itoa(os.Getpid()))
 			if err := os.WriteFile(instance.PIDFile(), pid, 0o600); err != nil {

--- a/rdd/pkg/util/process/keys.go
+++ b/rdd/pkg/util/process/keys.go
@@ -9,7 +9,7 @@ package process
 // process is ours but that it plays the expected role. Only long-lived processes
 // that record a PID register a handler: the control-plane daemon and each
 // hostagent. On Windows the key becomes part of the event name; on Unix the key
-// is ignored (Interrupt sends SIGINT and IsOurProcess is a no-op).
+// is ignored (Interrupt sends SIGINT and IsOurProcess checks only liveness).
 
 // ServeInterruptKey is the interrupt key for the control-plane daemon
 // (`rdd service serve`).

--- a/rdd/pkg/util/process/keys.go
+++ b/rdd/pkg/util/process/keys.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package process
+
+// Interrupt keys namespace a process's interrupt event by role (and, for
+// hostagents, by instance), so an IsOurProcess check confirms not only that a
+// process is ours but that it plays the expected role. Only long-lived processes
+// that record a PID register a handler: the control-plane daemon and each
+// hostagent. On Windows the key becomes part of the event name; on Unix the key
+// is ignored (Interrupt sends SIGINT and IsOurProcess is a no-op).
+
+// ServeInterruptKey is the interrupt key for the control-plane daemon
+// (`rdd service serve`).
+const ServeInterruptKey = "serve"
+
+// HostagentInterruptKey returns the interrupt key for the hostagent of the named
+// Lima instance. Including the instance (not just the PID) means a recycled PID
+// belonging to a *different* instance's hostagent is not mistaken for this one.
+// Lima instance names are simple identifiers used as directory names, so they
+// are safe to embed in a Windows event name (no backslash).
+func HostagentInterruptKey(instance string) string {
+	return "hostagent-" + instance
+}

--- a/rdd/pkg/util/process/keys_test.go
+++ b/rdd/pkg/util/process/keys_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package process
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestInterruptKeys pins the interrupt-key format. Both ends of an interrupt —
+// the process that registers (the hostagent / daemon) and the one that signals
+// or checks it (the lima controller / CLI) — must derive the same key, so the
+// format is part of the contract.
+func TestInterruptKeys(t *testing.T) {
+	assert.Equal(t, ServeInterruptKey, "serve")
+	assert.Equal(t, HostagentInterruptKey("rd"), "hostagent-rd")
+	assert.Equal(t, HostagentInterruptKey("rancher-desktop-2"), "hostagent-rancher-desktop-2")
+}

--- a/rdd/pkg/util/process/process_unix.go
+++ b/rdd/pkg/util/process/process_unix.go
@@ -38,28 +38,19 @@ func RegisterInterruptHandler(_ string, _ func()) (func(), error) {
 	return func() {}, nil
 }
 
-// IsOurProcess reports whether pid is a live process we may signal under key. On
-// Unix it is always true: a deliberate no-op, not a guard, so the parameters go
-// unused. They exist for signature parity with the Windows build, where the
-// check confirms a PID belongs to one of our processes (by named-event
-// registration) before a caller acts on it. Unix needs no such confirmation:
-// Interrupt/Kill use signals, and PID reuse is far less aggressive than on
-// Windows.
+// IsOurProcess reports whether pid is one of our live processes. On Unix the key
+// is unused and this checks only liveness, since PID reuse is far less aggressive
+// than on Windows, where the key confirms the process registered our interrupt
+// event. A non-positive PID is never ours.
 //
-// Residual risk: callers that read an on-disk PID (ha.pid from a previous
-// service) can, after a crash or reboot leaves the file behind, act on a PID
-// the OS recycled to an unrelated live process — SIGINT on the signal path,
-// SIGKILL of its process group on the forced path. We accept it because Unix
-// recycles PIDs only after the counter wraps, far less aggressively than
-// Windows.
-func IsOurProcess(_ string, _ int) bool {
-	return true
-}
-
-// IsAlive reports whether a process with the given PID currently exists. A
-// process that exists but cannot be signalled by this user (EPERM) still counts
-// as alive.
-func IsAlive(pid int) bool {
+// Residual risk: a caller acting on an on-disk PID (ha.pid from a previous
+// service) can, after a crash leaves the file behind, reach a PID the OS recycled
+// to an unrelated live process. We accept it because Unix recycles PIDs only
+// after the counter wraps.
+func IsOurProcess(_ string, pid int) bool {
+	if pid <= 0 {
+		return false
+	}
 	err := unix.Kill(pid, 0)
 	return err == nil || errors.Is(err, unix.EPERM)
 }

--- a/rdd/pkg/util/process/process_unix.go
+++ b/rdd/pkg/util/process/process_unix.go
@@ -22,16 +22,29 @@ func SetGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
-// Interrupt sends SIGINT to the process with the given PID.
-func Interrupt(pid int) error {
+// Interrupt sends SIGINT to the process with the given PID. The key is ignored
+// on Unix (it namespaces the named event used on Windows); a signal reaches the
+// process regardless of which console either party is attached to.
+func Interrupt(_ string, pid int) error {
 	return unix.Kill(pid, unix.SIGINT)
 }
 
-// IsOurProcess reports whether pid is a live process running this program's own
-// executable. On Unix it is always true: a deliberate no-op, not a guard, so
-// the parameters go unused (they exist for signature parity with the Windows
-// build, where the check defends GenerateConsoleCtrlEvent against PID reuse — a
-// console-signal hazard that does not exist on Unix).
+// RegisterInterruptHandler is a no-op on Unix and returns a no-op release
+// function. Interrupt here sends SIGINT, which processes already handle via
+// signal.Notify / genericapiserver.SetupSignalContext, so no extra wiring is
+// needed. It exists for signature parity with the Windows build, where Interrupt
+// signals a named event the target must create at startup.
+func RegisterInterruptHandler(_ string, _ func()) (func(), error) {
+	return func() {}, nil
+}
+
+// IsOurProcess reports whether pid is a live process we may signal under key. On
+// Unix it is always true: a deliberate no-op, not a guard, so the parameters go
+// unused. They exist for signature parity with the Windows build, where the
+// check confirms a PID belongs to one of our processes (by named-event
+// registration) before a caller acts on it. Unix needs no such confirmation:
+// Interrupt/Kill use signals, and PID reuse is far less aggressive than on
+// Windows.
 //
 // Residual risk: callers that read an on-disk PID (ha.pid from a previous
 // service) can, after a crash or reboot leaves the file behind, act on a PID
@@ -39,15 +52,16 @@ func Interrupt(pid int) error {
 // SIGKILL of its process group on the forced path. We accept it because Unix
 // recycles PIDs only after the counter wraps, far less aggressively than
 // Windows.
-func IsOurProcess(_ int, _ ...string) bool {
+func IsOurProcess(_ string, _ int) bool {
 	return true
 }
 
-// IsOurProcessWithArg is the whole-argument counterpart of IsOurProcess. On
-// Unix it is the same deliberate no-op, returning true for signature parity
-// with the Windows build.
-func IsOurProcessWithArg(_ int, _ string) bool {
-	return true
+// IsAlive reports whether a process with the given PID currently exists. A
+// process that exists but cannot be signalled by this user (EPERM) still counts
+// as alive.
+func IsAlive(pid int) bool {
+	err := unix.Kill(pid, 0)
+	return err == nil || errors.Is(err, unix.EPERM)
 }
 
 // Kill sends SIGTERM to the process with the given PID.

--- a/rdd/pkg/util/process/process_unix_test.go
+++ b/rdd/pkg/util/process/process_unix_test.go
@@ -13,17 +13,13 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// TestIsAlive confirms liveness detection on Unix: the running test process is
-// alive, and an unassigned PID is not.
-func TestIsAlive(t *testing.T) {
-	assert.Assert(t, IsAlive(os.Getpid()), "the test process is alive")
-	assert.Assert(t, !IsAlive(0x7FFFFFF0), "an unassigned pid is not alive")
-}
-
-// TestIsOurProcessNoOp confirms the Unix identity check is a no-op that returns
-// true regardless of key or PID; on Unix, Interrupt uses signals, so there is no
-// per-process registration to consult.
-func TestIsOurProcessNoOp(t *testing.T) {
-	assert.Assert(t, IsOurProcess(ServeInterruptKey, os.Getpid()))
-	assert.Assert(t, IsOurProcess(HostagentInterruptKey("rd"), 0x7FFFFFF0))
+// TestIsOurProcess confirms the Unix identity check reports liveness only — the
+// key is ignored — and rejects a non-positive PID.
+func TestIsOurProcess(t *testing.T) {
+	assert.Assert(t, IsOurProcess(ServeInterruptKey, os.Getpid()),
+		"the live test process is ours")
+	assert.Assert(t, !IsOurProcess(ServeInterruptKey, 0x7FFFFFF0),
+		"an unassigned pid is not ours")
+	assert.Assert(t, !IsOurProcess(ServeInterruptKey, 0),
+		"a non-positive pid is never ours")
 }

--- a/rdd/pkg/util/process/process_unix_test.go
+++ b/rdd/pkg/util/process/process_unix_test.go
@@ -1,0 +1,29 @@
+//go:build unix
+
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package process
+
+import (
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestIsAlive confirms liveness detection on Unix: the running test process is
+// alive, and an unassigned PID is not.
+func TestIsAlive(t *testing.T) {
+	assert.Assert(t, IsAlive(os.Getpid()), "the test process is alive")
+	assert.Assert(t, !IsAlive(0x7FFFFFF0), "an unassigned pid is not alive")
+}
+
+// TestIsOurProcessNoOp confirms the Unix identity check is a no-op that returns
+// true regardless of key or PID; on Unix, Interrupt uses signals, so there is no
+// per-process registration to consult.
+func TestIsOurProcessNoOp(t *testing.T) {
+	assert.Assert(t, IsOurProcess(ServeInterruptKey, os.Getpid()))
+	assert.Assert(t, IsOurProcess(HostagentInterruptKey("rd"), 0x7FFFFFF0))
+}

--- a/rdd/pkg/util/process/process_windows.go
+++ b/rdd/pkg/util/process/process_windows.go
@@ -34,12 +34,9 @@ func SetGroup(cmd *exec.Cmd) {
 
 // interruptEventName returns the name of the event Interrupt signals to ask the
 // process identified by (key, pid) to shut down gracefully. The Local\ namespace
-// scopes the event to the current session, which is where the control plane and
-// the CLI run (same user, interactive session); a daemon running as a session-0
-// Windows service would need the Global\ namespace. instance.Suffix() namespaces
-// the event by rdd instance and key by role (see ServeInterruptKey /
-// HostagentInterruptKey), so a PID recycled to a different instance or role
-// creates no matching event and IsOurProcess can confirm both.
+// scopes it to the current session, where the control plane and CLI both run.
+// instance.Suffix() namespaces the event by rdd instance and key by role, so a
+// PID recycled to a different instance or role has no matching event.
 func interruptEventName(key string, pid int) string {
 	return fmt.Sprintf(`Local\rdd-%s-interrupt-%s-%d`, instance.Suffix(), key, pid)
 }
@@ -56,15 +53,11 @@ func openInterruptEvent(key string, pid int) (windows.Handle, error) {
 }
 
 // Interrupt asks the process identified by (key, pid) to shut down gracefully by
-// signalling its named interrupt event (see RegisterInterruptHandler). A named
-// event reaches the target regardless of which console either party is attached
-// to, so `rdd svc delete` can gracefully stop a daemon the GUI app started in
-// another console.
-//
-// It is also inherently safe against PID reuse: only an RDD process that called
-// RegisterInterruptHandler with this key creates the event, so OpenEvent fails
-// for a recycled or unrelated PID and Interrupt returns an error rather than
-// disturbing it. Callers fall back to Kill/KillTree on error.
+// signalling its named interrupt event (see RegisterInterruptHandler). The event
+// reaches the target regardless of which console either party is attached to, so
+// `rdd svc stop` can stop a daemon the GUI app started elsewhere. OpenEvent fails
+// for a recycled, unrelated, or exited PID, so Interrupt returns an error rather
+// than disturbing it.
 func Interrupt(key string, pid int) error {
 	handle, err := openInterruptEvent(key, pid)
 	if err != nil {
@@ -89,7 +82,7 @@ func RegisterInterruptHandler(key string, onInterrupt func()) (func(), error) {
 	// Manual-reset so the signal latches: the watcher cannot miss a caller's
 	// SetEvent by racing it, and a later look still sees the event set.
 	evt, err := windows.CreateEvent(nil, 1, 0, name)
-	if err != nil && !errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+	if err != nil {
 		return nil, fmt.Errorf("create interrupt event: %w", err)
 	}
 	// Unnamed companion event, used only to wake the watcher on release.
@@ -123,33 +116,20 @@ func RegisterInterruptHandler(key string, onInterrupt func()) (func(), error) {
 
 // IsOurProcess reports whether pid is a live RDD process that registered an
 // interrupt handler under key — that is, whether its per-process interrupt event
-// exists. Only the daemon (ServeInterruptKey) and hostagents
-// (HostagentInterruptKey) register, so a match confirms both that the process is
-// ours and that it plays the expected role; a recycled or unrelated PID has no
-// such event. It never errors: anything it cannot positively confirm reads as
-// false ("not ours"). On non-Windows it is a no-op that returns true.
+// exists. Only the daemon and hostagents register, so a match confirms the
+// process is ours and plays the expected role. It never errors; anything it
+// cannot positively confirm reads as not-ours. On non-Windows it checks only
+// that the PID is live.
 func IsOurProcess(key string, pid int) bool {
+	if pid <= 0 {
+		return false
+	}
 	handle, err := openInterruptEvent(key, pid)
 	if err != nil {
 		return false
 	}
 	_ = windows.CloseHandle(handle)
 	return true
-}
-
-// IsAlive reports whether a process with the given PID currently exists. It is
-// used to decide whether a recorded PID is merely stale (the process is gone, so
-// its PID file can be cleaned up) or still running (leave the file alone). A
-// process we may open but not synchronize on (a higher-integrity one) counts as
-// alive.
-func IsAlive(pid int) bool {
-	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
-	if err != nil {
-		return errors.Is(err, windows.ERROR_ACCESS_DENIED)
-	}
-	defer func() { _ = windows.CloseHandle(handle) }()
-	result, err := windows.WaitForSingleObject(handle, 0)
-	return err == nil && result == uint32(windows.WAIT_TIMEOUT)
 }
 
 // Kill terminates the process with the given PID.

--- a/rdd/pkg/util/process/process_windows.go
+++ b/rdd/pkg/util/process/process_windows.go
@@ -10,20 +10,19 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"slices"
 	"strconv"
-	"strings"
+	"sync"
 	"time"
-	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
 // SetGroup configures the command to run in its own process group.
-// On Windows, CREATE_NEW_PROCESS_GROUP allows GenerateConsoleCtrlEvent to
-// target only the child process (using its PID as the group ID) without
-// affecting the parent process.
+// On Windows, CREATE_NEW_PROCESS_GROUP detaches the child from the parent's
+// Ctrl-C/Ctrl-Break, so a backgrounded daemon or hostagent is not torn down
+// when the launching console receives one. Detachment is its only role here:
+// graceful shutdown goes through Interrupt's named event (see Interrupt and
+// RegisterInterruptHandler), independent of the process group.
 func SetGroup(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &windows.SysProcAttr{}
@@ -31,225 +30,123 @@ func SetGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP
 }
 
-// Interrupt sends a graceful shutdown signal to the process with the given PID.
-// On Windows, this uses GenerateConsoleCtrlEvent with CTRL_BREAK_EVENT targeted
-// at the process group (requires CREATE_NEW_PROCESS_GROUP via SetGroup).
-func Interrupt(pid int) error {
-	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(pid))
+// interruptEventName returns the name of the event Interrupt signals to ask the
+// process identified by (key, pid) to shut down gracefully. The Local\ namespace
+// scopes the event to the current session, which is where the control plane and
+// the CLI run (same user, interactive session); a daemon running as a session-0
+// Windows service would need the Global\ namespace. key namespaces the event by
+// role (see ServeInterruptKey / HostagentInterruptKey) so a name collision
+// across roles is impossible and IsOurProcess can confirm the role.
+func interruptEventName(key string, pid int) string {
+	return fmt.Sprintf(`Local\rdd-interrupt-%s-%d`, key, pid)
 }
 
-// IsOurProcess reports whether pid is a live process running this program's own
-// executable with a command line that contains every string in cmdlineSubstrings.
+// openInterruptEvent opens the interrupt event for (key, pid). It fails when no
+// process registered that event — the target is gone, recycled, unrelated, or
+// not playing the keyed role — which both Interrupt and IsOurProcess rely on.
+func openInterruptEvent(key string, pid int) (windows.Handle, error) {
+	name, err := windows.UTF16PtrFromString(interruptEventName(key, pid))
+	if err != nil {
+		return 0, err
+	}
+	return windows.OpenEvent(windows.EVENT_MODIFY_STATE, false, name)
+}
+
+// Interrupt asks the process identified by (key, pid) to shut down gracefully by
+// signalling its named interrupt event (see RegisterInterruptHandler). A named
+// event reaches the target regardless of which console either party is attached
+// to, so `rdd svc delete` can gracefully stop a daemon the GUI app started in
+// another console.
 //
-// It guards graceful shutdown via Interrupt against PID reuse. Windows recycles
-// PIDs aggressively, and GenerateConsoleCtrlEvent(CTRL_BREAK) delivered to a
-// recycled PID can reach unrelated processes that share the console — including
-// the rdd service and the controlling terminal — rather than the intended
-// target. Callers confirm identity here before signalling; on a mismatch they
-// fall back to KillTree, which terminates a single PID and cannot escape to the
-// console.
-//
-// It returns false (never an error) whenever identity cannot be positively
-// confirmed — the process is gone, inaccessible, or no longer ours — so callers
-// treat "unknown" as "not ours" and never signal it.
-//
-// Each substring is matched with strings.Contains, not as a whole argument, so a
-// discriminator must be specific enough that it cannot appear in an unrelated
-// process's command line. An instance name that is a prefix of another (e.g.
-// "vm" and "vm2") matches both; pass a name distinct enough to avoid that.
-//
-// With no substrings the image-path match alone decides the result, which a
-// recycled PID running any other rdd process would satisfy; production callers
-// should always pass a discriminator. To match a short token that could also
-// appear inside the image path, use IsOurProcessWithArg, which compares whole
-// arguments instead of substrings.
-func IsOurProcess(pid int, cmdlineSubstrings ...string) bool {
-	cmdline, ok := ourProcessCommandLine(pid)
-	if !ok {
+// It is also inherently safe against PID reuse: only an RDD process that called
+// RegisterInterruptHandler with this key creates the event, so OpenEvent fails
+// for a recycled or unrelated PID and Interrupt returns an error rather than
+// disturbing it. Callers fall back to Kill/KillTree on error.
+func Interrupt(key string, pid int) error {
+	handle, err := openInterruptEvent(key, pid)
+	if err != nil {
+		return fmt.Errorf("open interrupt event %q for pid %d: %w", key, pid, err)
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	return windows.SetEvent(handle)
+}
+
+// RegisterInterruptHandler creates this process's named interrupt event for key
+// and runs onInterrupt when another process signals it via Interrupt. Every RDD
+// process that can be the target of Interrupt — the control plane daemon
+// (ServeInterruptKey) and each hostagent (HostagentInterruptKey) — must call
+// this once at startup with its own key; the returned function stops the watcher
+// and releases the event. On Unix it is a no-op: Interrupt there sends SIGINT,
+// which the process already handles via signal.Notify / SetupSignalContext.
+func RegisterInterruptHandler(key string, onInterrupt func()) (func(), error) {
+	name, err := windows.UTF16PtrFromString(interruptEventName(key, os.Getpid()))
+	if err != nil {
+		return nil, err
+	}
+	// Manual-reset so the signal latches: the watcher cannot miss a caller's
+	// SetEvent by racing it, and a later look still sees the event set.
+	evt, err := windows.CreateEvent(nil, 1, 0, name)
+	if err != nil && !errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+		return nil, fmt.Errorf("create interrupt event: %w", err)
+	}
+	// Unnamed companion event, used only to wake the watcher on release.
+	release, err := windows.CreateEvent(nil, 1, 0, nil)
+	if err != nil {
+		_ = windows.CloseHandle(evt)
+		return nil, fmt.Errorf("create release event: %w", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// WAIT_OBJECT_0 == the interrupt event fired; WAIT_OBJECT_0+1 == release.
+		ret, waitErr := windows.WaitForMultipleObjects(
+			[]windows.Handle{evt, release}, false, windows.INFINITE)
+		if waitErr == nil && ret == windows.WAIT_OBJECT_0 {
+			onInterrupt()
+		}
+	}()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			_ = windows.SetEvent(release)
+			<-done
+			_ = windows.CloseHandle(evt)
+			_ = windows.CloseHandle(release)
+		})
+	}, nil
+}
+
+// IsOurProcess reports whether pid is a live RDD process that registered an
+// interrupt handler under key — that is, whether its per-process interrupt event
+// exists. Only the daemon (ServeInterruptKey) and hostagents
+// (HostagentInterruptKey) register, so a match confirms both that the process is
+// ours and that it plays the expected role; a recycled or unrelated PID has no
+// such event. It never errors: anything it cannot positively confirm reads as
+// false ("not ours"). On non-Windows it is a no-op that returns true.
+func IsOurProcess(key string, pid int) bool {
+	handle, err := openInterruptEvent(key, pid)
+	if err != nil {
 		return false
 	}
-	for _, s := range cmdlineSubstrings {
-		if !strings.Contains(cmdline, s) {
-			return false
-		}
-	}
+	_ = windows.CloseHandle(handle)
 	return true
 }
 
-// IsOurProcessWithArg reports whether pid is a live process running this
-// program's own executable with arg as one of its command-line arguments
-// (argv[1:], excluding the executable path). Unlike IsOurProcess, which matches
-// a raw substring of the whole command line, this matches a complete argument,
-// so a short token such as a subcommand name cannot be satisfied by an
-// unrelated process whose image path merely contains that text.
-//
-// It shares IsOurProcess's identity guarantees and failure semantics: it
-// returns false (never an error) whenever identity cannot be positively
-// confirmed, so callers treat "unknown" as "not ours". On non-Windows it is a
-// no-op that returns true, like IsOurProcess.
-func IsOurProcessWithArg(pid int, arg string) bool {
-	cmdline, ok := ourProcessCommandLine(pid)
-	if !ok {
-		return false
-	}
-	return commandLineHasArg(cmdline, arg)
-}
-
-// commandLineHasArg reports whether arg appears as a complete argument in
-// commandLine, ignoring argv[0] (the executable path). It parses the command
-// line with the same rules Windows uses (CommandLineToArgvW, via
-// DecomposeCommandLine), so a quoted path containing spaces stays a single
-// argument and a token that is only a substring of argv[0] is not matched.
-func commandLineHasArg(commandLine, arg string) bool {
-	args, err := windows.DecomposeCommandLine(commandLine)
-	if err != nil || len(args) < 2 {
-		return false
-	}
-	return slices.Contains(args[1:], arg)
-}
-
-// ourProcessCommandLine returns pid's command line when pid is a live process
-// running this program's own executable, and false otherwise. It centralises
-// the OpenProcess and image-path comparison that the identity checks share.
-func ourProcessCommandLine(pid int) (string, bool) {
-	self, err := os.Executable()
+// IsAlive reports whether a process with the given PID currently exists. It is
+// used to decide whether a recorded PID is merely stale (the process is gone, so
+// its PID file can be cleaned up) or still running (leave the file alone). A
+// process we may open but not synchronize on (a higher-integrity one) counts as
+// alive.
+func IsAlive(pid int) bool {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
 	if err != nil {
-		return "", false
-	}
-	handle, err := windows.OpenProcess(
-		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
-	if err != nil {
-		return "", false
+		return errors.Is(err, windows.ERROR_ACCESS_DENIED)
 	}
 	defer func() { _ = windows.CloseHandle(handle) }()
-
-	image, err := processImagePath(handle)
-	if err != nil || !samePath(image, self) {
-		return "", false
-	}
-	cmdline, err := processCommandLine(handle)
-	if err != nil {
-		return "", false
-	}
-	return cmdline, true
-}
-
-// samePath reports whether image and self name the same on-disk executable.
-// It resolves each to its long (non-8.3) form first, so a process launched
-// through a short path such as C:\PROGRA~1\... still matches the same binary
-// named by its long path. The two rdd processes compared need not have been
-// launched the same way.
-func samePath(image, self string) bool {
-	return strings.EqualFold(longPath(image), longPath(self))
-}
-
-// longPath returns p in its long, non-8.3 form. If the long form cannot be
-// resolved (for example the file no longer exists), it falls back to
-// filepath.Clean(p) so a transient resolution failure degrades to a lexical
-// comparison rather than a guaranteed mismatch — for the service PID a false
-// "not ours" would orphan a live control plane.
-func longPath(p string) string {
-	if resolved, err := resolveLongPath(p); err == nil {
-		return filepath.Clean(resolved)
-	}
-	return filepath.Clean(p)
-}
-
-// resolveLongPath expands any 8.3 short components of p via GetLongPathName,
-// growing the buffer up to the Windows extended-path ceiling the way
-// processImagePath does.
-func resolveLongPath(p string) (string, error) {
-	p16, err := windows.UTF16PtrFromString(p)
-	if err != nil {
-		return "", err
-	}
-	for bufSize := uint32(1024); bufSize <= 32768; bufSize *= 2 {
-		buf := make([]uint16, bufSize)
-		n, err := windows.GetLongPathName(p16, &buf[0], bufSize)
-		if err != nil {
-			return "", err
-		}
-		if n < bufSize {
-			return windows.UTF16ToString(buf[:n]), nil
-		}
-		// n >= bufSize: the buffer was too small and n is the required size; grow.
-	}
-	return "", windows.ERROR_INSUFFICIENT_BUFFER
-}
-
-// processImagePath returns the full path to the executable backing the process.
-// QueryFullProcessImageName does not report the size it needs on failure, so on
-// ERROR_INSUFFICIENT_BUFFER this doubles the buffer and retries, up to the
-// Windows extended-path ceiling of 32767 characters.
-func processImagePath(handle windows.Handle) (string, error) {
-	for bufSize := 1024; bufSize <= 32768; bufSize *= 2 {
-		buf := make([]uint16, bufSize)
-		size := uint32(len(buf))
-		err := windows.QueryFullProcessImageName(handle, 0, &buf[0], &size)
-		if err == nil {
-			return windows.UTF16ToString(buf[:size]), nil
-		}
-		if !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
-			return "", err
-		}
-	}
-	return "", windows.ERROR_INSUFFICIENT_BUFFER
-}
-
-// processCommandLine reads the target process's command line out of its PEB.
-// Windows exposes no API for another process's command line, so we follow the
-// documented PEB -> RTL_USER_PROCESS_PARAMETERS -> CommandLine chain via
-// ReadProcessMemory. The handle must carry PROCESS_VM_READ.
-func processCommandLine(handle windows.Handle) (string, error) {
-	var pbi windows.PROCESS_BASIC_INFORMATION
-	var retLen uint32
-	if err := windows.NtQueryInformationProcess(handle, windows.ProcessBasicInformation,
-		unsafe.Pointer(&pbi), uint32(unsafe.Sizeof(pbi)), &retLen); err != nil {
-		return "", err
-	}
-
-	var peb windows.PEB
-	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(pbi.PebBaseAddress)),
-		unsafe.Pointer(&peb), unsafe.Sizeof(peb)); err != nil {
-		return "", err
-	}
-
-	var params windows.RTL_USER_PROCESS_PARAMETERS
-	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(peb.ProcessParameters)),
-		unsafe.Pointer(&params), unsafe.Sizeof(params)); err != nil {
-		return "", err
-	}
-
-	length := params.CommandLine.Length
-	// Under one UTF-16 unit — including an impossible odd byte count — there is
-	// no command line to read, and length/2 would size buf to zero and panic the
-	// &buf[0] deref below. Treat it as empty.
-	if length < 2 || params.CommandLine.Buffer == nil {
-		return "", nil
-	}
-	// NTUnicodeString.Length counts bytes; the buffer holds UTF-16 code units.
-	// Read len(buf)*2 bytes rather than Length itself, so the read can never
-	// exceed the buffer if Length is ever odd — it is not on supported Windows,
-	// but pairing the read size to the buffer makes the invariant explicit.
-	buf := make([]uint16, length/2)
-	if err := readProcessMemory(handle, uintptr(unsafe.Pointer(params.CommandLine.Buffer)),
-		unsafe.Pointer(&buf[0]), uintptr(len(buf)*2)); err != nil {
-		return "", err
-	}
-	return windows.UTF16ToString(buf), nil
-}
-
-// readProcessMemory copies size bytes at addr in the target process into dest,
-// erroring unless the full range was read.
-func readProcessMemory(handle windows.Handle, addr uintptr, dest unsafe.Pointer, size uintptr) error {
-	var read uintptr
-	if err := windows.ReadProcessMemory(handle, addr, (*byte)(dest), size, &read); err != nil {
-		return err
-	}
-	if read != size {
-		return fmt.Errorf("short read at %#x: got %d of %d bytes", addr, read, size)
-	}
-	return nil
+	result, err := windows.WaitForSingleObject(handle, 0)
+	return err == nil && result == uint32(windows.WAIT_TIMEOUT)
 }
 
 // Kill terminates the process with the given PID.

--- a/rdd/pkg/util/process/process_windows.go
+++ b/rdd/pkg/util/process/process_windows.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"golang.org/x/sys/windows"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
 // SetGroup configures the command to run in its own process group.
@@ -34,11 +36,12 @@ func SetGroup(cmd *exec.Cmd) {
 // process identified by (key, pid) to shut down gracefully. The Local\ namespace
 // scopes the event to the current session, which is where the control plane and
 // the CLI run (same user, interactive session); a daemon running as a session-0
-// Windows service would need the Global\ namespace. key namespaces the event by
-// role (see ServeInterruptKey / HostagentInterruptKey) so a name collision
-// across roles is impossible and IsOurProcess can confirm the role.
+// Windows service would need the Global\ namespace. instance.Suffix() namespaces
+// the event by rdd instance and key by role (see ServeInterruptKey /
+// HostagentInterruptKey), so a PID recycled to a different instance or role
+// creates no matching event and IsOurProcess can confirm both.
 func interruptEventName(key string, pid int) string {
-	return fmt.Sprintf(`Local\rdd-interrupt-%s-%d`, key, pid)
+	return fmt.Sprintf(`Local\rdd-%s-interrupt-%s-%d`, instance.Suffix(), key, pid)
 }
 
 // openInterruptEvent opens the interrupt event for (key, pid). It fails when no

--- a/rdd/pkg/util/process/process_windows_test.go
+++ b/rdd/pkg/util/process/process_windows_test.go
@@ -6,6 +6,7 @@ package process
 
 import (
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,40 +19,35 @@ import (
 // a graceful shutdown across consoles.
 func TestRegisterInterruptHandlerAndInterrupt(t *testing.T) {
 	const key = ServeInterruptKey
-	fired := make(chan struct{})
-	release, err := RegisterInterruptHandler(key, func() { close(fired) })
+	var fired atomic.Bool
+	release, err := RegisterInterruptHandler(key, func() { fired.Store(true) })
 	assert.NilError(t, err)
 	defer release()
 
 	assert.Assert(t, IsOurProcess(key, os.Getpid()),
 		"a process that registered key %q should be recognised as ours", key)
-	assert.Assert(t, !IsOurProcess(HostagentInterruptKey("rd"), os.Getpid()),
+	assert.Assert(t, !IsOurProcess("invalid-key", os.Getpid()),
 		"a key the process did not register must not match")
 
 	assert.NilError(t, Interrupt(key, os.Getpid()))
 
-	var ok bool
-	select {
-	case <-fired:
-		ok = true
-	case <-time.After(10 * time.Second):
+	// onInterrupt runs on RegisterInterruptHandler's watcher goroutine.
+	for range 100 {
+		if fired.Load() {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
-	assert.Assert(t, ok, "interrupt handler did not fire within 10s")
+	assert.Assert(t, fired.Load(), "interrupt handler did not fire within 10s")
 }
 
 // TestInterruptUnregisteredFails confirms Interrupt and IsOurProcess reject a PID
 // with no registered event — a dead, recycled, or unrelated process — so callers
 // fall back to a force kill instead of disturbing it.
 func TestInterruptUnregisteredFails(t *testing.T) {
-	assert.Assert(t, Interrupt(ServeInterruptKey, 0x7FFFFFF0) != nil,
+	unregistered := os.Getpid() + 1
+	assert.Assert(t, Interrupt(ServeInterruptKey, unregistered) != nil,
 		"interrupting a pid with no registered event should fail")
-	assert.Assert(t, !IsOurProcess(ServeInterruptKey, 0x7FFFFFF0),
+	assert.Assert(t, !IsOurProcess(ServeInterruptKey, unregistered),
 		"a pid with no registered event is not ours")
-}
-
-// TestIsAlive confirms liveness detection on Windows: the running test process
-// is alive, and an unassigned PID is not.
-func TestIsAlive(t *testing.T) {
-	assert.Assert(t, IsAlive(os.Getpid()), "the test process is alive")
-	assert.Assert(t, !IsAlive(0x7FFFFFF0), "an unassigned pid is not alive")
 }

--- a/rdd/pkg/util/process/process_windows_test.go
+++ b/rdd/pkg/util/process/process_windows_test.go
@@ -6,163 +6,52 @@ package process
 
 import (
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
+	"time"
 
-	"golang.org/x/sys/windows"
 	"gotest.tools/v3/assert"
 )
 
-func openSelf(t *testing.T) windows.Handle {
-	t.Helper()
-	handle, err := windows.OpenProcess(
-		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(os.Getpid()))
+// TestRegisterInterruptHandlerAndInterrupt confirms the named-event round trip:
+// after a process registers a handler for a key, Interrupt(key, pid) fires it
+// and IsOurProcess(key, pid) recognises it. This is the mechanism that delivers
+// a graceful shutdown across consoles.
+func TestRegisterInterruptHandlerAndInterrupt(t *testing.T) {
+	const key = ServeInterruptKey
+	fired := make(chan struct{})
+	release, err := RegisterInterruptHandler(key, func() { close(fired) })
 	assert.NilError(t, err)
-	t.Cleanup(func() { _ = windows.CloseHandle(handle) })
-	return handle
-}
+	defer release()
 
-// TestProcessCommandLineReadsOwnCommandLine exercises the PEB walk against the
-// running test process, catching struct-offset regressions in the unsafe reads.
-func TestProcessCommandLineReadsOwnCommandLine(t *testing.T) {
-	cmdline, err := processCommandLine(openSelf(t))
-	assert.NilError(t, err)
-	assert.Assert(t, cmdline != "", "command line should not be empty")
+	assert.Assert(t, IsOurProcess(key, os.Getpid()),
+		"a process that registered key %q should be recognised as ours", key)
+	assert.Assert(t, !IsOurProcess(HostagentInterruptKey("rd"), os.Getpid()),
+		"a key the process did not register must not match")
 
-	base := filepath.Base(os.Args[0])
-	assert.Assert(t, strings.Contains(cmdline, base),
-		"command line %q should contain argv0 base %q", cmdline, base)
-}
+	assert.NilError(t, Interrupt(key, os.Getpid()))
 
-// TestIsOurProcess confirms identity matching: the running process matches its
-// own executable and command line, and rejects absent substrings and dead PIDs.
-func TestIsOurProcess(t *testing.T) {
-	pid := os.Getpid()
-	base := filepath.Base(os.Args[0])
-
-	assert.Assert(t, IsOurProcess(pid), "current process should match its own executable")
-	assert.Assert(t, IsOurProcess(pid, base),
-		"current process should match its own argv0 base %q", base)
-	assert.Assert(t, !IsOurProcess(pid, "substring-that-cannot-appear-9c1f"),
-		"a substring absent from the command line should not match")
-	// A PID this high is never assigned, so OpenProcess fails and the result
-	// must be false rather than an accidental match.
-	assert.Assert(t, !IsOurProcess(0xFFFFFFF0, "hostagent"),
-		"a nonexistent PID should not match")
-}
-
-// TestCommandLineHasArg confirms whole-argument matching: a token is matched
-// only as a complete argument in argv[1:], never as a substring of argv[0] or
-// of another argument. This is the property that keeps the service-PID guard
-// from accepting an unrelated rdd process whose image path contains "serve".
-func TestCommandLineHasArg(t *testing.T) {
-	assert.Assert(t, commandLineHasArg(`C:\rdd.exe service serve --secure-port 6443`, "serve"),
-		"the canonical self-spawn carries serve as an argument")
-	assert.Assert(t, commandLineHasArg(`C:\rdd.exe svc serve`, "serve"),
-		"the svc alias also carries serve as an argument")
-	assert.Assert(t, commandLineHasArg(`"C:\Program Files\rdd\rdd.exe" service serve`, "serve"),
-		"a quoted image path with spaces stays a single argv[0]")
-	// argv[0] containing the token as a substring must not match.
-	assert.Assert(t, !commandLineHasArg(`C:\observer\rdd.exe ctl get`, "serve"),
-		"serve inside the image path is not an argument")
-	assert.Assert(t, !commandLineHasArg(`C:\webserver\rdd.exe ctl`, "serve"),
-		"serve inside the image path is not an argument")
-	// Another rdd subcommand is not the control plane.
-	assert.Assert(t, !commandLineHasArg(`C:\rdd.exe hostagent --pidfile C:\x\ha.pid vm`, "serve"),
-		"the hostagent subcommand is not serve")
-	// argv[0] alone, with no arguments, never matches.
-	assert.Assert(t, !commandLineHasArg(`C:\rdd.exe`, "serve"),
-		"a bare image path has no arguments to match")
-}
-
-// TestIsOurProcessWithArg confirms the whole-argument identity check: the argv0
-// base name is a substring of the command line but not an argument, so it must
-// not match — the behaviour that distinguishes IsOurProcessWithArg from
-// IsOurProcess and closes the image-path over-match.
-func TestIsOurProcessWithArg(t *testing.T) {
-	pid := os.Getpid()
-	base := filepath.Base(os.Args[0])
-
-	assert.Assert(t, !IsOurProcessWithArg(pid, base),
-		"the argv0 base %q is part of argv0, not an argument", base)
-	assert.Assert(t, !IsOurProcessWithArg(pid, "arg-that-cannot-appear-9c1f"),
-		"an argument absent from the command line should not match")
-	assert.Assert(t, !IsOurProcessWithArg(0xFFFFFFF0, "serve"),
-		"a nonexistent PID should not match")
-	if len(os.Args) > 1 {
-		assert.Assert(t, IsOurProcessWithArg(pid, os.Args[1]),
-			"the running process should match its own argument %q", os.Args[1])
+	var ok bool
+	select {
+	case <-fired:
+		ok = true
+	case <-time.After(10 * time.Second):
 	}
+	assert.Assert(t, ok, "interrupt handler did not fire within 10s")
 }
 
-// TestIsOurProcessRejectsForeignExecutable confirms the image-path check: a live
-// process running a different executable is not ours, even when a requested
-// substring appears in its command line. This is the branch that defends against
-// PID reuse.
-func TestIsOurProcessRejectsForeignExecutable(t *testing.T) {
-	// ping runs for several seconds without console input, giving a stable live
-	// PID backed by an executable other than the test binary.
-	cmd := exec.CommandContext(t.Context(), "ping.exe", "-n", "10", "127.0.0.1")
-	assert.NilError(t, cmd.Start())
-	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	})
-
-	pid := cmd.Process.Pid
-
-	// Confirm the rejection comes from the image-path mismatch rather than an
-	// OpenProcess failure or an already-exited process: open the child the way
-	// IsOurProcess does and verify its image is readable and differs from the
-	// test binary. Without this, a denied OpenProcess would let the assertions
-	// below pass without exercising the defense.
-	handle, err := windows.OpenProcess(
-		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, uint32(pid))
-	assert.NilError(t, err)
-	defer func() { _ = windows.CloseHandle(handle) }()
-	image, err := processImagePath(handle)
-	assert.NilError(t, err)
-	self, err := os.Executable()
-	assert.NilError(t, err)
-	assert.Assert(t, !strings.EqualFold(filepath.Clean(image), filepath.Clean(self)),
-		"ping image %q must differ from the test binary %q", image, self)
-
-	assert.Assert(t, !IsOurProcess(pid),
-		"a live process running a different executable should not match")
-	assert.Assert(t, !IsOurProcess(pid, "ping"),
-		"a command-line substring match must not override an executable mismatch")
+// TestInterruptUnregisteredFails confirms Interrupt and IsOurProcess reject a PID
+// with no registered event — a dead, recycled, or unrelated process — so callers
+// fall back to a force kill instead of disturbing it.
+func TestInterruptUnregisteredFails(t *testing.T) {
+	assert.Assert(t, Interrupt(ServeInterruptKey, 0x7FFFFFF0) != nil,
+		"interrupting a pid with no registered event should fail")
+	assert.Assert(t, !IsOurProcess(ServeInterruptKey, 0x7FFFFFF0),
+		"a pid with no registered event is not ours")
 }
 
-// TestSamePathMatchesShortAndLongForms confirms samePath treats an 8.3 short
-// path and its long form as the same executable. A user can launch rdd through
-// either form, so the identity check must recognize a live control plane no
-// matter which form named the process being checked.
-func TestSamePathMatchesShortAndLongForms(t *testing.T) {
-	// A directory name with no natural 8.3 form makes Windows synthesize a
-	// distinct short name where 8.3 generation is enabled on the volume.
-	longDir := filepath.Join(t.TempDir(), "LongDirectoryNameBeyond8dot3")
-	assert.NilError(t, os.Mkdir(longDir, 0o755))
-	longFile := filepath.Join(longDir, "control-plane-binary.exe")
-	assert.NilError(t, os.WriteFile(longFile, []byte("stub"), 0o644))
-
-	short := shortPathName(t, longFile)
-	if strings.EqualFold(filepath.Clean(short), filepath.Clean(longFile)) {
-		t.Skip("8.3 short-name generation is disabled on this volume")
-	}
-	assert.Assert(t, samePath(short, longFile),
-		"short form %q and long form %q must resolve to the same executable", short, longFile)
-}
-
-// shortPathName returns the 8.3 short form of p via GetShortPathName.
-func shortPathName(t *testing.T, p string) string {
-	t.Helper()
-	p16, err := windows.UTF16PtrFromString(p)
-	assert.NilError(t, err)
-	buf := make([]uint16, 1024)
-	n, err := windows.GetShortPathName(p16, &buf[0], uint32(len(buf)))
-	assert.NilError(t, err)
-	assert.Assert(t, n < uint32(len(buf)), "short-path buffer too small")
-	return windows.UTF16ToString(buf[:n])
+// TestIsAlive confirms liveness detection on Windows: the running test process
+// is alive, and an unassigned PID is not.
+func TestIsAlive(t *testing.T) {
+	assert.Assert(t, IsAlive(os.Getpid()), "the test process is alive")
+	assert.Assert(t, !IsAlive(0x7FFFFFF0), "an unassigned pid is not alive")
 }


### PR DESCRIPTION
On Windows, `rdd svc stop`/`delete` could not gracefully stop a control plane the GUI app had started in another console. `Interrupt` used `GenerateConsoleCtrlEvent(CTRL_BREAK)`, which reaches only processes sharing the caller's console, so it fell back to a hard kill that orphaned hostagents. The identity check compounded this: it read the target's command line from its PEB and compared image paths, so a daemon started from a different `rdd.exe` — app bundle vs standalone, or a binary moved aside by a reinstall — read as "not ours". `PID()` then deleted the pidfile, `delete` skipped the shutdown, and the live daemon was orphaned holding state.db.

`Interrupt` now signals a per-process named event, `Local\rdd-interrupt-<key>-<pid>`, where `<key>` is the process's role: `serve` for the daemon, `hostagent-<instance>` for each hostagent. Every process that can be a target registers its event at startup with `RegisterInterruptHandler`; `Interrupt` opens and sets it. Delivery no longer needs a shared console, and identity (`IsOurProcess`) becomes a single `OpenEvent` on that name — path-independent, so any `rdd` binary is recognised, and recycle-PID safe, since an unrelated PID created no such event. Keying by role and instance also keeps a recycled PID from one hostagent being mistaken for another. The whole PEB/command-line/image-path machinery goes away.

`Interrupt`, `RegisterInterruptHandler`, and `IsOurProcess` take a key on every platform; Unix ignores it (`Interrupt` is `SIGINT`, `IsOurProcess` a no-op). `CREATE_NEW_PROCESS_GROUP` stays only to detach background processes from the console's Ctrl-C; `Kill`/`KillTree` remain the force-kill fallback.

Two guardrails close the residual "alive but never registered" case (failed registration):

- `PID()` removes the pidfile only when the recorded PID is dead (new IsAlive); a live but unconfirmed PID keeps its file, which nothing acts on and the next Start overwrites.

- `Delete` removes `db/` first and aborts if `state.db` is still locked, before it can strip the pidfile and leave a half-deleted instance dir.
