### PR TITLE
Raise the BATS target timeout to 60 minutes

### DIFF
--- a/rdd/bats/Makefile
+++ b/rdd/bats/Makefile
@@ -9,7 +9,10 @@ BATS_CORE := ./lib/bats-core/bin/bats
 # BATS_TIMEOUT=0 disables the wrapper entirely, which also disables
 # support-bundle capture; for long local runs, set a large value
 # (e.g. 86400) instead of 0.
-BATS_TIMEOUT ?= 2700
+#
+# bats-app on macos-15-intel runners exceeds 45 minutes. Raising the cap is a
+# stopgap; splitting the suite and cutting VM restarts is the real fix.
+BATS_TIMEOUT ?= 3600
 BATS = $(if $(filter-out 0,$(BATS_TIMEOUT)),../scripts/bats-with-timeout.sh $(BATS_TIMEOUT)) $(BATS_CORE)
 
 default: bats-all


### PR DESCRIPTION
bats-app on macos-15-intel runners no longer fits in 45 minutes, so we keep rerunning failed jobs by hand. Splitting the suite and cutting its VM restarts remains the real fix; this only buys time until then.

Raising the timeout globally; the other suites never exceed it anyways.