### PR TITLE
Serialize kubeconfig writes and make them atomic

### DIFF
--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_context.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_context.go
@@ -12,7 +12,13 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/atomicfile"
 )
+
+// testAfterLoadKubeConfig, when non-nil, runs between createReplaceKubeContext's
+// load and write; regression tests use it to interleave a concurrent writer.
+var testAfterLoadKubeConfig func()
 
 // kubeConfigPath returns ~/.kube/config, or $KUBECONFIG if set.
 // Computed dynamically so t.Setenv("HOME", …) works in tests.
@@ -34,6 +40,26 @@ func loadKubeConfig(path string) (*clientcmdapi.Config, error) {
 		return clientcmdapi.NewConfig(), nil
 	}
 	return cfg, err
+}
+
+// updateKubeConfig loads the kubeconfig at path, applies mutate, and writes
+// it back atomically. atomicfile serializes concurrent updates and skips the
+// write when nothing changed, so steady-state reconciles do not keep
+// rewriting the file.
+func updateKubeConfig(path string, mutate func(*clientcmdapi.Config) error) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	return atomicfile.Update(path, 0o600, func(current []byte) ([]byte, error) {
+		cfg, err := clientcmd.Load(current)
+		if err != nil {
+			return nil, fmt.Errorf("load %s: %w", path, err)
+		}
+		if err := mutate(cfg); err != nil {
+			return nil, err
+		}
+		return clientcmd.Write(*cfg)
+	})
 }
 
 // instanceClusterUser reads the k3s mirror kubeconfig at srcPath and returns its
@@ -77,23 +103,19 @@ func createReplaceKubeContext(contextName, srcPath string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
-		return fmt.Errorf("create .kube dir: %w", err)
-	}
 
-	cfg, err := loadKubeConfig(destPath)
-	if err != nil {
-		return fmt.Errorf("load ~/.kube/config: %w", err)
-	}
-
-	cfg.Clusters[contextName] = cluster
-	cfg.AuthInfos[contextName] = user
-	cfg.Contexts[contextName] = &clientcmdapi.Context{
-		Cluster:  contextName,
-		AuthInfo: contextName,
-	}
-
-	return clientcmd.WriteToFile(*cfg, destPath)
+	return updateKubeConfig(destPath, func(cfg *clientcmdapi.Config) error {
+		if testAfterLoadKubeConfig != nil {
+			testAfterLoadKubeConfig()
+		}
+		cfg.Clusters[contextName] = cluster
+		cfg.AuthInfos[contextName] = user
+		cfg.Contexts[contextName] = &clientcmdapi.Context{
+			Cluster:  contextName,
+			AuthInfo: contextName,
+		}
+		return nil
+	})
 }
 
 // deleteKubeContext removes the cluster, user, and context named contextName
@@ -104,16 +126,12 @@ func deleteKubeContext(contextName string) error {
 		return err
 	}
 
-	cfg, err := loadKubeConfig(destPath)
-	if err != nil {
-		return fmt.Errorf("load ~/.kube/config: %w", err)
-	}
-
-	delete(cfg.Clusters, contextName)
-	delete(cfg.AuthInfos, contextName)
-	delete(cfg.Contexts, contextName)
-
-	return clientcmd.WriteToFile(*cfg, destPath)
+	return updateKubeConfig(destPath, func(cfg *clientcmdapi.Config) error {
+		delete(cfg.Clusters, contextName)
+		delete(cfg.AuthInfos, contextName)
+		delete(cfg.Contexts, contextName)
+		return nil
+	})
 }
 
 // writeInstanceKubeConfig writes a standalone kubeconfig to destPath holding
@@ -135,10 +153,14 @@ func writeInstanceKubeConfig(contextName, srcPath, destPath string) error {
 	}
 	cfg.CurrentContext = contextName
 
