### PR TITLE
Download guest distro as an rddepman dependency

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -9,6 +9,13 @@
 check-spelling:
   version: 0.0.26
   checksums: {}
+distro:
+  version: 0.2.8
+  checksums:
+    distro.v0.2.8.amd64.raw.xz: sha256:a589e020df983d6b971fbbe73d1b378fb3dfaaa6c0a6056ac48a168f646e9007
+    distro.v0.2.8.arm64.raw.xz: sha256:64136a49ecebdf09e88d5026e942595e0c8b5c92d21f9d4e5e6bdfa85c2673dd
+    distro.v0.2.8.amd64.tar.xz: sha256:3d356fc196a5b929de075d132a3f46688fd881fadad16219172bde392a3a82e0
+    distro.v0.2.8.arm64.tar.xz: sha256:cd8d237c230bebc04dd1b77c5597302f68195de25b063b5f2876d6377ecafa79
 electron:
   version: 42.1.0
   checksums:

--- a/rdd/.gitignore
+++ b/rdd/.gitignore
@@ -1,2 +1,3 @@
 /bin/*
+/pkg/embedded/distro.img.xz
 /pkg/guestagent/lima-guestagent.gz

--- a/scripts/dependencies/global.ts
+++ b/scripts/dependencies/global.ts
@@ -8,6 +8,7 @@ import { VersionedDependency } from '@/scripts/lib/dependencies';
 
 export const globalDependencies: VersionedDependency[] = [
   new tools.CheckSpelling(),
+  new tools.Distro(),
   new Electron(),
   new tools.DockerCLI(),
   new tools.DockerBuildx(),

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 
 import { defined } from '@/pkg/rancher-desktop/utils/typeUtils';
@@ -7,6 +8,7 @@ import {
   fetchUpstreamChecksums,
   GitHubDependency,
   GlobalDependency,
+  GoArch,
   lookupChecksum,
   Sha256Checksum,
   Platform,
@@ -225,6 +227,47 @@ export class Steve extends GlobalDependency(GitHubDependency) {
 
       return [archiveName, checksum] as const;
     }))).filter(defined));
+  }
+}
+
+export class Distro extends GlobalDependency(GitHubDependency) {
+  readonly name = 'distro';
+  readonly githubOwner = 'rancher-sandbox';
+  readonly githubRepo = 'rancher-desktop-opensuse';
+
+  /** The release asset filename for an image form and arch. */
+  protected assetName(version: string, form: 'raw' | 'tar', arch: GoArch): string {
+    return `distro.v${ version }.${ arch }.${ form }.xz`;
+  }
+
+  async download(context: DownloadContext): Promise<void> {
+    const version = context.dependencies.distro.version;
+    // Unix hosts boot the raw ext4 image; Windows (WSL2) boots the tarball.
+    const form = context.goPlatform === 'windows' ? 'tar' : 'raw';
+    const archiveName = this.assetName(version, form, context.goArch);
+    const url = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ version }/${ archiveName }`;
+    // Stage the compressed image in the rdd tree for a later build step
+    // to embed in the rdd binary; keep it non-executable.
+    const destPath = path.join(import.meta.dirname, '..', '..', 'rdd', 'pkg', 'embedded', 'distro.img.xz');
+    const expectedChecksum = lookupChecksum(context, this.name, archiveName);
+
+    await download(url, destPath, { expectedChecksum, access: fs.constants.W_OK });
+  }
+
+  async getChecksums(version: string): Promise<Record<string, Sha256Checksum>> {
+    const baseURL = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ version }`;
+    const artifacts = cartesian(['raw', 'tar'] as const, ['amd64', 'arm64'] as const);
+
+    return Object.fromEntries(await Promise.all(artifacts.map(async([form, arch]) => {
+      const archiveName = this.assetName(version, form, arch);
+      const url = `${ baseURL }/${ archiveName }`;
+      const sidecar = await fetchUpstreamChecksums(`${ url }.sha256`, 'sha256');
+      const checksum = await downloadAndHash(url, {
+        verify: { algorithm: 'sha256', expected: sidecar[archiveName] },
+      });
+
+      return [archiveName, checksum];
+    })));
   }
 }
 

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -39,6 +39,7 @@ export type Version = string;
 
 export interface DependencyVersions {
   'check-spelling':                string;
+  distro:                          string;
   dockerCLI:                       string;
   dockerBuildx:                    string;
   dockerCompose:                   string;

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -56,6 +56,7 @@ const vmDependencies: Dependency[] = [];
 // Dependencies that are specific to hosts.
 const hostDependencies = [
   new tools.Steve(),
+  new tools.Distro(),
   new Electron(),
   new RDD(),
 ];


### PR DESCRIPTION
First step toward embedding the guest distro in the rdd binary: add the openSUSE distro as an `rddepman` dependency so `yarn install` fetches it.

The download stages the compressed image at the gitignored go:embed path (`rdd/pkg/embedded/distro.img.xz`); this PoC keeps download = embed. A later step adds the overlay and the code that consumes the blob.
