### PR TITLE
RDA: Vuex: Use app as backing for preferences

### DIFF
--- a/pkg/rancher-desktop/entry/store.ts
+++ b/pkg/rancher-desktop/entry/store.ts
@@ -37,11 +37,6 @@ export type Modules = typeof modules;
 export type RootState = {
   [K in keyof Modules]: ReturnType<Modules[K]['state']>;
 };
-export type RootGetters = {
-  [K in keyof Modules]: Modules[K] extends { getters: any } ? {
-    [key in keyof Modules[K]['getters']]: ReturnType<Modules[K]['getters'][key]>;
-  } : never;
-};
 
 export default createStore<any>({
   modules: Object.fromEntries(Object.entries(modules).map(([k, v]) => [k, { namespaced: true, ...v }])),

--- a/pkg/rancher-desktop/store/__tests__/preferences.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/preferences.spec.ts
@@ -1,0 +1,461 @@
+import { describe, jest, it, expect } from '@jest/globals';
+import _ from 'lodash';
+
+import { actions as rawActions, appMissingStatus, generatePatch, plugins, state as stateFn } from '@pkg/store/preferences';
+import { ActionContext } from '@pkg/store/ts-helpers';
+import Latch from '@pkg/utils/latch';
+import * as RDDClient from '@rdd-client';
+import { AppRancherdesktopIoV1alpha1Api as Api, IoRancherdesktopAppV1alpha1App as App } from '@rdd-client';
+
+import type { Dispatch } from 'vuex';
+
+let oldStructuredClone: { has: boolean, value: any };
+beforeEach(() => {
+  oldStructuredClone = { has: 'structuredClone' in global, value: global.structuredClone };
+  global.structuredClone ??= (obj: any) => _.cloneDeep(obj);
+});
+afterEach(() => {
+  if (oldStructuredClone.has) {
+    global.structuredClone = oldStructuredClone.value;
+  } else {
+    delete (global as any).structuredClone;
+  }
+});
+
+describe('actions', () => {
+  const commit = jest.fn(function(this: ReturnType<typeof makeContext>, type: string, payload: any) {
+    if (type === 'SET_CHANGES') {
+      this.state.changes = payload;
+    }
+  });
+  const dispatch = jest.fn<Dispatch>(() => Promise.resolve());
+  const client = jest.mocked({ patchApp: jest.fn() } as unknown as Api);
+  const rootState = {
+    'rdd-connection': {
+      config: {
+        makeApiClient: jest.fn((arg: any) => {
+          expect(arg).toBe(Api);
+          return client;
+        }),
+      } as unknown as RDDClient.KubeConfig,
+    },
+  };
+  const app = { spec: { running: false } } as unknown as App;
+  const rootGetters = { 'rdd/app': app };
+  const getters = {
+    get committed() {
+      return app.spec;
+    },
+  };
+  // Convert `actions` to take anything as `this`, so we can avoid contortions
+  // when calling them.
+  const actions = Object.fromEntries(Object.entries(rawActions).map(
+    ([k, v]) => [k, v.bind({ watch: jest.fn(() => jest.fn()) } as any)])) as {
+    [K in keyof typeof rawActions]: typeof rawActions[K] extends (...args: any) => any ?
+      (this: any, ...args: Parameters<typeof rawActions[K]>) => ReturnType<typeof rawActions[K]> : typeof rawActions[K];
+  };
+
+  function makeContext(options: { [ K in keyof ActionContext<any>]?: any } = {}): any {
+    const result = {
+      state:       options.state ?? stateFn(),
+      getters:     options.getters ?? getters,
+      commit:      options.commit ?? commit,
+      dispatch:    options.dispatch ?? dispatch,
+      rootState:   options.rootState ?? rootState,
+      rootGetters: options.rootGetters ?? rootGetters,
+    };
+    result.commit = commit.bind(result);
+    return result;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _.merge(app, { metadata: { name: 'app' }, spec: { running: false } });
+    rootGetters['rdd/app'] = app;
+  });
+
+  interface mockRequestContext {
+    signal:         AbortSignal | undefined;
+    setHeaderParam: jest.Mock;
+    setSignal:      jest.Mock;
+  }
+  /**
+   * Create an API client; the callback will be called when `patchApp` is
+   * called, and `patchApp` will only return when the result resolves.
+   */
+  function makeClient(callback: (requestContext: mockRequestContext) => Promise<void>) {
+    let requestContext: mockRequestContext = {
+      signal:         undefined,
+      setHeaderParam: jest.fn(),
+      setSignal:      jest.fn((signal: AbortSignal) => {
+        requestContext.signal = signal;
+      }),
+    } as any;
+    const api = {
+      patchApp: jest.fn(async(app: any, options: RDDClient.ConfigurationOptions) => {
+        for (const m of options.middleware ?? []) {
+          requestContext = await m.pre(requestContext as any).toPromise() as any;
+        }
+        await callback(requestContext);
+        for (const m of options.middleware ?? []) {
+          requestContext = await m.post(requestContext as any).toPromise() as any;
+        }
+        return app;
+      }),
+    } as unknown as Api;
+    return [api, requestContext] as const;
+  }
+
+  describe('modify', () => {
+    it('should update preferences and changes', async() => {
+      let context = makeContext();
+      let newChange = { key: 'kubernetes.version', value: 'yes' as string } as const;
+      let expectedChanges = { ...context.state.changes, [newChange.key]: newChange.value };
+
+      // This ignores setting the error; that will be tested elsewhere.
+      await actions.modify(context, newChange);
+
+      expect(commit).toHaveBeenCalledWith('SET_CHANGES', expectedChanges);
+
+      context = makeContext({ state: { namespace: 'laputa' } });
+
+      newChange = { key: 'kubernetes.version', value: 'maybe' } as const;
+      expectedChanges = { ...context.state.changes, [newChange.key]: newChange.value };
+      await actions.modify(context, newChange);
+
+      expect(commit).toHaveBeenCalledWith('SET_CHANGES', expectedChanges);
+    });
+
+    it('should remove change if value is reverted to committed state', async() => {
+      // The committed state has kubernetes.version=hello
+      _.set(app, 'spec.kubernetes.version', 'hello');
+      const context = makeContext();
+
+      // The changes has kubernetes.version=maybe queued.
+      context.state.changes = { 'kubernetes.version': 'maybe' };
+
+      // Set kubernetes.version=hello again, so the changes should be erased.
+      await actions.modify(context, { key: 'kubernetes.version', value: 'hello' });
+      expect(commit).toHaveBeenCalledWith('SET_CHANGES', {});
+      // Because the was no change, `patchApp` should not have been called.
+      expect(client.patchApp).not.toHaveBeenCalled();
+    });
+
+    it('should set error if app is missing', async() => {
+      const context = makeContext({ rootGetters: { 'rdd/app': undefined } });
+
+      await actions.modify(context, { key: 'running', value: true });
+
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', appMissingStatus);
+      expect(client.patchApp).not.toHaveBeenCalled();
+    });
+
+    it('should set error if patch fails', async() => {
+      const context = makeContext();
+      const error = new Error('error from unit test');
+      rootGetters['rdd/app'] = { metadata: { name: 'test', namespace: 'default' } };
+      client.patchApp.mockRejectedValue(error);
+
+      await actions.modify(context, { key: 'running', value: true });
+
+      expect(client.patchApp).toHaveBeenCalledWith(
+        expect.objectContaining({ body: generatePatch(context.state.changes) }),
+        expect.anything());
+      expect(dispatch).toHaveBeenCalledWith('setError', error);
+    });
+
+    it('should clear error if patch succeeds', async() => {
+      const context = makeContext();
+      rootGetters['rdd/app'] = { metadata: { name: 'test', namespace: 'default' } };
+      client.patchApp.mockResolvedValue(app);
+
+      await actions.modify(context, { key: 'running', value: true });
+
+      expect(client.patchApp).toHaveBeenCalledWith(
+        expect.objectContaining({ body: generatePatch(context.state.changes) }),
+        expect.anything());
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', undefined);
+    });
+
+    it('should abandon patch if a new modify is called before the previous one completes', async() => {
+      // The flow to test the abort is:
+      // - A request is made; its middleware pre() hooks are run (to set up the signal)
+      // - That request is then suspended
+      // - A second request is made, running the same middleware hooks and aborting the first request
+      // - The second request runs to completion.
+      // - The first request resumes, and is aborted from the signal.
+      const requestCompleted = Latch<void>();
+      const middlewarePreCompleted = Latch<void>();
+      const [stuckClient, stuckRequestContext] = makeClient(async(requestContext) => {
+        expect(requestContext.setSignal).toHaveBeenCalled();
+        middlewarePreCompleted.resolve();
+        await requestCompleted;
+        expect(requestContext.signal).toHaveProperty('aborted', true);
+        requestContext.signal?.throwIfAborted();
+      });
+      const [fastClient, _requestContext] = makeClient((requestContext) => {
+        expect(requestContext.setSignal).toHaveBeenCalled();
+        return Promise.resolve();
+      });
+      const context = makeContext();
+      rootGetters['rdd/app'] = { metadata: { name: 'test', namespace: 'default' } };
+      context.state.changes = { 'kubernetes.version': 'one' };
+
+      jest.mocked(rootState['rdd-connection'].config.makeApiClient).mockReturnValueOnce(stuckClient);
+      const first = actions.modify(context, { key: 'kubernetes.version', value: 'two' });
+      await middlewarePreCompleted;
+
+      jest.mocked(rootState['rdd-connection'].config.makeApiClient).mockReturnValueOnce(fastClient);
+      await actions.modify(context, { key: 'kubernetes.version', value: 'three' });
+      requestCompleted.resolve(); // Let the first request complete, but it should be abandoned.
+      await first;
+
+      expect(fastClient.patchApp).toHaveBeenCalled();
+      expect(stuckRequestContext.setSignal).toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalledWith('setError', expect.anything());
+      expect(stuckRequestContext.signal?.aborted).toBe(true);
+    });
+
+    it('should skip validation if there are no changes', async() => {
+      // If one request changess something, and then a second request reverts it
+      // before the first request completes, we should pass validation.
+      const context = makeContext();
+      _.set(app, 'spec.running', false); // Ensure the committed state.
+      // Make a request, but do not let it complete.
+      const promise = actions.modify(context, { key: 'running', value: true });
+      // Revert the change.
+      await actions.modify(context, { key: 'running', value: false });
+      await promise;
+    });
+  });
+
+  describe('commit', () => {
+    it('should set error if app is missing', async() => {
+      rootGetters['rdd/app'] = undefined as any;
+      const context = makeContext();
+      const result = await actions.commit.call(null as any, context);
+
+      expect(result).toBe(false);
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', appMissingStatus);
+      expect(client.patchApp).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if there are no changes', async() => {
+      rootGetters['rdd/app'] = { metadata: { name: 'test', namespace: 'default' } };
+      const context = makeContext();
+      context.state.changes = {};
+      const result = await actions.commit.call(null as any, context);
+
+      expect(result).toBe(true);
+      expect(client.patchApp).not.toHaveBeenCalled();
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', undefined);
+      expect(commit).not.toHaveBeenCalledWith('SET_CHANGES', expect.anything());
+    });
+
+    it('should set error if patch fails', async() => {
+      const context = makeContext({ state: _.merge(stateFn(), { changes: { running: true } }) });
+      const error = new Error('error from unit test');
+      client.patchApp.mockRejectedValue(error);
+
+      const body = generatePatch(context.state.changes);
+      const result = await actions.commit(context);
+
+      expect(result).toBe(false);
+      // Should not call `commit` directly, but go through `dispatch('setError')`.
+      expect(commit).not.toHaveBeenCalledWith('SET_ERROR_STATUS', expect.anything());
+      // On failure, it should not clear changes that were not applied.
+      expect(commit).not.toHaveBeenCalledWith('SET_CHANGES', expect.anything());
+      expect(client.patchApp).toHaveBeenCalledWith(expect.objectContaining({ body }), expect.anything());
+      expect(dispatch).toHaveBeenCalledWith('setError', error);
+    });
+
+    it('should clear error if patch succeeds', async() => {
+      rootGetters['rdd/app'] = { metadata: { name: 'test', namespace: 'default' } };
+      const state = _.merge(stateFn(), { changes: { running: true, 'kubernetes.enabled': undefined, 'invalid/name~': 1 } });
+      const context = makeContext({ state });
+      client.patchApp.mockResolvedValue(app);
+
+      // Save the expected body before `commit` modifies `state.changes`.
+      const body = generatePatch(context.state.changes);
+
+      // We use a custom `watch` to call the callback immediately.
+      const watch = jest.fn((getter: () => number, callback: (value: number) => void) => {
+        callback(getter());
+        return jest.fn();
+      });
+      const result = await rawActions.commit.call({ watch } as any, context);
+
+      expect(result).toBe(true);
+      expect(client.patchApp).toHaveBeenCalledWith(
+        expect.objectContaining({ body }), expect.anything());
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', undefined);
+    });
+
+    it('should wait for the generation to update', async() => {
+      rootGetters['rdd/app'] = { metadata: { name: 'test', namespace: 'default', generation: 1 } };
+      const context = makeContext({ state: _.merge(stateFn(), { changes: { running: true } }) });
+      const resultApp = { metadata: { name: 'test', generation: 3 } };
+
+      client.patchApp.mockResolvedValue(resultApp as any);
+
+      let watchCallback: (gen: number) => void = () => { };
+      const unwatch = jest.fn();
+      const watch = jest.fn((getter: () => number, callback: (gen: number) => void, options: any) => {
+        expect(getter()).toBe(1);
+        expect(options).toMatchObject({ immediate: true });
+        watchCallback = callback;
+        return unwatch;
+      });
+      const commitPromise = rawActions.commit.call({ watch } as any, context);
+
+      // Wait for the watch to be set up.
+      await new Promise(process.nextTick);
+      expect(client.patchApp).toHaveBeenCalled();
+      expect(watch).toHaveBeenCalled();
+      expect(unwatch).not.toHaveBeenCalled();
+
+      // Check that an early callback does not resolve the promise.
+      _.set(rootGetters['rdd/app'], 'metadata.generation', resultApp.metadata.generation - 1);
+      watchCallback(resultApp.metadata.generation - 1);
+      expect(unwatch).not.toHaveBeenCalled();
+
+      // Simulate the generation updating.
+      _.set(rootGetters['rdd/app'], 'metadata.generation', resultApp.metadata.generation);
+      watchCallback(resultApp.metadata.generation);
+
+      const result = await commitPromise;
+
+      expect(result).toBe(true);
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', undefined);
+      expect(unwatch).toHaveBeenCalled();
+    });
+  });
+
+  describe('setError', () => {
+    // `setError` also logs the status to the console; we don't care about testing that.
+    beforeAll(() => {
+      jest.spyOn(global.console, 'error').mockImplementation(() => { /* ignore */ });
+    });
+    afterAll(() => {
+      jest.mocked(global.console.error).mockRestore();
+    });
+
+    it('should use message for unknown error', () => {
+      const context = makeContext();
+      const error = new Error('error from unit test');
+
+      actions.setError(context, error);
+
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', expect.objectContaining({
+        message: 'Error: error from unit test',
+      }));
+    });
+
+    it('should use status from ApiException', () => {
+      const context: any = { commit };
+      const status: RDDClient.V1Status = {
+        message: 'error from unit test',
+        details: {
+          causes: [],
+        },
+      };
+      const error = new RDDClient.ApiException(500, 'error from unit test', JSON.stringify(status), {});
+
+      actions.setError(context, error);
+
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', status);
+    });
+
+    it('should fall back to message if ApiException body is not JSON', () => {
+      const context: any = { commit };
+      const error = new RDDClient.ApiException(500, 'error from unit test', 'not JSON', {});
+
+      actions.setError(context, error);
+
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', expect.objectContaining({
+        message: 'not JSON',
+      }));
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear changes and error', () => {
+      rootGetters['rdd/app'] = { spec: { running: false } };
+      const context = makeContext();
+
+      actions.clear(context);
+
+      expect(commit).toHaveBeenCalledWith('SET_CHANGES', {});
+      expect(commit).toHaveBeenCalledWith('SET_ERROR_STATUS', undefined);
+    });
+  });
+});
+
+describe('generatePatch', () => {
+  it('should generate a JSON patch from changes', () => {
+    const changes = { running: true, 'kubernetes.enabled': undefined, 'invalid/name~': 1 };
+    const patch = generatePatch(changes);
+
+    expect(patch).toEqual([
+      { op: 'add', path: '/spec/running', value: true },
+      { op: 'remove', path: '/spec/kubernetes/enabled' },
+      { op: 'add', path: '/spec/invalid~1name~0', value: 1 },
+    ]);
+  });
+});
+
+describe('plugins', () => {
+  function testWatchCallback(testImpl: (callback: (app: any) => any, app: App, changesGetter: jest.Mock, store: any) => any) {
+    const app = { spec: { running: false } } as App;
+    const getters = { 'rdd/app': app };
+    const changesGetter = jest.fn().mockReturnValue({});
+    const store = {
+      state:  { preferences: { } },
+      commit: jest.fn(),
+      watch:  jest.fn(
+        (getter: (state: any, getters: any) => any, callback: (app: any) => any, options: any) => {
+          expect(getter({}, getters)).toBe(app);
+
+          testImpl(callback, app, changesGetter, store);
+        },
+      ),
+    };
+    Object.defineProperty(store.state.preferences, 'changes', { get: changesGetter });
+    const plugin = plugins[0];
+    plugin(store as any);
+
+    expect(plugins).toHaveLength(1);
+    expect(store.watch).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      { deep: true },
+    );
+  }
+
+  it('should do nothing if the app is undefined', () => {
+    testWatchCallback((callback, _app, changesGetter, store) => {
+      expect(() => callback(undefined)).not.toThrow();
+      expect(changesGetter).not.toHaveBeenCalled();
+      expect(store.commit).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should do nothing if the app has no spec', () => {
+    testWatchCallback((callback, app, changesGetter, store) => {
+      app.spec = undefined;
+      expect(() => callback(app)).not.toThrow();
+      expect(changesGetter).not.toHaveBeenCalled();
+      expect(store.commit).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should clear applied settings', () => {
+    testWatchCallback((callback, app, changesGetter, store) => {
+      changesGetter.mockReturnValue({ running: false, 'kubernetes.version': 'eclair' });
+      expect(() => callback(app)).not.toThrow();
+      expect(changesGetter).toHaveBeenCalled();
+      expect(store.commit).toHaveBeenCalledWith(
+        'preferences/SET_CHANGES', { 'kubernetes.version': 'eclair' });
+    });
+  });
+});

--- a/pkg/rancher-desktop/store/preferences.ts
+++ b/pkg/rancher-desktop/store/preferences.ts
@@ -1,267 +1,384 @@
 import _ from 'lodash';
+import { toRaw } from 'vue';
+import { MutationTree, Plugin } from 'vuex';
 
-import { ActionContext, ActionTree, MutationsType } from './ts-helpers';
+import { RootState } from '@pkg/entry/store';
+import { ActionContext, ActionTree, GetterTree, MutationsType } from '@pkg/store/ts-helpers';
+import Latch from '@pkg/utils/latch';
+import { FieldType, RecursiveLeafKeys, RecursiveReadonly } from '@pkg/utils/typeUtils';
+import * as RDDClient from '@rdd-client';
 
-import { CURRENT_SETTINGS_VERSION, defaultSettings, Settings, LockedSettingsType } from '@pkg/config/settings';
-import { ipcRenderer } from '@pkg/utils/ipcRenderer';
-import { RecursiveKeys, RecursivePartial, RecursiveTypes } from '@pkg/utils/typeUtils';
+/** The field manager we set for preferences we modify. */
+const fieldManager = 'rancher-desktop-app';
 
-import type { GetterTree, MutationTree } from 'vuex';
-
-interface Severities {
-  reset:   boolean;
-  restart: boolean;
-  error:   boolean;
-}
-
-interface PreferencesState {
-  initialPreferences: Settings;
-  preferences:        Settings;
-  lockedPreferences:  LockedSettingsType;
-  wslIntegrations:    Record<string, string | boolean>;
-  isPlatformWindows:  boolean;
-  hasError:           boolean;
-  severities:         Severities;
-  preferencesError:   string;
-  canApply:           boolean;
-}
-
-interface CommitArgs {
-  payload?: RecursivePartial<Settings>;
-}
-
-const uri = (port: number, path: string) => `http://localhost:${ port }/v1/${ path }`;
-
-const proposedSettings = (port: number) => uri(port, 'propose_settings');
-
-const settingsUri = (port: number) => uri(port, 'settings');
-
-const lockedUri = (port: number) => uri(port, 'settings/locked');
+type AppSpec = RDDClient.IoRancherdesktopAppV1alpha1AppSpec;
 
 /**
- * Normalize WSL integrations configuration.
- * @param integrations The source collection, containing all WSL integrations.
- * @param mode How normalization should take place.
- *    'diff': Normalize for comparing to see if changes need to be applied.
- *    'submit': Normalize for submitting preferences.
- * @returns Returns a new object with normalized WSL configuration.
+ * PreferencesState is the state for preferences the user has changed but not
+ * yet committed.  This is used for the preferences dialog, where the user can
+ * change preferences and then either commit or discard them.
  */
-const normalizeWslIntegrations = (integrations: Record<string, boolean>, mode: 'diff' | 'submit') => {
-  const normalizeFn = {
-    diff:   (entries: [string, boolean][]) => entries.filter(([, v]) => v),
-    submit: (entries: [string, boolean][]) => entries.map(([k, v]) => [k, v || null] as const),
-  }[mode];
+type PreferencesState = ReturnType<typeof state>;
 
-  return Object.fromEntries(normalizeFn(Object.entries(integrations)));
+/**
+ * Changes is a type that represents the changes made to the preferences.  It is
+ * a mapping of dot-separated keys to the new values.
+ * @note It is therefore not possible for a key to contain a dot.
+ */
+type Changes = {
+  [K in RecursiveLeafKeys<AppSpec>]?: FieldType<AppSpec, K>;
 };
 
 /**
- * Normalizes preferences for consistent usage between API and UI
- * @param preferences The preferences object to normalize.
- * @param mode How the preferences should be normalized.
- * @returns Returns a new object, containing normalized preferences data.
+ * JSON-Patch structure, per RFC 6902.
  */
-const normalizePreferences = (preferences: Settings, mode: 'diff' | 'submit') => {
-  return {
-    ...preferences,
-    WSL: {
-      ...preferences.WSL,
-      integrations: normalizeWslIntegrations(preferences.WSL.integrations, mode),
-    },
-  };
-};
+type JSONPatch = ({
+  op:    'add' | 'replace',
+  path:  string,
+  value: any,
+} | { op: 'remove', path: string })[];
 
-export const state: () => PreferencesState = () => (
-  {
-    initialPreferences: _.cloneDeep(defaultSettings),
-    preferences:        _.cloneDeep(defaultSettings),
-    lockedPreferences:  { },
-    wslIntegrations:    { },
-    isPlatformWindows:  false,
-    hasError:           false,
-    severities:         {
-      reset: false, restart: false, error: false,
-    },
-    preferencesError: '',
-    canApply:         false,
+/**
+ * SerializedRequestMiddleware is a middleware that serializes requests, so that
+ * only one request is in flight at a time.  This is used to ensure that we don't
+ * have multiple requests to patch the app in flight at the same time, which can
+ * cause race conditions and validation errors.
+ */
+class SerializedRequestMiddleware implements RDDClient.ObservableMiddleware {
+  private _controller?: AbortController;
+  readonly abortError:  Error;
+
+  constructor(name: string) {
+    this.abortError = new Error(`New ${ name } request was made`);
   }
-);
+
+  pre(context: RDDClient.RequestContext): RDDClient.Observable<RDDClient.RequestContext> {
+    // It is safe to call `abort` on an AbortController that has already aborted.
+    this._controller?.abort(this.abortError);
+    this._controller = new AbortController();
+    context.setSignal(this._controller.signal);
+    return new RDDClient.Observable(Promise.resolve(context));
+  }
+
+  post(context: RDDClient.ResponseContext): RDDClient.Observable<RDDClient.ResponseContext> {
+    return new RDDClient.Observable(Promise.resolve(context));
+  }
+
+  /** Aborts the current request, if any. */
+  abort() {
+    this._controller?.abort(this.abortError);
+    this._controller = undefined;
+  }
+
+  /** Returns the current AbortSignal, for testing use only. */
+  get signal() {
+    return this._controller?.signal;
+  }
+}
+/** modifySerializer is used to serialize modify requests. */
+const modifySerializer = new SerializedRequestMiddleware('modify');
+/** commitSerializer is used to serialize commit requests. */
+const commitSerializer = new SerializedRequestMiddleware('commit');
+
+/**
+ * pendingCommit is unresolved when there is a commit in progress; this is used
+ * to prevent concurrent calls to modify().
+ */
+const pendingCommit = Latch();
+pendingCommit.resolve();
+
+export const state = () => ({
+  /** The list of changes that have been made but not yet applied. */
+  changes:           {} as Changes,
+  /** Error status is a V1Status object representing validation issues for the preferences. */
+  errorStatus:       undefined as RDDClient.V1Status | undefined,
+});
 
 export const mutations = {
-  SET_PREFERENCES(state, preferences) {
-    state.preferences = preferences;
-    state.canApply = false;
+  SET_CHANGES(state, changes) {
+    state.changes = changes;
   },
-  SET_INITIAL_PREFERENCES(state, preferences) {
-    state.initialPreferences = preferences;
+  SET_ERROR_STATUS(state, errorStatus) {
+    state.errorStatus = errorStatus;
   },
-  SET_LOCKED_PREFERENCES(state, preferences) {
-    state.lockedPreferences = preferences;
-  },
-  SET_WSL_INTEGRATIONS(state, integrations) {
-    state.wslIntegrations = integrations;
-  },
-  SET_IS_PLATFORM_WINDOWS(state, isPlatformWindows) {
-    state.isPlatformWindows = isPlatformWindows;
-  },
-  SET_HAS_ERROR(state, hasError) {
-    state.hasError = hasError;
-  },
-  SET_SEVERITIES(state, severities) {
-    state.severities = severities;
-  },
-  SET_PREFERENCES_ERROR(state, error) {
-    state.preferencesError = error;
-  },
-  SET_CAN_APPLY(state, canApply) {
-    state.canApply = canApply;
-  },
-} satisfies Partial<MutationsType<PreferencesState>> & MutationTree<PreferencesState>;
-
-type PrefActionContext = ActionContext<PreferencesState, typeof mutations>;
-interface ProposePreferencesPayload { preferences?: Settings }
-
-export const actions = {
-  setPreferences({ commit }, preferences: Settings) {
-    commit('SET_PREFERENCES', _.cloneDeep(preferences));
-  },
-  initializePreferences({ commit }, preferences: Settings) {
-    commit('SET_PREFERENCES', _.cloneDeep(preferences));
-    commit('SET_INITIAL_PREFERENCES', _.cloneDeep(preferences));
-  },
-  async fetchPreferences({ dispatch, commit, rootState }) {
-    commit('SET_HAS_ERROR', true);
-
-    await new Promise<void>(resolve => resolve());
-  },
-  async fetchLocked({ commit, rootState }) {
-    commit('SET_HAS_ERROR', true);
-
-    await new Promise<void>(resolve => resolve());
-  },
-  async commitPreferences({ commit }, args: CommitArgs = {}) {
-    commit('SET_HAS_ERROR', true);
-
-    await new Promise<void>(resolve => resolve());
-  },
-
-  /**
-   * Update a given property for preferences. Propose the new preferences after
-   * each update to check if kubernetes requires a reset or restart.
-   * @param context The vuex context object
-   * @param args Key, value pair that corresponds to a property and its value
-   * in the preferences object
-   */
-  async updatePreferencesData<P extends RecursiveKeys<Settings>>({
-    commit, dispatch, state, rootState,
-  }: PrefActionContext, args: { property: P, value: RecursiveTypes<Settings>[P] }): Promise<void> {
-    const { property, value } = args;
-
-    commit('SET_PREFERENCES', _.set(_.cloneDeep(state.preferences), property, value));
-
-    await dispatch(
-      'preferences/proposePreferences',
-      { },
-      { root: true },
-    );
-  },
-  setWslIntegrations({ commit, state }, integrations: Record<string, string | boolean>) {
-    /**
-     * Merge integrations if they exist during initialization.
-     *
-     * Issue #3232: First-time render of tabs causes the entire DOM tree to
-     * refresh, causing Preferences to initialize more than once.
-     */
-    const updatedIntegrations = _.merge({}, integrations, state.wslIntegrations);
-
-    commit('SET_WSL_INTEGRATIONS', updatedIntegrations);
-  },
-  updateWslIntegrations({ commit, state }, args: { distribution: string, value: boolean }) {
-    const { distribution, value } = args;
-
-    const integrations = _.set(_.cloneDeep(state.wslIntegrations), distribution, value);
-
-    commit('SET_WSL_INTEGRATIONS', integrations);
-  },
-  setPlatformWindows({ commit }, isPlatformWindows: boolean) {
-    commit('SET_IS_PLATFORM_WINDOWS', isPlatformWindows);
-  },
-  /**
-   * Validates the provided preferences object. Commits SET_SEVERITIES and
-   * SET_PREFERENCES_ERROR based on the validation response.
-   * @param context The vuex context object
-   * @param payload Contains credentials and an
-   * optional preferences object. Defaults to preferences stored in state if
-   * preferences are not provided.
-   * @returns A collection of severities to indicate any errors or side-effects
-   * associated with the preferences.
-   */
-  async proposePreferences(
-    { commit, state, getters, rootState },
-    { preferences }: ProposePreferencesPayload = {},
-  ): Promise<Severities> {
-    commit('SET_HAS_ERROR', true);
-
-    await new Promise<void>(resolve => resolve());
-
-    const severities: Severities = {
-      reset:   true,
-      restart: true,
-      error:   false,
-    };
-
-    commit('SET_SEVERITIES', severities);
-    commit('SET_PREFERENCES_ERROR', '');
-
-    return severities;
-  },
-  async setShowMuted({ dispatch }, isMuted: boolean) {
-    await dispatch(
-      'preferences/commitPreferences',
-      {
-        payload: {
-          version:     CURRENT_SETTINGS_VERSION,
-          diagnostics: { showMuted: isMuted },
-        },
-      },
-      { root: true },
-    );
-  },
-  setCanApply({ commit }, canApply: boolean) {
-    commit('SET_CAN_APPLY', canApply);
-  },
-} satisfies ActionTree<PreferencesState, any, typeof mutations, typeof getters>;
+} satisfies MutationsType<PreferencesState> & MutationTree<PreferencesState>;
 
 export const getters = {
-  getPreferences(state) {
-    return state.preferences;
+  committed: (_state, _getters, _rootState, rootGetters) => {
+    return (rootGetters['rdd/app']?.spec ?? {}) as Required<RecursiveReadonly<AppSpec>>;
   },
-  isPreferencesDirty(state) {
-    const isDirty = !_.isEqual(
-      normalizePreferences(state.initialPreferences, 'diff'),
-      normalizePreferences(state.preferences, 'diff'),
+  preferences: (state, getters) => {
+    const modified = structuredClone(toRaw(getters.committed));
+    for (const [key, value] of Object.entries(state.changes)) {
+      _.set(modified, key, value);
+    }
+    return modified;
+  },
+  isPreferenceLocked: () => (key: RecursiveLeafKeys<AppSpec>) => {
+    // TODO: deployment profiles https://github.com/rancher-sandbox/rancher-desktop-2/issues/513
+    return false;
+  },
+} satisfies GetterTree<PreferencesState>;
+
+/**
+ * appMissingStatus is a V1Status object that represents the error that occurs
+ * when the app is missing.  This is used to fake a status so we can report the
+ * error to the alert component easier.
+ * @note This is only exported for testing; it should not be used outside of this module.
+ */
+export const appMissingStatus: RDDClient.V1Status = {
+  details: {
+    causes: [
+      {
+        field:   'metadata.name',
+        message: 'Cannot commit preferences: app is missing',
+        reason:  'NotFound',
+      },
+    ],
+  },
+};
+
+export const actions = {
+  /**
+   * Modify the preferences with the given change, and validate the result.
+   * This does not commit the changes; it only updates the preferences in the store.
+   * @param key The key of the preference to modify, in dot notation.
+   * @param value The new value for the preference.
+   * @note If a commit is in progress, this waits for that to finish first.
+   */
+  async modify(context, { key, value }: { key: RecursiveLeafKeys<AppSpec>, value: FieldType<AppSpec, typeof key> }) {
+    // Apply the changes immediately, so the UI can reflect the new state.
+    const { state, getters, commit } = context;
+    // Merge the state with the new preferences.
+    if (_.get(getters.committed, key) === value) {
+      // Reverting a change; remove it from the changes list, so the UI does not
+      // allow committing if all changes are being reverted.
+      const { [key]: _unused, ...modified } = state.changes;
+      commit('SET_CHANGES', modified);
+    } else {
+      commit('SET_CHANGES', { ...state.changes, [key]: value });
+    }
+
+    // Wait for any in-progress commit to finish, to avoid validating a state
+    // that will never be committed.
+    await pendingCommit;
+
+    // Request validation; note that this may be different from the state we
+    // originally requested, because `state.changes` may have been modified by
+    // the `commit` that finished.  This is fine, as what we actually care about
+    // is whether doing a `commit` will be accepted.
+    await patchApp(context, state.changes, modifySerializer, 'All');
+  },
+
+  /**
+   * Commit the current set of changes to the backend.
+   * @returns Whether the commit was successful.
+   * @note If a commit is already in progress, the previous call will be aborted.
+   * @note Calling this will abort any in-flight validation requests.
+   */
+  async commit(context): Promise<boolean> {
+    const { state, rootGetters } = context;
+    const appliedChanges = structuredClone(state.changes);
+    pendingCommit.reset();
+
+    // Clear any in-flight validation calls.
+    modifySerializer.abort();
+
+    let result: Awaited<ReturnType<typeof patchApp>> = PatchAppResult.failure;
+    let skipResolve = false;
+
+    try {
+      result = await patchApp(context, appliedChanges, commitSerializer);
+
+      // We update `state.changes` via the plugin below (by monitoring when
+      // `app.spec` changes), so there is no need to do that here.
+
+      // Check the result, and resolve `pendingCommit` if we are not interrupted.
+      switch (result) {
+      case PatchAppResult.skipped:
+        return true;
+      case PatchAppResult.failure:
+        return false;
+      case PatchAppResult.interrupted:
+        // Don't resolve the pending commit; the replacement request will do that.
+        skipResolve = true;
+        return false;
+      default: {
+        if (typeof result !== 'number') {
+          // Compile-time check that we handled all PatchAppResult cases.
+          result satisfies never;
+        }
+        // The patch was successful; wait for `app.spec` to be updated.
+        const latch = Latch();
+        const timeout = setTimeout(() => {
+          latch.resolve();
+          unwatch();
+        }, 1_000);
+        const generation = result;
+        const unwatch = this.watch(
+          () => rootGetters['rdd/app']?.metadata?.generation ?? 0,
+          (newGeneration) => {
+            if (newGeneration >= generation) {
+              clearTimeout(timeout);
+              // Make sure `watch` returns before evaluating `unwatch`.
+              queueMicrotask(() => unwatch());
+              latch.resolve();
+            }
+          }, { immediate: true });
+        await latch;
+        return true;
+      }
+      }
+    } finally {
+      if (!skipResolve) {
+        pendingCommit.resolve();
+      }
+    }
+  },
+
+  /**
+   * setError is a helper to handle errors from patching the app.
+   */
+  setError({ commit }, error: unknown) {
+    let status: RDDClient.V1Status = {
+      message: `${ error }`,
+      details: {
+        causes: [],
+      },
+    };
+    if (error instanceof RDDClient.ApiException) {
+      try {
+        status = JSON.parse(error.body);
+      } catch {
+        // The error message is not JSON.
+        status.message = `${ error.body }`;
+      }
+    }
+    console.error('Failed to patch app:', status);
+    commit('SET_ERROR_STATUS', status);
+  },
+
+  clear({ commit }) {
+    commit('SET_CHANGES', {});
+    commit('SET_ERROR_STATUS', undefined);
+  },
+} satisfies ActionTree<PreferencesState>;
+
+/**
+ * Helper function to generate a JSON patch from the given changes.
+ * This ensures that the patch we submit for validation is the same as the patch
+ * we submit for committing.
+ * @note This is only exported for testing; it should not be used outside of
+ * this module.
+ */
+export function generatePatch(changes: Changes): JSONPatch {
+  const result: JSONPatch = [];
+  for (const [key, value] of Object.entries(changes)) {
+    const pathParts = ['', 'spec', ...key.split('.')]
+      .map(k => k.replaceAll('~', '~0').replaceAll('/', '~1'));
+    const path = pathParts.join('/');
+    if (value === undefined) {
+      result.push({ op: 'remove', path });
+    } else {
+      // TODO: Handle array values.
+      result.push({ op: 'add', path, value });
+    }
+  }
+  return result;
+}
+
+enum PatchAppResult {
+  /** There were no changes to apply. */
+  skipped = 'skipped',
+  /** The patch has failed; `commit('SET_ERROR_STATUS')` has been called. */
+  failure = 'failure',
+  /** Another request has replaced this one. */
+  interrupted = 'interrupted',
+}
+
+/**
+ * Helper function to patch the app with the given changes, possibly in dry-run.
+ * This is used by `modify` and `commit`.
+ * @return If successful, the generation of the updated app. Otherwise, a reason
+ * the app was not patched.
+ */
+async function patchApp(
+  context: ActionContext<PreferencesState, typeof mutations>,
+  changes: Changes,
+  serializer: SerializedRequestMiddleware,
+  dryRun?: 'All',
+): Promise<number | PatchAppResult> {
+  const { commit, dispatch, rootState, rootGetters } = context;
+
+  // Request validation of the merged preferences.
+  const config = rootState['rdd-connection'].config;
+  const client = config.makeApiClient(RDDClient.AppRancherdesktopIoV1alpha1Api);
+  const app = rootGetters['rdd/app'];
+  if (!app?.metadata?.name) {
+    commit('SET_ERROR_STATUS', appMissingStatus);
+    return PatchAppResult.failure;
+  }
+
+  if (Object.keys(changes).length === 0) {
+    // No changes to validate or commit; clear any existing error status.
+    serializer.abort();
+    commit('SET_ERROR_STATUS', undefined);
+    return PatchAppResult.skipped;
+  }
+
+  // Submit the changes as a JSON patch, so that we don't have to provide
+  // values for things we don't care about that are marked as required.
+  try {
+    const result = await client.patchApp(
+      {
+        name:            app.metadata.name,
+        body:            generatePatch(changes),
+        fieldManager,
+        fieldValidation: 'Strict',
+        dryRun,
+      },
+      RDDClient.setHeaderOptions(
+        'Content-Type',
+        RDDClient.PatchStrategy.JsonPatch,
+        { middleware: [serializer] }),
     );
+    commit('SET_ERROR_STATUS', undefined);
+    return result.metadata?.generation ?? 0;
+  } catch (error) {
+    if (Object.is(error, serializer.abortError)) {
+      // This is a request that was aborted because a new request was made.  We
+      // don't need to report this as an error.
+      return PatchAppResult.interrupted;
+    }
+    await dispatch('setError', error);
+    return PatchAppResult.failure;
+  }
+}
 
-    ipcRenderer.send('preferences-set-dirty', isDirty);
-
-    return isDirty;
+export const plugins: Plugin<RootState>[] = [
+  // Whenever the app changes, check if any of the changes pending match the new
+  // state, and clear any that do.
+  function(store) {
+    store.watch(
+      (state, getters) => getters['rdd/app'],
+      (app) => {
+        if (!app?.spec) {
+          // This could happen if the user deletes the app from under us.
+          return;
+        }
+        const modified = structuredClone(toRaw(store.state.preferences.changes));
+        let changed = false;
+        for (const [key, value] of Object.entries(modified)) {
+          if (_.get(app.spec, key) === value) {
+            delete modified[key as keyof Changes];
+            changed = true;
+          }
+        }
+        if (changed) {
+          store.commit('preferences/SET_CHANGES', modified);
+        }
+      },
+      { deep: true },
+    );
   },
-  getWslIntegrations(state) {
-    return state.wslIntegrations;
-  },
-  isPlatformWindows(state) {
-    return state.isPlatformWindows;
-  },
-  hasError(state) {
-    return state.hasError;
-  },
-  canApply(state, getters) {
-    return (getters.isPreferencesDirty && state.preferencesError.length === 0) || state.canApply;
-  },
-  showMuted(state) {
-    return state.preferences.diagnostics.showMuted;
-  },
-  isPreferenceLocked: (state) => (value: string) => {
-    return _.get(state.lockedPreferences, value);
-  },
-} satisfies GetterTree<PreferencesState, any>;
+];

--- a/pkg/rancher-desktop/store/ts-helpers.ts
+++ b/pkg/rancher-desktop/store/ts-helpers.ts
@@ -1,4 +1,4 @@
-import type { Modules, RootGetters, RootState } from '@pkg/entry/store';
+import type { Modules, RootState } from '@pkg/entry/store';
 import type { UnionToIntersection, UpperSnakeCase } from '@pkg/utils/typeUtils';
 
 import type { CommitOptions, Dispatch, MutationTree, Store } from 'vuex';
@@ -24,8 +24,12 @@ type MutationsPayloadType<M> = {
 type moduleNames = keyof Modules;
 type mutationTypes<MN extends moduleNames> = keyof Modules[MN]['mutations'] & string;
 type fullMutationType<MN extends moduleNames, MT extends mutationTypes<MN>> = `${ MN }/${ MT }`;
+type moduleName<S> = { [MN in moduleNames]: S extends ReturnType<Modules[MN]['state']> ? MN : never }[moduleNames];
+type moduleFor<S> = moduleName<S> extends never ? never : Modules[moduleName<S>];
+type mutationsFor<S> = moduleFor<S> extends { mutations: any } ? moduleFor<S>['mutations'] : MutationsType<S> & MutationTree<S>;
+type gettersFor<S> = moduleFor<S> extends { getters: any } ? moduleFor<S>['getters'] : GetterTree<S, any>;
 
-type flattenedGetters = UnionToIntersection<{
+export type RootGetters = UnionToIntersection<{
   [MN in moduleNames]: Modules[MN] extends { getters: any } ? {
     [getter in keyof Modules[MN]['getters'] & string as `${ MN }/${ getter }`]:
     Modules[MN]['getters'][getter] extends (...args: any) => infer R ? R : never;
@@ -43,7 +47,7 @@ export interface ActionContext<S, M = MutationsType<S>, G = GetterTree<S>> {
   state:       S;
   rootState:   RootState;
   getters:     { [key in keyof G]: G[key] extends (...args: any) => any ? ReturnType<G[key]> : never };
-  rootGetters: flattenedGetters;
+  rootGetters: RootGetters;
 }
 
 export interface Commit<M> {
@@ -68,6 +72,11 @@ export type ActionTree<
   R = RootState,
   M extends MutationsType<S> & MutationTree<S> = MutationsType<S> & MutationTree<S>,
   G extends GetterTree<S, any> = GetterTree<S, any>,
-> = Record<string, Action<S, R, M, G>>;
+> = moduleName<S> extends never
+  ? Record<string, Action<S, R, M, G>>
+  : Record<string, Action<S, RootState, mutationsFor<S>, gettersFor<S>>>;
 
-export type GetterTree<S, R = RootState, G = any> = Record<string, (state: S, getters: G, rootState: R, rootGetters: RootGetters) => any>;
+// Unfortunately, we can't use the `RootGetters` type here, as that would lead to
+// a circular definition, since this is used to define the per-module getters.
+export type GetterTree<S, R = RootState, G = any> =
+  Record<string, (state: S, getters: G, rootState: R, rootGetters: Record<`${ string }/${ string }`, any>) => any>;

--- a/pkg/rancher-desktop/typings/store.d.ts
+++ b/pkg/rancher-desktop/typings/store.d.ts
@@ -1,6 +1,7 @@
 import { Store } from 'vuex/types';
 
-import type { Modules, RootGetters } from '@pkg/entry/store';
+import type { Modules } from '@pkg/entry/store';
+import type { RootGetters } from '@pkg/store/ts-helpers';
 
 type Actions<
   module extends string,
@@ -20,12 +21,6 @@ type storeActions = Intersect<Values<{
   [module in keyof Modules]:
   Modules[module] extends { actions: any } ?
     Actions<module, Modules[module]['actions']> : never;
-}>>;
-
-type storeGetters = Intersect<Values<{
-  [module in keyof RootGetters]:
-  { [key in keyof RootGetters[module] as `${ module }/${ key & string }`]:
-    RootGetters[module][key] };
 }>>;
 
 type Mutations<
@@ -73,7 +68,7 @@ declare module 'vuex/types' {
   export function useStore(): Omit<Store<{
     [key in keyof Modules]: ReturnType<Modules[key]['state']>;
   }>, 'getters'> & {
-    getters: storeGetters;
+    getters: RootGetters;
   };
 }
 

--- a/pkg/rancher-desktop/utils/typeUtils.ts
+++ b/pkg/rancher-desktop/utils/typeUtils.ts
@@ -5,16 +5,14 @@
 export type RecursivePartial<T> = {
   [P in keyof T]?:
   T[P] extends (infer U)[] ? RecursivePartial<U>[] :
-
-    T[P] extends Record<string, unknown> ? RecursivePartial<T[P]> :
+    T[P] extends object ? RecursivePartial<T[P]> :
       T[P];
 };
 
 export type RecursiveReadonly<T> = {
   readonly [P in keyof T]:
   T[P] extends (infer U)[] ? readonly RecursiveReadonly<U>[] :
-
-    T[P] extends Record<string, unknown> ? RecursiveReadonly<T[P]> :
+    T[P] extends object ? RecursiveReadonly<T[P]> :
       T[P];
 };
 
@@ -70,10 +68,42 @@ export function UpperSnakeCase<T extends string>(input: T): UpperSnakeCase<T> {
 export type RecursiveKeys<T> =
   Record<string, unknown> extends T ? string :
     T extends readonly unknown[] ? RecursiveKeys<T[number]> :
-      T extends Record<string, unknown> ? keyof T & string | RecursiveKeysInner<T, keyof T & string> :
+      T extends object ? keyof T & string | RecursiveKeysInner<Required<T>, keyof T & string> :
         never;
 
 type RecursiveKeysInner<T, K extends string> = K extends keyof T ? `${ K }.${ RecursiveKeys<T[K]> }` : never;
+
+/**
+ * RecursiveLeafKeys returns the set of all keys of a type, recursively, without
+ * any intermediate keys, separated by dots.
+ *
+ * @example RecursiveLeafKeys<{a: { b: number}, c: number}> = 'a.b' | 'c'
+ * @note This currently does not handle arrays.
+ */
+export type RecursiveLeafKeys<T> =
+  T extends readonly unknown[] ? RecursiveLeafKeys<T[number]> :
+    T extends object ?
+      RecursiveLeafKeysInner<Required<T>, keyof T & string> :
+      never;
+
+type RecursiveLeafKeysInner<T, K extends string> =
+  K extends keyof T ?
+    NonNullable<T[K]> extends object ?
+      `${ K }.${ RecursiveLeafKeys<T[K]> }` :
+      `${ K }` :
+    never;
+
+/**
+ * Get the type of a value at a given key in a nested object type.
+ * @example FieldType<{ a: { b: number } }, 'a.b'> = number
+ * @note This currently does not handle arrays.
+ */
+export type FieldType<T, K extends RecursiveLeafKeys<T>> =
+  K extends `${ infer P }.${ infer R }` ?
+    P extends keyof T ?
+      FieldType<NonNullable<T[P]>, R & RecursiveLeafKeys<T[P]>> :
+      never :
+    K extends keyof T ? T[K] : never;
 
 /**
  * RecursiveTypes returns a single-level type mapping of RecursiveKeys<T> to


### PR DESCRIPTION
This rewrites the vuex preferences store to use `App.spec` instead of the `Settings` object that used IPC.  The last commit is a bunch of tests.