### PR TITLE
download: retry transient network failures, not just DNS

### DIFF
--- a/scripts/lib/__tests__/download.spec.ts
+++ b/scripts/lib/__tests__/download.spec.ts
@@ -18,7 +18,6 @@ describe('fetchWithRetry', () => {
 
   beforeEach(() => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
-    jest.spyOn(console, 'dir').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -30,6 +29,21 @@ describe('fetchWithRetry', () => {
     const response = { ok: true } as Response;
     const fetchMock = jest.fn<typeof fetch>()
       .mockRejectedValueOnce(fetchFailed('ECONNRESET'))
+      .mockResolvedValueOnce(response);
+
+    global.fetch = fetchMock;
+
+    await expect(fetchWithRetry('https://example.test/x', { baseDelayMs: 0 })).resolves.toBe(response);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries when the retryable code is nested deeper in the cause chain', async() => {
+    const response = { ok: true } as Response;
+    const nested = Object.assign(new TypeError('fetch failed'), {
+      cause: Object.assign(new Error('proxy error'), { cause: fetchFailed('ECONNRESET').cause }),
+    });
+    const fetchMock = jest.fn<typeof fetch>()
+      .mockRejectedValueOnce(nested)
       .mockResolvedValueOnce(response);
 
     global.fetch = fetchMock;

--- a/scripts/lib/__tests__/download.spec.ts
+++ b/scripts/lib/__tests__/download.spec.ts
@@ -14,27 +14,24 @@ function fetchFailed(code: string): TypeError {
 }
 
 describe('fetchWithRetry', () => {
-  const realFetch = global.fetch;
+  let fetchSpy: jest.SpiedFunction<typeof global.fetch>;
 
   beforeEach(() => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
   });
 
   afterEach(() => {
-    global.fetch = realFetch;
     jest.restoreAllMocks();
   });
 
   it('retries a transient ECONNRESET and returns the eventual response', async() => {
     const response = { ok: true } as Response;
-    const fetchMock = jest.fn<typeof fetch>()
-      .mockRejectedValueOnce(fetchFailed('ECONNRESET'))
-      .mockResolvedValueOnce(response);
 
-    global.fetch = fetchMock;
+    fetchSpy.mockRejectedValueOnce(fetchFailed('ECONNRESET')).mockResolvedValueOnce(response);
 
     await expect(fetchWithRetry('https://example.test/x', { baseDelayMs: 0 })).resolves.toBe(response);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
   it('retries when the retryable code is nested deeper in the cause chain', async() => {
@@ -42,32 +39,26 @@ describe('fetchWithRetry', () => {
     const nested = Object.assign(new TypeError('fetch failed'), {
       cause: Object.assign(new Error('proxy error'), { cause: fetchFailed('ECONNRESET').cause }),
     });
-    const fetchMock = jest.fn<typeof fetch>()
-      .mockRejectedValueOnce(nested)
-      .mockResolvedValueOnce(response);
 
-    global.fetch = fetchMock;
+    fetchSpy.mockRejectedValueOnce(nested).mockResolvedValueOnce(response);
 
     await expect(fetchWithRetry('https://example.test/x', { baseDelayMs: 0 })).resolves.toBe(response);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
   it('does not retry a non-transient error', async() => {
     const fatal = fetchFailed('CERT_HAS_EXPIRED');
-    const fetchMock = jest.fn<typeof fetch>().mockRejectedValue(fatal);
 
-    global.fetch = fetchMock;
+    fetchSpy.mockRejectedValue(fatal);
 
     await expect(fetchWithRetry('https://example.test/x', { baseDelayMs: 0 })).rejects.toBe(fatal);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it('gives up after exhausting the retry budget', async() => {
-    const fetchMock = jest.fn<typeof fetch>().mockRejectedValue(fetchFailed('ECONNRESET'));
-
-    global.fetch = fetchMock;
+    fetchSpy.mockRejectedValue(fetchFailed('ECONNRESET'));
 
     await expect(fetchWithRetry('https://example.test/x', { retries: 2, baseDelayMs: 0 })).rejects.toThrow('fetch failed');
-    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 initial attempt + 2 retries
+    expect(fetchSpy).toHaveBeenCalledTimes(3); // 1 initial attempt + 2 retries
   });
 });

--- a/scripts/lib/__tests__/download.spec.ts
+++ b/scripts/lib/__tests__/download.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ */
+
+import { jest } from '@jest/globals';
+
+import { fetchWithRetry } from '../download';
+
+/** Builds the error `fetch` throws when the socket drops mid-request. */
+function fetchFailed(code: string): TypeError {
+  return Object.assign(new TypeError('fetch failed'), {
+    cause: Object.assign(new Error(`read ${ code }`), { code }),
+  });
+}
+
+describe('fetchWithRetry', () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'dir').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('retries a transient ECONNRESET and returns the eventual response', async() => {
+    const response = { ok: true } as Response;
+    const fetchMock = jest.fn<typeof fetch>()
+      .mockRejectedValueOnce(fetchFailed('ECONNRESET'))
+      .mockResolvedValueOnce(response);
+
+    global.fetch = fetchMock;
+
+    await expect(fetchWithRetry('https://example.test/x', { baseDelayMs: 0 })).resolves.toBe(response);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a non-transient error', async() => {
+    const fatal = fetchFailed('CERT_HAS_EXPIRED');
+    const fetchMock = jest.fn<typeof fetch>().mockRejectedValue(fatal);
+
+    global.fetch = fetchMock;
+
+    await expect(fetchWithRetry('https://example.test/x', { baseDelayMs: 0 })).rejects.toBe(fatal);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after exhausting the retry budget', async() => {
+    const fetchMock = jest.fn<typeof fetch>().mockRejectedValue(fetchFailed('ECONNRESET'));
+
+    global.fetch = fetchMock;
+
+    await expect(fetchWithRetry('https://example.test/x', { retries: 2, baseDelayMs: 0 })).rejects.toThrow('fetch failed');
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 initial attempt + 2 retries
+  });
+});

--- a/scripts/lib/download.ts
+++ b/scripts/lib/download.ts
@@ -80,9 +80,7 @@ export async function fetchWithRetry(
       const delayMs = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
 
       console.log(`Recoverable error (${ code }) downloading ${ url }, retrying in ${ Math.round(delayMs / 1_000) }s (${ attempt + 1 }/${ retries })...`);
-      if (delayMs > 0) {
-        await util.promisify(setTimeout)(delayMs);
-      }
+      await util.promisify(setTimeout)(delayMs);
     }
   }
 }

--- a/scripts/lib/download.ts
+++ b/scripts/lib/download.ts
@@ -29,18 +29,56 @@ export type ArchiveDownloadOptions = DownloadOptions & {
   entryName?: string;
 };
 
-async function fetchWithRetry(url: string) {
-  while (true) {
+/** Network error codes worth retrying: DNS hiccups and dropped connections. */
+const RETRYABLE_CODES = new Set([
+  'EAI_AGAIN',               // DNS lookup timed out
+  'ECONNRESET',              // connection reset by peer mid-transfer
+  'ECONNREFUSED',            // connection refused
+  'ETIMEDOUT',               // connection timed out
+  'EPIPE',                   // broken pipe
+  'UND_ERR_CONNECT_TIMEOUT', // undici connect timeout
+  'UND_ERR_SOCKET',          // undici socket closed early
+]);
+
+/**
+ * Returns the retryable network error code carried by `ex`, if any.  `fetch`
+ * wraps the underlying socket error as `TypeError: fetch failed` with the real
+ * error in `cause`, so we inspect `cause` as well as the error itself.
+ */
+function retryableNetworkError(ex: any): string | undefined {
+  return [ex?.code, ex?.errno, ex?.cause?.code, ex?.cause?.errno]
+    .find((code): code is string => typeof code === 'string' && RETRYABLE_CODES.has(code));
+}
+
+/**
+ * Fetches `url`, retrying transient network failures (a DNS hiccup or a dropped
+ * connection such as ECONNRESET) with exponential backoff.  The default
+ * schedule — 1s, 2s, 4s, 8s, 16s, then 30s — spans ~2 minutes before giving up,
+ * after which a CI re-run covers a longer outage.  Non-transient errors
+ * propagate immediately.
+ */
+export async function fetchWithRetry(
+  url: string,
+  { retries = 8, baseDelayMs = 1_000, maxDelayMs = 30_000 } = {},
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
     try {
       return await fetch(url, { redirect: 'follow' });
     } catch (ex: any) {
-      if (ex?.errno === 'EAI_AGAIN') {
-        console.log(`Recoverable error downloading ${ url } (${ ex }), retrying...`);
-        await new Promise<void>(resolve => setTimeout(resolve, 1_000));
-        continue;
+      const code = retryableNetworkError(ex);
+
+      if (!code || attempt >= retries) {
+        console.dir(ex);
+        throw ex;
       }
-      console.log(`Failed to download ${ url }: ${ ex }`);
-      throw ex;
+      const delayMs = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+
+      console.log(`Recoverable error (${ code }) downloading ${ url }, retrying in ${ Math.round(delayMs / 1_000) }s (${ attempt + 1 }/${ retries })...`);
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, delayMs);
+        });
+      }
     }
   }
 }

--- a/scripts/lib/download.ts
+++ b/scripts/lib/download.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import stream from 'stream';
+import util from 'util';
 
 import { simpleSpawn } from '@/scripts/simple_process';
 
@@ -43,11 +44,17 @@ const RETRYABLE_CODES = new Set([
 /**
  * Returns the retryable network error code carried by `ex`, if any.  `fetch`
  * wraps the underlying socket error as `TypeError: fetch failed` with the real
- * error in `cause`, so we inspect `cause` as well as the error itself.
+ * error in `cause`, so we walk the `cause` chain to any depth.
  */
 function retryableNetworkError(ex: any): string | undefined {
-  return [ex?.code, ex?.errno, ex?.cause?.code, ex?.cause?.errno]
-    .find((code): code is string => typeof code === 'string' && RETRYABLE_CODES.has(code));
+  for (const prop of ['code', 'errno']) {
+    if (typeof ex?.[prop] === 'string' && RETRYABLE_CODES.has(ex[prop])) {
+      return ex[prop];
+    }
+  }
+  if (ex?.cause) {
+    return retryableNetworkError(ex.cause);
+  }
 }
 
 /**
@@ -68,16 +75,13 @@ export async function fetchWithRetry(
       const code = retryableNetworkError(ex);
 
       if (!code || attempt >= retries) {
-        console.dir(ex);
         throw ex;
       }
       const delayMs = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
 
       console.log(`Recoverable error (${ code }) downloading ${ url }, retrying in ${ Math.round(delayMs / 1_000) }s (${ attempt + 1 }/${ retries })...`);
       if (delayMs > 0) {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, delayMs);
-        });
+        await util.promisify(setTimeout)(delayMs);
       }
     }
   }


### PR DESCRIPTION
`yarn install` postinstall intermittently fails in CI when the GitHub release CDN drops a connection mid-download (`read ECONNRESET`).

`fetchWithRetry` only retried `EAI_AGAIN`, and read it off the thrown TypeError rather than its `cause`, where `fetch` reports the underlying socket error. It now inspects both the error and its `cause`, retries a small set of transient codes (ECONNRESET, ETIMEDOUT, …), and gives up after a bounded number of attempts instead of looping forever.