+	data, err := clientcmd.Write(*cfg)
+	if err != nil {
+		return fmt.Errorf("serialize kubeconfig: %w", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
 		return fmt.Errorf("create instance dir: %w", err)
 	}
-	return clientcmd.WriteToFile(*cfg, destPath)
+	return atomicfile.Write(destPath, data, 0o600)
 }
 
 // removeInstanceKubeConfig deletes the standalone instance kubeconfig at
@@ -170,15 +192,10 @@ func setCurrentKubeContext(name string) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := loadKubeConfig(destPath)
-	if err != nil {
-		return fmt.Errorf("load ~/.kube/config: %w", err)
-	}
-	if cfg.CurrentContext == name {
+	return updateKubeConfig(destPath, func(cfg *clientcmdapi.Config) error {
+		cfg.CurrentContext = name
 		return nil
-	}
-	cfg.CurrentContext = name
-	return clientcmd.WriteToFile(*cfg, destPath)
+	})
 }
 
 // clearCurrentKubeContext clears current-context if it matches name; no-op otherwise.
@@ -187,13 +204,10 @@ func clearCurrentKubeContext(name string) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := loadKubeConfig(destPath)
-	if err != nil {
-		return fmt.Errorf("load ~/.kube/config: %w", err)
-	}
-	if cfg.CurrentContext != name {
+	return updateKubeConfig(destPath, func(cfg *clientcmdapi.Config) error {
+		if cfg.CurrentContext == name {
+			cfg.CurrentContext = ""
+		}
 		return nil
-	}
-	cfg.CurrentContext = ""
-	return clientcmd.WriteToFile(*cfg, destPath)
+	})
 }

