### PR TITLE
Wix: name the installer after the full version

### DIFF
--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -10,7 +10,7 @@
     Id="*"
     Name="$(var.appName)"
     UpgradeCode="{37829D57-C0BA-4A9C-B354-05168523D013}"
-    Version="{{appVersion}}"
+    Version="{{productVersion}}"
     Language="1033"
     Codepage="65001"
     Manufacturer="SUSE">

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -36,12 +36,20 @@ async function getElectronBuilderConfig(appDir: string): Promise<Record<string, 
  * Given an unpacked application directory, return the application version.
  */
 function getAppVersion(appDir: string): string {
-  const packageVersion = getPackageJson(appDir).version;
-  // We have a git describe style version, 1.2.3-1234-gabcdef
-  const [, semver, offset] = /^v?(\d+\.\d+\.\d+)(?:-(\d+))?/.exec(packageVersion) ?? [];
+  return getPackageJson(appDir).version;
+}
+
+/**
+ * Convert an application version into the all-numeric form that Windows
+ * Installer requires for ProductVersion.  A `git describe` style version,
+ * 1.2.3-1234-gabcdef, keeps the commit count as a fourth field; a prerelease
+ * tag has no numeric equivalent, so 2.0.0-alpha.1 collapses to 2.0.0.
+ */
+function getProductVersion(appVersion: string): string {
+  const [, semver, offset] = /^v?(\d+\.\d+\.\d+)(?:-(\d+))?/.exec(appVersion) ?? [];
 
   if (!semver) {
-    throw new Error(`Could not parse version string ${ packageVersion }`);
+    throw new Error(`Could not parse version string ${ appVersion }`);
   }
 
   return offset ? `${ semver }.${ offset }` : semver;
@@ -67,6 +75,7 @@ export async function buildCustomAction(): Promise<string> {
  */
 export default async function buildInstaller(workDir: string, appDir: string, outDir: string): Promise<string> {
   const appVersion = getAppVersion(appDir);
+  const productVersion = getProductVersion(appVersion);
   const electronBuilderConfig = await getElectronBuilderConfig(appDir);
   const { productName } = electronBuilderConfig;
   // Strip any versions, to avoid `Rancher Desktop 2 Setup 1.2.3.msi`.
@@ -77,7 +86,7 @@ export default async function buildInstaller(workDir: string, appDir: string, ou
   await writeUpdateConfig(appDir);
   const fileList = await generateFileList(appDir);
   const template = await fs.promises.readFile(path.join(process.cwd(), 'build', 'wix', 'main.wxs'), 'utf-8');
-  const output = Mustache.render(template, { appVersion, fileList });
+  const output = Mustache.render(template, { productVersion, fileList });
   const wixDir = path.join(process.cwd(), 'resources', 'host', 'wix');
 
   console.log('Writing out WiX definition...');


### PR DESCRIPTION
Fixes #572

Every build off the `2.0.0-alpha.1` tag shipped as `Rancher.Desktop.Setup.2.0.0.msi`, while the other artifacts carry the full version. The name reused the MSI ProductVersion, which Windows Installer requires to be all-numeric, a constraint the file name does not share.

ProductVersion still collapses every alpha to `2.0.0`. I left that alone, because `2.0.0.562` would rank an alpha above the eventual `2.0.0` release and `DowngradeErrorMessage` would then block that install. `AllowSameVersionUpgrades="yes"` keeps alpha-over-alpha upgrades working meanwhile.
