### PR TITLE
Fix smoke tests on Windows

### DIFF
--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -22,6 +22,12 @@
 
 set -o errexit -o nounset
 shopt -s nullglob
+# On bash 4.4+, command substitution `$(command ...)` does _not_ inherit
+# errexit; set `inherit_errexit` here to make it work like older version.  We
+# want to ignore failure here because macOS may be on bash 3.2 that does not
+# support this option; that is fine, because in that case command substitution
+# does inherit errexit.
+shopt -s inherit_errexit &>/dev/null || true
 
 export MSYS2_ARG_CONV_EXCL='*'
 RDD= # Path to rdd
@@ -56,15 +62,16 @@ get_archive() {
     for checksum in *.sha512sum; do
         archiveName=${checksum%.sha512sum}
         if command -v sha512sum &>/dev/null; then
-            sha512sum --check --quiet --strict "$checksum"
+            sha512sum --check --quiet --strict "$checksum" >&2
         else
-            shasum --check --quiet --algorithm 512 "$checksum"
+            shasum --check --quiet --algorithm 512 "$checksum" >&2
         fi
         grep --quiet "$archiveName" "$checksum"
         readlink -f "$archiveName"
         return
     done
     echo "Failed to find archive." >&2
+    ls -l
     exit 1
 }
 

--- a/build/signing-config-win.yaml
+++ b/build/signing-config-win.yaml
@@ -4,7 +4,7 @@
 # The value is an array of files in that directory to sign, or an explicit
 # negation (prefixed with "!").  Any files not listed is an error.
 .:
-- Rancher Desktop.exe
+- Rancher Desktop 2.exe
 - wix-custom-action.dll
 - '!dxcompiler.dll'     # spellcheck-ignore-line
 - '!ffmpeg.dll'

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -279,12 +279,15 @@ class Builder {
       }
     }
 
-    // Update signing configuration
+    // Ensure that the signing config contains the proper name for the excutable.
+    // This is needed because the smoke test script uses that config file to find
+    // files to check; if it does not match, the smoke tests will fail.
     const { productName } = buildUtils.packageMeta;
-    const windowsSigningConfig = yaml.parse(await fs.promises.readFile('build/signing-config-win.yaml', 'utf-8'));
-    windowsSigningConfig['.'] = windowsSigningConfig['.'].map((filename: string) => {
-      return /^Rancher Desktop.*\.exe$/.test(filename) ? `${ productName }.exe` : filename;
-    });
+    const windowsSigningConfig: Record<string, string[]> =
+      yaml.parse(await fs.promises.readFile('build/signing-config-win.yaml', 'utf-8'));
+    if (!windowsSigningConfig['.'].includes(`${ productName }.exe`)) {
+      throw new Error(`signing-config-win.yaml does not contain the expected executable name: ${ productName }.exe`);
+    }
     await fs.promises.writeFile(
       path.join(workDir, 'signing-config-win.yaml'),
       yaml.stringify(windowsSigningConfig), 'utf-8');


### PR DESCRIPTION
- Fix not erroring out when the checksum is invalid
- Fix the signing config, so we can verify signatures correctly.

With this the smoke tests for v2.0.0-alpha.1 should pass (without modifying the uploaded bits).