### PR TITLE
RDA: Enable i18n

### DIFF
--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -18,7 +18,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 
 ## Architecture
 
-The renderer (Vuex store `store/i18n.js`) and the main process
+The renderer (Vuex store `store/i18n.ts`) and the main process
 (`main/i18n.ts`) both format through `intl-messageformat`, so every key
 speaks the same ICU MessageFormat dialect. Both load YAML through
 webpack's `js-yaml-loader` at build time via the shared

--- a/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
@@ -9,13 +9,9 @@ import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 defineOptions({ name: 'preferences-application-general' });
 
 const store = useStore();
-const preferences = computed(() => store.getters['preferences/preferences']);
 const isPreferenceLocked = computed(() => store.getters['preferences/isPreferenceLocked']);
 const availableLocales = computed(() => store.getters['i18n/availableLocales']);
-const selectedLocale = computed(() => {
-  const locale = 'none'; // preferences.value.application.locale;
-  return (!locale || locale === 'none') ? 'en-us' : locale;
-});
+const selectedLocale = computed(() => store.getters['i18n/current']);
 const showLocaleDisclaimer = computed(() => selectedLocale.value !== 'en-us');
 
 function onLocaleChange(newLocale: string) {
@@ -26,7 +22,6 @@ function onLocaleChange(newLocale: string) {
 <template>
   <div class="application-general">
     <rd-fieldset
-      v-if="(() => false /* temporarily commented out */)()"
       data-test="locale"
       class="width-xs"
       :legend-text="t('application.locale.legendText')"
@@ -37,7 +32,7 @@ function onLocaleChange(newLocale: string) {
         :model-value="selectedLocale"
         :aria-label="t('application.locale.legendText')"
         :is-locked="isPreferenceLocked('application.locale')"
-        @change="onLocaleChange"
+        @input="onLocaleChange"
       >
         <option
           v-for="(label, code) in availableLocales"

--- a/pkg/rancher-desktop/entry/store.ts
+++ b/pkg/rancher-desktop/entry/store.ts
@@ -1,4 +1,4 @@
-import { createStore, mapActions, mapGetters, mapMutations, mapState, ModuleTree, Plugin } from 'vuex';
+import { createStore, mapActions, mapGetters, mapMutations, mapState, Plugin } from 'vuex';
 
 import * as ActionMenu from '../store/action-menu';
 import * as ContainerEngine from '../store/container-engine';

--- a/pkg/rancher-desktop/main/i18n.ts
+++ b/pkg/rancher-desktop/main/i18n.ts
@@ -8,24 +8,25 @@ import get from 'lodash/get.js';
 
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import logging from '@pkg/utils/logging';
-import { loadTranslations } from '@pkg/utils/translationLoader';
+import { loadTranslations, LocaleString } from '@pkg/utils/translationLoader';
 
 export { availableLocales } from '@pkg/utils/translationLoader';
 
 type TranslationMap = Record<string, unknown>;
+type TranslationsCache = Partial<Record<LocaleString, TranslationMap>> & { 'en-us': TranslationMap };
 
 const console = logging.i18n;
 const ipcMain = getIpcMainProxy(console);
-let currentLocale = 'en-us';
-const translations: Record<string, TranslationMap> = { 'en-us': loadTranslations('en-us') };
+let currentLocale: LocaleString = 'en-us';
+const translations: TranslationsCache = { 'en-us': loadTranslations('en-us') };
 const localeChangeCallbacks: (() => void)[] = [];
 
 /**
  * Look up a dotted key path, returning the value only when it is a string;
  * a key that resolves to a subtree counts as missing.
  */
-function getByPath(obj: TranslationMap, path: string): string | undefined {
-  const value = get(obj, path);
+function getByPath(obj: TranslationMap | undefined, path: string): string | undefined {
+  const value = get(obj ?? {}, path);
 
   return typeof value === 'string' ? value : undefined;
 }
@@ -33,7 +34,7 @@ function getByPath(obj: TranslationMap, path: string): string | undefined {
 /**
  * Load a locale's translations if not already loaded.
  */
-function loadLocale(locale: string): boolean {
+function loadLocale(locale: LocaleString): boolean {
   if (translations[locale]) {
     return true;
   }
@@ -103,13 +104,6 @@ export function t(key: string, args?: Record<string, string | number>): string {
 }
 
 /**
- * The locale currently in effect.
- */
-export function getLocale(): string {
-  return currentLocale;
-}
-
-/**
  * Register a callback to run after the locale has been loaded.
  * Use this instead of listening to settings-update directly, which
  * would race against the locale loading.
@@ -140,7 +134,8 @@ export function initMainI18n() {
       return; // load failed, stay on current locale
     }
     currentLocale = locale;
-    // We don't bother persisting here; the renderer will put it in the cookie.
+    // The renderer is responsible for persisting the locale (in local storage
+    // as well as app preferences).
     for (const callback of [...localeChangeCallbacks]) {
       try {
         callback();

--- a/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
@@ -61,6 +61,13 @@ const de = {
   greet:  'Hallo {name}',
 };
 
+beforeEach(() => {
+  // Clear the cache so that each test starts with a clean slate.
+  for (const key of Object.keys(i18n._intlCache)) {
+    delete i18n._intlCache[key as keyof typeof i18n._intlCache];
+  }
+});
+
 describe('i18n store getters', () => {
   let state: ReturnType<typeof makeState>;
   let getters: ReturnType<typeof makeGetters>;

--- a/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
@@ -25,6 +25,28 @@ function makeState(translations: Record<string, unknown>, selected = 'de') {
   };
 }
 
+/**
+ * Resolves all getters against a state, removing one layer of indirection so
+ * that getters which return functions (t, exists, withFallback, …) can be
+ * called directly, and getters that depend on other getters receive already-
+ * resolved peers.
+ */
+function makeGetters(state: Record<string, unknown>) {
+  let resolved: Record<string, unknown> = {};
+  resolved = Object.create(null, Object.fromEntries(Object.entries(i18n.getters).map(([key, getter]) => {
+    return [key, {
+      get: () => (getter as (...args: any[]) => unknown)(state, resolved),
+    }];
+  })));
+
+  return resolved as {
+    [K in keyof typeof i18n.getters]:
+      typeof i18n.getters[K] extends (...args: any[]) => infer R
+        ? R
+        : never;
+  };
+}
+
 const en = {
   simple:  'Plain text',
   nested:  { child: 'Nested value' },
@@ -41,71 +63,93 @@ const de = {
 
 describe('i18n store getters', () => {
   let state: ReturnType<typeof makeState>;
+  let getters: ReturnType<typeof makeGetters>;
 
   beforeEach(() => {
     state = makeState({ 'en-us': en, de });
+    getters = makeGetters(state);
   });
 
-  const t = (key: string, args?: Record<string, unknown>) => (i18n.getters as any).t(state)(key, args);
-
   it('returns the selected locale translation', () => {
-    expect(t('simple')).toEqual('Einfacher Text');
+    expect(getters.t('simple')).toEqual('Einfacher Text');
   });
 
   it('falls back to en-us per key', () => {
-    expect(t('nested.child')).toEqual('Nested value');
+    expect(getters.t('nested.child')).toEqual('Nested value');
   });
 
   it('returns a visible %key% placeholder for a missing key', () => {
-    expect(t('no.such.key')).toEqual('%no.such.key%');
+    expect(getters.t('no.such.key')).toEqual('%no.such.key%');
   });
 
   it('formats ICU plurals', () => {
-    expect(t('plural', { count: 1 })).toEqual('1 item');
-    expect(t('plural', { count: 3 })).toEqual('3 items');
+    expect(getters.t('plural', { count: 1 })).toEqual('1 item');
+    expect(getters.t('plural', { count: 3 })).toEqual('3 items');
   });
 
   it('interpolates arguments', () => {
-    expect(t('greet', { name: 'Jan' })).toEqual('Hallo Jan');
+    expect(getters.t('greet', { name: 'Jan' })).toEqual('Hallo Jan');
   });
 
   it('injects the product name for {appName}', () => {
-    expect(t('product')).toEqual(`Made by ${ packageJSON.productName }`);
+    expect(getters.t('product')).toEqual(`Made by ${ packageJSON.productName }`);
   });
 
   it('degrades to the raw pattern when an argument is missing', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(t('plural', {})).toEqual(en.plural);
+    expect(getters.t('plural', {})).toEqual(en.plural);
     spy.mockRestore();
   });
 
   it('degrades to the raw text for malformed ICU patterns', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(t('invalid')).toEqual('Unbalanced {brace');
+    expect(getters.t('invalid')).toEqual('Unbalanced {brace');
     spy.mockRestore();
   });
 
   it("does not HTML-escape; escaping is the sink's responsibility", () => {
-    expect(t('special')).toEqual('Command & "Args"');
+    expect(getters.t('special')).toEqual('Command & "Args"');
   });
 
   it('reports key existence', () => {
-    const exists = (key: string) => (i18n.getters as any).exists(state)(key);
+    expect(getters.exists('simple')).toBe(true);
+    expect(getters.exists('no.such.key')).toBe(false);
+  });
+});
 
-    expect(exists('simple')).toBe(true);
-    expect(exists('no.such.key')).toBe(false);
+describe('withFallback getter', () => {
+  let state: ReturnType<typeof makeState>;
+  let getters: ReturnType<typeof makeGetters>;
+
+  beforeEach(() => {
+    state = makeState({ 'en-us': en, de });
+    getters = makeGetters(state);
+  });
+
+  it('returns the selected locale translation', () => {
+    expect(getters.withFallback('simple', 'fallback')).toEqual('Einfacher Text');
+  });
+
+  it('falls back to en-us per key', () => {
+    expect(getters.withFallback('nested.child', 'fallback')).toEqual('Nested value');
+  });
+
+  it('returns the fallback string for a missing key', () => {
+    expect(getters.withFallback('no.such.key', {}, 'Default value')).toEqual('Default value');
+  });
+
+  it('returns the fallback translation for a missing key when fallbackIsKey is true', () => {
+    expect(getters.withFallback('no.such.key', {}, 'simple', true)).toEqual('Einfacher Text');
   });
 });
 
 describe('availableLocales getter', () => {
-  const availableLocales = (state: unknown) => (i18n.getters as any).availableLocales(state);
-
   // Codes whose alphabetical order differs from their labels', as in the real
   // locale set: by code ja < ko < pt-br, by label Português < 한국어 < 日本語.
-  function scriptState(selected: string | null) {
-    return {
+  function scriptGetters(selected: string | null) {
+    return makeGetters({
       default:      'en-us',
       selected,
       available:    ['ja', 'ko', 'pt-br'],
@@ -119,12 +163,12 @@ describe('availableLocales getter', () => {
         ko:      { locale: { ko: '한국어' } },
         'pt-br': { locale: { 'pt-br': 'Português (Brasil)' } },
       },
-    };
+    });
   }
 
   // German collates Ä with A, Swedish sorts it after Z.
-  function collationState(selected: string) {
-    return {
+  function collationGetters(selected: string) {
+    return makeGetters({
       default:      'en-us',
       selected,
       available:    ['de', 'sv'],
@@ -133,23 +177,23 @@ describe('availableLocales getter', () => {
         de:      { locale: { de: 'Zebra' } },
         sv:      { locale: { sv: 'Äpfel' } },
       },
-    };
+    });
   }
 
   it('orders locales by label rather than by locale code', () => {
-    expect(Object.keys(availableLocales(scriptState('en-us')))).toEqual(['pt-br', 'ko', 'ja']);
+    expect(Object.keys(scriptGetters('en-us').availableLocales)).toEqual(['pt-br', 'ko', 'ja']);
   });
 
   it('collates in the selected locale', () => {
-    expect(Object.keys(availableLocales(collationState('de')))).toEqual(['sv', 'de']);
-    expect(Object.keys(availableLocales(collationState('sv')))).toEqual(['de', 'sv']);
+    expect(Object.keys(collationGetters('de').availableLocales)).toEqual(['sv', 'de']);
+    expect(Object.keys(collationGetters('sv').availableLocales)).toEqual(['de', 'sv']);
   });
 
   it('collates with the default locale before a selection is made', () => {
-    expect(Object.keys(availableLocales(scriptState(null)))).toEqual(['pt-br', 'ko', 'ja']);
+    expect(Object.keys(scriptGetters(null).availableLocales)).toEqual(['pt-br', 'ko', 'ja']);
   });
 
   it('collates with the default locale when the selection is not a bundled locale', () => {
-    expect(Object.keys(availableLocales(scriptState('none')))).toEqual(['pt-br', 'ko', 'ja']);
+    expect(Object.keys(scriptGetters('none').availableLocales)).toEqual(['pt-br', 'ko', 'ja']);
   });
 });

--- a/pkg/rancher-desktop/store/i18n.ts
+++ b/pkg/rancher-desktop/store/i18n.ts
@@ -1,66 +1,71 @@
 import { IntlMessageFormat } from 'intl-messageformat';
-import { MutationTree } from 'vuex';
 
-import { ActionTree, GetterTree, MutationsType } from './ts-helpers';
 import packageJson from '../../../package.json' with { type: 'json' };
 
-import { LOCALE } from '@pkg/config/cookies';
 import { getVendor } from '@pkg/config/private-label';
-import { RootState } from '@pkg/entry/store';
+import type { RootState } from '@pkg/entry/store';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { get } from '@pkg/utils/object';
-import { availableLocales, loadTranslations } from '@pkg/utils/translationLoader';
+import { availableLocales, loadTranslations, type LocaleString } from '@pkg/utils/translationLoader';
+
+import type { ActionTree, GetterTree, MutationsType } from './ts-helpers';
+import type { MutationTree, Plugin } from 'vuex';
 
 type I18nState = ReturnType<typeof state>;
 
-// Formatters can't be serialized into state
-const intlCache: Record<string, IntlMessageFormat | string> = {};
-let ipcListenersBound = false;
+/**
+ * A cache of translation keys (as `<locale>/<key>`) to the corresponding
+ * message (or formatter) for the current locale.
+ * @note This is only exported for testing; do not use this.
+ * @note This is cleared on locale change.
+ * @note This is not part of the state because formatter instances do not work
+ *   well there; also, this is shared between different states (i.e. windows).
+ * @internal
+ */
+export const _intlCache: Record<`${ LocaleString }/${ string }`, IntlMessageFormat | string> = {};
 
-export const state = function() {
-  const out = {
-    default:      'en-us',
-    selected:     null as string | null,
-    available:    [...availableLocales],
-    translations: { 'en-us': loadTranslations('en-us') } as Record<string, Record<string, unknown>>,
-  };
-
-  return out;
-};
+export const state = () => ({
+  default:      'en-us' as LocaleString,
+  selected:     null as LocaleString | null,
+  available:    [...availableLocales],
+  translations: { 'en-us': loadTranslations('en-us') } as Partial<Record<LocaleString, Record<string, unknown>>>,
+});
 
 export const getters = {
   availableLocales(state, getters) {
+    const current: LocaleString = getters.current;
     const labelled = state.available.map((locale) => {
-      const nativeName = get(state.translations[locale], `locale.${ locale }`);
-      const translatedName =
-        get(state.translations[getters.current()], `locale.${ locale }`) ??
+      const nativeName: string = get(state.translations[locale], `locale.${ locale }`);
+      const translatedName: string =
+        get(state.translations[current], `locale.${ locale }`) ??
         get(state.translations[state.default], `locale.${ locale }`);
 
       if ( !nativeName || !translatedName || nativeName === translatedName ) {
-        return [locale, nativeName ?? translatedName ?? locale];
+        return [locale, nativeName ?? translatedName ?? locale] as const;
       }
 
-      return [locale, `${ nativeName } (${ translatedName })`];
+      return [locale, `${ nativeName } (${ translatedName })`] as const;
     });
 
     // Sort by the label the user reads, collated in the selected locale.
     // Fall back to the default when the selection is not a bundled locale,
     // because Intl.Collator rejects an unknown tag. The selection is null
     // until init runs, and older settings can carry 'none'.
-    const collationLocale = state.available.includes(getters.current()) ? getters.current() : state.default;
+    const collationLocale = state.available.includes(current) ? current : state.default;
     const collator = new Intl.Collator(collationLocale);
 
     labelled.sort(([, a], [, b]) => collator.compare(a, b));
 
-    return Object.fromEntries(labelled);
+    return Object.fromEntries(labelled) as Record<LocaleString, string>;
   },
 
   t: (state, getters) => (key: string, args?: Record<string, unknown>) => {
-    const cacheKey = `${ getters.current() }/${ key }`;
-    let formatter = intlCache[cacheKey];
+    const current: LocaleString = getters.current;
+    const cacheKey = `${ current }/${ key }` as const;
+    let formatter = _intlCache[cacheKey];
 
     if ( !formatter ) {
-      let msg = get(state.translations[getters.current()], key);
+      let msg = get(state.translations[current], key);
 
       if ( !msg ) {
         msg = get(state.translations[state.default], key);
@@ -89,7 +94,7 @@ export const getters = {
           // Uses the selected locale for formatting even when falling back to
           // English text. Acceptable: plural rules rarely diverge for the
           // strings used here.
-          formatter = new IntlMessageFormat(msg, getters.current());
+          formatter = new IntlMessageFormat(msg, current);
         } catch (e) {
           console.error(`Malformed ICU pattern for key "${ key }":`, e);
           formatter = msg;
@@ -98,7 +103,7 @@ export const getters = {
         formatter = msg;
       }
 
-      intlCache[cacheKey] = formatter;
+      _intlCache[cacheKey] = formatter;
     }
 
     if ( typeof formatter === 'string' ) {
@@ -118,36 +123,29 @@ export const getters = {
         // degrade to the raw pattern like the main-process interpolator.
         console.error(`Cannot format translation for key "${ key }":`, e);
 
-        return get(state.translations[getters.current()], key) ?? get(state.translations[state.default], key);
+        return get(state.translations[current], key) ?? get(state.translations[state.default], key);
       }
     }
   },
 
   exists: (state, getters) => (key: string) => {
-    const cacheKey = `${ getters.current() }/${ key }`;
+    const current: LocaleString = getters.current;
+    const cacheKey = `${ current }/${ key }` as const;
 
-    if ( intlCache[cacheKey] ) {
+    if ( _intlCache[cacheKey] ) {
       return true;
     }
 
-    let msg = get(state.translations[state.default], key);
-
-    if ( !msg && state.selected ) {
-      msg = get(state.translations[getters.current()], key);
-    }
-
-    if ( msg !== undefined ) {
-      return true;
-    }
-
-    return false;
+    return [current, state.default].some((locale) => {
+      return get(state.translations[locale], key) !== undefined;
+    });
   },
 
-  current: state => () => {
+  current(state) {
     return state.selected ?? state.default;
   },
 
-  default: state => () => {
+  default(state) {
     return state.default;
   },
 
@@ -176,17 +174,17 @@ export const getters = {
 } satisfies GetterTree<I18nState>;
 
 export const mutations = {
-  loadTranslations(state, { locale, translations }: { locale: string, translations: Record<string, unknown> }) {
+  loadTranslations(state, { locale, translations }: { locale: LocaleString, translations: Record<string, unknown> }) {
     state.translations[locale] = translations;
   },
 
-  setSelected(state, locale: string) {
+  setSelected(state, locale: LocaleString) {
     state.selected = locale;
   },
 } satisfies MutationsType<I18nState> & MutationTree<I18nState>;
 
 export const actions = {
-  async init({ state, commit, dispatch }) {
+  async init({ state, dispatch }) {
     // Load all translation files so availableLocales can show native names.
     // Acceptable overhead with a small number of locales; revisit if locale
     // count grows significantly.
@@ -196,33 +194,14 @@ export const actions = {
         .map(locale => dispatch('load', locale)),
     );
 
-    // The main process passes the resolved locale as a URL param, so the first
-    // paint is already localized; the cookie is a fallback for a window opened
-    // without one. Later changes arrive via settings-update below.
-    const urlLocale = new URLSearchParams(window.location.search).get('locale');
-    let selected = urlLocale || this.$cookies.get(LOCALE, { parseJSON: false });
-
-    if ( !selected ) {
-      selected = state.default;
-    }
-
-    if (!ipcListenersBound) {
-      ipcListenersBound = true;
-
-      // Listen for settings changes (from preferences UI or rdctl) to sync locale.
-      ipcRenderer.on('settings-update', (_, settings) => {
-        const locale = settings?.application?.locale || state.default;
-
-        if ( locale !== state.selected ) {
-          dispatch('switchTo', locale);
-        }
-      });
-    }
+    // Default to the locale stored in local storage; we will pick up the
+    // locale from the app once that exists.
+    const selected = localStorage.getItem('locale') as LocaleString | null || state.default;
 
     return dispatch('switchTo', selected);
   },
 
-  load({ commit }, locale: string) {
+  load({ commit }, locale: LocaleString) {
     const translations = loadTranslations(locale);
 
     commit('loadTranslations', { locale, translations });
@@ -230,7 +209,7 @@ export const actions = {
     return true;
   },
 
-  async switchTo({ state, commit, dispatch }, locale: string) {
+  async switchTo({ state, commit, dispatch }, locale: LocaleString) {
     if ( !locale ) {
       locale = state.default;
     }
@@ -239,27 +218,35 @@ export const actions = {
       try {
         await dispatch('load', locale);
       } catch (e) {
+        console.error(`Failed to load translations for locale "${ locale }":`, e);
         if ( locale !== 'en-us' ) {
           // Try to show something...
-
-          commit('setSelected', 'en-us');
-
-          return;
+          locale = 'en-us';
         }
       }
     }
 
-    for (const key of Object.keys(intlCache)) {
-      delete intlCache[key];
+    for (const key of Object.keys(_intlCache)) {
+      delete _intlCache[key as keyof typeof _intlCache];
     }
 
     commit('setSelected', locale);
-    this.$cookies.set(LOCALE, locale, {
-      encode: x => x,
-      maxAge: 86400 * 365,
-      secure: true,
-      path:   '/',
-    });
+    localStorage.setItem('locale', locale);
+    ipcRenderer.send('i18n/locale-change', locale);
   },
 
 } satisfies ActionTree<I18nState, RootState, typeof mutations, typeof getters>;
+
+export const plugins: Plugin<RootState>[] = [
+  // Update the selected locale when it has been set from the preferences.
+  function(store) {
+    store.watch(
+      (state, getters) => getters['preferences/preferences']?.application?.locale,
+      (newLocale: LocaleString | undefined) => {
+        if (newLocale && newLocale !== store.state.i18n.selected) {
+          store.dispatch('i18n/switchTo', newLocale);
+        }
+      },
+    );
+  },
+];

--- a/pkg/rancher-desktop/store/i18n.ts
+++ b/pkg/rancher-desktop/store/i18n.ts
@@ -249,4 +249,18 @@ export const plugins: Plugin<RootState>[] = [
       },
     );
   },
+  // Update the _displayed_ locale when the local storage value has changed;
+  // this happens to the main window when the preferences dialog was changed
+  // without saving.
+  function(store) {
+    addEventListener('storage', (event) => {
+      if ( event.key === 'locale' ) {
+        const newLocale = event.newValue as LocaleString | null;
+
+        if (newLocale && newLocale !== store.state.i18n.selected) {
+          store.dispatch('i18n/switchTo', newLocale);
+        }
+      }
+    });
+  },
 ];

--- a/pkg/rancher-desktop/store/i18n.ts
+++ b/pkg/rancher-desktop/store/i18n.ts
@@ -1,34 +1,40 @@
 import { IntlMessageFormat } from 'intl-messageformat';
+import { MutationTree } from 'vuex';
 
+import { ActionTree, GetterTree, MutationsType } from './ts-helpers';
 import packageJson from '../../../package.json' with { type: 'json' };
 
 import { LOCALE } from '@pkg/config/cookies';
 import { getVendor } from '@pkg/config/private-label';
+import { RootState } from '@pkg/entry/store';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { get } from '@pkg/utils/object';
 import { availableLocales, loadTranslations } from '@pkg/utils/translationLoader';
 
+type I18nState = ReturnType<typeof state>;
+
 // Formatters can't be serialized into state
-const intlCache = {};
+const intlCache: Record<string, IntlMessageFormat | string> = {};
 let ipcListenersBound = false;
 
 export const state = function() {
   const out = {
     default:      'en-us',
-    selected:     null,
+    selected:     null as string | null,
     available:    [...availableLocales],
-    translations: { 'en-us': loadTranslations('en-us') },
+    translations: { 'en-us': loadTranslations('en-us') } as Record<string, Record<string, unknown>>,
   };
 
   return out;
 };
 
 export const getters = {
-  availableLocales(state) {
+  availableLocales(state, getters) {
     const labelled = state.available.map((locale) => {
       const nativeName = get(state.translations[locale], `locale.${ locale }`);
-      const translatedName = get(state.translations[state.selected], `locale.${ locale }`) ??
-                          get(state.translations[state.default], `locale.${ locale }`);
+      const translatedName =
+        get(state.translations[getters.current()], `locale.${ locale }`) ??
+        get(state.translations[state.default], `locale.${ locale }`);
 
       if ( !nativeName || !translatedName || nativeName === translatedName ) {
         return [locale, nativeName ?? translatedName ?? locale];
@@ -41,7 +47,7 @@ export const getters = {
     // Fall back to the default when the selection is not a bundled locale,
     // because Intl.Collator rejects an unknown tag. The selection is null
     // until init runs, and older settings can carry 'none'.
-    const collationLocale = state.available.includes(state.selected) ? state.selected : state.default;
+    const collationLocale = state.available.includes(getters.current()) ? getters.current() : state.default;
     const collator = new Intl.Collator(collationLocale);
 
     labelled.sort(([, a], [, b]) => collator.compare(a, b));
@@ -49,12 +55,12 @@ export const getters = {
     return Object.fromEntries(labelled);
   },
 
-  t: state => (key, args) => {
-    const cacheKey = `${ state.selected }/${ key }`;
+  t: (state, getters) => (key: string, args?: Record<string, unknown>) => {
+    const cacheKey = `${ getters.current() }/${ key }`;
     let formatter = intlCache[cacheKey];
 
     if ( !formatter ) {
-      let msg = get(state.translations[state.selected], key);
+      let msg = get(state.translations[getters.current()], key);
 
       if ( !msg ) {
         msg = get(state.translations[state.default], key);
@@ -72,12 +78,18 @@ export const getters = {
         return `%${ key }%`;
       }
 
+      if ( typeof msg !== 'string' ) {
+        console.error('Translation for', cacheKey, 'is not a string:', msg);
+
+        msg = String(msg);
+      }
+
       if ( msg?.includes('{')) {
         try {
           // Uses the selected locale for formatting even when falling back to
           // English text. Acceptable: plural rules rarely diverge for the
           // strings used here.
-          formatter = new IntlMessageFormat(msg, state.selected);
+          formatter = new IntlMessageFormat(msg, getters.current());
         } catch (e) {
           console.error(`Malformed ICU pattern for key "${ key }":`, e);
           formatter = msg;
@@ -91,7 +103,7 @@ export const getters = {
 
     if ( typeof formatter === 'string' ) {
       return formatter;
-    } else if ( formatter && formatter.format ) {
+    } else {
       // Inject things like appName so they're always available in any translation
       const moreArgs = {
         vendor:  getVendor(),
@@ -106,15 +118,13 @@ export const getters = {
         // degrade to the raw pattern like the main-process interpolator.
         console.error(`Cannot format translation for key "${ key }":`, e);
 
-        return get(state.translations[state.selected], key) ?? get(state.translations[state.default], key);
+        return get(state.translations[getters.current()], key) ?? get(state.translations[state.default], key);
       }
-    } else {
-      return '?';
     }
   },
 
-  exists: state => (key) => {
-    const cacheKey = `${ state.selected }/${ key }`;
+  exists: (state, getters) => (key: string) => {
+    const cacheKey = `${ getters.current() }/${ key }`;
 
     if ( intlCache[cacheKey] ) {
       return true;
@@ -123,7 +133,7 @@ export const getters = {
     let msg = get(state.translations[state.default], key);
 
     if ( !msg && state.selected ) {
-      msg = get(state.translations[state.selected], key);
+      msg = get(state.translations[getters.current()], key);
     }
 
     if ( msg !== undefined ) {
@@ -134,39 +144,46 @@ export const getters = {
   },
 
   current: state => () => {
-    return state.selected;
+    return state.selected ?? state.default;
   },
 
   default: state => () => {
     return state.default;
   },
 
-  withFallback: (state, getters) => (key, args, fallback, fallbackIsKey = false) => {
-    // Support withFallback(key,fallback) when no args
-    if ( !fallback && typeof args === 'string' ) {
-      fallback = args;
-      args = {};
-    }
+  withFallback(state, getters) {
+    function withFallback(key: string, fallback: string): string;
+    function withFallback(key: string, args: Record<string, unknown>, fallback: string, fallbackIsKey?: boolean): string;
+    function withFallback(key: string, args: Record<string, unknown> | string, fallback?: string, fallbackIsKey = false) {
+      // Support withFallback(key,fallback) when no args
+      const parsedFallback = typeof args === 'string' ? args : fallback;
+      const parsedArgs = typeof args === 'string' ? {} : args;
 
-    if ( getters.exists(key) ) {
-      return getters.t(key, args);
-    } else if ( fallbackIsKey ) {
-      return getters.t(fallback, args);
-    } else {
-      return fallback;
+      if ( getters.exists(key) ) {
+        return getters.t(key, parsedArgs);
+      } else if ( parsedFallback === undefined ) {
+        console.error(`withFallback called for missing key "${ key }" without a fallback`);
+
+        return `%${ key }%`;
+      } else if ( fallbackIsKey ) {
+        return getters.t(parsedFallback, parsedArgs);
+      } else {
+        return parsedFallback;
+      }
     }
+    return withFallback;
   },
-};
+} satisfies GetterTree<I18nState>;
 
 export const mutations = {
-  loadTranslations(state, { locale, translations }) {
+  loadTranslations(state, { locale, translations }: { locale: string, translations: Record<string, unknown> }) {
     state.translations[locale] = translations;
   },
 
-  setSelected(state, locale) {
+  setSelected(state, locale: string) {
     state.selected = locale;
   },
-};
+} satisfies MutationsType<I18nState> & MutationTree<I18nState>;
 
 export const actions = {
   async init({ state, commit, dispatch }) {
@@ -205,7 +222,7 @@ export const actions = {
     return dispatch('switchTo', selected);
   },
 
-  async load({ commit }, locale) {
+  load({ commit }, locale: string) {
     const translations = loadTranslations(locale);
 
     commit('loadTranslations', { locale, translations });
@@ -213,7 +230,7 @@ export const actions = {
     return true;
   },
 
-  async switchTo({ state, commit, dispatch }, locale) {
+  async switchTo({ state, commit, dispatch }, locale: string) {
     if ( !locale ) {
       locale = state.default;
     }
@@ -245,4 +262,4 @@ export const actions = {
     });
   },
 
-};
+} satisfies ActionTree<I18nState, RootState, typeof mutations, typeof getters>;

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -17,7 +17,7 @@ export interface IpcMainEvents {
   'factory-reset':         (keepSystemImages: boolean) => void;
   'update-network-status': (status: boolean) => void;
   /** The locale has been changed; also emitted on initialization. */
-  'i18n/locale-change':    (locale: string) => void;
+  'i18n/locale-change':    (locale: import('@pkg/utils/translationLoader').LocaleString) => void;
 
   // #region backend
   /** The app status has changed.  The input is the status conditions on the app. */

--- a/pkg/rancher-desktop/typings/vuex-cookies.d.ts
+++ b/pkg/rancher-desktop/typings/vuex-cookies.d.ts
@@ -1,0 +1,12 @@
+/**
+ * This file declares our use of `cookie-universal` in the Vuex store; see
+ * {@link ../entry/index.ts} for the actual implementation.
+ */
+
+import type { ICookie } from 'cookie-universal';
+
+declare module 'vuex' {
+  interface Store<S> {
+    $cookies: ICookie;
+  }
+}

--- a/pkg/rancher-desktop/utils/translationLoader.ts
+++ b/pkg/rancher-desktop/utils/translationLoader.ts
@@ -13,9 +13,13 @@ import { fileURLToPath } from 'url';
 
 import yaml from 'js-yaml';
 
+// TODO: generate this list from a script (e.g. as a `prebuild` script in
+// `package.json`).
+export type LocaleString = 'de' | 'en-us' | 'es' | 'fr' | 'it' | 'ja' | 'ko' | 'pt-br' | 'zh-hans';
+
 interface TranslationSource {
-  locales: string[];
-  load(locale: string): Record<string, unknown>;
+  locales: LocaleString[];
+  load(locale: LocaleString): Record<string, unknown>;
 }
 
 function webpackSource(): TranslationSource {
@@ -26,7 +30,7 @@ function webpackSource(): TranslationSource {
   );
 
   return {
-    locales: context.keys().map(p => p.replace(/^.*\/([^\/]+)\.[^.]+$/, '$1')),
+    locales: context.keys().map(p => p.replace(/^.*\/([^\/]+)\.[^.]+$/, '$1') as LocaleString),
     load:    locale => context(`./${ locale }.yaml`) as Record<string, unknown>,
   };
 }
@@ -35,7 +39,7 @@ function filesystemSource(): TranslationSource {
   const dir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'assets', 'translations');
 
   return {
-    locales: fs.readdirSync(dir).filter(f => f.endsWith('.yaml')).map(f => f.replace(/\.yaml$/, '')),
+    locales: fs.readdirSync(dir).filter(f => f.endsWith('.yaml')).map(f => f.replace(/\.yaml$/, '') as LocaleString),
     load:    locale => yaml.load(fs.readFileSync(path.join(dir, `${ locale }.yaml`), 'utf8')) as Record<string, unknown>,
   };
 }
@@ -43,9 +47,9 @@ function filesystemSource(): TranslationSource {
 const source = import.meta.webpack ? webpackSource() : filesystemSource();
 
 /** Locale codes derived from the bundled translation files. */
-export const availableLocales: string[] = source.locales;
+export const availableLocales: LocaleString[] = source.locales;
 
 /** Returns the parsed translations for a bundled locale. */
-export function loadTranslations(locale: string): Record<string, unknown> {
+export function loadTranslations(locale: LocaleString): Record<string, unknown> {
   return source.load(locale);
 }

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -6,7 +6,6 @@ import Electron, {
 } from 'electron';
 
 import { getSettings } from '@pkg/config/settingsImpl';
-import { getLocale } from '@pkg/main/i18n';
 import { IpcRendererEvents } from '@pkg/typings/electron-ipc';
 import { isDevBuild } from '@pkg/utils/environment';
 import Logging from '@pkg/utils/logging';
@@ -96,12 +95,7 @@ export function createWindow(name: string, url: string, options: Electron.Browse
     Logging[`window_${ name }`].error(`Failed to load ${ url }: ${ errorCode } (${ errorDescription })`, event);
   });
   console.debug('createWindow() name:', name, ' url:', url);
-  // Give the renderer its locale in the URL so the first paint is already
-  // localized, without waiting on a settings roundtrip.
-  const localizedUrl = new URL(url);
-
-  localizedUrl.searchParams.set('locale', getLocale());
-  window.loadURL(localizedUrl.toString());
+  window.loadURL(url);
   windowMapping[name] = window.id;
 
   return window;

--- a/pkg/rdd-client/gen/models/IoRancherdesktopAppV1alpha1AppSpecApplication.ts
+++ b/pkg/rdd-client/gen/models/IoRancherdesktopAppV1alpha1AppSpecApplication.ts
@@ -17,6 +17,10 @@ import { HttpFile } from '../http/http';
 * application specifies the settings for the Rancher Desktop Electron frontend.
 */
 export class IoRancherdesktopAppV1alpha1AppSpecApplication {
+    /**
+    * locale is the language/locale to use for the Rancher Desktop App.
+    */
+    'locale'?: string;
     'updates'?: IoRancherdesktopAppV1alpha1AppSpecApplicationUpdates;
 
     static readonly discriminator: string | undefined = undefined;
@@ -24,6 +28,12 @@ export class IoRancherdesktopAppV1alpha1AppSpecApplication {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "locale",
+            "baseName": "locale",
+            "type": "string",
+            "format": ""
+        },
         {
             "name": "updates",
             "baseName": "updates",

--- a/rdd/docs/design/api_app.md
+++ b/rdd/docs/design/api_app.md
@@ -56,6 +56,7 @@ metadata:
 
 spec:
   application:
+    locale: en-zz
     updates:
       enabled: true
   containerEngine:
@@ -88,6 +89,9 @@ status:
     observedGeneration: 1
 ```
 
+- **spec.application.locale**: The display language to be used by the application; this may also
+  affect other text for display.  Defaults to `en-us`.
+
 - **spec.application.updates.enabled**: For use by the Electron front end, to control whether the
   application will attempt to update itself.  Defaults to `true`.
 
@@ -95,7 +99,7 @@ status:
 
 - **spec.running**: Set to `true` to start the LimaVM, `false` to stop it. The App controller propagates this value to `LimaVM.spec.running` on every reconcile.
 
-**spec.containerEngine.name**: The container engine to use inside the VM. Valid values: `moby` (Docker-compatible, default) and `containerd`. Propagated to the `CONTAINER_ENGINE` Lima template param.
+- **spec.containerEngine.name**: The container engine to use inside the VM. Valid values: `moby` (Docker-compatible, default) and `containerd`. Propagated to the `CONTAINER_ENGINE` Lima template param.
 
 - **spec.kubernetes.enabled**: Whether Kubernetes should be enabled in the VM. Defaults to `false`. Propagated to the `KUBERNETES_ENABLED` Lima template param.
 

--- a/rdd/pkg/apis/app/v1alpha1/app_types.go
+++ b/rdd/pkg/apis/app/v1alpha1/app_types.go
@@ -177,6 +177,10 @@ type ApplicationSpec struct {
 	// +optional
 	// +kubebuilder:default={enabled:true}
 	Updates ApplicationUpdatesSpec `json:"updates,omitempty"`
+	// locale is the language/locale to use for the Rancher Desktop App.
+	// +optional
+	// +kubebuilder:default="en-us"
+	Locale string `json:"locale,omitempty"`
 }
 
 // ApplicationUpdatesSpec defines settings for the Rancher Desktop App's update

--- a/rdd/pkg/controllers/app/app/crd.yaml
+++ b/rdd/pkg/controllers/app/app/crd.yaml
@@ -54,6 +54,11 @@ spec:
                 description: application specifies the settings for the Rancher Desktop
                   Electron frontend.
                 properties:
+                  locale:
+                    default: en-us
+                    description: locale is the language/locale to use for the Rancher
+                      Desktop App.
+                    type: string
                   updates:
                     default:
                       enabled: true

--- a/rdd/pkg/controllers/mock/crd.yaml
+++ b/rdd/pkg/controllers/mock/crd.yaml
@@ -54,6 +54,11 @@ spec:
                 description: application specifies the settings for the Rancher Desktop
                   Electron frontend.
                 properties:
+                  locale:
+                    default: en-us
+                    description: locale is the language/locale to use for the Rancher
+                      Desktop App.
+                    type: string
                   updates:
                     default:
                       enabled: true


### PR DESCRIPTION
This implements locale switching for RDA.  The selected locale is also stored on the app object, though that mostly exists right now so the existing code to handle preferences dialog states can be correct.