### PR TITLE
RDA: E2E Tests for Kubernetes versions preferences

### DIFF
--- a/e2e/pages/preferences/checkbox.ts
+++ b/e2e/pages/preferences/checkbox.ts
@@ -1,0 +1,22 @@
+import type { Locator } from '@playwright/test';
+
+/**
+ * RDCheckbox returns a locator suitable for a <rd-checkbox>.
+ */
+export default function RDCheckbox(locator: Locator): Locator {
+  const l = locator.locator('input[type="checkbox"]');
+  return Object.create(l, {
+    // Override `check` to always use force, as Playwright detects that the
+    // clicks are handled by a different element.
+    check: {
+      value: function(options?: Parameters<Locator['check']>[0]) {
+        return l.check({ ...options, force: true });
+      },
+    },
+    uncheck: {
+      value: function(options?: Parameters<Locator['uncheck']>[0]) {
+        return l.uncheck({ ...options, force: true });
+      },
+    },
+  });
+}

--- a/e2e/pages/preferences/index.ts
+++ b/e2e/pages/preferences/index.ts
@@ -1,10 +1,10 @@
+import { expect, Page } from '@playwright/test';
+
 import { ApplicationNav } from './application';
 import { ContainerEngineNav } from './containerEngine';
 import { KubernetesNav } from './kubernetes';
 import { VirtualMachineNav } from './virtualMachine';
 import { WslNav } from './wsl';
-
-import type { Page } from '@playwright/test';
 
 export class PreferencesPage {
   readonly page:            Page;
@@ -21,5 +21,11 @@ export class PreferencesPage {
     this.containerEngine = new ContainerEngineNav(page);
     this.kubernetes = new KubernetesNav(page);
     this.wsl = new WslNav(page);
+  }
+
+  async waitForLoad() {
+    // Wait for the navigation to appear; this only happens once the current
+    // preferences have been loaded.
+    await expect(this.page.locator('.preferences-nav')).toBeVisible();
   }
 }

