### PR TITLE
CI: Use vault secrets for OBS uploads

### DIFF
--- a/.github/actions/get-token/action.yaml
+++ b/.github/actions/get-token/action.yaml
@@ -8,7 +8,7 @@ description: >-
 inputs:
   token-secret:
     description: Secret to fall back to
-    required: false
+    required: true
 outputs:
   token:
     description: The GitHub token retrieved
@@ -18,7 +18,7 @@ runs:
   steps:
   - id: vault
     name: Read vault secrets
-    continue-on-error: true
+    if: github.repository_owner == 'rancher-sandbox'
     uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
     with:
       secrets: |
@@ -32,9 +32,9 @@ runs:
       client-id: ${{ env.CLIENT_ID }}
       private-key: ${{ env.PRIVATE_KEY }}
   - id: get-secret
-    name: Fetch secret.
-    if: steps.gen-token.outcome != 'success'
-    run: echo "token=$SECRET" >> "$GITHUB_OUTPUT"
+    name: Fall back to GitHub-hosted secrets
+    if: steps.vault.outcome == 'skipped'
+    run: echo "token=${SECRET:?Secret not found}" >> "$GITHUB_OUTPUT"
     shell: bash
     env:
       SECRET: ${{ inputs.token-secret }}

--- a/.github/actions/get-token/action.yaml
+++ b/.github/actions/get-token/action.yaml
@@ -12,28 +12,28 @@ inputs:
 outputs:
   token:
     description: The GitHub token retrieved
-    value: ${{ github.repository == 'rancher-sandbox/rancher-desktop-2' && steps.gen-token.outputs.token || steps.get-secret.outputs.token }}
+    value: ${{ steps.gen-token.outcome == 'success' && steps.gen-token.outputs.token || steps.get-secret.outputs.token }}
 runs:
   using: composite
   steps:
   - id: vault
     name: Read vault secrets
-    if: github.repository == 'rancher-sandbox/rancher-desktop-2'
+    continue-on-error: true
     uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
     with:
       secrets: |
-        secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+        secret/data/github/repo/${{ github.repository }}/github/app-credentials clientId | CLIENT_ID ;
         secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
   - id: gen-token
     name: Generate token
-    if: github.repository == 'rancher-sandbox/rancher-desktop-2'
+    if: steps.vault.outcome == 'success'
     uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
     with:
-      app-id: ${{ env.APP_ID }}
+      client-id: ${{ env.CLIENT_ID }}
       private-key: ${{ env.PRIVATE_KEY }}
   - id: get-secret
     name: Fetch secret.
-    if: github.repository != 'rancher-sandbox/rancher-desktop-2'
+    if: steps.gen-token.outcome != 'success'
     run: echo "token=$SECRET" >> "$GITHUB_OUTPUT"
     shell: bash
     env:

--- a/.github/workflows/go-mod-k8s-sync.yaml
+++ b/.github/workflows/go-mod-k8s-sync.yaml
@@ -75,6 +75,7 @@ jobs:
       id: get-token
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: ./.github/actions/get-token
+      continue-on-error: true
       with:
         token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -118,32 +118,42 @@ jobs:
     name: Trigger OBS build
     needs: package
     runs-on: ubuntu-latest
-    if: github.ref_type == 'branch' && ( startsWith(github.ref_name, 'main') || startsWith(github.ref_name, 'release-') )
+    # `vars.OBS_DEVEL_PROJECT` is set in the repository settings; for
+    # `rancher-sandbox/rancher-desktop-2`, it is `isv:Rancher:dev`.
+    # This job is skipped if it is not set, which should be the default case
+    # for forks.
+    if: >-
+      vars.OBS_DEVEL_PROJECT != '' &&
+      github.ref_type == 'branch' &&
+      ( github.ref_name == 'main' || startsWith(github.ref_name, 'release-') )
     permissions:
       contents: read
       id-token: write # Needed for read-value-secrets
     steps:
-    - id: get-token
+    - id: get-vault-secrets
       name: Read vault secrets
