### PR TITLE
Answer two outstanding review comments from PR #479

### DIFF
--- a/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
+++ b/rdd/pkg/controllers/lima/limavm/controllers/limavm_lifecycle.go
@@ -354,6 +354,12 @@ func (r *LimaVMReconciler) handleRestartNeeded(ctx context.Context, limaVM *v1al
 // on its own, because its WSL2 driver only re-imports a distro that is absent
 // from `wsl --list`. It arises when an instance directory is removed without
 // `wsl --unregister`. Always false off Windows, where VMType is never WSL2.
+//
+// inst.Status can read StatusRunning here even though no live process holds
+// the disk open. The only caller that reaches this with StatusRunning
+// (handleWatchedState's phaseStopped-but-shouldRun case) already ran
+// stopInstanceForcibly, which terminates the WSL2 distro first. Preserve that
+// ordering in any new startInstance caller, or this stat becomes a race.
 func wsl2RegistrationIsOrphaned(inst *limatype.Instance) bool {
 	if inst.VMType != limatype.WSL2 || inst.Status == limatype.StatusUninitialized {
 		return false

--- a/rdd/pkg/util/wsl/wsl.go
+++ b/rdd/pkg/util/wsl/wsl.go
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: The Rancher Desktop Authors
 
 // Package wsl wraps the wsl.exe commands rdd uses to manage the WSL2 distros
-// that back Lima instances on Windows. Every command is a no-op off Windows,
-// where Lima creates no WSL2 distros.
+// that back Lima instances on Windows. Every command is a no-op on
+// non-Windows, where Lima creates no WSL2 distros.
 package wsl
 
 import (
@@ -33,15 +33,15 @@ func DistroName(instName string) string {
 }
 
 // Terminate runs `wsl.exe --terminate` to shut the distro down, releasing the
-// kernel state that can make a following --unregister deadlock. No-op off
-// Windows.
+// kernel state that can make a following --unregister deadlock. No-op on
+// non-Windows.
 func Terminate(ctx context.Context, distroName string) error {
 	return run(ctx, terminateTimeout, "--terminate", distroName)
 }
 
 // Unregister runs `wsl.exe --unregister`, dropping the WSL2 registration and
 // the distro's ext4.vhdx so Lima imports a fresh distro on the next start.
-// Terminate the distro first. No-op off Windows.
+// Terminate the distro first. No-op on non-Windows.
 func Unregister(ctx context.Context, distroName string) error {
 	return run(ctx, unregisterTimeout, "--unregister", distroName)
 }


### PR DESCRIPTION
This is the final follow-up to comments on #479.

* Comments on `wsl2RegistrationIsOrphaned`.
* Reword "No-op off Windows" to "No-op on non-Windows".