### PR TITLE
CI: Smoke tests: Fix Tumbleweed

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -82,7 +82,7 @@ runs:
         case $id in
           suse|opensuse)
             ${{ steps.sudo.outputs.sudo }} zypper --non-interactive install \
-              fuse gawk git GraphicsMagick gtk3-tools jq mozilla-nss \
+              fuse /usr/bin/awk git GraphicsMagick gtk3-tools jq mozilla-nss \
               noto-sans-fonts password-store sudo xvfb-run xauth which
             if [[ ${GITHUB_JOB:-unknown} =~ appimage ]]; then
               ${{ steps.sudo.outputs.sudo }} zypper --non-interactive install \

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -233,7 +233,7 @@ jobs:
       if: contains(matrix.id, 'opensuse')
       run: >-
         zypper --non-interactive install
-        git-core tar
+        gawk git-core tar
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false


### PR DESCRIPTION
Tumbleweed was failing because `git-core` requires `/usr/bin/awk`, and it likes to pick `busybox-awk`; however, we later explicitly install `gawk`, and that introduces a conflict.  A normal person would be able to resolve that interactively, but CI can't.

We do that fix in two ways, to be sure:
- Install `gawk` when installing `git-core`, so we can install the correct `awk` implementation to start with.
- When we later install an `awk`, we just ask for `/usr/bin/awk`, and let the resolve pick whichever one is easier in that situation.

Cherry-picked from: 90179cd8107a1779beeb79bbdacd4a50e730d1f1 (https://github.com/rancher-sandbox/rancher-desktop/pull/10479)