### PR TITLE
RDA: Preferences: VM (memory & CPU)

### DIFF
--- a/e2e/pages/preferences/index.ts
+++ b/e2e/pages/preferences/index.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { expect, Page, Locator } from '@playwright/test';
 
 import { ApplicationNav } from './application';
 import { ContainerEngineNav } from './containerEngine';
@@ -8,6 +8,7 @@ import { WslNav } from './wsl';
 
 export class PreferencesPage {
   readonly page:            Page;
+  readonly body:            Locator;
   readonly application:     ApplicationNav;
   readonly virtualMachine:  VirtualMachineNav;
   readonly containerEngine: ContainerEngineNav;
@@ -16,6 +17,7 @@ export class PreferencesPage {
 
   constructor(page: Page) {
     this.page = page;
+    this.body = page.getByTestId('preferences-body');
     this.application = new ApplicationNav(page);
     this.virtualMachine = new VirtualMachineNav(page);
     this.containerEngine = new ContainerEngineNav(page);

--- a/e2e/pages/preferences/kubernetes.ts
+++ b/e2e/pages/preferences/kubernetes.ts
@@ -12,7 +12,7 @@ export class KubernetesNav {
 
   constructor(page: Page) {
     this.page = page;
-    this.nav = page.locator('[data-test="nav-kubernetes"]');
+    this.nav = page.getByTestId('nav-kubernetes');
     this.kubernetesToggle = RDCheckbox(page.locator('[data-test="kubernetesToggle"]'));
     this.kubernetesVersion = page.locator('[data-test="kubernetesVersion"] select');
     this.kubernetesOptions = page.locator('[data-test="kubernetesOptions"]');

--- a/e2e/pages/preferences/virtualMachine.ts
+++ b/e2e/pages/preferences/virtualMachine.ts
@@ -1,10 +1,20 @@
 import type { Page, Locator } from '@playwright/test';
 
+class RDSlider {
+  readonly value: Locator;
+  readonly marks: Locator;
+
+  constructor(public container: Locator) {
+    this.value = container.locator('input.slider-input');
+    this.marks = container.locator('.vue-slider-mark');
+  }
+}
+
 export class VirtualMachineNav {
   readonly page:            Page;
   readonly nav:             Locator;
-  readonly memory:          Locator;
-  readonly cpus:            Locator;
+  readonly memory:          RDSlider;
+  readonly cpus:            RDSlider;
   readonly mountType:       Locator;
   readonly reverseSshFs:    Locator;
   readonly ninep:           Locator;
@@ -23,9 +33,9 @@ export class VirtualMachineNav {
 
   constructor(page: Page) {
     this.page = page;
-    this.nav = page.locator('[data-test="nav-virtual-machine"]');
-    this.memory = page.locator('#memoryInGBWrapper');
-    this.cpus = page.locator('#numCPUWrapper');
+    this.nav = page.getByTestId('nav-virtual-machine');
+    this.memory = new RDSlider(page.locator('#memoryInGBWrapper'));
+    this.cpus = new RDSlider(page.locator('#numCPUWrapper'));
     this.mountType = page.locator('[data-test="mountType"]');
     this.reverseSshFs = page.locator('[data-test="reverse-sshfs"]');
     this.ninep = page.locator('[data-test="9p"]');

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -6,17 +6,16 @@ import semver from 'semver';
 import { NavPage } from './pages/nav-page';
 import { PreferencesPage } from './pages/preferences';
 import { KubernetesNav } from './pages/preferences/kubernetes';
+import { VirtualMachineNav } from './pages/preferences/virtualMachine';
 import { rdd, startRancherDesktop, teardown } from './utils/TestUtils';
 
 import type { ElectronApplication } from '@playwright/test';
 
 let mainNav: NavPage;
 
-/**
- * Using test.describe.serial make the test execute step by step, as described on each `test()` order
- * Playwright executes test in parallel by default and it will not work for our app backend loading process.
- * */
-test.describe.serial('Preferences Dialog', () => {
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Preferences Dialog', () => {
   let electronApp: ElectronApplication;
   let prefPage: PreferencesPage;
 
@@ -85,28 +84,36 @@ test.describe.serial('Preferences Dialog', () => {
     await expect(application.pathManagement).toBeVisible();
   });
 
-  test.fixme('should navigate to virtual machine and render hardware tab', async() => {
-    test.skip(os.platform() === 'win32', 'Virtual Machine not available on Windows');
-    const { virtualMachine, application } = prefPage;
+  test.describe('Virtual Machine', () => {
+    let virtualMachine: VirtualMachineNav;
 
-    await virtualMachine.nav.click();
+    test('should navigate to virtual machine', async() => {
+      virtualMachine = prefPage.virtualMachine;
 
-    await expect(application.nav).toHaveClass('preferences-nav-item');
-    await expect(virtualMachine.nav).toHaveClass('preferences-nav-item active');
+      await virtualMachine.nav.click();
 
-    await expect(virtualMachine.tabHardware).toHaveText('Hardware');
-    await expect(virtualMachine.tabVolumes).toBeVisible();
-    await expect(virtualMachine.tabVolumes).toHaveText('Volumes');
+      await expect(virtualMachine.nav).toHaveClass('preferences-nav-item active');
+      await expect(prefPage.body).toHaveAttribute('data-test-component', 'Virtual Machine');
+    });
 
-    if (os.platform() === 'darwin') {
-      await expect(virtualMachine.tabEmulation).toBeVisible();
-      await expect(virtualMachine.tabEmulation).toHaveText('Emulation');
-    } else {
-      await expect(virtualMachine.tabEmulation).not.toBeVisible();
-    }
+    test('should render hardware tab', async() => {
+      await expect(virtualMachine.tabHardware).toBeVisible();
+      await virtualMachine.tabHardware.click();
 
-    await expect(virtualMachine.memory).toBeVisible();
-    await expect(virtualMachine.cpus).toBeVisible();
+      // The max values are from `mock/hostinfo_reconciler.go`.
+
+      await expect(virtualMachine.memory.container).toBeVisible();
+      await expect(virtualMachine.memory.marks.first()).toHaveText('2');
+      await expect(virtualMachine.memory.marks.last()).toHaveText('12');
+      await virtualMachine.memory.marks.getByText('8').click();
+      await expect(virtualMachine.memory.value).toHaveValue('8');
+
+      await expect(virtualMachine.cpus.container).toBeVisible();
+      await expect(virtualMachine.cpus.marks.first()).toHaveText('2');
+      await expect(virtualMachine.cpus.marks.last()).toHaveText('32');
+      await virtualMachine.cpus.marks.getByText('10').click();
+      await expect(virtualMachine.cpus.value).toHaveValue('10');
+    });
   });
 
   test.fixme('should render volumes tab', async() => {
@@ -189,30 +196,39 @@ test.describe.serial('Preferences Dialog', () => {
 
   test.describe('Kubernetes', () => {
     let kubernetes: KubernetesNav;
+
     test('should navigate to kubernetes', async() => {
       kubernetes = prefPage.kubernetes;
 
       await kubernetes.nav.click();
 
       await expect(kubernetes.nav).toHaveClass('preferences-nav-item active');
-      await expect(kubernetes.kubernetesToggle).toBeVisible();
-      await expect(kubernetes.kubernetesVersion).toBeVisible();
+      await expect(prefPage.body).toHaveAttribute('data-test-component', 'Kubernetes');
     });
 
     test('Kubernetes enabled checkbox should exist', async() => {
       await expect(kubernetes.kubernetesToggle).toBeVisible();
+      await expect(kubernetes.kubernetesVersion).toBeVisible();
+
       await kubernetes.kubernetesToggle.uncheck();
       await expect(kubernetes.kubernetesToggle).not.toBeChecked();
       await expect(kubernetes.kubernetesVersion).toBeDisabled();
+
       await kubernetes.kubernetesToggle.check();
       await expect(kubernetes.kubernetesToggle).toBeChecked();
     });
 
     test('Kubernetes version dropdown should have the correct versions', async() => {
+      await kubernetes.kubernetesToggle.check();
+      await expect(kubernetes.kubernetesToggle).toBeChecked();
       await expect(kubernetes.kubernetesVersion).toBeVisible();
       await expect(kubernetes.kubernetesVersion).toBeEnabled();
+
       const options = kubernetes.kubernetesVersion.locator('option');
+      // Check `stable` and `latest` separately, to avoid assuming order.
+      // It is also possible that they are on the same version.
       await expect(options).toContainText(['stable']);
+      await expect(options).toContainText(['latest']);
 
       const namespace = await rdd('ctl', 'get', 'app/app', '--output=jsonpath={.spec.namespace}');
       const versionsText = await rdd('ctl', 'get', 'configmap/k3s-versions',
@@ -231,7 +247,7 @@ test.describe.serial('Preferences Dialog', () => {
         return [version, channels.sort()] as const;
       }).filter(([_, channels]) => channels.length > 0);
       const recommendedLabels = recommendedVersions.map(([version, channels]) => {
-        const filteredChannels = channels.filter(c => !/^\d+\.\d+/.test(c));
+        const filteredChannels = channels.filter(c => !/^v?\d+\.\d+/.test(c));
         if (filteredChannels.length === 0) {
           return version;
         }

--- a/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
@@ -1,56 +1,42 @@
-<script lang="ts">
-import os from 'os';
+<script lang="ts" setup>
 
-import { Component, defineComponent } from 'vue';
-import { mapGetters, mapState } from 'vuex';
+import { Component, computed } from 'vue';
+import { useStore } from 'vuex';
 
 import PreferencesVirtualMachineEmulation from '@pkg/components/Preferences/VirtualMachineEmulation.vue';
 import PreferencesVirtualMachineHardware from '@pkg/components/Preferences/VirtualMachineHardware.vue';
 import PreferencesVirtualMachineVolumes from '@pkg/components/Preferences/VirtualMachineVolumes.vue';
 import RdTabbed from '@pkg/components/Tabbed/RdTabbed.vue';
 import Tab from '@pkg/components/Tabbed/Tab.vue';
-import { Settings } from '@pkg/config/settings';
-import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 
-import type { PropType } from 'vue';
+import type { ComputedRef } from 'vue';
 
-export default defineComponent({
-  name:       'preferences-body-virtual-machine',
-  components: {
-    RdTabbed,
-    Tab,
-    PreferencesVirtualMachineHardware,
-    PreferencesVirtualMachineVolumes,
-    PreferencesVirtualMachineEmulation,
-  },
-  props: {
-    preferences: {
-      type:     Object as PropType<Settings>,
-      required: true,
-    },
-  },
-  computed: {
-    ...mapGetters('preferences', ['isPlatformWindows']),
-    ...mapGetters('transientSettings', ['getActiveTab']),
-    ...mapState('credentials', ['credentials']),
-    activeTab(): string {
-      return this.getActiveTab || 'hardware';
-    },
-    isPlatformDarwin(): boolean {
-      return os.platform() === 'darwin';
-    },
-  },
-  methods: {
-    async tabSelected({ tab }: { tab: Component }) {
-      if (this.activeTab !== tab.name) {
-        await this.navigate('Virtual Machine', tab.name || '');
-      }
-    },
-    async navigate(navItem: string, tab: string) {
-      // TODO: Implement.
-    },
-  },
+defineOptions({ name: 'preferences-body-virtual-machine' });
+
+type tabName = typeof store.state['transient-preferences']['navigation']['preferences']['virtual-machine'];
+
+const store = useStore();
+const preferences = computed(() => store.getters['preferences/preferences']);
+const navigation = computed(() => store.state['transient-preferences'].navigation);
+const activeTab = computed((): tabName => navigation.value?.preferences?.['virtual-machine'] || 'hardware');
+
+const componentFromTab: ComputedRef<Component> = computed(() => {
+  return ({
+    hardware:  PreferencesVirtualMachineHardware,
+    volumes:   PreferencesVirtualMachineVolumes,
+    emulation: PreferencesVirtualMachineEmulation,
+  } as const)[activeTab.value];
 });
+
+function tabSelected({ selectedName }: { selectedName: tabName }) {
+  if (activeTab.value !== selectedName) {
+    store.dispatch('transient-preferences/navigate', { 'preferences.virtual-machine': selectedName })
+      // TODO: Actual error handling
+      // https://github.com/rancher-sandbox/rancher-desktop-2/issues/574
+      .catch(console.error);
+  }
+}
+
 </script>
 
 <template>
@@ -64,26 +50,28 @@ export default defineComponent({
   >
     <template #tabs>
       <tab
-        v-if="isPlatformDarwin"
-        label="Emulation"
-        name="emulation"
-        :weight="1"
+        label="Hardware"
+        name="hardware"
+        :weight="4"
       />
+      <!--
       <tab
         label="Volumes"
         name="volumes"
         :weight="3"
       />
       <tab
-        label="Hardware"
-        name="hardware"
-        :weight="4"
+        v-if="isPlatformDarwin"
+        label="Emulation"
+        name="emulation"
+        :weight="1"
       />
+      -->
     </template>
     <div class="virtual-machine-content">
       <component
         v-bind="$attrs"
-        :is="`preferences-virtual-machine-${activeTab}`"
+        :is="componentFromTab"
         :preferences="preferences"
       />
     </div>

--- a/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
@@ -8,6 +8,7 @@ import PreferencesVirtualMachineHardware from '@pkg/components/Preferences/Virtu
 import PreferencesVirtualMachineVolumes from '@pkg/components/Preferences/VirtualMachineVolumes.vue';
 import RdTabbed from '@pkg/components/Tabbed/RdTabbed.vue';
 import Tab from '@pkg/components/Tabbed/Tab.vue';
+import { preferencesNavItems } from '@pkg/window/preferenceConstants';
 
 import type { ComputedRef } from 'vue';
 
@@ -19,6 +20,7 @@ const store = useStore();
 const preferences = computed(() => store.getters['preferences/preferences']);
 const navigation = computed(() => store.state['transient-preferences'].navigation);
 const activeTab = computed((): tabName => navigation.value?.preferences?.['virtual-machine'] || 'hardware');
+const tabs = computed(() => preferencesNavItems['Virtual Machine'].tabs);
 
 const componentFromTab: ComputedRef<Component> = computed(() => {
   return ({
@@ -50,23 +52,12 @@ function tabSelected({ selectedName }: { selectedName: tabName }) {
   >
     <template #tabs>
       <tab
-        label="Hardware"
-        name="hardware"
-        :weight="4"
+        v-for="([name, label], index) in tabs"
+        :key="name"
+        :label="label"
+        :name="name"
+        :weight="tabs.length - index"
       />
-      <!--
-      <tab
-        label="Volumes"
-        name="volumes"
-        :weight="3"
-      />
-      <tab
-        v-if="isPlatformDarwin"
-        label="Emulation"
-        name="emulation"
-        :weight="1"
-      />
-      -->
     </template>
     <div class="virtual-machine-content">
       <component

--- a/pkg/rancher-desktop/components/Preferences/ModalBody.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalBody.vue
@@ -31,7 +31,11 @@ const componentFromNavItem: ComputedRef<Component> = computed(() => {
 </script>
 
 <template>
-  <div class="preferences-body">
+  <div
+    class="preferences-body"
+    data-testid="preferences-body"
+    :data-test-component="currentNavItem"
+  >
     <slot>
       <component
         v-bind="$attrs"

--- a/pkg/rancher-desktop/components/Preferences/ModalNav.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalNav.vue
@@ -32,7 +32,7 @@ function navToKebab(navItem: preferencesNavItemName): string {
     <nav-item
       v-for="navItem in navItems"
       :key="navItem"
-      :data-test="navToKebab(navItem)"
+      :data-testid="navToKebab(navItem)"
       :name="navItem"
       :active="currentNavItem === navItem"
       @click="navClicked"

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineHardware.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineHardware.vue
@@ -1,61 +1,61 @@
-<script lang="ts">
-import os from 'os';
-
-import { defineComponent } from 'vue';
-import { mapGetters } from 'vuex';
+<script lang="ts" setup>
+import { computed, onBeforeMount, onBeforeUnmount } from 'vue';
+import { useStore } from 'vuex';
 
 import SystemPreferences from '@pkg/components/SystemPreferences.vue';
-import { defaultSettings, Settings } from '@pkg/config/settings';
-import { RecursiveTypes } from '@pkg/utils/typeUtils';
+import { quantityToScalar } from '@rdd-client';
 
-import type { PropType } from 'vue';
+defineOptions({ name: 'preferences-virtual-machine-hardware' });
 
-export default defineComponent({
-  name:       'preferences-virtual-machine-hardware',
-  components: { SystemPreferences },
-  props:      {
-    preferences: {
-      type:     Object as PropType<Settings>,
-      required: true,
-    },
-  },
-  data() {
-    return { settings: defaultSettings };
-  },
-  computed: {
-    ...mapGetters('preferences', ['isPreferenceLocked']),
-    hasSystemPreferences(): boolean {
-      return !os.platform().startsWith('win');
-    },
-    availMemoryInGB(): number {
-      return Math.ceil(os.totalmem() / 2 ** 30);
-    },
-    availNumCPUs(): number {
-      return os.cpus().length;
-    },
-  },
-  methods: {
-    onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
-      this.$store.dispatch('preferences/updatePreferencesData', { property, value });
-    },
-  },
+const gigaScale = BigInt(2) ** BigInt(30);
+const store = useStore();
+const preferences = computed(() => store.getters['preferences/preferences']);
+const isPreferenceLocked = computed(() => store.getters['preferences/isPreferenceLocked']);
+const memoryInGB = computed(() => {
+  // quantityToScalar will return BigInts in our case; convert it to gigabytes,
+  // at which point it should be reasonable for us.
+  const memoryInBytes = BigInt(quantityToScalar(preferences.value?.virtualMachine?.memory ?? '2Gi'));
+  return Number(memoryInBytes / gigaScale);
 });
+const hostInfo = computed(() => store.state.rdd.hostInfos?.[0]);
+const availMemoryInGB = computed(() => {
+  const memoryInBytes = BigInt(hostInfo.value?.status?.memory || BigInt(2) * gigaScale);
+  return Number(memoryInBytes / gigaScale);
+});
+const availNumCPUs = computed(() => hostInfo.value?.status?.cpus || 1);
+
+function setCPUs(value: number) {
+  store.dispatch('preferences/modify', { key: 'virtualMachine.cpus', value });
+}
+
+function setMemory(value: number) {
+  // The value is in GB; always add the `Gi` suffix when storing it.
+  store.dispatch('preferences/modify', { key: 'virtualMachine.memory', value: value + 'Gi' });
+}
+
+onBeforeMount(() => {
+  store.dispatch('rdd/watchResources', ['hostInfos']);
+});
+
+onBeforeUnmount(() => {
+  store.dispatch('rdd/unwatchResources', ['hostInfos']);
+});
+
 </script>
 
 <template>
   <div class="virtual-machine-hardware">
     <system-preferences
-      v-if="hasSystemPreferences"
-      :memory-in-g-b="preferences.virtualMachine.memoryInGB"
-      :number-c-p-us="preferences.virtualMachine.numberCPUs"
+      :memory-in-g-b="memoryInGB"
+      :number-c-p-us="preferences?.virtualMachine?.cpus ?? 1"
       :avail-memory-in-g-b="availMemoryInGB"
       :avail-num-c-p-us="availNumCPUs"
       :reserved-memory-in-g-b="6"
       :reserved-num-c-p-us="1"
-      :is-locked-memory="isPreferenceLocked('virtualMachine.memoryInGB')"
-      :is-locked-cpu="isPreferenceLocked('virtualMachine.numberCPUs')"
-      @update:memory="onChange('virtualMachine.memoryInGB', $event)"
-      @update:cpu="onChange('virtualMachine.numberCPUs', $event)"
+      :is-locked-memory="isPreferenceLocked('virtualMachine.memory')"
+      :is-locked-cpu="isPreferenceLocked('virtualMachine.cpus')"
+      @update:memory="setMemory($event)"
+      @update:cpu="setCPUs($event)"
     />
   </div>
 </template>

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineHardware.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineHardware.vue
@@ -3,7 +3,7 @@ import { computed, onBeforeMount, onBeforeUnmount } from 'vue';
 import { useStore } from 'vuex';
 
 import SystemPreferences from '@pkg/components/SystemPreferences.vue';
-import { quantityToScalar } from '@rdd-client';
+import parseQuantity from '@pkg/utils/parseQuantity';
 
 defineOptions({ name: 'preferences-virtual-machine-hardware' });
 
@@ -14,7 +14,7 @@ const isPreferenceLocked = computed(() => store.getters['preferences/isPreferenc
 const memoryInGB = computed(() => {
   // quantityToScalar will return BigInts in our case; convert it to gigabytes,
   // at which point it should be reasonable for us.
-  const memoryInBytes = BigInt(quantityToScalar(preferences.value?.virtualMachine?.memory ?? '2Gi'));
+  const memoryInBytes = parseQuantity(preferences.value?.virtualMachine?.memory ?? '2Gi');
   return Number(memoryInBytes / gigaScale);
 });
 const hostInfo = computed(() => store.state.rdd.hostInfos?.[0]);

--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -4,43 +4,40 @@ import mainEvents from '@pkg/main/mainEvents';
 import type { TransientPreferencesState } from '@pkg/types/transientPreferences';
 
 type PrefNav = TransientPreferencesState['navigation']['preferences'];
-type LowerKebabCase<K extends string> = K extends `${ infer P } ${ infer R }`
-  ? `${ Lowercase<P> }-${ LowerKebabCase<R> }`
-  : Lowercase<K>;
 /** TopKey is any key for the top-level preferences. */
-type TopKey = LowerKebabCase<PrefNav['top']> | Exclude<keyof PrefNav, 'top'>;
+type TopKey = Exclude<keyof PrefNav, 'top'>;
 /** TabKey is the preference mapping key, as `<top>/<inner tab>`. */
 type TabKey = {
   [K in TopKey]:
-  LowerKebabCase<K> extends keyof PrefNav
-    ? `${ LowerKebabCase<K> }/${ PrefNav[LowerKebabCase<K>] }`
-    : LowerKebabCase<K>;
+  [PrefNav[K]] extends [never]
+    ? K
+    : `${ K }/${ PrefNav[K] }`
 }[TopKey];
 
 const baseUrl = process.env.RD_DOCS_URL ?? 'https://docs.rancherdesktop.io';
 
 class PreferencesHelp {
   private readonly mapping = {
-    'application/behavior':            'ui/preferences/application/behavior',
-    'application/environment':         'ui/preferences/application/environment',
+    // 'application/behavior':            'ui/preferences/application/behavior',
+    // 'application/environment':         'ui/preferences/application/environment',
     'application/general':             'ui/preferences/application/general',
     'virtual-machine/hardware':        'ui/preferences/virtual-machine/hardware',
-    'virtual-machine/volumes':         'ui/preferences/virtual-machine/volumes',
-    'virtual-machine/emulation':       'ui/preferences/virtual-machine/emulation',
-    'container-engine/general':        'ui/preferences/container-engine/general',
-    'container-engine/allowed-images': 'ui/preferences/container-engine/allowed-images',
-    'wsl/integrations':                'ui/preferences/wsl/integrations',
-    'wsl/proxy':                       'ui/preferences/wsl/proxy',
+    // 'virtual-machine/volumes':         'ui/preferences/virtual-machine/volumes',
+    // 'virtual-machine/emulation':       'ui/preferences/virtual-machine/emulation',
+    // 'container-engine/general':        'ui/preferences/container-engine/general',
+    // 'container-engine/allowed-images': 'ui/preferences/container-engine/allowed-images',
+    // 'wsl/integrations':                'ui/preferences/wsl/integrations',
+    // 'wsl/proxy':                       'ui/preferences/wsl/proxy',
     kubernetes:                        'ui/preferences/kubernetes',
-  } as const satisfies Partial<Record<TabKey, string>>;
+  } as const satisfies Record<TabKey, `ui/preferences/${ string }`>;
 
   async openUrl() {
     const transientPreferences = await mainEvents.invoke('transient-preferences/get');
     const { preferences } = transientPreferences.navigation;
     const { top } = preferences;
     type topKeys = Exclude<keyof typeof preferences, 'top'>;
-    const current = top.toLowerCase().replace(/ /g, '-') as LowerKebabCase<typeof top>;
-    const tab = current in preferences ? `/${ preferences[current as topKeys] }` as const : '';
+    const current = top.toLowerCase().replace(/ /g, '-') as topKeys;
+    const tab = current in preferences ? `/${ preferences[current] }` as const : '';
     const key = `${ current }${ tab }` as const;
     let url = baseUrl;
 

--- a/pkg/rancher-desktop/pages/Preferences.vue
+++ b/pkg/rancher-desktop/pages/Preferences.vue
@@ -22,7 +22,7 @@ const store = useStore();
 const navigation = computed(() => store.state['transient-preferences'].navigation);
 const committed = computed(() => store.getters['preferences/committed']);
 const hasPreferences = computed(() => Object.keys(committed.value).length > 0);
-const navItems = computed(() => preferencesNavItems.map(({ name }) => name));
+const navItems = computed(() => Object.keys(preferencesNavItems) as preferencesNavItemName[]);
 const currentNavItem = computed(() => navigation.value.preferences.top);
 
 async function navChanged(current: preferencesNavItemName) {

--- a/pkg/rancher-desktop/store/__tests__/transient-preferences.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/transient-preferences.spec.ts
@@ -40,12 +40,12 @@ describe('transient-preferences', () => {
     it('SET_ALL should assign incoming partial preferences onto state', () => {
       const state = stateFn();
 
-      state.navigation.preferences.application = 'environment';
+      state.navigation.preferences.application = 'general';
       mutations.SET_ALL(state, { __test: { value: 123 } } as any);
 
       expect((state as any).__test.value).toBe(123);
       // It should not have removed existing keys.
-      expect(state.navigation.preferences.application).toBe('environment');
+      expect(state.navigation.preferences.application).toBe('general');
     });
 
     it('navigate should set navigation keys using dot notation', () => {

--- a/pkg/rancher-desktop/store/rdd.ts
+++ b/pkg/rancher-desktop/store/rdd.ts
@@ -28,6 +28,12 @@ const resources = [
     path:       () => '/apis/app.rancherdesktop.io/v1alpha1/apps',
     makeClient: config => config.makeApiClient(RDDClient.AppRancherdesktopIoV1alpha1Api),
   }),
+  defineResource({
+    name:       'hostInfos',
+    type:       'HostInfo',
+    path:       () => '/apis/rdd.rancherdesktop.io/v1alpha1/hostinfos',
+    makeClient: config => config.makeApiClient(RDDClient.RddRancherdesktopIoV1alpha1Api),
+  }),
 ] as const;
 
 export const state = () => ({

--- a/pkg/rancher-desktop/types/transientPreferences.ts
+++ b/pkg/rancher-desktop/types/transientPreferences.ts
@@ -1,4 +1,4 @@
-import { preferencesNavItemName, preferencesNavItems } from '@pkg/window/preferenceConstants';
+import { preferencesNavDefaults } from '@pkg/window/preferenceConstants';
 
 /**
  * TransientPreferencesState is the state for the transient preferences; it
@@ -13,13 +13,7 @@ export type TransientPreferencesState = typeof defaultTransientPreferences;
 const defaultTransientPreferences = {
   /** navigation state, e.g. which tab is selected */
   navigation: {
-    preferences: {
-      top:                preferencesNavItems[0].name as preferencesNavItemName,
-      application:        'general' as 'general' | 'behavior' | 'environment',
-      'virtual-machine':  'hardware' as 'hardware' | 'volumes' | 'emulation',
-      wsl:                'integrations' as 'integrations' | 'proxy',
-      'container-engine': 'general' as 'general' | 'allowed-images',
-    },
+    preferences: preferencesNavDefaults,
   },
 };
 

--- a/pkg/rancher-desktop/utils/__tests__/parseQuantity.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/parseQuantity.spec.ts
@@ -1,0 +1,66 @@
+import parseQuantity from '../parseQuantity';
+
+describe('parseQuantity', () => {
+  test('returns 0n for undefined/empty', () => {
+    expect(parseQuantity(undefined)).toBe(0n);
+    expect(parseQuantity('')).toBe(0n);
+    expect(parseQuantity('   ')).toBe(0n);
+  });
+
+  test('parses plain bytes', () => {
+    expect(parseQuantity('0')).toBe(0n);
+    expect(parseQuantity('123')).toBe(123n);
+    expect(parseQuantity('123B')).toBe(123n);
+  });
+
+  test('parses BinarySI', () => {
+    expect(parseQuantity('1Ki')).toBe(1024n);
+    expect(parseQuantity('1.5KiB')).toBe(1536n);
+    expect(parseQuantity('2Mi')).toBe(2n * (2n ** 20n));
+  });
+
+  test('parses DecimalSI', () => {
+    expect(parseQuantity('1k')).toBe(1_000n);
+    expect(parseQuantity('1K')).toBe(1_000n);
+    expect(parseQuantity('1M')).toBe(1_000_000n);
+    expect(parseQuantity('1MB')).toBe(1_000_000n);
+    expect(parseQuantity('1.5K')).toBe(1_500n);
+  });
+
+  test('parses DecimalSI sub-byte quantities (truncate toward zero)', () => {
+    expect(parseQuantity('1m')).toBe(0n);
+    expect(parseQuantity('1500m')).toBe(1n);
+    expect(parseQuantity('1u')).toBe(0n);
+    expect(parseQuantity('1n')).toBe(0n);
+  });
+
+  test('parses decimal exponent', () => {
+    expect(parseQuantity('1e3')).toBe(1_000n);
+    expect(parseQuantity('1.5e3')).toBe(1_500n);
+    expect(parseQuantity('2E+3')).toBe(2_000n);
+    expect(parseQuantity('2E-1')).toBe(0n);
+    expect(parseQuantity('1e3B')).toBe(1_000n);
+  });
+
+  test('parses signed values', () => {
+    expect(parseQuantity('+2Ki')).toBe(2n * 1024n);
+    expect(parseQuantity('-1.5Ki')).toBe(-1536n);
+  });
+
+  test('parses with whitespace', () => {
+    expect(parseQuantity('  10  MiB')).toBe(10n * (2n ** 20n));
+    expect(parseQuantity('5 Gi')).toBe(5n * (2n ** 30n));
+  });
+
+  test('throws on unknown suffix', () => {
+    expect(() => parseQuantity('1mi')).toThrow('Unknown units: mi');
+    expect(() => parseQuantity('1Zi')).toThrow('Unknown units: Zi');
+    expect(() => parseQuantity('1MBi')).toThrow('Unknown units: MBi');
+  });
+
+  test('throws on malformed quantity', () => {
+    expect(() => parseQuantity('abc')).toThrow('Malformed quantity: abc');
+    expect(() => parseQuantity('Ki')).toThrow('Malformed quantity: Ki');
+    expect(() => parseQuantity('1..2')).toThrow('Malformed quantity: 1..2');
+  });
+});

--- a/pkg/rancher-desktop/utils/parseQuantity.ts
+++ b/pkg/rancher-desktop/utils/parseQuantity.ts
@@ -1,0 +1,73 @@
+/**
+ * Parse a Kubernetes-style quantity string into bytes.
+ * @note Values are truncated toward zero.
+ */
+export default function parseQuantity(value: string | undefined): bigint {
+  if (value === undefined) {
+    return 0n;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return 0n;
+  }
+
+  const [, numeral, rawSuffix] = /^([+-]?[0-9.]+)\s*([^0-9.]\S*)?$/.exec(trimmed) ?? [];
+  if (numeral === undefined) {
+    throw new Error(`Malformed quantity: ${ trimmed }`);
+  }
+  const suffix = rawSuffix?.replace(/B$/, '') ?? ''; // remove trailing B if present
+
+  let scale = 1n; // Negative scale means divide.
+  const scaleMapping: Record<string, bigint> = {
+    '': 1n,
+    n:  -(10n ** 9n),
+    u:  -(10n ** 6n),
+    µ:  -(10n ** 6n),
+    μ:  -(10n ** 6n),
+    m:  -(10n ** 3n),
+    k:  10n ** 3n,
+    K:  10n ** 3n,
+    M:  10n ** 6n,
+    G:  10n ** 9n,
+    T:  10n ** 12n,
+    P:  10n ** 15n,
+    E:  10n ** 18n,
+    Ki: 2n ** 10n,
+    Mi: 2n ** 20n,
+    Gi: 2n ** 30n,
+    Ti: 2n ** 40n,
+    Pi: 2n ** 50n,
+    Ei: 2n ** 60n,
+  };
+
+  if (suffix in scaleMapping) {
+    scale = scaleMapping[suffix];
+  } else {
+    const [, sign, exponent] = /^[eE]([+-]?)(\d+)$/.exec(suffix) ?? [];
+    if (exponent !== undefined) {
+      scale *= 10n ** BigInt(exponent);
+      if (sign === '-') {
+        scale = -scale;
+      }
+    } else {
+      throw new Error(`Unknown units: ${ rawSuffix || trimmed }`);
+    }
+  }
+
+  const [, sign, whole, fraction = '0'] = /^([+-]?)([0-9]+)?(?:\.([0-9]+))?$/.exec(numeral) ?? [];
+
+  if (whole === undefined) {
+    throw new Error(`Malformed quantity: ${ trimmed }`);
+  }
+
+  const denom = 10n ** BigInt(fraction.length);
+  const numer = (BigInt(whole) * denom + BigInt(fraction)) * (sign === '-' ? -1n : 1n);
+
+  if (scale < 0n) {
+    return numer / (-scale * denom);
+  }
+
+  return (numer * scale) / denom;
+}

--- a/pkg/rancher-desktop/utils/typeUtils.ts
+++ b/pkg/rancher-desktop/utils/typeUtils.ts
@@ -33,7 +33,7 @@ type UpperAlpha =
   'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z';
 
 /** Alpha is the set of upper- or lower-case alphabets. */
-type Alpha<T> = T extends UpperAlpha ? T : T extends Lowercase<UpperAlpha> ? T : never;
+export type Alpha<T> = T extends UpperAlpha ? T : T extends Lowercase<UpperAlpha> ? T : never;
 
 type UpperSnakeCaseInner<T extends string> =
   T extends '' ? never :

--- a/pkg/rancher-desktop/window/preferenceConstants.ts
+++ b/pkg/rancher-desktop/window/preferenceConstants.ts
@@ -1,4 +1,12 @@
-export const preferencesNavItems = [
+import _ from 'lodash';
+
+import type { Alpha } from '@pkg/utils/typeUtils';
+
+/**
+ * prefItemData is the list of navigation items and their associated tabs for
+ * the preferences window.
+ */
+const prefItemData = [
   {
     name: 'Application',
     tabs: ['general'/* 'behavior', 'environment' */],
@@ -12,5 +20,68 @@ export const preferencesNavItems = [
   //   tabs: ['general'/*, 'allowed-images' */],
   // },
   { name: 'Kubernetes' },
-] as const satisfies readonly { name: string; tabs?: readonly string[] }[];
-export type preferencesNavItemName = (typeof preferencesNavItems)[number]['name'];
+] as const satisfies navItemEntry[];
+
+/**
+ * Represents a navigation item entry in the preferences window.
+ */
+interface navItemEntry {
+  applicable?: () => boolean;
+  name:        string;
+  tabs?:       readonly string[];
+}
+
+/**
+ * Represents the result of filtering navigation items
+ * @returns A mapping of top level navigation item name to a list of the tabs
+ * available for that navigation item.
+ */
+type navItemResult<T extends readonly navItemEntry[]> = {
+  [K in T[number]['name']]: Omit<Extract<T[number], { name: K }>, 'applicable' | 'name'> & { index: number };
+};
+
+/**
+ * Filters the navigation items based on the current platform.
+ */
+function filterNavItems<T extends readonly navItemEntry[]>(items: T): navItemResult<T> {
+  return Object.fromEntries(items
+    .filter(item => item.applicable?.() ?? true)
+    .map((item, index) => [item.name, (({ name, applicable, ...rest }) => ({ ...rest, index }))(item)] as const),
+  ) as navItemResult<T>;
+}
+
+export const preferencesNavItems = filterNavItems(prefItemData);
+
+type KebabCase<T extends string> = T extends `${ infer Head }${ infer Tail }`
+  ? `${ Head extends Alpha<Head> ? Lowercase<Head> : KebabCase<Tail> extends `-${ string }` ? '' : '-' }${ KebabCase<Tail> }`
+  : T;
+
+type PreferenceNavTabDefaults = {
+  [K in keyof typeof preferencesNavItems as KebabCase<K>]:
+  (typeof preferencesNavItems)[K] extends { tabs: readonly (infer T)[] } ? T : never;
+};
+
+/**
+ * preferencesNavTabDefaults is the default navigation state for the preferences
+ * window for the tabs of each top level navigation item.
+ */
+const preferencesNavTabDefaults = Object.fromEntries(prefItemData
+  .filter((item): item is typeof item & { tabs: readonly string[] } => {
+    return 'tabs' in item && item.tabs?.length > 0 && !!item.tabs[0];
+  }).map(item => {
+    return [_.kebabCase(item.name), item.tabs[0]] as const;
+  })) as PreferenceNavTabDefaults;
+
+/**
+ * preferencesNavDefaults is the default navigation state for the preferences
+ * window.  This should only be used by transient preferences.
+ */
+export const preferencesNavDefaults = {
+  top: prefItemData[0].name as typeof prefItemData[number]['name'],
+  ...preferencesNavTabDefaults,
+};
+
+/**
+ * preferencesNavItemName is the type of the top level navigation item names.
+ */
+export type preferencesNavItemName = typeof prefItemData[number]['name'];

--- a/pkg/rancher-desktop/window/preferenceConstants.ts
+++ b/pkg/rancher-desktop/window/preferenceConstants.ts
@@ -11,9 +11,17 @@ const prefItemData = [
     name: 'Application',
     tabs: ['general'/* 'behavior', 'environment' */],
   },
+  {
+    // For now, show the Virtual Machine tab on all platforms, per
+    // https://github.com/rancher-sandbox/rancher-desktop-2/issues/581
+    // applicable: () => process.platform === 'darwin' || process.platform === 'linux',
+    name:      'Virtual Machine',
+    tabs:      ['hardware'/*, 'volumes', 'network', 'emulation' */],
+  },
   // {
-  //   name: process.platform === 'win32' ? 'WSL' : 'Virtual Machine',
-  //   tabs: vmTabs,
+  //   applicable: () => process.platform === 'win32',
+  //   name:      'WSL',
+  //   tabs:      ['integrations', 'network', 'proxy'],
   // },
   // {
   //   name: 'Container Engine',

--- a/pkg/rancher-desktop/window/preferenceConstants.ts
+++ b/pkg/rancher-desktop/window/preferenceConstants.ts
@@ -9,23 +9,23 @@ import type { Alpha } from '@pkg/utils/typeUtils';
 const prefItemData = [
   {
     name: 'Application',
-    tabs: ['general'/* 'behavior', 'environment' */],
+    tabs: [['general', 'General']/* 'behavior', 'environment' */],
   },
   {
     // For now, show the Virtual Machine tab on all platforms, per
     // https://github.com/rancher-sandbox/rancher-desktop-2/issues/581
     // applicable: () => process.platform === 'darwin' || process.platform === 'linux',
     name:      'Virtual Machine',
-    tabs:      ['hardware'/*, 'volumes', 'network', 'emulation' */],
+    tabs:      [['hardware', 'Hardware']/*, ['volumes', 'Volumes'], ['network', 'Network'], ['emulation', 'Emulation'] */],
   },
   // {
   //   applicable: () => process.platform === 'win32',
   //   name:      'WSL',
-  //   tabs:      ['integrations', 'network', 'proxy'],
+  //   tabs:      [['integrations', 'Integrations'], ['network', 'Network'], ['proxy', 'Proxy']],
   // },
   // {
   //   name: 'Container Engine',
-  //   tabs: ['general'/*, 'allowed-images' */],
+  //   tabs: [['general', 'General']/*, ['allowed-images', 'Allowed Images'] */],
   // },
   { name: 'Kubernetes' },
 ] as const satisfies navItemEntry[];
@@ -36,7 +36,7 @@ const prefItemData = [
 interface navItemEntry {
   applicable?: () => boolean;
   name:        string;
-  tabs?:       readonly string[];
+  tabs?:       readonly [string, string][];
 }
 
 /**
@@ -66,7 +66,7 @@ type KebabCase<T extends string> = T extends `${ infer Head }${ infer Tail }`
 
 type PreferenceNavTabDefaults = {
   [K in keyof typeof preferencesNavItems as KebabCase<K>]:
-  (typeof preferencesNavItems)[K] extends { tabs: readonly (infer T)[] } ? T : never;
+  (typeof preferencesNavItems)[K] extends { tabs: readonly ([infer T, string])[] } ? T : never;
 };
 
 /**
@@ -74,10 +74,10 @@ type PreferenceNavTabDefaults = {
  * window for the tabs of each top level navigation item.
  */
 const preferencesNavTabDefaults = Object.fromEntries(prefItemData
-  .filter((item): item is typeof item & { tabs: readonly string[] } => {
+  .filter((item): item is typeof item & { tabs: readonly ([string, string])[] } => {
     return 'tabs' in item && item.tabs?.length > 0 && !!item.tabs[0];
   }).map(item => {
-    return [_.kebabCase(item.name), item.tabs[0]] as const;
+    return [_.kebabCase(item.name), item.tabs[0][0]] as const;
   })) as PreferenceNavTabDefaults;
 
 /**

--- a/pkg/rancher-desktop/window/preferences.ts
+++ b/pkg/rancher-desktop/window/preferences.ts
@@ -58,7 +58,7 @@ export function openPreferences() {
       'Close preferences dialog',
     );
 
-    preferencesNavItems.forEach(({ name }, index) => {
+    for (const [name, { index }] of Object.entries(preferencesNavItems)) {
       Shortcuts.register(
         window,
         {
@@ -68,7 +68,7 @@ export function openPreferences() {
         () => window.webContents.send('route', { name }),
         `switch preferences tabs ${ name }`,
       );
-    });
+    }
 
     Shortcuts.register(
       window,

--- a/pkg/rdd-client/index.ts
+++ b/pkg/rdd-client/index.ts
@@ -5,4 +5,5 @@ export * from './middleware';
 export * from './object';
 export * from './patch';
 export * from './types';
+export * from './util';
 export * from './watch';

--- a/rdd/pkg/controllers/mock/hostinfo_reconciler.go
+++ b/rdd/pkg/controllers/mock/hostinfo_reconciler.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package mock
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	rddv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/rdd/v1alpha1"
+)
+
+type hostInfoReconciler struct {
+	client.Client
+}
+
+const hostInfoName = "system"
+
+func (r *hostInfoReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	// For the mock controller, we just always create a hostinfo resource whenever
+	// we get triggered.
+
+	hi := rddv1alpha1.HostInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hostInfoName,
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r, &hi, nil); err != nil {
+		return ctrl.Result{}, err
+	}
+	hi.Status.CPUs = 32
+	hi.Status.Memory = 12 * 1024 * 1024 * 1024
+	if err := r.Status().Update(ctx, &hi); err != nil {
+		logger.Error(err, "Failed to update HostInfo status", "name", hi.Name)
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("reconciled host-info", "name", hi.Name)
+	return ctrl.Result{}, nil
+}
+
+func (r *hostInfoReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("hostinfo_reconciler").
+		// We get triggered on App changes.
+		For(&appv1alpha1.App{}).
+		// We also watch hostinfo changes, to revert them as needed.
+		Watches(&rddv1alpha1.HostInfo{}, handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []ctrl.Request {
+			return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: "unused"}}} // We never actually look at the request.
+		})).
+		Complete(r)
+}

--- a/rdd/pkg/controllers/mock/mock_controller.go
+++ b/rdd/pkg/controllers/mock/mock_controller.go
@@ -19,6 +19,7 @@ import (
 
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
 	containersv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
+	rddv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/rdd/v1alpha1"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/k3sversions/controllers"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 )
@@ -155,6 +156,14 @@ func (c *controller) setupReconciler(ctx context.Context, mgr ctrl.Manager) erro
 		return err
 	}
 
+	log.Info("Setting up Mock HostInfoReconciler")
+	err = (&hostInfoReconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -196,6 +205,9 @@ func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 	if err := containersv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+	if err := rddv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This restores the part of the preferences dialog that adjusts how much CPU & memory are used by the VM.

Per #581, for now we're showing this part even on Windows.  This simplifies the E2E somewhat; we just always test it exists.

As usual, I have tries to make each commit a bit isolated. 