-      continue-on-error: true
+      if: github.repository_owner == 'rancher-sandbox'
       uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/obs/webhook-token token | OBS_WEBHOOK_TOKEN;
           secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_ACCESS_KEY_ID | AWS_ACCESS_KEY_ID;
           secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_SECRET_ACCESS_KEY | AWS_SECRET_ACCESS_KEY
-    - id: download
-      name: Download artifacts
-      if: >-
-        steps.get-token.outcome == 'success' &&
-        env.AWS_ACCESS_KEY_ID != '' &&
-        env.AWS_SECRET_ACCESS_KEY != '' &&
-        env.OBS_WEBHOOK_TOKEN != ''
+    - name: Fall back to GitHub-hosted secrets
+      if: steps.get-vault-secrets.outcome == 'skipped'
+      run: |
+        echo "OBS_WEBHOOK_TOKEN=${OBS_WEBHOOK_TOKEN:?Secret OBS_WEBHOOK_TOKEN not found}" >> "$GITHUB_ENV"
+        echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?Secret AWS_ACCESS_KEY_ID not found}" >> "$GITHUB_ENV"
+        echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?Secret AWS_SECRET_ACCESS_KEY not found}" >> "$GITHUB_ENV"
+      env:
+        OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - name: Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Rancher Desktop-linux.zip
     - name: Trigger OBS build
-      if: steps.download.outcome == 'success'
       run: |
         # in pull requests GITHUB_REF_NAME is in the form "<pr_number>/merge";
         # remove slashes since they aren't valid in filenames
@@ -158,9 +168,10 @@ jobs:
         # Trigger OBS services for relevant package in dev channel
         curl --request POST --fail-with-body \
           --header "Authorization: Token ${OBS_WEBHOOK_TOKEN}" \
-          "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:dev&package=rancher-desktop-2-${GITHUB_REF_NAME}"
+          "https://build.opensuse.org/trigger/runservice?project=${OBS_DEVEL_PROJECT}&package=rancher-desktop-2-${GITHUB_REF_NAME}"
       env:
         AWS_DEFAULT_REGION: us-east-1
+        OBS_DEVEL_PROJECT: ${{ vars.OBS_DEVEL_PROJECT }} # Per-repo, e.g. `isv:Rancher:dev`.
 
   sign-win:
     name: Test Signing (Windows)

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -23,6 +23,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   check-paths:
     uses: ./.github/workflows/paths-ignore.yaml
@@ -110,13 +113,38 @@ jobs:
         name: Rancher Desktop-linux.zip
         path: dist/rancher-desktop-*-linux.zip
         if-no-files-found: error
+
+  trigger-obs:
+    name: Trigger OBS build
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'branch' && ( startsWith(github.ref_name, 'main') || startsWith(github.ref_name, 'release-') )
+    permissions:
+      contents: read
+      id-token: write # Needed for read-value-secrets
+    steps:
+    - id: get-token
+      name: Read vault secrets
+      continue-on-error: true
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/obs/webhook-token token | OBS_WEBHOOK_TOKEN;
+          secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_ACCESS_KEY_ID | AWS_ACCESS_KEY_ID;
+          secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_SECRET_ACCESS_KEY | AWS_SECRET_ACCESS_KEY
+    - id: download
+      name: Download artifacts
+      if: >-
+        steps.get-token.outcome == 'success' &&
+        env.AWS_ACCESS_KEY_ID != '' &&
+        env.AWS_SECRET_ACCESS_KEY != '' &&
+        env.OBS_WEBHOOK_TOKEN != ''
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: Rancher Desktop-linux.zip
     - name: Trigger OBS build
-      if: matrix.platform == 'linux' && github.ref_type == 'branch' && ( startsWith(github.ref_name, 'main') || startsWith(github.ref_name, 'release-') )
+      if: steps.download.outcome == 'success'
       run: |
-        if [[ -z $AWS_ACCESS_KEY_ID ]] || [[ -z $OBS_WEBHOOK_TOKEN ]]; then
-          echo "Secrets unavailable, skipping."
-          exit 0
-        fi
         # in pull requests GITHUB_REF_NAME is in the form "<pr_number>/merge";
         # remove slashes since they aren't valid in filenames
         no_slash_ref_name="${GITHUB_REF_NAME//\//-}"
