### PR TITLE
RDA: Follow-up to #585

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/ModalNav.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalNav.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import kebabCase from 'lodash/kebabCase';
-
 import NavItem from '@pkg/components/Preferences/ModalNavItem.vue';
 import type { preferencesNavItem } from '@pkg/window/preferenceConstants';
 
@@ -22,11 +20,6 @@ function navClicked(tabName: preferencesNavItemName) {
     emit('nav-changed', tabName);
   }
 }
-
-function navToKebab(navItem: preferencesNavItemName): string {
-  return `nav-${ kebabCase(navItem) }`;
-}
-
 </script>
 
 <template>
@@ -34,7 +27,7 @@ function navToKebab(navItem: preferencesNavItemName): string {
     <nav-item
       v-for="navItem in navItems"
       :key="navItem.name"
-      :data-testid="navToKebab(navItem.name)"
+      :data-testid="`nav-${navItem.name}`"
       :name="navItem.name"
       :active="currentNavItem === navItem.name"
       @click="navClicked"

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineHardware.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineHardware.vue
@@ -7,20 +7,19 @@ import parseQuantity from '@pkg/utils/parseQuantity';
 
 defineOptions({ name: 'preferences-virtual-machine-hardware' });
 
-const gigaScale = BigInt(2) ** BigInt(30);
+const gigaScale = 2 ** 30;
 const store = useStore();
 const preferences = computed(() => store.getters['preferences/preferences']);
 const isPreferenceLocked = computed(() => store.getters['preferences/isPreferenceLocked']);
 const memoryInGB = computed(() => {
-  // quantityToScalar will return BigInts in our case; convert it to gigabytes,
-  // at which point it should be reasonable for us.
+  // parseQuantity returns bytes; that is unreasonable for UI, so convert to GiB.
   const memoryInBytes = parseQuantity(preferences.value?.virtualMachine?.memory ?? '2Gi');
-  return Number(memoryInBytes / gigaScale);
+  return Math.floor(memoryInBytes / gigaScale);
 });
 const hostInfo = computed(() => store.state.rdd.hostInfos?.[0]);
 const availMemoryInGB = computed(() => {
-  const memoryInBytes = BigInt(hostInfo.value?.status?.memory || BigInt(2) * gigaScale);
-  return Number(memoryInBytes / gigaScale);
+  const memoryInBytes = hostInfo.value?.status?.memory || 2 * gigaScale;
+  return Math.floor(memoryInBytes / gigaScale);
 });
 const availNumCPUs = computed(() => hostInfo.value?.status?.cpus || 1);
 

--- a/pkg/rancher-desktop/components/Preferences/__tests__/VirtualMachineHardware.spec.ts
+++ b/pkg/rancher-desktop/components/Preferences/__tests__/VirtualMachineHardware.spec.ts
@@ -1,0 +1,134 @@
+import { jest } from '@jest/globals';
+import { shallowMount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import { createStore } from 'vuex';
+
+import VirtualMachineHardware from '@pkg/components/Preferences/VirtualMachineHardware.vue';
+import SystemPreferences from '@pkg/components/SystemPreferences.vue';
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+mockModules({
+  '@pkg/entry/store': {},
+});
+
+describe('VirtualMachineHardware', () => {
+  function makeStore({
+    memory = '4Gi',
+    cpus = 3,
+    hostMemoryBytes = 16 * 2 ** 30,
+    hostCPUs = 8,
+    locked = new Set<string>(['virtualMachine.memory']),
+  }: {
+    memory?:          string | number;
+    cpus?:            number;
+    hostMemoryBytes?: number;
+    hostCPUs?:        number;
+    locked?:          Set<string>;
+  } = {}) {
+    const modify = jest.fn();
+    const watchResources = jest.fn();
+    const unwatchResources = jest.fn();
+
+    const store = createStore({
+      modules: {
+        preferences: {
+          namespaced: true,
+          getters:    {
+            preferences:        () => ({ virtualMachine: { memory, cpus } }),
+            isPreferenceLocked: () => (key: string) => locked.has(key),
+          },
+          actions: {
+            modify,
+          },
+        },
+        rdd: {
+          namespaced: true,
+          state:      () => ({
+            hostInfos: [{
+              status: {
+                memory: hostMemoryBytes,
+                cpus:   hostCPUs,
+              },
+            }],
+          }),
+          actions: {
+            watchResources,
+            unwatchResources,
+          },
+        },
+      },
+    });
+
+    return { store, actions: { modify, watchResources, unwatchResources } };
+  }
+
+  test('passes computed hardware values and lock states to SystemPreferences', () => {
+    const { store } = makeStore();
+    const wrapper = shallowMount(VirtualMachineHardware, {
+      global: { plugins: [store] },
+    });
+
+    const systemPrefs = wrapper.findComponent(SystemPreferences);
+
+    expect(systemPrefs.exists()).toBe(true);
+    expect(systemPrefs.props('memoryInGB')).toBe(4);
+    expect(systemPrefs.props('numberCPUs')).toBe(3);
+    expect(systemPrefs.props('availMemoryInGB')).toBe(16);
+    expect(systemPrefs.props('availNumCPUs')).toBe(8);
+    expect(systemPrefs.props('reservedMemoryInGB')).toBe(6);
+    expect(systemPrefs.props('reservedNumCPUs')).toBe(1);
+    expect(systemPrefs.props('isLockedMemory')).toBe(true);
+    expect(systemPrefs.props('isLockedCpu')).toBe(false);
+  });
+
+  test.each([
+    ['2560Mi', 2],
+    ['5.Gi', 5],
+    [3 * (2 ** 30), 3],
+  ])('computes memoryInGB from preferences.virtualMachine.memory=%p', (memory, expectedGiB) => {
+    const { store } = makeStore({ memory });
+    const wrapper = shallowMount(VirtualMachineHardware, {
+      global: { plugins: [store] },
+    });
+
+    const systemPrefs = wrapper.findComponent(SystemPreferences);
+
+    expect(systemPrefs.props('memoryInGB')).toBe(expectedGiB);
+  });
+
+  test('watches hostInfos on mount and unwatches on unmount', () => {
+    const { store, actions } = makeStore();
+
+    const wrapper = shallowMount(VirtualMachineHardware, {
+      global: { plugins: [store] },
+    });
+
+    expect(actions.watchResources).toHaveBeenCalledWith(expect.anything(), ['hostInfos']);
+
+    wrapper.unmount();
+
+    expect(actions.unwatchResources).toHaveBeenCalledWith(expect.anything(), ['hostInfos']);
+  });
+
+  test('dispatches preference updates for CPU and memory events', async() => {
+    const { store, actions } = makeStore();
+    const wrapper = shallowMount(VirtualMachineHardware, {
+      global: { plugins: [store] },
+    });
+
+    const systemPrefs = wrapper.findComponent(SystemPreferences);
+
+    systemPrefs.vm.$emit('update:cpu', 6);
+    systemPrefs.vm.$emit('update:memory', 10);
+    await nextTick();
+
+    expect(actions.modify).toHaveBeenCalledWith(expect.anything(), {
+      key:   'virtualMachine.cpus',
+      value: 6,
+    });
+    expect(actions.modify).toHaveBeenCalledWith(expect.anything(), {
+      key:   'virtualMachine.memory',
+      value: '10Gi',
+    });
+  });
+});

--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -2,6 +2,7 @@ import { shell } from 'electron';
 
 import mainEvents from '@pkg/main/mainEvents';
 import type { TransientPreferencesState } from '@pkg/types/transientPreferences';
+import { kebabCase } from '@pkg/utils/string-utils';
 
 type PrefNav = TransientPreferencesState['navigation']['preferences'];
 /** TopKey is any key for the top-level preferences. */
@@ -35,8 +36,7 @@ class PreferencesHelp {
     const transientPreferences = await mainEvents.invoke('transient-preferences/get');
     const { preferences } = transientPreferences.navigation;
     const { top } = preferences;
-    type topKeys = Exclude<keyof typeof preferences, 'top'>;
-    const current = top.toLowerCase().replace(/ /g, '-') as topKeys;
+    const current = kebabCase(top);
     const tab = current in preferences ? `/${ preferences[current] }` as const : '';
     const key = `${ current }${ tab }` as const;
     let url = baseUrl;

--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -2,7 +2,6 @@ import { shell } from 'electron';
 
 import mainEvents from '@pkg/main/mainEvents';
 import type { TransientPreferencesState } from '@pkg/types/transientPreferences';
-import { kebabCase } from '@pkg/utils/string-utils';
 
 type PrefNav = TransientPreferencesState['navigation']['preferences'];
 /** TopKey is any key for the top-level preferences. */
@@ -36,9 +35,8 @@ class PreferencesHelp {
     const transientPreferences = await mainEvents.invoke('transient-preferences/get');
     const { preferences } = transientPreferences.navigation;
     const { top } = preferences;
-    const current = kebabCase(top);
-    const tab = current in preferences ? `/${ preferences[current] }` as const : '';
-    const key = `${ current }${ tab }` as const;
+    const tab = top in preferences ? `/${ preferences[top] }` as const : '';
+    const key = `${ top }${ tab }` as const;
     let url = baseUrl;
 
     if (key in this.mapping) {

--- a/pkg/rancher-desktop/store/__tests__/transient-preferences.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/transient-preferences.spec.ts
@@ -40,12 +40,12 @@ describe('transient-preferences', () => {
     it('SET_ALL should assign incoming partial preferences onto state', () => {
       const state = stateFn();
 
-      state.navigation.preferences.application = 'general';
+      state.navigation.preferences.top = 'virtual-machine';
       mutations.SET_ALL(state, { __test: { value: 123 } } as any);
 
       expect((state as any).__test.value).toBe(123);
       // It should not have removed existing keys.
-      expect(state.navigation.preferences.application).toBe('general');
+      expect(state.navigation.preferences.top).toBe('virtual-machine');
     });
 
     it('navigate should set navigation keys using dot notation', () => {

--- a/pkg/rancher-desktop/utils/__tests__/parseQuantity.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/parseQuantity.spec.ts
@@ -1,66 +1,93 @@
 import parseQuantity from '../parseQuantity';
 
 describe('parseQuantity', () => {
-  test('returns 0n for undefined/empty', () => {
-    expect(parseQuantity(undefined)).toBe(0n);
-    expect(parseQuantity('')).toBe(0n);
-    expect(parseQuantity('   ')).toBe(0n);
+  test('returns 0 for undefined/empty', () => {
+    expect(parseQuantity(undefined)).toBe(0);
+    expect(parseQuantity('')).toBe(0);
+    expect(parseQuantity('   ')).toBe(0);
+  });
+
+  test('accepts numbers', () => {
+    expect(parseQuantity(0)).toBe(0);
+    expect(parseQuantity(123)).toBe(123);
+    expect(parseQuantity(-456)).toBe(-456);
   });
 
   test('parses plain bytes', () => {
-    expect(parseQuantity('0')).toBe(0n);
-    expect(parseQuantity('123')).toBe(123n);
-    expect(parseQuantity('123B')).toBe(123n);
+    expect(parseQuantity('0')).toBe(0);
+    expect(parseQuantity('123')).toBe(123);
   });
 
   test('parses BinarySI', () => {
-    expect(parseQuantity('1Ki')).toBe(1024n);
-    expect(parseQuantity('1.5KiB')).toBe(1536n);
-    expect(parseQuantity('2Mi')).toBe(2n * (2n ** 20n));
+    expect(parseQuantity('1Ki')).toBe(1024);
+    expect(parseQuantity('1.5Ki')).toBe(1536);
+    expect(parseQuantity('2Mi')).toBe(2 * (2 ** 20));
   });
 
   test('parses DecimalSI', () => {
-    expect(parseQuantity('1k')).toBe(1_000n);
-    expect(parseQuantity('1K')).toBe(1_000n);
-    expect(parseQuantity('1M')).toBe(1_000_000n);
-    expect(parseQuantity('1MB')).toBe(1_000_000n);
-    expect(parseQuantity('1.5K')).toBe(1_500n);
+    expect(parseQuantity('1k')).toBe(1_000);
+    expect(parseQuantity('1M')).toBe(1_000_000);
+    expect(parseQuantity('1.5G')).toBe(1_500_000_000);
   });
 
-  test('parses DecimalSI sub-byte quantities (truncate toward zero)', () => {
-    expect(parseQuantity('1m')).toBe(0n);
-    expect(parseQuantity('1500m')).toBe(1n);
-    expect(parseQuantity('1u')).toBe(0n);
-    expect(parseQuantity('1n')).toBe(0n);
+  test('parses DecimalSI sub-byte quantities', () => {
+    expect(parseQuantity('1m')).toBe(0.001);
+    expect(parseQuantity('1500m')).toBe(1.5);
+    expect(parseQuantity('1u')).toBe(0.000001);
+    expect(parseQuantity('1n')).toBe(0.000000001);
   });
 
   test('parses decimal exponent', () => {
-    expect(parseQuantity('1e3')).toBe(1_000n);
-    expect(parseQuantity('1.5e3')).toBe(1_500n);
-    expect(parseQuantity('2E+3')).toBe(2_000n);
-    expect(parseQuantity('2E-1')).toBe(0n);
-    expect(parseQuantity('1e3B')).toBe(1_000n);
+    expect(parseQuantity('1e3')).toBe(1_000);
+    expect(parseQuantity('1.5e3')).toBe(1_500);
+    expect(parseQuantity('2E+3')).toBe(2_000);
+    expect(parseQuantity('2E-1')).toBe(0.2);
   });
 
   test('parses signed values', () => {
-    expect(parseQuantity('+2Ki')).toBe(2n * 1024n);
-    expect(parseQuantity('-1.5Ki')).toBe(-1536n);
+    expect(parseQuantity('+2Ki')).toBe(2 * 1024);
+    expect(parseQuantity('-1.5Ki')).toBe(-1536);
   });
 
   test('parses with whitespace', () => {
-    expect(parseQuantity('  10  MiB')).toBe(10n * (2n ** 20n));
-    expect(parseQuantity('5 Gi')).toBe(5n * (2n ** 30n));
+    expect(parseQuantity('  10  Mi')).toBe(10 * (2 ** 20));
+    expect(parseQuantity('5 Gi')).toBe(5 * (2 ** 30));
+  });
+
+  test('accepts trailing dot', () => {
+    expect(parseQuantity('10.G')).toBe(10_000_000_000);
+  });
+
+  test('accepts leading dot', () => {
+    expect(parseQuantity('.5k')).toBe(500);
+  });
+
+  test('accepts limits of Number', () => {
+    expect(parseQuantity(`${ Number.MAX_SAFE_INTEGER }`)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(parseQuantity(`${ Number.MIN_SAFE_INTEGER }`)).toBe(Number.MIN_SAFE_INTEGER);
+  });
+
+  test('throws on invalid numbers', () => {
+    expect(() => parseQuantity(parseFloat('NaN'))).toThrow('Malformed quantity: NaN');
+    expect(() => parseQuantity(Number.POSITIVE_INFINITY)).toThrow('Malformed quantity: Infinity');
   });
 
   test('throws on unknown suffix', () => {
     expect(() => parseQuantity('1mi')).toThrow('Unknown units: mi');
     expect(() => parseQuantity('1Zi')).toThrow('Unknown units: Zi');
     expect(() => parseQuantity('1MBi')).toThrow('Unknown units: MBi');
+    expect(() => parseQuantity('1toString')).toThrow('Unknown units: toString');
+  });
+
+  test('throws on scientific notation with suffix', () => {
+    expect(() => parseQuantity('1e3Ki')).toThrow('Unknown units: e3Ki');
+    expect(() => parseQuantity('2.5E-1Mi')).toThrow('Unknown units: E-1Mi');
   });
 
   test('throws on malformed quantity', () => {
     expect(() => parseQuantity('abc')).toThrow('Malformed quantity: abc');
     expect(() => parseQuantity('Ki')).toThrow('Malformed quantity: Ki');
     expect(() => parseQuantity('1..2')).toThrow('Malformed quantity: 1..2');
+    expect(() => parseQuantity('1.2.3')).toThrow('Malformed quantity: 1.2.3');
   });
 });

--- a/pkg/rancher-desktop/utils/__tests__/string-utils.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/string-utils.spec.ts
@@ -1,0 +1,55 @@
+import { KebabCase, kebabCase } from '../string-utils';
+
+describe('kebabCase', () => {
+  const cases = [
+    ['camelCase', 'camel-case'],
+    ['PascalCase', 'pascal-case'],
+    ['word', 'word'],
+    ['', ''],
+    ['stringWith123Numbers', 'string-with123-numbers'],
+    ['stringWith$pecialChars!', 'string-with$pecial-chars!'],
+    ['HeLLoWorld', 'he-l-lo-world'],
+    ['  string  ', 'string'],
+    ['string   with   spaces', 'string-with-spaces'],
+    ['string_with_underscores', 'string-with-underscores'],
+    ['string-with-hyphens', 'string-with-hyphens'],
+    ['string--with--multiple--hyphens', 'string-with-multiple-hyphens'],
+    ['-prefix-suffix-', '-prefix-suffix-'],
+    ['WSL Integration', 'w-s-l-integration'],
+    // Emojis should not be affected.
+    // U+1F426 U+200D U+1F525 bird + fire = phoenix
+    // U+1D468 mathematical bold italic capital A
+    // U+1F638 grinning cat face with smiling eyes
+    ['\u{1F426}\u200D\u{1F525}\u{1D468}\u{1F638}', '\uD83D\uDC26\u200D\uD83D\uDD25\uD835\uDC68\uD83D\uDE38'],
+  ] as const;
+  it.each(cases)('should convert "%s" to "%s"', (input, expected) => {
+    expect(kebabCase(input)).toBe(expected);
+  });
+
+  // TypeScript compile-time checks for KebabCase<T>
+  type Equal<A, B> =
+    (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2) ? true : false;
+
+  type TupleKeys<T extends readonly unknown[]> = Exclude<keyof T, keyof any[]>;
+
+  type TypeFailure<
+    Input extends string,
+    Actual extends string,
+    Expected extends string,
+  > = ['FAIL', { input: Input; actual: Actual; expected: Expected }];
+
+  type CheckCase<C> =
+    C extends readonly [infer Input extends string, infer Expected extends string]
+      ? Equal<KebabCase<Input>, Expected> extends true
+        ? never
+        : TypeFailure<Input, KebabCase<Input>, Expected>
+      : ['INVALID_CASE_SHAPE', C];
+
+  type Failures = {
+    [K in TupleKeys<typeof cases>]: CheckCase<(typeof cases)[K]>
+  }[TupleKeys<typeof cases>];
+
+  type AssertNoFailures<T extends never> = T;
+  type _TypeTests = AssertNoFailures<Failures>;
+});

--- a/pkg/rancher-desktop/utils/parseQuantity.ts
+++ b/pkg/rancher-desktop/utils/parseQuantity.ts
@@ -1,73 +1,62 @@
 /**
  * Parse a Kubernetes-style quantity string into bytes.
- * @note Values are truncated toward zero.
+ * @note As this does not use BigInt, numbers beyond the usual range
+ * (Number.MIN/MAX_SAFE_INTEGER) will not be supported correctly.
+ * @note This means exabytes (EB/EiB) and beyond will not be supported correctly.
  */
-export default function parseQuantity(value: string | undefined): bigint {
+export default function parseQuantity(value: string | number | undefined): number {
   if (value === undefined) {
-    return 0n;
+    return 0;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Malformed quantity: ${ value }`);
+    }
+    return value;
   }
 
   const trimmed = value.trim();
 
   if (!trimmed) {
-    return 0n;
+    return 0;
   }
 
-  const [, numeral, rawSuffix] = /^([+-]?[0-9.]+)\s*([^0-9.]\S*)?$/.exec(trimmed) ?? [];
-  if (numeral === undefined) {
+  const [numeral = ''] = /^[+-]?[0-9.]+(?:[eE][+-]?[0-9]+$)?/.exec(trimmed) ?? [];
+  const suffix = trimmed.slice(numeral.length).trim();
+  if (!numeral) {
     throw new Error(`Malformed quantity: ${ trimmed }`);
   }
-  const suffix = rawSuffix?.replace(/B$/, '') ?? ''; // remove trailing B if present
 
-  let scale = 1n; // Negative scale means divide.
-  const scaleMapping: Record<string, bigint> = {
-    '': 1n,
-    n:  -(10n ** 9n),
-    u:  -(10n ** 6n),
-    µ:  -(10n ** 6n),
-    μ:  -(10n ** 6n),
-    m:  -(10n ** 3n),
-    k:  10n ** 3n,
-    K:  10n ** 3n,
-    M:  10n ** 6n,
-    G:  10n ** 9n,
-    T:  10n ** 12n,
-    P:  10n ** 15n,
-    E:  10n ** 18n,
-    Ki: 2n ** 10n,
-    Mi: 2n ** 20n,
-    Gi: 2n ** 30n,
-    Ti: 2n ** 40n,
-    Pi: 2n ** 50n,
-    Ei: 2n ** 60n,
+  const scaleMapping: Record<string, number> = {
+    '': 1,
+    n:  10 ** -9,
+    u:  10 ** -6,
+    m:  10 ** -3,
+    k:  10 ** 3,
+    M:  10 ** 6,
+    G:  10 ** 9,
+    T:  10 ** 12,
+    P:  10 ** 15,
+    E:  10 ** 18, // Loses precision.
+    Ki: 2 ** 10,
+    Mi: 2 ** 20,
+    Gi: 2 ** 30,
+    Ti: 2 ** 40,
+    Pi: 2 ** 50,
+    Ei: 2 ** 60, // Loses precision.
   };
+  const scale: number | undefined = scaleMapping[suffix];
 
-  if (suffix in scaleMapping) {
-    scale = scaleMapping[suffix];
-  } else {
-    const [, sign, exponent] = /^[eE]([+-]?)(\d+)$/.exec(suffix) ?? [];
-    if (exponent !== undefined) {
-      scale *= 10n ** BigInt(exponent);
-      if (sign === '-') {
-        scale = -scale;
-      }
-    } else {
-      throw new Error(`Unknown units: ${ rawSuffix || trimmed }`);
-    }
+  if (typeof scale !== 'number') {
+    throw new Error(`Unknown units: ${ suffix }`);
   }
 
-  const [, sign, whole, fraction = '0'] = /^([+-]?)([0-9]+)?(?:\.([0-9]+))?$/.exec(numeral) ?? [];
+  const parsedNumeral = Number(numeral);
 
-  if (whole === undefined) {
+  if (Number.isNaN(parsedNumeral)) {
     throw new Error(`Malformed quantity: ${ trimmed }`);
   }
 
-  const denom = 10n ** BigInt(fraction.length);
-  const numer = (BigInt(whole) * denom + BigInt(fraction)) * (sign === '-' ? -1n : 1n);
-
-  if (scale < 0n) {
-    return numer / (-scale * denom);
-  }
-
-  return (numer * scale) / denom;
+  return parsedNumeral * scale;
 }

--- a/pkg/rancher-desktop/utils/string-utils.ts
+++ b/pkg/rancher-desktop/utils/string-utils.ts
@@ -1,0 +1,61 @@
+import type { Alpha } from './typeUtils';
+
+type Whitespace = ' ' | '\n' | '\t' | '\r' | '\f' | '\v';
+type Separator = Whitespace | '-' | '_';
+
+type TrimLeft<S extends string> = S extends `${ Whitespace }${ infer R }` ? TrimLeft<R> : S;
+type TrimRight<S extends string> = S extends `${ infer R }${ Whitespace }` ? TrimRight<R> : S;
+type Trim<S extends string> = TrimLeft<TrimRight<S>>;
+
+type IsUpperAlpha<C extends string> =
+  C extends Alpha<C>
+    ? C extends Lowercase<C>
+      ? false
+      : true
+    : false;
+
+type InsertDashesForKebab<
+  S extends string,
+  IsFirst extends boolean = true,
+> = S extends `${ infer C }${ infer Rest }`
+  ? `${
+    IsUpperAlpha<C> extends true
+      ? IsFirst extends true
+        ? Lowercase<C> // C is the first character, so don't insert a dash
+        : `-${ Lowercase<C> }` // C is uppercase, so insert a dash before it
+      : C extends Separator
+        ? '-' // C is a separator, so replace it with a dash
+        : C // C is not uppercase or separator
+    }${
+      InsertDashesForKebab<Rest, false>
+    }`
+  : S;
+
+type CollapseSeparators<
+  S extends string,
+> = S extends `${ infer C }${ infer Rest }`
+  ? C extends Separator
+    ? Rest extends `${ Separator }${ string }`
+      ? CollapseSeparators<Rest> // Multiple separators in a row
+      : `${ C }${ CollapseSeparators<Rest> }` // Keep single separator
+    : `${ C }${ CollapseSeparators<Rest> }`
+  : S; // Base case: S is empty
+
+/**
+ * Transform a string into kebab-case (lowercase, dash-separated).
+ * @note This is guaranteed to be the same output as the `kebabCase` function,
+ * at least for ASCII strings.
+ */
+export type KebabCase<T extends string> =
+  CollapseSeparators<InsertDashesForKebab<Trim<T>>>;
+
+/**
+ * Converts a string to kebab-case.
+ * @example kebabCase('HelloWorld') == 'hello-world'
+ */
+export function kebabCase<T extends string>(input: T): KebabCase<T> {
+  return input
+    .trim()
+    .replace(/./ug, (c, i) => (i > 0 && /[A-Z]/.test(c) ? '-' : '') + c.toLowerCase())
+    .replace(/[\s_-]+/g, '-') as KebabCase<T>;
+}

--- a/pkg/rancher-desktop/window/preferenceConstants.ts
+++ b/pkg/rancher-desktop/window/preferenceConstants.ts
@@ -1,6 +1,4 @@
-import _ from 'lodash';
-
-import type { Alpha } from '@pkg/utils/typeUtils';
+import { kebabCase, KebabCase } from '@pkg/utils/string-utils';
 
 /**
  * prefItemData is the list of navigation items and their associated tabs for
@@ -83,10 +81,6 @@ export const preferencesNavItems = prefItemData.filter((item: navItemEntry) =>
 
 export const preferencesNavItemsMap = mapNavItems(preferencesNavItems);
 
-type KebabCase<T extends string> = T extends `${ infer Head }${ infer Tail }`
-  ? `${ Head extends Alpha<Head> ? Lowercase<Head> : KebabCase<Tail> extends `-${ string }` ? '' : '-' }${ KebabCase<Tail> }`
-  : T;
-
 type PreferenceNavTabDefaults = {
   [K in keyof typeof preferencesNavItemsMap as KebabCase<K>]:
   (typeof preferencesNavItemsMap)[K] extends { tabs: readonly ([infer T, string])[] } ? T : never;
@@ -95,12 +89,13 @@ type PreferenceNavTabDefaults = {
 /**
  * preferencesNavTabDefaults is the default navigation state for the preferences
  * window for the tabs of each top level navigation item.
+ * @note For pages with no tabs, the type will be `page-name: never`.
  */
 const preferencesNavTabDefaults = Object.fromEntries(prefItemData
   .filter((item): item is typeof item & { tabs: readonly ([string, string])[] } => {
     return 'tabs' in item && item.tabs?.length > 0 && !!item.tabs[0];
   }).map(item => {
-    return [_.kebabCase(item.name), item.tabs[0][0]] as const;
+    return [kebabCase(item.name), item.tabs[0][0]] as const;
   })) as PreferenceNavTabDefaults;
 
 /**

--- a/pkg/rancher-desktop/window/preferenceConstants.ts
+++ b/pkg/rancher-desktop/window/preferenceConstants.ts
@@ -1,10 +1,10 @@
-import { kebabCase, KebabCase } from '@pkg/utils/string-utils';
+import type { KebabCase } from '@pkg/utils/string-utils';
 
 /**
  * prefItemData is the list of navigation items and their associated tabs for
  * the preferences window.
  */
-const prefItemData = [
+const prefItemData = defineNavItems([
   {
     name:     'application',
     labelKey: 'preferences.nav.application',
@@ -45,7 +45,7 @@ const prefItemData = [
   //   ],
   // },
   { name: 'kubernetes', labelKey: 'preferences.nav.kubernetes' },
-] as const satisfies navItemEntry[];
+] as const);
 
 /**
  * Represents a navigation item entry in the preferences window.
@@ -55,6 +55,42 @@ interface navItemEntry {
   name:        string;
   labelKey:    string;
   tabs?:       readonly [string, string][];
+}
+
+/**
+ * EnforceKebabNames is a type that ensures that the following properties of
+ * each navigation item is in kebab case:
+ * - The `name` property of the navigation item.
+ * - The first element of each tuple in the `tabs` property of the navigation item.
+ */
+type EnforceKebabNames<T extends readonly navItemEntry[]> = {
+  [I in keyof T]:
+  T[I] extends { name: infer N extends string }
+    ? Omit<T[I], 'name' | 'tabs'> & {
+      name: KebabCase<N>;
+    } & (
+        T[I] extends { tabs: infer Tabs extends readonly unknown[] }
+          ? {
+            tabs: {
+              [J in keyof Tabs]:
+              Tabs[J] extends [infer U extends string, infer V extends string]
+                ? [KebabCase<U>, V]
+                : never
+            }
+          }
+          : unknown
+      )
+    : T[I];
+};
+
+/**
+ * defineNavItems is a helper function that enforces the correct types for
+ * {@link prefItemData}.
+ */
+function defineNavItems<const T extends readonly navItemEntry[]>(
+  items: EnforceKebabNames<T>,
+): EnforceKebabNames<T> {
+  return items;
 }
 
 /**
@@ -82,7 +118,7 @@ export const preferencesNavItems = prefItemData.filter((item: navItemEntry) =>
 export const preferencesNavItemsMap = mapNavItems(preferencesNavItems);
 
 type PreferenceNavTabDefaults = {
-  [K in keyof typeof preferencesNavItemsMap as KebabCase<K>]:
+  [K in keyof typeof preferencesNavItemsMap]:
   (typeof preferencesNavItemsMap)[K] extends { tabs: readonly ([infer T, string])[] } ? T : never;
 };
 
@@ -95,7 +131,7 @@ const preferencesNavTabDefaults = Object.fromEntries(prefItemData
   .filter((item): item is typeof item & { tabs: readonly ([string, string])[] } => {
     return 'tabs' in item && item.tabs?.length > 0 && !!item.tabs[0];
   }).map(item => {
-    return [kebabCase(item.name), item.tabs[0][0]] as const;
+    return [item.name, item.tabs[0][0]] as const;
   })) as PreferenceNavTabDefaults;
 
 /**


### PR DESCRIPTION
This fixes additional review comments from #585.  In particular:
- Makes the quantity parsing (currently used for the VM memory spec) more conformant to Kubernetes.
- Fixes the issues with kebab casing; we now use a custom version to have correct typing.

Fixes #590