### PR TITLE
CI: reject a stale package in the release smoke test

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -38,6 +38,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag }}
     outputs:
       release-tag: ${{ steps.set-release-tag.outputs.release-tag }}
+      release-commit: ${{ steps.set-release-tag.outputs.release-commit }}
     steps:
     - name: Find release
       if: inputs.tag == ''
@@ -52,8 +53,27 @@ jobs:
         echo "RELEASE_TAG=$RELEASE_TAG" >>"$GITHUB_ENV"
       env:
         GH_TOKEN: ${{ github.token }}
+    - name: Resolve the release commit
+      run: |
+        set -o xtrace
+        # A draft release has no tag ref yet, so go through the release's
+        # target rather than resolving the tag.
+        commitish=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+          --jq ".[] | select(.tag_name == \"${RELEASE_TAG}\") | .target_commitish" \
+          | head -1)
+        RELEASE_COMMIT=$(gh api \
+          "repos/${GITHUB_REPOSITORY}/commits/${commitish:-$RELEASE_TAG}" --jq .sha)
+        if [[ -z "$RELEASE_COMMIT" ]]; then
+          echo "Failed to resolve a commit for $RELEASE_TAG" >&2
+          exit 1
+        fi
+        echo "RELEASE_COMMIT=$RELEASE_COMMIT" >>"$GITHUB_ENV"
+      env:
+        GH_TOKEN: ${{ github.token }}
     - id: set-release-tag
-      run: printf "release-tag=%s\n" "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+      run: |
+        printf "release-tag=%s\n" "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+        printf "release-commit=%s\n" "$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
   download-installer:
     name: Download Installers
     needs: find-release
@@ -264,6 +284,7 @@ jobs:
       run: .github/workflows/smoke-test/install-from-repo.sh
       env:
         RD_VERSION: ${{ needs.find-release.outputs.release-tag }}
+        RD_COMMIT: ${{ needs.find-release.outputs.release-commit }}
         OBS_PROJECT: ${{ inputs.obs-project }}
     - name: Run smoke test
       shell: bash

--- a/.github/workflows/smoke-test/install-from-repo.sh
+++ b/.github/workflows/smoke-test/install-from-repo.sh
@@ -7,10 +7,37 @@
 #      Rancher Desktop version; either major.minor (`1.20`) or the tag (`v1.20.0`).
 #   OBS_PROJECT
 #      The openSUSE Build Service project to use, in the form `isv:Rancher:dev`.
+#   RD_COMMIT
+#      Full commit sha of the release under test, used to reject a stale
+#      package. The check is skipped when this is empty.
 
 set -o errexit -o nounset
 
 PACKAGE_NAME="rancher-desktop-2"
+
+# OBS publishes only the newest successful build of a package, so a failed
+# rebuild leaves the previous one in the repository and every version matcher
+# still selects it. The version ends in the commit OBS built from, which is the
+# only way to tell that apart from the release.
+# shellcheck disable=2329 # Called from the dynamically invoked install functions
+verify_package_commit() {
+    local version=$1 built_from
+    if [[ -z "${RD_COMMIT:-}" ]]; then
+        return
+    fi
+    built_from=${version%%-*}    # drop the packaging release suffix
+    built_from=${built_from##*.} # the commit is the last version component
+    if [[ ! "$built_from" =~ ^[0-9a-f]{7,}$ ]]; then
+        printf "Found no commit at the end of version '%s'\n" "$version" >&2
+        exit 1
+    fi
+    if [[ "$RD_COMMIT" != "$built_from"* ]]; then
+        printf "%s %s was built from %s, but the release is %s\n" \
+            "$PACKAGE_NAME" "$version" "$built_from" "$RD_COMMIT" >&2
+        printf "The repository is serving an older build than the release.\n" >&2
+        exit 1
+    fi
+}
 
 # shellcheck disable=2329 # The function is invoked dynamically
 install_linux_debian() {
@@ -35,6 +62,7 @@ install_linux_debian() {
         apt-cache show --quiet "${PACKAGE_NAME}" | sed 's@^@    @' >&2
         exit 1
     fi
+    verify_package_commit "${version}"
     apt-get install -y "${PACKAGE_NAME}=${version}"
 }
 
@@ -50,6 +78,7 @@ install_linux_opensuse() {
         zypper --non-interactive search --details --match-exact "${PACKAGE_NAME}" | sed 's@^@    @' >&2
         exit 1
     fi
+    verify_package_commit "${version}"
     zypper --non-interactive install "${PACKAGE_NAME}=${version}"
 }
 
@@ -65,6 +94,7 @@ install_linux_fedora() {
         dnf --quiet info --showduplicates "${PACKAGE_NAME}.$(uname -m)" | sed 's@^@    @' >&2
         exit 1
     fi
+    verify_package_commit "${version}"
     dnf --assumeyes install "${PACKAGE_NAME}-${version}"
 }
 


### PR DESCRIPTION
The Alpha 2 smoke test reported a chrome-sandbox failure that had been fixed for days, because OBS was still serving a package built a month earlier. This compares the commit in the package version against the commit the release was cut from, and stops before installing. The commit message has the detail, including the live-API check.

Nothing exercises this until the next release smoke test runs. The guard fails open when RD_COMMIT is empty, so running the script by hand behaves as before.