@@ -124,18 +152,15 @@ jobs:
 
         # Copy zip file to S3
         aws s3 cp \
-          dist/rancher-desktop-*-linux.zip \
+          rancher-desktop-*-linux.zip \
           "s3://rancher-desktop-assets-for-obs/$zip_name"
 
         # Trigger OBS services for relevant package in dev channel
-        curl -X POST \
-          -H "Authorization: Token ${OBS_WEBHOOK_TOKEN}" \
+        curl --request POST --fail-with-body \
+          --header "Authorization: Token ${OBS_WEBHOOK_TOKEN}" \
           "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:dev&package=rancher-desktop-2-${GITHUB_REF_NAME}"
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: us-east-1
-        OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}
 
   sign-win:
     name: Test Signing (Windows)

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -10,25 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  get-token:
-    # rddepman needs a token whose pull requests trigger CI; the
-    # workflow-provided github.token does not trigger further workflows.
-    outputs:
-      token: ${{ steps.get-token.outputs.token }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        persist-credentials: false
-    - id: get-token
-      uses: ./.github/actions/get-token
-      continue-on-error: true
-      with:
-        token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
-
   check-update-versions:
-    needs: get-token
-    if: needs.get-token.outputs.token != ''
     permissions:
       contents: read
       id-token: write # Required for ./.github/actions/get-token
@@ -44,6 +26,13 @@ jobs:
 
       - uses: ./.github/actions/yarn-install
 
+      - id: get-token
+        uses: ./.github/actions/get-token
+        continue-on-error: true
+        with:
+          token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+
       - run: yarn rddepman
+        if: steps.get-token.outcome == 'success'
         env:
-          GITHUB_TOKEN: ${{ needs.get-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -10,19 +10,25 @@ permissions:
   contents: read
 
 jobs:
-  check-for-token:
+  get-token:
+    # rddepman needs a token whose pull requests trigger CI; the
+    # workflow-provided github.token does not trigger further workflows.
     outputs:
-      has-token: ${{ steps.calc.outputs.HAS_SECRET }}
+      token: ${{ steps.get-token.outputs.token }}
     runs-on: ubuntu-latest
     steps:
-    - id: calc
-      run: echo "HAS_SECRET=${HAS_SECRET}" >> "${GITHUB_OUTPUT}"
-      env:
-        HAS_SECRET: ${{ github.repository == 'rancher-sandbox/rancher-desktop-2' || secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - id: get-token
+      uses: ./.github/actions/get-token
+      continue-on-error: true
+      with:
+        token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
 
   check-update-versions:
-    needs: check-for-token
-    if: needs.check-for-token.outputs.has-token == 'true'
+    needs: get-token
+    if: needs.get-token.outputs.token != ''
     permissions:
       contents: read
       id-token: write # Required for ./.github/actions/get-token
@@ -36,15 +42,8 @@ jobs:
           # github.token would override that, so keep it out of git config.
           persist-credentials: false
 
-      - # rddepman needs a token whose pull requests trigger CI; the
-        # workflow-provided github.token does not trigger further workflows.
-        id: get-token
-        uses: ./.github/actions/get-token
-        with:
-          token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
-
       - uses: ./.github/actions/yarn-install
 
       - run: yarn rddepman
         env:
-          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+          GITHUB_TOKEN: ${{ needs.get-token.outputs.token }}

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -28,11 +28,9 @@ jobs:
 
       - id: get-token
         uses: ./.github/actions/get-token
-        continue-on-error: true
         with:
           token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
 
       - run: yarn rddepman
-        if: steps.get-token.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
For #453; draft because I need to be on this repo to test the vault action.

The OBS trigger step has been moved to a new job, to help scope access to the tokens to fewer things.  The overall permissions for the workflow has been explicitly set to `contents: read` as well.

Sample run: https://github.com/rancher-sandbox/rancher-desktop-2/actions/runs/29133328785/job/86494046525

That had an extra (intentionally not signed-off) commit to force trigger when not on `main`; that has been dropped.

#554 is a PR from a fork; that should fail (because it can't get secrets).