### PR TITLE
Wait for async kubeconfig write before removeKubeContext returns

### DIFF
--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_context.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_context.go
@@ -20,6 +20,11 @@ import (
 // load and write; regression tests use it to interleave a concurrent writer.
 var testAfterLoadKubeConfig func()
 
+// testBeforeSetCurrentKubeContext, when non-nil, runs before setCurrentKubeContext
+// takes atomicfile's lock, so a test can hold the probe's write open without also
+// blocking the writes removeKubeContext makes while it waits.
+var testBeforeSetCurrentKubeContext func()
+
 // kubeConfigPath returns ~/.kube/config, or $KUBECONFIG if set.
 // Computed dynamically so t.Setenv("HOME", …) works in tests.
 func kubeConfigPath() (string, error) {
@@ -188,6 +193,9 @@ func getCurrentKubeContext() (string, error) {
 
 // setCurrentKubeContext sets current-context in ~/.kube/config. No-op if already set.
 func setCurrentKubeContext(name string) error {
+	if testBeforeSetCurrentKubeContext != nil {
+		testBeforeSetCurrentKubeContext()
+	}
 	destPath, err := kubeConfigPath()
 	if err != nil {
 		return err

--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -464,14 +464,9 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) error {
 
 	r.contextProbeWg.Add(1)
 	go func() {
-		// Use sync.Once so contextProbeWg.Done() fires exactly once, either
-		// explicitly after the HTTP probe or via defer on early return.
-		// Crucially, Done() must be called BEFORE setCurrentKubeContext so that
-		// removeKubeContext.Wait() is not held hostage by a slow or blocking
-		// write to ~/.kube/config.
-		var wgDone sync.Once
-		signalDone := func() { wgDone.Do(r.contextProbeWg.Done) }
-		defer signalDone()
+		// Done fires after the kubeconfig write below, so removeKubeContext.Wait()
+		// covers that write instead of racing it.
+		defer r.contextProbeWg.Done()
 		defer func() {
 			r.contextMu.Lock()
 			if r.contextProbeGen == myGen {
@@ -488,10 +483,6 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) error {
 		}
 
 		healthy := probeCurrentKubeContext(probeCtx, current)
-
-		// Signal the WaitGroup before writing to ~/.kube/config so that
-		// removeKubeContext.Wait() is not blocked by a slow file write.
-		signalDone()
 
 		// Guard against writing after removeKubeContext cancelled probeCtx.
 		if !healthy && probeCtx.Err() == nil {

--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler.go
@@ -102,12 +102,10 @@ type KubernetesReconciler struct {
 	// inject a path under a temp directory.
 	InstanceKubeConfigPath string
 
-	// contextMu protects contextProbeCancel and contextProbeGen.
+	// contextMu protects contextProbeCancel.
 	contextMu sync.Mutex
 	// contextProbeCancel cancels the in-flight current-context probe goroutine.
 	contextProbeCancel context.CancelFunc
-	// contextProbeGen detects superseded goroutines.
-	contextProbeGen int
 	// contextProbeWg lets removeKubeContext wait for any probe to finish.
 	contextProbeWg sync.WaitGroup
 
@@ -458,8 +456,6 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) error {
 	}
 	probeCtx, cancel := context.WithCancel(ctx)
 	r.contextProbeCancel = cancel
-	r.contextProbeGen++
-	myGen := r.contextProbeGen
 	r.contextMu.Unlock()
 
 	r.contextProbeWg.Add(1)
@@ -468,8 +464,10 @@ func (r *KubernetesReconciler) manageKubeContext(ctx context.Context) error {
 		// covers that write instead of racing it.
 		defer r.contextProbeWg.Done()
 		defer func() {
+			// Both paths that replace contextProbeCancel cancel probeCtx first, so
+			// an uncancelled probeCtx means the field still holds our cancel func.
 			r.contextMu.Lock()
-			if r.contextProbeGen == myGen {
+			if probeCtx.Err() == nil {
 				r.contextProbeCancel = nil
 			}
 			r.contextMu.Unlock()

--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
 )
 
 // fakeK3sServer starts an httptest TLS server that answers /healthz with
@@ -814,4 +816,58 @@ func Test_classifyProbeError(t *testing.T) {
 			assert.Equal(t, classifyProbeError(tc.err), tc.want)
 		})
 	}
+}
+
+// Test_RemoveKubeContext_WaitsForProbeWrite pins the ordering between the probe
+// goroutine and removeKubeContext. Once the probe is past its cancellation guard,
+// removeKubeContext must not return until the probe's write lands, or it clears a
+// current-context that the probe then restores.
+func Test_RemoveKubeContext_WaitsForProbeWrite(t *testing.T) {
+	dir := t.TempDir()
+	isolateKubeconfig(t, dir)
+
+	r := &KubernetesReconciler{
+		K3sConfigPath:          makeSrcKubeconfig(t, dir),
+		InstanceKubeConfigPath: filepath.Join(dir, "kube.config"),
+	}
+
+	inWrite := make(chan struct{})
+	release := make(chan struct{})
+	releaseProbe := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseProbe)
+	testBeforeSetCurrentKubeContext = func() {
+		close(inWrite)
+		<-release
+	}
+	t.Cleanup(func() { testBeforeSetCurrentKubeContext = nil })
+
+	// The kubeconfig has no current-context, so the probe reports it unhealthy
+	// and goes on to write one, parking in the seam above.
+	assert.NilError(t, r.manageKubeContext(context.Background()))
+	select {
+	case <-inWrite:
+	case <-time.After(10 * time.Second):
+		assert.Assert(t, false, "probe never reached the current-context write")
+	}
+
+	removed := make(chan struct{})
+	go func() {
+		r.removeKubeContext(context.Background())
+		close(removed)
+	}()
+
+	select {
+	case <-removed:
+		assert.Assert(t, false,
+			"removeKubeContext returned while the probe's kubeconfig write was in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseProbe()
+	<-removed
+
+	cfg := loadDest(t, filepath.Join(dir, ".kube", "config"))
+	assert.Equal(t, cfg.CurrentContext, "", "probe restored a current-context that removeKubeContext cleared")
+	_, found := cfg.Contexts[instance.Name()]
+	assert.Assert(t, !found, "removeKubeContext should have deleted the context")
 }


### PR DESCRIPTION
The `manageKubeContext` goroutine signaled completion before it wrote current-context to `~/.kube/config`, so `removeKubeContext` could return while that write was still in flight. In unit tests the write then raced `t.TempDir` cleanup and produced the "directory not empty" flake in `Test_Reconcile_KubernetesReady_GatedUntilNodeReady`. In production it could restore a current-context that `removeKubeContext` had just cleared.

The early signal was meant to keep a slow kubeconfig write from blocking the wait, but `removeKubeContext` writes the same file right after the wait, so a slow write delays it there anyway.

The regression test parks the probe inside its kubeconfig write and asserts that `removeKubeContext` does not return until the write lands. It fails against the old code.

The second commit drops `contextProbeGen`. Every path that supersedes the probe cancels its `probeCtx` first, so `probeCtx.Err() == nil` already means it is the current probe.

Example of a flaked job: https://github.com/rancher-sandbox/rancher-desktop-2/actions/runs/28683701733/job/85072203379
