### PR TITLE
CI: Get rddepman running via vault app credentials

### DIFF
--- a/.github/actions/get-token/action.yaml
+++ b/.github/actions/get-token/action.yaml
@@ -12,24 +12,28 @@ inputs:
 outputs:
   token:
     description: The GitHub token retrieved
-    value: ${{ github.repository_owner == 'rancher-sandbox' && steps.copy-token.outputs.token || steps.get-secret.outputs.token }}
+    value: ${{ github.repository == 'rancher-sandbox/rancher-desktop-2' && steps.gen-token.outputs.token || steps.get-secret.outputs.token }}
 runs:
   using: composite
   steps:
   - id: vault
     name: Read vault secrets
-    if: github.repository_owner == 'rancher-sandbox'
+    if: github.repository == 'rancher-sandbox/rancher-desktop-2'
     uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
     with:
       secrets: |
-        github/token/${{ github.repository_owner }}--rancher-desktop-daemon--pull_requests--write token | GH_TOKEN
-  - id: copy-token
-    if: github.repository_owner == 'rancher-sandbox'
-    shell: bash
-    run: echo "token=$GH_TOKEN" >> "$GITHUB_OUTPUT"
+        secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+        secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
+  - id: gen-token
+    name: Generate token
+    if: github.repository == 'rancher-sandbox/rancher-desktop-2'
+    uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    with:
+      app-id: ${{ env.APP_ID }}
+      private-key: ${{ env.PRIVATE_KEY }}
   - id: get-secret
     name: Fetch secret.
-    if: github.repository_owner != 'rancher-sandbox'
+    if: github.repository != 'rancher-sandbox/rancher-desktop-2'
     run: echo "token=$SECRET" >> "$GITHUB_OUTPUT"
     shell: bash
     env:

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -1,12 +1,13 @@
 name: Update external dependencies
+# When run upstream, this workflow gets its token from vault; elsewhere it
+# needs the RUN_WORKFLOW_FROM_WORKFLOW secret, and skips when that is unset.
 on:
   schedule:
     - cron: '23 8 * * *'
   workflow_dispatch: {}
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   check-for-token:
@@ -17,20 +18,33 @@ jobs:
     - id: calc
       run: echo "HAS_SECRET=${HAS_SECRET}" >> "${GITHUB_OUTPUT}"
       env:
-        HAS_SECRET: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
+        HAS_SECRET: ${{ github.repository == 'rancher-sandbox/rancher-desktop-2' || secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
 
   check-update-versions:
     needs: check-for-token
     if: needs.check-for-token.outputs.has-token == 'true'
+    permissions:
+      contents: read
+      id-token: write # Required for ./.github/actions/get-token
     runs-on: ubuntu-latest
     steps:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # rddepman pushes with the vault app token in the URL; a persisted
+          # github.token would override that, so keep it out of git config.
+          persist-credentials: false
+
+      - # rddepman needs a token whose pull requests trigger CI; the
+        # workflow-provided github.token does not trigger further workflows.
+        id: get-token
+        uses: ./.github/actions/get-token
+        with:
+          token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
 
       - uses: ./.github/actions/yarn-install
 
       - run: yarn rddepman
         env:
-          GITHUB_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -306,7 +306,9 @@ async function checkDependencies(): Promise<void> {
     git('checkout', '-b', branchName, MAIN_BRANCH);
     git('add', ...await dependency.updateManifest(latestVersion, newChecksums));
     git('commit', '--signoff', '--message', commitMessage);
-    git('push', '--force', `https://${ process.env.GITHUB_TOKEN }@github.com/${ GITHUB_OWNER }/${ GITHUB_REPO }`);
+    // GitHub accepts an app installation token only as the password, so
+    // pass it via `x-access-token:`; a bare `token@host` fails.
+    git('push', '--force', `https://x-access-token:${ process.env.GITHUB_TOKEN }@github.com/${ GITHUB_OWNER }/${ GITHUB_REPO }`);
     await createDependencyBumpPR(dependency, currentVersion, latestVersion);
   }
 }


### PR DESCRIPTION
Replace repo secret with vault token.

Previous run: https://github.com/rancher-sandbox/rancher-desktop-2/actions/runs/28963422125/job/85940448568 (created PRs that have been merged)

Latest run: https://github.com/rancher-sandbox/rancher-desktop-2/actions/runs/28970280660 (but does not need to create more PRs)