### PR TITLE
Cap the BATS job at 120m so a wedged step fails fast

### DIFF
--- a/.github/workflows/rdd-bats.yaml
+++ b/.github/workflows/rdd-bats.yaml
@@ -76,6 +76,10 @@ jobs:
     # Run on ubuntu-latest if we don't need to actually run the tests, because
     # they start faster (and are cheaper).
     runs-on: ${{ case(needs.check-paths.outputs.should-run == 'true', matrix.runs-on, 'ubuntu-latest') }}
+    # Cap the job so a wedged setup or build step fails in 2h instead of
+    # inheriting GitHub's 6h default. The slowest real job (macos bats-app) runs
+    # ~90m, so 120m leaves margin.
+    timeout-minutes: 120
     steps:
     - name: "Linux: Install prerequisites"
       if: needs.check-paths.outputs.should-run && runner.os == 'Linux'
@@ -99,7 +103,7 @@ jobs:
         readlink -f bin >> "$GITHUB_PATH"
 
         # Install a newer version of jq
-        wget --output-document=bin/jq https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64
+        wget --timeout=30 --tries=3 --output-document=bin/jq https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64
         chmod a+x bin/jq
 
     - name: "macOS: Install prerequisites"


### PR DESCRIPTION
A `bats-app` job wedged in the Linux "Install prerequisites" step and, with no job-level timeout, would have held the runner until GitHub's 6h default. It was observed running for over 2h before being cancelled.

`timeout-minutes: 120` caps a hang in any setup or build step. The bats invocation itself is already bounded by `BATS_TIMEOUT` (60m), and the slowest real job (macos bats-app) runs ~90m all-in, so 120m leaves margin without false-failing slow runs.

The `wget` of jq had no timeout, so a stalled download could retry for a long time; `--timeout=30 --tries=3` bounds it. That is the most likely cause of this stall, though the in-progress job's logs were not available to confirm.
