### PR TITLE
dependabot: hold etcd at 3.6.x and move its group to /rdd

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,8 +52,6 @@ updates:
   - # Swagger dependencies must match whatever the CLI generate.
     dependency-name: "github.com/go-openapi/swag"
   groups:
-    etcd:
-      patterns: ["go.etcd.io/etcd/*"]
     golang-x:
       patterns: ["golang.org/x/*"]
     k8s:
@@ -66,6 +64,11 @@ updates:
   cooldown:
     default-days: 7
   ignore:
+  - # etcd 3.7 regenerated its protobuf API, which kine and the embedded k8s
+    # apiserver do not yet implement, so the build breaks. Allow 3.6.x patch
+    # updates; drop this once kine and k8s move to 3.7.
+    dependency-name: go.etcd.io/etcd/*
+    update-types: [version-update:semver-minor, version-update:semver-major]
   - { dependency-name: k8s.io/api }
   - { dependency-name: k8s.io/apiextensions-apiserver }
   - { dependency-name: k8s.io/apimachinery }
@@ -100,5 +103,7 @@ updates:
   - { dependency-name: k8s.io/sample-controller }
   - { dependency-name: k8s.io/streaming }
   groups:
+    etcd:
+      patterns: [ go.etcd.io/etcd/* ]
     golang-x:
       patterns: [ golang.org/x/* ]


### PR DESCRIPTION
Dependabot's #564 bumped only `go.etcd.io/etcd/api/v3` to 3.7.0 and broke the build. Both kine and the embedded k8s apiserver still implement etcd's 3.6 gRPC API, so the whole module set is stuck on 3.6 until they adopt 3.7.

This holds etcd below 3.7 and groups the modules in the `/rdd` block — the only one Dependabot updates here — while still allowing 3.6.x patch bumps. It also reverts #565, which added the group to `/src/go` instead; that block mirrors RD1 to keep merges clean, and RD1 does not group etcd.

Once this merges, Dependabot will close #564 (3.7 becomes ignored).