--- a/e2e/pages/preferences/kubernetes.ts
+++ b/e2e/pages/preferences/kubernetes.ts
@@ -1,3 +1,5 @@
+import RDCheckbox from './checkbox';
+
 import type { Page, Locator } from '@playwright/test';
 
 export class KubernetesNav {
@@ -11,8 +13,8 @@ export class KubernetesNav {
   constructor(page: Page) {
     this.page = page;
     this.nav = page.locator('[data-test="nav-kubernetes"]');
-    this.kubernetesToggle = page.locator('[data-test="kubernetesToggle"]');
-    this.kubernetesVersion = page.locator('[data-test="kubernetesVersion"]');
+    this.kubernetesToggle = RDCheckbox(page.locator('[data-test="kubernetesToggle"]'));
+    this.kubernetesVersion = page.locator('[data-test="kubernetesVersion"] select');
     this.kubernetesOptions = page.locator('[data-test="kubernetesOptions"]');
     this.kubernetesVersionLockedFields = page.locator('[data-test="kubernetesVersion"] > .select-k8s-version > .icon-lock');
   }

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -10,7 +10,7 @@ import { reopenLogs } from '@pkg/utils/logging';
 
 import type { ElectronApplication, Page } from '@playwright/test';
 
-let page: Page;
+let mainNav: NavPage;
 
 /**
  * Using test.describe.serial make the test execute step by step, as described on each `test()` order
@@ -23,16 +23,18 @@ test.describe.serial('Main App Test', () => {
   test.beforeAll(async({ colorScheme }, testInfo) => {
     electronApp = await startRancherDesktop(testInfo);
 
-    page = await electronApp.firstWindow();
-    await new NavPage(page).preferencesButton.click();
-    preferencesWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
+    mainNav = new NavPage(await electronApp.firstWindow());
   });
 
   test.afterAll(async({ colorScheme }, testInfo) => {
     await teardown(electronApp, testInfo);
   });
 
+  test('should finish loading', () => mainNav.waitForAppSettled());
+
   test('should open preferences modal', async() => {
+    await mainNav.preferencesButton.click();
+    preferencesWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
     expect(preferencesWindow).toBeDefined();
 
     // Wait for the navigation to appear; this only happens once the current
@@ -237,7 +239,7 @@ test.describe.serial('Main App Test', () => {
     });
 
     test.beforeEach(async() => {
-      await new NavPage(page).preferencesButton.click();
+      await mainNav.preferencesButton.click();
       preferencesWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
     });
 

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -1,14 +1,14 @@
 import os from 'os';
 
 import { test, expect, _electron } from '@playwright/test';
+import semver from 'semver';
 
 import { NavPage } from './pages/nav-page';
 import { PreferencesPage } from './pages/preferences';
-import { createDefaultSettings, startRancherDesktop, teardown, tool } from './utils/TestUtils';
+import { KubernetesNav } from './pages/preferences/kubernetes';
+import { rdd, startRancherDesktop, teardown } from './utils/TestUtils';
 
-import { reopenLogs } from '@pkg/utils/logging';
-
-import type { ElectronApplication, Page } from '@playwright/test';
+import type { ElectronApplication } from '@playwright/test';
 
 let mainNav: NavPage;
 
@@ -16,9 +16,9 @@ let mainNav: NavPage;
  * Using test.describe.serial make the test execute step by step, as described on each `test()` order
  * Playwright executes test in parallel by default and it will not work for our app backend loading process.
  * */
-test.describe.serial('Main App Test', () => {
+test.describe.serial('Preferences Dialog', () => {
   let electronApp: ElectronApplication;
-  let preferencesWindow: Page;
+  let prefPage: PreferencesPage;
 
   test.beforeAll(async({ colorScheme }, testInfo) => {
     electronApp = await startRancherDesktop(testInfo);
@@ -34,16 +34,15 @@ test.describe.serial('Main App Test', () => {
 
   test('should open preferences modal', async() => {
     await mainNav.preferencesButton.click();
-    preferencesWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
-    expect(preferencesWindow).toBeDefined();
+    const prefWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
+    expect(prefWindow).toBeDefined();
+    prefPage = new PreferencesPage(prefWindow);
 
-    // Wait for the navigation to appear; this only happens once the current
-    // preferences have been loaded.
-    await expect(preferencesWindow.locator('.preferences-nav')).toBeVisible();
+    await prefPage.waitForLoad();
   });
 
   test.fixme('should show application page and render general tab', async() => {
-    const { application } = new PreferencesPage(preferencesWindow);
+    const { application } = prefPage;
 
     await expect(application.nav).toHaveClass('preferences-nav-item active');
 
@@ -63,7 +62,7 @@ test.describe.serial('Main App Test', () => {
   });
 
   test.fixme('should render behavior tab', async() => {
-    const { application } = new PreferencesPage(preferencesWindow);
+    const { application } = prefPage;
 
     await application.tabBehavior.click();
 
@@ -76,7 +75,7 @@ test.describe.serial('Main App Test', () => {
 
   test.fixme('should render environment tab', async() => {
     test.skip(os.platform() === 'win32', 'Environment tab not available on Windows');
-    const { application } = new PreferencesPage(preferencesWindow);
+    const { application } = prefPage;
 
     await application.tabEnvironment.click();
 
@@ -88,7 +87,7 @@ test.describe.serial('Main App Test', () => {
 
   test.fixme('should navigate to virtual machine and render hardware tab', async() => {
     test.skip(os.platform() === 'win32', 'Virtual Machine not available on Windows');
-    const { virtualMachine, application } = new PreferencesPage(preferencesWindow);
+    const { virtualMachine, application } = prefPage;
 
     await virtualMachine.nav.click();
 
@@ -112,7 +111,7 @@ test.describe.serial('Main App Test', () => {
 
   test.fixme('should render volumes tab', async() => {
     test.skip(os.platform() === 'win32', 'Virtual Machine not available on Windows');
-    const { virtualMachine } = new PreferencesPage(preferencesWindow);
+    const { virtualMachine } = prefPage;
 
     await virtualMachine.tabVolumes.click();
 
@@ -145,7 +144,7 @@ test.describe.serial('Main App Test', () => {
   test.fixme('should render emulation tab on macOS', async() => {
     test.skip(os.platform() !== 'darwin', 'Emulation tab only available on macOS');
 
-    const { virtualMachine } = new PreferencesPage(preferencesWindow);
+    const { virtualMachine } = prefPage;
 
     await virtualMachine.tabEmulation.click();
     await expect(virtualMachine.vmType).toBeVisible();
@@ -168,7 +167,7 @@ test.describe.serial('Main App Test', () => {
   });
 
   test.fixme('should navigate to container engine', async() => {
-    const { containerEngine } = new PreferencesPage(preferencesWindow);
+    const { containerEngine } = prefPage;
 
     await containerEngine.nav.click();
 
@@ -180,7 +179,7 @@ test.describe.serial('Main App Test', () => {
   });
 
   test.fixme('should render allowed images tab after click on allowed images tab', async() => {
-    const { containerEngine } = new PreferencesPage(preferencesWindow);
+    const { containerEngine } = prefPage;
 
     await containerEngine.tabAllowedImages.click();
 
@@ -188,20 +187,68 @@ test.describe.serial('Main App Test', () => {
     await expect(containerEngine.containerEngine).not.toBeVisible();
   });
 
-  test('should navigate to kubernetes', async() => {
-    const { kubernetes } = new PreferencesPage(preferencesWindow);
+  test.describe('Kubernetes', () => {
+    let kubernetes: KubernetesNav;
+    test('should navigate to kubernetes', async() => {
+      kubernetes = prefPage.kubernetes;
 
-    await kubernetes.nav.click();
+      await kubernetes.nav.click();
 
-    await expect(kubernetes.nav).toHaveClass('preferences-nav-item active');
-    await expect(kubernetes.kubernetesToggle).toBeVisible();
-    await expect(kubernetes.kubernetesVersion).toBeVisible();
-    // await expect(kubernetes.kubernetesOptions).toBeVisible();
+      await expect(kubernetes.nav).toHaveClass('preferences-nav-item active');
+      await expect(kubernetes.kubernetesToggle).toBeVisible();
+      await expect(kubernetes.kubernetesVersion).toBeVisible();
+    });
+
+    test('Kubernetes enabled checkbox should exist', async() => {
+      await expect(kubernetes.kubernetesToggle).toBeVisible();
+      await kubernetes.kubernetesToggle.uncheck();
+      await expect(kubernetes.kubernetesToggle).not.toBeChecked();
+      await expect(kubernetes.kubernetesVersion).toBeDisabled();
+      await kubernetes.kubernetesToggle.check();
+      await expect(kubernetes.kubernetesToggle).toBeChecked();
+    });
+
+    test('Kubernetes version dropdown should have the correct versions', async() => {
+      await expect(kubernetes.kubernetesVersion).toBeVisible();
+      await expect(kubernetes.kubernetesVersion).toBeEnabled();
+      const options = kubernetes.kubernetesVersion.locator('option');
+      await expect(options).toContainText(['stable']);
+
+      const namespace = await rdd('ctl', 'get', 'app/app', '--output=jsonpath={.spec.namespace}');
+      const versionsText = await rdd('ctl', 'get', 'configmap/k3s-versions',
+        `--namespace=${ namespace }`, '--output=jsonpath={.data.versions}');
+      const versionMap: Record<string, string> = JSON.parse(versionsText);
+      const channelsText = await rdd('ctl', 'get', 'configmap/k3s-versions',
+        `--namespace=${ namespace }`, '--output=jsonpath={.data.channels}');
+      const channelsMap: Record<string, string> = JSON.parse(channelsText);
+      const versions = Object.keys(versionMap).sort((a, b) => {
+        return semver.compare(b, a); // Newest first.
+      });
+      const recommendedVersions = versions.map(version => {
+        const channels = Object.entries(channelsMap)
+          .filter(([_, v]) => v === version)
+          .map(([k]) => k);
+        return [version, channels.sort()] as const;
+      }).filter(([_, channels]) => channels.length > 0);
+      const recommendedLabels = recommendedVersions.map(([version, channels]) => {
+        const filteredChannels = channels.filter(c => !/^\d+\.\d+/.test(c));
+        if (filteredChannels.length === 0) {
+          return version;
+        }
+        return `${ version } (${ filteredChannels.join(', ') })`;
+      });
+      const otherVersions = versions.filter(version => !recommendedVersions.some(([v]) => v === version));
+      await expect(options).toContainText([...recommendedLabels, ...otherVersions]);
+    });
+
+    test.fixme('Kubernetes options should exist', async() => {
+      await expect(kubernetes.kubernetesOptions).toBeVisible();
+    });
   });
 
   test.fixme('should navigate to WSL and render integrations tab', async() => {
     test.skip(os.platform() !== 'win32', 'WSL nav item not available on macOS & Linux');
-    const { wsl } = new PreferencesPage(preferencesWindow);
+    const { wsl } = prefPage;
 
     await wsl.nav.click();
 
@@ -213,14 +260,14 @@ test.describe.serial('Main App Test', () => {
 
   test.fixme('should not render WSL nav item on macOS and Linux', async() => {
     test.skip(os.platform() === 'win32', 'WSL nav item is only available on Windows');
-    const { wsl } = new PreferencesPage(preferencesWindow);
+    const { wsl } = prefPage;
 
     await expect(wsl.nav).not.toBeVisible();
   });
 
   test.describe.fixme('Preferences State', () => {
     test.beforeAll(async() => {
-      const { application } = new PreferencesPage(preferencesWindow);
+      const { application } = prefPage;
 
       // Start this collection of tests on the environment tab
       await application.nav.click();
@@ -233,28 +280,29 @@ test.describe.serial('Main App Test', () => {
       // This collection of tests is about making sure that we persist state
       // in the preferences window, so we close the preferences window before
       // beginning this test collection.
-      if (preferencesWindow) {
-        await preferencesWindow.close();
+      if (prefPage) {
+        await prefPage.page.close();
       }
     });
 
     test.beforeEach(async() => {
       await mainNav.preferencesButton.click();
-      preferencesWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
+      const prefWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
+      prefPage = new PreferencesPage(prefWindow);
     });
 
     test.afterEach(async() => {
-      if (preferencesWindow) {
-        await preferencesWindow.close();
+      if (prefPage) {
+        await prefPage.page.close();
       }
     });
 
     test('should render environment tab after close and reopen preferences modal', async() => {
       test.skip(os.platform() === 'win32', 'Environment tab not available on Windows');
 
-      expect(preferencesWindow).toBeDefined();
+      expect(prefPage).toBeDefined();
 
-      const { application, containerEngine } = new PreferencesPage(preferencesWindow);
+      const { application, containerEngine } = prefPage;
 
       await application.tabEnvironment.click();
 
@@ -272,11 +320,9 @@ test.describe.serial('Main App Test', () => {
     });
 
     test('should render container engine page after close and reopen preferences modal', async() => {
-      expect(preferencesWindow).toBeDefined();
-      // Wait for the window to actually load (i.e. transition from
-      // app://index.html/#/preferences to app://index.html/#/Preferences#general)
-      await preferencesWindow.waitForURL(/Preferences#/i);
-      const { containerEngine } = new PreferencesPage(preferencesWindow);
+      expect(prefPage).toBeDefined();
+      await prefPage.waitForLoad();
+      const { containerEngine } = prefPage;
 
       if (os.platform() === 'win32') {
         // We didn't run the previous test which landed on `tabGeneral`, so run that here.
@@ -294,11 +340,9 @@ test.describe.serial('Main App Test', () => {
     });
 
     test('should render allowed image tab in container engine page after close and reopen preferences modal', async() => {
-      expect(preferencesWindow).toBeDefined();
-      // Wait for the window to actually load (i.e. transition from
-      // app://index.html/#/preferences to app://index.html/#/Preferences#general)
-      await preferencesWindow.waitForURL(/Preferences#/i);
-      const { containerEngine } = new PreferencesPage(preferencesWindow);
+      expect(prefPage).toBeDefined();
+      await prefPage.waitForLoad();
+      const { containerEngine } = prefPage;
 
       await expect(containerEngine.nav).toHaveClass('preferences-nav-item active');
       await expect(containerEngine.allowedImages).toBeVisible();

--- a/rdd/pkg/controllers/mock/mock_controller.go
+++ b/rdd/pkg/controllers/mock/mock_controller.go
@@ -19,6 +19,7 @@ import (
 
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	containersv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/k3sversions/controllers"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 )
 
@@ -141,6 +142,14 @@ func (c *controller) setupReconciler(ctx context.Context, mgr ctrl.Manager) erro
 	err = (&volumeReconciler{
 		Client:   mgr.GetClient(),
 		Recorder: mgr.GetEventRecorder(controllerLongName),
+	}).SetupWithManager(mgr)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Setting up K3s versions reconciler")
+	err = (&controllers.K3sVersionsReconciler{
+		Client: mgr.GetClient(),
 	}).SetupWithManager(mgr)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds E2E tests to the pref dialog for Kubernetes versions (see #571).

- We now load the real k3s-versions reconciler into the mock controller, so we get the correct format for the k3s-versions config map.
- This means we can test the pref dialog, comparing the expected versions (introspected from the config map) to the actually displayed items.

If we ever end up doing more complicated version fetching in the reconciler, we may need to duplicate it into a mock version with static assets instead; but that's not today.