### PR TITLE
Restore the DEB chrome-sandbox setuid bit and follow up on #601

### DIFF
--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -20,6 +20,25 @@ jobs:
       with:
         persist-credentials: false
         fetch-depth: 0
+    - id: get-vault-secrets
+      name: Read vault secrets
+      if: github.repository_owner == 'rancher-sandbox'
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/obs/webhook-token token | OBS_WEBHOOK_TOKEN;
+          secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_ACCESS_KEY_ID | AWS_ACCESS_KEY_ID;
+          secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_SECRET_ACCESS_KEY | AWS_SECRET_ACCESS_KEY
+    - name: Fall back to GitHub-hosted secrets
+      if: steps.get-vault-secrets.outcome == 'skipped'
+      run: |
+        echo "OBS_WEBHOOK_TOKEN=${OBS_WEBHOOK_TOKEN:?Secret OBS_WEBHOOK_TOKEN not found}" >> "$GITHUB_ENV"
+        echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?Secret AWS_ACCESS_KEY_ID not found}" >> "$GITHUB_ENV"
+        echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?Secret AWS_SECRET_ACCESS_KEY not found}" >> "$GITHUB_ENV"
+      env:
+        OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Populate necessary env vars
       run: |
         # get the env vars
@@ -42,25 +61,6 @@ jobs:
         repository: ${{ github.repository }}
         version_with_v: ${{ env.version_with_v }}
         release_zip_name: ${{ env.release_zip_name }}
-    - id: get-vault-secrets
-      name: Read vault secrets
-      if: github.repository_owner == 'rancher-sandbox'
-      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
-      with:
-        secrets: |
-          secret/data/github/repo/${{ github.repository }}/obs/webhook-token token | OBS_WEBHOOK_TOKEN;
-          secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_ACCESS_KEY_ID | AWS_ACCESS_KEY_ID;
-          secret/data/github/repo/${{ github.repository }}/aws/credentials AWS_SECRET_ACCESS_KEY | AWS_SECRET_ACCESS_KEY
-    - name: Fall back to GitHub-hosted secrets
-      if: steps.get-vault-secrets.outcome == 'skipped'
-      run: |
-        echo "OBS_WEBHOOK_TOKEN=${OBS_WEBHOOK_TOKEN:?Secret OBS_WEBHOOK_TOKEN not found}" >> "$GITHUB_ENV"
-        echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?Secret AWS_ACCESS_KEY_ID not found}" >> "$GITHUB_ENV"
-        echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?Secret AWS_SECRET_ACCESS_KEY not found}" >> "$GITHUB_ENV"
-      env:
-        OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Upload zip file to S3
       run: >-
         aws s3 cp

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -45,6 +45,8 @@ jobs:
         version_with_v=${GITHUB_REF#"refs/tags/"}
         release_zip_name="rancher-desktop-linux-${version_with_v}.zip"
         major_minor=$(echo ${version_with_v} | sed -E 's/v([0-9]+\.[0-9]+)\.[0-9]+.*/\1/g')
+        # The stable package's _service in OBS fetches this exact name, so
+        # renaming it here alone breaks the rebuild.
         s3_zip_name="rancher-desktop-2-linux-${major_minor}.zip"
 
         # make variables available in subsequent steps
@@ -55,7 +57,7 @@ jobs:
     - run: mkdir -p dist
     - name: Fetch the .zip file from release
       run: >-
-        curl --fail --location -o "dist/${release_zip_name}"
+        curl --fail --location --output "dist/${release_zip_name}"
         "https://github.com/${repository}/releases/download/${version_with_v}/${release_zip_name}"
       env:
         repository: ${{ github.repository }}
@@ -68,8 +70,10 @@ jobs:
         "s3://rancher-desktop-assets-for-obs/${s3_zip_name}"
       env:
         AWS_DEFAULT_REGION: us-east-1
+    # curl exits 0 on an HTTP error, so without --fail-with-body a wrong
+    # package name would skip the stable rebuild silently.
     - name: Trigger OBS services for relevant package in stable channel
       run: >-
-        curl --fail-with-body -X POST
-        -H "Authorization: Token ${OBS_WEBHOOK_TOKEN}"
+        curl --request POST --fail-with-body
+        --header "Authorization: Token ${OBS_WEBHOOK_TOKEN}"
         "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:stable&package=rancher-desktop-2-${major_minor}"

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -192,9 +192,11 @@ chmod 4755 "%{buildroot}/opt/%{name}/chrome-sandbox"
 ln -sf "/opt/%{name}/%{name}" "%{buildroot}%{_bindir}/%{name}"
 
 %post
-# This is needed to ensure Debian packages have proper file permissions;
-# otherwise the postinst script is not generated correctly.
-true
+# debbuild's generated postinst chowns /opt/%{name} recursively, and chown
+# clears the setuid bit that %install set. %post runs after those chowns, so
+# the mode set here sticks. rpm applies the mode from the package header, so
+# the chmod is a no-op there.
+chmod 4755 /opt/%{name}/chrome-sandbox
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
The DEB shipped chrome-sandbox at 755, and the first commit restores the setuid bit. The other two follow up on #601. One moves the vault step above the download so a throwaway tag can exercise it without publishing a release; the other records why the OBS zip name and `--fail-with-body` have to stay.

The spec fix ships without a new tag. The stable package takes its spec from the release branch, and its version from `@PARENT_TAG@`.

Publishing still won't rebuild stable. All five repositories in `isv:Rancher:stable` have the `rancher-desktop-2-2.0` package disabled, so someone has to enable the builds first.
