### PR TITLE
Linux: name the executable and desktop files after the package

### DIFF
--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -186,7 +186,7 @@ install_linux() {
     RDD="/opt/rancher-desktop-2/resources/linux/bin/rdd"
     export RDD_VM_CPUS
 
-    /opt/rancher-desktop-2/rancher-desktop &
+    /opt/rancher-desktop-2/rancher-desktop-2 &
 }
 
 # Helper function on Windows to verify the signature of a file (provided as the
@@ -281,7 +281,7 @@ wait_for_backend() {
     while [[ $(date +%s) -lt $deadline ]]; do
         if [[ -n "${APPIMAGE_PID:-}" ]] && [[ -z "${RDD:-}" ]]; then
             local rd_pid
-            rd_pid=$(pidof --separator $'\n' rancher-desktop | sort -n | head -n 1 || echo missing)
+            rd_pid=$(pidof --separator $'\n' rancher-desktop-2 | sort -n | head -n 1 || echo missing)
             if [[ -e "/proc/$rd_pid/exe" ]]; then
                 # The AppImage initialization is complete, we can locate rdd and poll for status.
                 RDD=$(dirname "$(readlink "/proc/$rd_pid/exe")")/resources/linux/bin/rdd

--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -63,7 +63,9 @@ win:
   - { from: dist/electron-builder.yaml, to: electron-builder.yml }
 linux:
   category: Utility
-  executableName: rancher-desktop
+  # Also names the .desktop file and its icon, so it must differ from
+  # Rancher Desktop 1 for parallel installs.
+  executableName: rancher-desktop-2
   artifactName: ${name}-${version}-linux.zip
   target: [ zip ]
 publish:

--- a/packaging/linux/appimage.yml
+++ b/packaging/linux/appimage.yml
@@ -1,4 +1,4 @@
-app: rancher-desktop
+app: rancher-desktop-2
 
 build:
   packages:
@@ -7,10 +7,10 @@ build:
     - libcairo2
 
 script:
-  - rm -rf $BUILD_APPDIR/* && mkdir -p $BUILD_APPDIR/opt/rancher-desktop $BUILD_APPDIR/usr/share/metainfo $BUILD_APPDIR/usr/bin $BUILD_APPDIR/usr/lib64
-  - unzip $BUILD_SOURCE_DIR/rancher-desktop*.zip -d $BUILD_APPDIR/opt/rancher-desktop
-  - chmod 04755 $BUILD_APPDIR/opt/rancher-desktop/chrome-sandbox
-  - mv $BUILD_APPDIR/opt/rancher-desktop/resources/linux/rancher-desktop.desktop $BUILD_APPDIR
-  - convert -resize 512x512 $BUILD_APPDIR/opt/rancher-desktop/resources/icons/logo-square-512.png $BUILD_APPDIR/rancher-desktop.png
+  - rm -rf $BUILD_APPDIR/* && mkdir -p $BUILD_APPDIR/opt/rancher-desktop-2 $BUILD_APPDIR/usr/share/metainfo $BUILD_APPDIR/usr/bin $BUILD_APPDIR/usr/lib64
+  - unzip $BUILD_SOURCE_DIR/rancher-desktop*.zip -d $BUILD_APPDIR/opt/rancher-desktop-2
+  - chmod 04755 $BUILD_APPDIR/opt/rancher-desktop-2/chrome-sandbox
+  - mv $BUILD_APPDIR/opt/rancher-desktop-2/resources/linux/rancher-desktop-2.desktop $BUILD_APPDIR
+  - convert -resize 512x512 $BUILD_APPDIR/opt/rancher-desktop-2/resources/icons/logo-square-512.png $BUILD_APPDIR/rancher-desktop-2.png
   - cp /usr/lib64/libcairo* $BUILD_APPDIR/usr/lib64/
-  - ln -s ../../opt/rancher-desktop/rancher-desktop $BUILD_APPDIR/usr/bin/rancher-desktop
+  - ln -s ../../opt/rancher-desktop-2/rancher-desktop-2 $BUILD_APPDIR/usr/bin/rancher-desktop-2

--- a/packaging/linux/flatpak.yaml
+++ b/packaging/linux/flatpak.yaml
@@ -24,8 +24,8 @@ finish-args:
   - --filesystem=home
   - --talk-name=org.freedesktop.Notifications
   - --own-name=org.kde.*
-rename-desktop-file: rancher-desktop.desktop
-rename-appdata-file: rancher-desktop.appdata.xml
+rename-desktop-file: rancher-desktop-2.desktop
+rename-appdata-file: rancher-desktop-2.appdata.xml
 modules:
   - name: rancher-desktop
     buildsystem: simple
@@ -56,8 +56,8 @@ modules:
           ffmpeg -i "${icon}" -vf scale="${size}" "/app/share/icons/hicolor/${size}/apps/io.rancherdesktop.app2.png"
         done
 
-        mv /app/lib/io.rancherdesktop.app2/resources/linux/rancher-desktop.desktop /app/share/applications
-        mv /app/lib/io.rancherdesktop.app2/resources/linux/rancher-desktop.appdata.xml /app/share/metainfo
+        mv /app/lib/io.rancherdesktop.app2/resources/linux/rancher-desktop-2.desktop /app/share/applications
+        mv /app/lib/io.rancherdesktop.app2/resources/linux/rancher-desktop-2.appdata.xml /app/share/metainfo
       # Install app wrapper
       - install -Dm755 -t /app/bin/ electron-wrapper
     modules:

--- a/packaging/linux/rancher-desktop-2.appdata.xml
+++ b/packaging/linux/rancher-desktop-2.appdata.xml
@@ -11,7 +11,7 @@
     </p>
   </description>
   <provides>
-    <binary>rancher-desktop</binary>
+    <binary>rancher-desktop-2</binary>
   </provides>
   <releases>
     <release version="" date=""/>

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -174,8 +174,8 @@ done
 
 # Desktop integration files
 mkdir -p share/applications share/metainfo
-mv resources/linux/rancher-desktop.desktop share/applications/rancher-desktop.desktop
-mv resources/linux/rancher-desktop.appdata.xml share/metainfo/rancher-desktop.appdata.xml
+mv resources/linux/%{name}.desktop share/applications/%{name}.desktop
+mv resources/linux/%{name}.appdata.xml share/metainfo/%{name}.appdata.xml
 
 %install
 mkdir -p "%{buildroot}%{_prefix}/bin" "%{buildroot}/opt/%{name}"
@@ -185,7 +185,7 @@ rm -rf ./share
 cp -ra ./* "%{buildroot}/opt/%{name}"
 
 # Link to the binary
-ln -sf "/opt/%{name}/rancher-desktop" "%{buildroot}%{_bindir}/rancher-desktop"
+ln -sf "/opt/%{name}/%{name}" "%{buildroot}%{_bindir}/%{name}"
 
 %post
 # This is needed to ensure Debian packages have proper file permissions;
@@ -198,9 +198,9 @@ true
 /opt/%{name}*
 %exclude /opt/%{name}/chrome-sandbox
 %attr(4755,root,root) /opt/%{name}/chrome-sandbox
-%{_bindir}/rancher-desktop
-%{_prefix}/share/applications/rancher-desktop.desktop
+%{_bindir}/%{name}
+%{_prefix}/share/applications/%{name}.desktop
 %{_prefix}/share/icons/hicolor/*
-%{_prefix}/share/metainfo/rancher-desktop.appdata.xml
+%{_prefix}/share/metainfo/%{name}.appdata.xml
 
 %changelog

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -218,7 +218,7 @@ class Builder {
   }
 
   protected async createLinuxResources(config: Configuration) {
-    const appData = 'packaging/linux/rancher-desktop.appdata.xml';
+    const appData = 'packaging/linux/rancher-desktop-2.appdata.xml';
     const input = await fs.promises.readFile(appData, 'utf-8');
     const doc = new DOMParser().parseFromString(input, 'text/xml');
 


### PR DESCRIPTION
The RPM and DEB both installed `/usr/bin/rancher-desktop`, `rancher-desktop.desktop`, and `rancher-desktop.appdata.xml`, so installing them next to Rancher Desktop 1 failed on three file conflicts.

All three names come from `executableName`, which also supplies the `Exec=` and `Icon=` keys of the generated desktop entry. So RD2 was already shipping a launcher that ran RD1's binary and looked for its icon under RD1's name:

```
Exec=rancher-desktop
Icon=rancher-desktop
```

Verified by installing a fixed RPM beside real `rancher-desktop-1.23.1`. The `package` workflow here confirms the generated names: `rancher-desktop-2`, `rancher-desktop-2.desktop`, `Exec=`/`Icon=rancher-desktop-2`.

Found while testing this: `chrome-sandbox` is missing from the RPM and non-setuid in the DEB, tracked separately in #588.

Fixes #509
