### PR TITLE
Linux: fix the Fedora build broken by a spec comment

### DIFF
--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -193,9 +193,9 @@ ln -sf "/opt/%{name}/%{name}" "%{buildroot}%{_bindir}/%{name}"
 
 %post
 # debbuild's generated postinst chowns /opt/%{name} recursively, and chown
-# clears the setuid bit that %install set. %post runs after those chowns, so
-# the mode set here sticks. rpm applies the mode from the package header, so
-# the chmod is a no-op there.
+# clears the setuid bit that the install section set. This scriptlet runs
+# after those chowns, so the mode set here sticks. rpm applies the mode from
+# the package header, so the chmod is a no-op there.
 chmod 4755 /opt/%{name}/chrome-sandbox
 
 %files


### PR DESCRIPTION
rpm 4.19, which OBS's fc40 builder ships, reads `%install` inside a comment as a second `%install` section, failing with `line 196: second %install`. The 4.20 on Leap and Tumbleweed accepts it.

Verified with `rpmspec --parse`: fedora:40 rejects the current comment and accepts this one; fedora:42, Leap and Tumbleweed accept both.
