### PR TITLE
CI: Linux-release: Use vault for secrets

### DIFF
--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -12,6 +12,9 @@ defaults:
 jobs:
   linux-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Needed for read-value-secrets
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -23,7 +26,7 @@ jobs:
         version_with_v=${GITHUB_REF#"refs/tags/"}
         release_zip_name="rancher-desktop-linux-${version_with_v}.zip"
         major_minor=$(echo ${version_with_v} | sed -E 's/v([0-9]+\.[0-9]+)\.[0-9]+.*/\1/g')
-        s3_zip_name="rancher-desktop-linux-${major_minor}.zip"
+        s3_zip_name="rancher-desktop-2-linux-${major_minor}.zip"
 
         # make variables available in subsequent steps
         echo "version_with_v=$version_with_v" >> $GITHUB_ENV
@@ -33,28 +36,40 @@ jobs:
     - run: mkdir -p dist
     - name: Fetch the .zip file from release
       run: >-
-        curl -L -o "dist/${release_zip_name}"
+        curl --fail --location -o "dist/${release_zip_name}"
         "https://github.com/${repository}/releases/download/${version_with_v}/${release_zip_name}"
       env:
         repository: ${{ github.repository }}
         version_with_v: ${{ env.version_with_v }}
         release_zip_name: ${{ env.release_zip_name }}
+    - id: get-vault-secrets
+      name: Read vault secrets
+      if: github.repository_owner == 'rancher-sandbox'
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/obs/webhook-token token | OBS_WEBHOOK_TOKEN;
+          secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_ACCESS_KEY_ID | AWS_ACCESS_KEY_ID;
+          secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_SECRET_ACCESS_KEY | AWS_SECRET_ACCESS_KEY
+    - name: Fall back to GitHub-hosted secrets
+      if: steps.get-vault-secrets.outcome == 'skipped'
+      run: |
+        echo "OBS_WEBHOOK_TOKEN=${OBS_WEBHOOK_TOKEN:?Secret OBS_WEBHOOK_TOKEN not found}" >> "$GITHUB_ENV"
+        echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?Secret AWS_ACCESS_KEY_ID not found}" >> "$GITHUB_ENV"
+        echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?Secret AWS_SECRET_ACCESS_KEY not found}" >> "$GITHUB_ENV"
+      env:
+        OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Upload zip file to S3
       run: >-
         aws s3 cp
         "dist/${release_zip_name}"
         "s3://rancher-desktop-assets-for-obs/${s3_zip_name}"
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: us-east-1
-        release_zip_name: ${{ env.release_zip_name }}
-        s3_zip_name: ${{ env.s3_zip_name }}
     - name: Trigger OBS services for relevant package in stable channel
       run: >-
-        curl -X POST
+        curl --fail-with-body -X POST
         -H "Authorization: Token ${OBS_WEBHOOK_TOKEN}"
-        "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:stable&package=rancher-desktop-${MAJOR_MINOR}"
-      env:
-        MAJOR_MINOR: ${{ env.major_minor }}
-        OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}
+        "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:stable&package=rancher-desktop-2-${major_minor}"


### PR DESCRIPTION
I don't actually know if this is needed; it's not like I can test that in a fork… So this PR is here if we need it.  This also means the PR is untested :(

Example release zip name: `rancher-desktop-linux-v2.0.0-alpha.1.zip`
Example S3 zip name: `rancher-desktop-2-linux-2.0.zip`
Example package name: `rancher-desktop-2-2.0`