--- a/rdd/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
+++ b/rdd/pkg/controllers/app/kubernetes/controllers/kube_context_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -230,6 +231,77 @@ func TestWriteInstanceKubeConfig(t *testing.T) {
 	user, ok := cfg.AuthInfos["rancher-desktop-2"]
 	assert.Assert(t, ok, "user rancher-desktop-2 not found")
 	assert.Equal(t, user.Token, "fake-token")
+}
+
+func TestCreateReplaceKubeContext_NoRewriteWhenUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+	srcPath := makeSrcKubeconfig(t, dir)
+
+	assert.NilError(t, createReplaceKubeContext("rancher-desktop-2", srcPath))
+	info1, err := os.Stat(destPath)
+	assert.NilError(t, err)
+
+	// Record mtime to verify the file is not rewritten.
+	assert.NilError(t, createReplaceKubeContext("rancher-desktop-2", srcPath))
+	info2, err := os.Stat(destPath)
+	assert.NilError(t, err)
+	assert.Equal(t, info1.ModTime(), info2.ModTime())
+}
+
+// TestKubeConfigWritersSerialized guards against the concurrent
+// load-modify-write races that tore ~/.kube/config into invalid YAML and
+// silently wiped user entries: while one writer sits between its load and its
+// write, a second writer must block, not interleave.
+func TestKubeConfigWritersSerialized(t *testing.T) {
+	dir := t.TempDir()
+	destPath := filepath.Join(dir, ".kube", "config")
+	t.Setenv("KUBECONFIG", destPath)
+	srcPath := makeSrcKubeconfig(t, dir)
+
+	// Seed a user-owned context so the final assertions can detect a wipe.
+	existing := clientcmdapi.NewConfig()
+	existing.Clusters["other"] = &clientcmdapi.Cluster{Server: "https://other:6443"}
+	existing.AuthInfos["other-user"] = &clientcmdapi.AuthInfo{Token: "other-token"}
+	existing.Contexts["other"] = &clientcmdapi.Context{Cluster: "other", AuthInfo: "other-user"}
+	existing.CurrentContext = "other"
+	assert.NilError(t, os.MkdirAll(filepath.Dir(destPath), 0o700))
+	assert.NilError(t, clientcmd.WriteToFile(*existing, destPath))
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	testAfterLoadKubeConfig = func() {
+		close(entered)
+		<-release
+	}
+	t.Cleanup(func() { testAfterLoadKubeConfig = nil })
+
+	mergeDone := make(chan error, 1)
+	go func() { mergeDone <- createReplaceKubeContext("rancher-desktop-2", srcPath) }()
+	<-entered
+
+	setDone := make(chan error, 1)
+	go func() { setDone <- setCurrentKubeContext("rancher-desktop-2") }()
+
+	select {
+	case <-setDone:
+		assert.Assert(t, false,
+			"setCurrentKubeContext completed inside createReplaceKubeContext's load-to-write window")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	assert.NilError(t, <-mergeDone)
+	assert.NilError(t, <-setDone)
+
+	cfg := loadDest(t, destPath)
+	_, ok := cfg.Clusters["other"]
+	assert.Assert(t, ok, "user cluster wiped by concurrent write")
+	_, ok = cfg.Clusters["rancher-desktop-2"]
+	assert.Assert(t, ok, "merged cluster missing")
+	// The later setCurrentKubeContext must not be reverted by the merge's write.
+	assert.Equal(t, cfg.CurrentContext, "rancher-desktop-2")
 }
 
 func TestRemoveInstanceKubeConfig(t *testing.T) {

--- a/rdd/pkg/util/atomicfile/atomicfile.go
+++ b/rdd/pkg/util/atomicfile/atomicfile.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package atomicfile updates file contents atomically and race-free: updates
+// to the same file are serialized, and the new content is staged in a
+// temporary file and renamed into place, so readers never see an empty or
+// partially written file.
+package atomicfile
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// pathLocks holds one mutex per resolved target, so concurrent updates to
+// the same file cannot lose each other's changes.
+var pathLocks sync.Map
+
+// Update replaces the contents of path with the result of modify, which
+// receives the current contents (nil if the file does not exist) and returns
+// the full new contents. Updates to the same file are serialized, and the
+// write is skipped when modify returns the contents unchanged.
+//
+// Update follows symlinks and replaces the target, so a symlinked file (a
+// dotfiles-managed kubeconfig or shell profile) keeps its link; a dangling
+// link gets its target created. The temporary file lands in the target's
+// directory, so the rename never crosses filesystems. An existing target
+// keeps its mode and, where supported, its ownership; a new file gets perm.
+//
+// On Windows the rename fails with a sharing violation while another process
+// holds the destination open (Go opens files without FILE_SHARE_DELETE);
+// callers for whom this matters must retry.
+func Update(path string, perm os.FileMode, modify func(current []byte) ([]byte, error)) error {
+	target := resolveTarget(path)
+	mu := lockPath(target)
+	mu.Lock()
+	defer mu.Unlock()
+
+	current, err := os.ReadFile(target)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		current = nil
+	}
+	updated, err := modify(current)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(current, updated) {
+		return nil
+	}
+	return replace(target, updated, perm)
+}
+
+// Write replaces the contents of path with data, ignoring the current
+// contents. Writing identical contents is a no-op. See Update for the
+// serialization, symlink, and metadata behavior, which Write shares.
+func Write(path string, data []byte, perm os.FileMode) error {
+	target := resolveTarget(path)
+	mu := lockPath(target)
+	mu.Lock()
+	defer mu.Unlock()
+
+	if current, err := os.ReadFile(target); err == nil && bytes.Equal(current, data) {
+		return nil
+	}
+	return replace(target, data, perm)
+}
+
+// lockPath returns the mutex serializing updates of target.
+func lockPath(target string) *sync.Mutex {
+	mu, _ := pathLocks.LoadOrStore(target, &sync.Mutex{})
+	return mu.(*sync.Mutex)
+}
+
+// replace writes data to a temporary file next to target and renames it into
+// place. The caller holds the target's lock and has already resolved symlinks.
+func replace(target string, data []byte, perm os.FileMode) (err error) {
+	tmp, err := os.CreateTemp(filepath.Dir(target), filepath.Base(target)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err = tmp.Write(data); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	mode := perm
+	if fi, statErr := os.Stat(target); statErr == nil && fi.Mode().IsRegular() {
+		mode = fi.Mode()
+		copyOwner(fi, tmpName)
+	}
+	if err = tmp.Chmod(mode); err != nil {
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err = tmp.Sync(); err != nil {
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	return os.Rename(tmpName, target)
+}
+
+// resolveTarget follows symlinks to the file the write must replace. For a
+// missing file or dangling link, EvalSymlinks fails with fs.ErrNotExist and
+// its PathError carries the path of the missing target.
+func resolveTarget(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+	var pathErr *fs.PathError
+	if errors.Is(err, fs.ErrNotExist) && errors.As(err, &pathErr) {
+		return pathErr.Path
+	}
+	return path
+}

--- a/rdd/pkg/util/atomicfile/atomicfile.go
+++ b/rdd/pkg/util/atomicfile/atomicfile.go
@@ -29,15 +29,20 @@ var pathLocks sync.Map
 //
 // Update follows symlinks and replaces the target, so a symlinked file (a
 // dotfiles-managed kubeconfig or shell profile) keeps its link; a dangling
-// link gets its target created. The temporary file lands in the target's
-// directory, so the rename never crosses filesystems. An existing target
-// keeps its mode and, where supported, its ownership; a new file gets perm.
+// link gets its target created. Update reports an error for a link it cannot
+// resolve, such as a symlink loop or an unreadable parent directory. The
+// temporary file lands in the target's directory, so the rename never crosses
+// filesystems. An existing target keeps its mode and, where supported, its
+// ownership; a new file gets perm.
 //
 // On Windows the rename fails with a sharing violation while another process
 // holds the destination open (Go opens files without FILE_SHARE_DELETE);
 // callers for whom this matters must retry.
 func Update(path string, perm os.FileMode, modify func(current []byte) ([]byte, error)) error {
-	target := resolveTarget(path)
+	target, err := resolveTarget(path)
+	if err != nil {
+		return err
+	}
 	mu := lockPath(target)
 	mu.Lock()
 	defer mu.Unlock()
@@ -45,7 +50,7 @@ func Update(path string, perm os.FileMode, modify func(current []byte) ([]byte, 
 	current, err := os.ReadFile(target)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("read %s: %w", path, err)
+			return err
 		}
 		current = nil
 	}
@@ -63,7 +68,10 @@ func Update(path string, perm os.FileMode, modify func(current []byte) ([]byte, 
 // contents. Writing identical contents is a no-op. See Update for the
 // serialization, symlink, and metadata behavior, which Write shares.
 func Write(path string, data []byte, perm os.FileMode) error {
-	target := resolveTarget(path)
+	target, err := resolveTarget(path)
+	if err != nil {
+		return err
+	}
 	mu := lockPath(target)
 	mu.Lock()
 	defer mu.Unlock()
@@ -117,16 +125,18 @@ func replace(target string, data []byte, perm os.FileMode) (err error) {
 }
 
 // resolveTarget follows symlinks to the file the write must replace. For a
-// missing file or dangling link, EvalSymlinks fails with fs.ErrNotExist and
-// its PathError carries the path of the missing target.
-func resolveTarget(path string) string {
+// missing file or dangling link, EvalSymlinks fails with fs.ErrNotExist, and
+// its PathError carries the path of the missing target. Any other failure —
+// a symlink loop, an unreadable parent — leaves the target unknown, so
+// resolveTarget reports it rather than let the caller replace the symlink.
+func resolveTarget(path string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err == nil {
-		return resolved
+		return resolved, nil
 	}
 	var pathErr *fs.PathError
 	if errors.Is(err, fs.ErrNotExist) && errors.As(err, &pathErr) {
-		return pathErr.Path
+		return pathErr.Path, nil
 	}
-	return path
+	return "", fmt.Errorf("resolve %s: %w", path, err)
 }

--- a/rdd/pkg/util/atomicfile/atomicfile_test.go
+++ b/rdd/pkg/util/atomicfile/atomicfile_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -27,6 +28,44 @@ func mkSymlink(t *testing.T, target, link string) {
 		t.Skipf("cannot create symlink: %v", err)
 	}
 	assert.NilError(t, err)
+}
+
+// mkUnreachableSymlink returns a link to a file inside a directory the caller
+// cannot traverse.
+func mkUnreachableSymlink(t *testing.T, dir string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not block traversal on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root traverses directories regardless of their mode")
+	}
+	secret := filepath.Join(dir, "secret")
+	assert.NilError(t, os.Mkdir(secret, 0o700))
+	target := filepath.Join(secret, "real-config")
+	assert.NilError(t, os.WriteFile(target, []byte("real"), 0o600))
+	link := filepath.Join(dir, "link-config")
+	mkSymlink(t, target, link)
+	assert.NilError(t, os.Chmod(secret, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o700) })
+	return link
+}
+
+// eachWriter runs fn against both entry points to test behavior they share.
+func eachWriter(t *testing.T, fn func(t *testing.T, write func(path string) error)) {
+	t.Helper()
+	t.Run("Write", func(t *testing.T) {
+		fn(t, func(path string) error {
+			return Write(path, []byte("content"), 0o600)
+		})
+	})
+	t.Run("Update", func(t *testing.T) {
+		fn(t, func(path string) error {
+			return Update(path, 0o600, func([]byte) ([]byte, error) {
+				return []byte("content"), nil
+			})
+		})
+	})
 }
 
 func assertMode(t *testing.T, path string, want os.FileMode) {
@@ -220,6 +259,36 @@ func TestWriteCreatesDanglingSymlinkTarget(t *testing.T) {
 	data, err := os.ReadFile(target)
 	assert.NilError(t, err)
 	assert.Equal(t, string(data), "content")
+}
+
+func TestSymlinkLoopIsRefused(t *testing.T) {
+	eachWriter(t, func(t *testing.T, write func(string) error) {
+		dir := t.TempDir()
+		first := filepath.Join(dir, "first")
+		second := filepath.Join(dir, "second")
+		mkSymlink(t, second, first)
+		mkSymlink(t, first, second)
+
+		assert.ErrorContains(t, write(first), "resolve")
+
+		fi, err := os.Lstat(first)
+		assert.NilError(t, err)
+		assert.Assert(t, fi.Mode()&os.ModeSymlink != 0, "link was replaced by a regular file")
+	})
+}
+
+func TestUnreachableSymlinkTargetIsRefused(t *testing.T) {
+	eachWriter(t, func(t *testing.T, write func(string) error) {
+		link := mkUnreachableSymlink(t, t.TempDir())
+
+		err := write(link)
+		assert.ErrorContains(t, err, "resolve")
+		assert.Assert(t, errors.Is(err, fs.ErrPermission))
+
+		fi, err := os.Lstat(link)
+		assert.NilError(t, err)
+		assert.Assert(t, fi.Mode()&os.ModeSymlink != 0, "link was replaced by a regular file")
+	})
 }
 
 func TestWriteLeavesNoTempFileOnSuccess(t *testing.T) {

--- a/rdd/pkg/util/atomicfile/atomicfile_test.go
+++ b/rdd/pkg/util/atomicfile/atomicfile_test.go
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package atomicfile
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+// mkSymlink creates a symlink, skipping the test on Windows where symlink
+// creation needs elevated privileges or developer mode.
+func mkSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	err := os.Symlink(target, link)
+	if err != nil && runtime.GOOS == "windows" {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	assert.NilError(t, err)
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	fi, err := os.Stat(path)
+	assert.NilError(t, err)
+	assert.Equal(t, fi.Mode().Perm(), want)
+}
+
+func TestWriteCreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+
+	assert.NilError(t, Write(path, []byte("content"), 0o600))
+
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "content")
+	assertMode(t, path, 0o600)
+}
+
+func TestWriteReplacesContentKeepingMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	assert.NilError(t, os.WriteFile(path, []byte("old"), 0o644))
+
+	assert.NilError(t, Write(path, []byte("new"), 0o600))
+
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "new")
+	// The existing file's mode wins over the perm argument.
+	assertMode(t, path, 0o644)
+}
+
+func TestWriteSkipsIdenticalContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	assert.NilError(t, Write(path, []byte("content"), 0o600))
+	info1, err := os.Stat(path)
+	assert.NilError(t, err)
+
+	assert.NilError(t, Write(path, []byte("content"), 0o600))
+
+	info2, err := os.Stat(path)
+	assert.NilError(t, err)
+	assert.Equal(t, info1.ModTime(), info2.ModTime())
+}
+
+func TestUpdateCreatesMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+
+	err := Update(path, 0o600, func(current []byte) ([]byte, error) {
+		assert.Assert(t, current == nil, "missing file must present nil contents")
+		return []byte("content"), nil
+	})
+	assert.NilError(t, err)
+
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "content")
+}
+
+func TestUpdateModifiesExistingContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	assert.NilError(t, os.WriteFile(path, []byte("old"), 0o600))
+
+	err := Update(path, 0o600, func(current []byte) ([]byte, error) {
+		return append(current, []byte("+new")...), nil
+	})
+	assert.NilError(t, err)
+
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "old+new")
+}
+
+func TestUpdateSkipsUnchangedContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	assert.NilError(t, os.WriteFile(path, []byte("content"), 0o600))
+	info1, err := os.Stat(path)
+	assert.NilError(t, err)
+
+	err = Update(path, 0o600, func(current []byte) ([]byte, error) {
+		return current, nil
+	})
+	assert.NilError(t, err)
+
+	info2, err := os.Stat(path)
+	assert.NilError(t, err)
+	assert.Equal(t, info1.ModTime(), info2.ModTime())
+}
+
+func TestUpdatePropagatesModifyError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	assert.NilError(t, os.WriteFile(path, []byte("content"), 0o600))
+
+	err := Update(path, 0o600, func([]byte) ([]byte, error) {
+		return nil, errors.New("modify failed")
+	})
+	assert.Error(t, err, "modify failed")
+
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "content")
+}
+
+func TestUpdatesSerialized(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	assert.NilError(t, os.WriteFile(path, []byte("start"), 0o600))
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- Update(path, 0o600, func([]byte) ([]byte, error) {
+			close(entered)
+			<-release
+			return []byte("first"), nil
+		})
+	}()
+	<-entered
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- Update(path, 0o600, func([]byte) ([]byte, error) {
+			return []byte("second"), nil
+		})
+	}()
+
+	select {
+	case <-secondDone:
+		assert.Assert(t, false, "second update ran inside the first update's critical section")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	assert.NilError(t, <-firstDone)
+	assert.NilError(t, <-secondDone)
+
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "second")
+}
+
+func TestWritePreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real-config")
+	link := filepath.Join(dir, "link-config")
+	assert.NilError(t, os.WriteFile(target, []byte("old"), 0o600))
+	mkSymlink(t, target, link)
+
+	assert.NilError(t, Write(link, []byte("new"), 0o600))
+
+	fi, err := os.Lstat(link)
+	assert.NilError(t, err)
+	assert.Assert(t, fi.Mode()&os.ModeSymlink != 0, "link was replaced by a regular file")
+	data, err := os.ReadFile(target)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "new")
+}
+
+func TestWritePreservesRelativeSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real-config")
+	link := filepath.Join(dir, "link-config")
+	assert.NilError(t, os.WriteFile(target, []byte("old"), 0o600))
+	mkSymlink(t, "real-config", link)
+
+	assert.NilError(t, Write(link, []byte("new"), 0o600))
+
+	fi, err := os.Lstat(link)
+	assert.NilError(t, err)
+	assert.Assert(t, fi.Mode()&os.ModeSymlink != 0, "link was replaced by a regular file")
+	data, err := os.ReadFile(target)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "new")
+}
+
+func TestWriteCreatesDanglingSymlinkTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "missing-config")
+	link := filepath.Join(dir, "link-config")
+	mkSymlink(t, target, link)
+
+	assert.NilError(t, Write(link, []byte("content"), 0o600))
+
+	fi, err := os.Lstat(link)
+	assert.NilError(t, err)
+	assert.Assert(t, fi.Mode()&os.ModeSymlink != 0, "link was replaced by a regular file")
+	data, err := os.ReadFile(target)
+	assert.NilError(t, err)
+	assert.Equal(t, string(data), "content")
+}
+
+func TestWriteLeavesNoTempFileOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+
+	assert.NilError(t, Write(path, []byte("content"), 0o600))
+
+	entries, err := os.ReadDir(dir)
+	assert.NilError(t, err)
+	assert.Equal(t, len(entries), 1)
+	assert.Equal(t, entries[0].Name(), "config")
+}
+
+func TestWriteNeverExposesPartialFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Go opens files without FILE_SHARE_DELETE, so the reader's open
+		// handle would make the writer's rename fail with a sharing violation.
+		t.Skip("rename over a concurrently open file is not atomic on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "config")
+	long := bytes.Repeat([]byte("a"), 4096)
+	short := bytes.Repeat([]byte("b"), 64)
+	assert.NilError(t, Write(path, long, 0o600))
+
+	stop := make(chan struct{})
+	bad := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			switch {
+			case err != nil:
+				bad <- fmt.Sprintf("read failed: %v", err)
+				return
+			case !bytes.Equal(data, long) && !bytes.Equal(data, short):
+				bad <- fmt.Sprintf("partial content: %d bytes", len(data))
+				return
+			}
+		}
+	}()
+
+	for i := range 500 {
+		content := long
+		if i%2 == 0 {
+			content = short
+		}
+		assert.NilError(t, Write(path, content, 0o600))
+	}
+	close(stop)
+	wg.Wait()
+	close(bad)
+	assert.Equal(t, <-bad, "")
+}

