### PR TITLE
Linux: ship chrome-sandbox setuid root in the RPM and DEB

### DIFF
--- a/.github/workflows/smoke-test/install-from-repo.sh
+++ b/.github/workflows/smoke-test/install-from-repo.sh
@@ -68,12 +68,24 @@ install_linux_fedora() {
     dnf --assumeyes install "${PACKAGE_NAME}-${version}"
 }
 
+# Chromium only uses its setuid sandbox when the helper is setuid root, so a
+# packaging mistake here degrades the sandbox silently.
+verify_sandbox_helper() {
+    local sandbox="/opt/${PACKAGE_NAME}/chrome-sandbox" mode
+    mode=$(stat --format='%a %U' "$sandbox")
+    if [[ "$mode" != "4755 root" ]]; then
+        printf "%s is '%s', expected '4755 root'\n" "$sandbox" "$mode" >&2
+        exit 1
+    fi
+}
+
 main() {
     RD_VERSION=$(grep --only-matching '\([0-9]\+\.[0-9]\+\)' <<< "$RD_VERSION")
     source /etc/os-release
     for id in ${ID:-} ${ID_LIKE:-}; do
         if [[ "$(type -t "install_linux_$id")" == function ]]; then
             eval "install_linux_$id"
+            verify_sandbox_helper
             exit 0
         fi
     done

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -184,6 +184,10 @@ cp -ra ./share "%{buildroot}%{_prefix}"
 rm -rf ./share
 cp -ra ./* "%{buildroot}/opt/%{name}"
 
+# Chromium's sandbox helper must be setuid root. Set the mode here because
+# debbuild ignores the attributes given in the file list.
+chmod 4755 "%{buildroot}/opt/%{name}/chrome-sandbox"
+
 # Link to the binary
 ln -sf "/opt/%{name}/%{name}" "%{buildroot}%{_bindir}/%{name}"
 
@@ -196,8 +200,6 @@ true
 %defattr(-,root,root,-)
 %dir /opt/%{name}
 /opt/%{name}*
-%exclude /opt/%{name}/chrome-sandbox
-%attr(4755,root,root) /opt/%{name}/chrome-sandbox
 %{_bindir}/%{name}
 %{_prefix}/share/applications/%{name}.desktop
 %{_prefix}/share/icons/hicolor/*


### PR DESCRIPTION
The `%exclude` that silenced the "file listed twice" warning also dropped chrome-sandbox from the RPM. The `%attr` line never worked for the DEB either, because debbuild ignores it once the glob has picked the file up. Setting the mode in `%install` covers both builders and keeps the file list free of duplicates.

OBS builds the real packages and CI never does, so the guard against a repeat goes into the release smoke test, which installs from there.

| variant | Leap 15.6 | Fedora 42 | Tumbleweed | debbuild |
|---|---|---|---|---|
| current | absent | absent | absent | 755 |
| `%exclude` dropped | 4755 | 4755 | 4755 | 755 |
| this PR | 4755 | 4755 | 4755 | 4755 |

Dropping `%exclude` alone, as the issue suggested, fixes only the RPM. RD1's DEB confirms that, since `rancher-desktop_1.23.1-3.1_amd64.deb` from OBS ships chrome-sandbox at 755. This PR leaves RD1 alone.

Fixes #588