--- a/rdd/pkg/util/atomicfile/owner_unix.go
+++ b/rdd/pkg/util/atomicfile/owner_unix.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build !windows
+
+package atomicfile
+
+import (
+	"os"
+	"syscall"
+)
+
+// copyOwner transfers src's ownership to dst, so a privileged process
+// replacing another user's file keeps that user as the owner. Best effort;
+// failures are ignored.
+func copyOwner(src os.FileInfo, dst string) {
+	if st, ok := src.Sys().(*syscall.Stat_t); ok {
+		_ = os.Chown(dst, int(st.Uid), int(st.Gid))
+	}
+}

--- a/rdd/pkg/util/atomicfile/owner_windows.go
+++ b/rdd/pkg/util/atomicfile/owner_windows.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build windows
+
+package atomicfile
+
+import "os"
+
+// copyOwner is a no-op: Windows file ownership does not transfer via chown.
+func copyOwner(_ os.FileInfo, _ string) {}


### PR DESCRIPTION
Nothing serialized the writers of `~/.kube/config`, and each rewrote the file in place, so overlapping writers could tear it into invalid YAML (the failed ubuntu bats run on #533) or read it empty mid-truncate and then silently drop the user's other clusters. The file was also rewritten on every reconcile even when unchanged, giving these rare races endless chances to fire.

The first commit adds a shared `atomicfile` helper that owns the whole update cycle (shell-profile editing will reuse it later); the second routes all kubeconfig writes through it.

Merging this before #533 forecloses the race that failed its CI; #533 stays as-is since it fixes a separate ordering race.