### PR TITLE
RDA: E2E: Prefs: locale switching

### DIFF
--- a/e2e/pages/nav-page.ts
+++ b/e2e/pages/nav-page.ts
@@ -53,10 +53,9 @@ export class NavPage {
       if (!stderr.includes('has been started: true')) {
         return false;
       }
-      // Check CRDs first, to avoid error messages when apps are not registered yet.
-      const AppsCRDSuffix = '/apps.app.rancherdesktop.io';
-      const crds = await rdd('ctl', 'get', 'crds', '--output=name');
-      if (!crds.split('\n').some(line => line.trim().endsWith(AppsCRDSuffix))) {
+      // Check API resources first, to avoid error messages when apps are not registered yet.
+      const resources = JSON.parse(await rdd('ctl', 'api-resources', '--output=json'));
+      if (!resources.resources.some((resource: { name: string }) => resource.name === 'apps')) {
         return false;
       }
       const rawApps = await rdd('ctl', 'get', 'apps', '--output=json');

--- a/e2e/pages/preferences/application.ts
+++ b/e2e/pages/preferences/application.ts
@@ -16,17 +16,17 @@ export class ApplicationNav {
 
   constructor(page: Page) {
     this.page = page;
-    this.nav = page.locator('[data-test="nav-application"]');
-    this.tabBehavior = page.locator('.tab >> text=Behavior');
-    this.tabEnvironment = page.locator('.tab >> text=Environment');
-    this.tabGeneral = page.locator('.tab >> text=General');
-    this.administrativeAccess = page.locator('[data-test="administrativeAccess"]');
-    this.automaticUpdates = page.locator('[data-test="automaticUpdates"]');
-    this.automaticUpdatesCheckbox = page.locator('[data-test="automaticUpdatesCheckbox"]');
-    this.statistics = page.locator('[data-test="statistics"]');
-    this.autoStart = page.locator('[data-test="autoStart"]');
-    this.background = page.locator('[data-test="background"]');
-    this.notificationIcon = page.locator('[data-test="notificationIcon"]');
-    this.pathManagement = page.locator('[data-test="pathManagement"]');
+    this.nav = page.getByTestId('nav-application');
+    this.tabBehavior = page.getByTestId('btn-behavior');
+    this.tabEnvironment = page.getByTestId('btn-environment');
+    this.tabGeneral = page.getByTestId('btn-general');
+    this.administrativeAccess = page.getByTestId('administrativeAccess');
+    this.automaticUpdates = page.getByTestId('automaticUpdates');
+    this.automaticUpdatesCheckbox = page.getByTestId('automaticUpdatesCheckbox');
+    this.statistics = page.getByTestId('statistics');
+    this.autoStart = page.getByTestId('autoStart');
+    this.background = page.getByTestId('background');
+    this.notificationIcon = page.getByTestId('notificationIcon');
+    this.pathManagement = page.getByTestId('pathManagement');
   }
 }

--- a/e2e/pages/preferences/application.ts
+++ b/e2e/pages/preferences/application.ts
@@ -5,6 +5,7 @@ export class ApplicationNav {
   readonly tabBehavior:              Locator;
   readonly tabEnvironment:           Locator;
   readonly tabGeneral:               Locator;
+  readonly localeSelect:             Locator;
   readonly administrativeAccess:     Locator;
   readonly automaticUpdates:         Locator;
   readonly automaticUpdatesCheckbox: Locator;
@@ -20,6 +21,7 @@ export class ApplicationNav {
     this.tabBehavior = page.getByTestId('btn-behavior');
     this.tabEnvironment = page.getByTestId('btn-environment');
     this.tabGeneral = page.getByTestId('btn-general');
+    this.localeSelect = page.getByTestId('localeSelect');
     this.administrativeAccess = page.getByTestId('administrativeAccess');
     this.automaticUpdates = page.getByTestId('automaticUpdates');
     this.automaticUpdatesCheckbox = page.getByTestId('automaticUpdatesCheckbox');

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -40,48 +40,61 @@ test.describe('Preferences Dialog', () => {
     await prefPage.waitForLoad();
   });
 
-  test.fixme('should show application page and render general tab', async() => {
-    const { application } = prefPage;
+  test.describe('Application', () => {
+    test('should show application page and render general tab', async() => {
+      const { application } = prefPage;
 
-    await expect(application.nav).toHaveClass('preferences-nav-item active');
+      await expect(application.nav).toHaveClass('preferences-nav-item active');
+      await expect(application.tabGeneral).toHaveText('General');
+      // TODO: environment tab visiblity.
+      // TODO: behavior tab visibility.
+      await expect(application.tabGeneral).toHaveAttribute('aria-selected', 'true');
 
-    if (!os.platform().startsWith('win')) {
-      await expect(application.tabEnvironment).toBeVisible();
-    } else {
-      await expect(application.tabEnvironment).not.toBeVisible();
-    }
+      await expect(application.automaticUpdates).toBeVisible();
+      // TODO: telemetry visibility.
+      // TODO: auto start (in)visibility.
+      // TODO: path management (in)visibility.
+    });
 
-    await expect(application.tabGeneral).toHaveText('General');
-    await expect(application.tabBehavior).toBeVisible();
+    test('should show locale selection', async() => {
+      const { application } = prefPage;
 
-    await expect(application.automaticUpdates).toBeVisible();
-    await expect(application.statistics).toBeVisible();
-    await expect(application.autoStart).not.toBeVisible();
-    await expect(application.pathManagement).not.toBeVisible();
-  });
+      await expect(application.localeSelect).toBeEnabled();
+      await expect(application.localeSelect).toHaveValue('en-us');
+      try {
+        await application.localeSelect.selectOption('ko');
+        // Changing the selected option should change the locale
+        await expect(application.tabGeneral).toHaveText(/^\p{Script=Hangul}+$/u);
+      } finally {
+        // Change the option back for future tests
+        await application.localeSelect.selectOption('en-us');
+      }
+      await expect(application.tabGeneral).toHaveText('General');
+    });
 
-  test.fixme('should render behavior tab', async() => {
-    const { application } = prefPage;
+    test.fixme('should render behavior tab', async() => {
+      const { application } = prefPage;
 
-    await application.tabBehavior.click();
+      await application.tabBehavior.click();
 
-    await expect(application.autoStart).toBeVisible();
-    await expect(application.background).toBeVisible();
-    await expect(application.notificationIcon).toBeVisible();
-    await expect(application.administrativeAccess).not.toBeVisible();
-    await expect(application.pathManagement).not.toBeVisible();
-  });
+      await expect(application.autoStart).toBeVisible();
+      await expect(application.background).toBeVisible();
+      await expect(application.notificationIcon).toBeVisible();
+      await expect(application.administrativeAccess).not.toBeVisible();
+      await expect(application.pathManagement).not.toBeVisible();
+    });
 
-  test.fixme('should render environment tab', async() => {
-    test.skip(os.platform() === 'win32', 'Environment tab not available on Windows');
-    const { application } = prefPage;
+    test.fixme('should render environment tab', async() => {
+      test.skip(os.platform() === 'win32', 'Environment tab not available on Windows');
+      const { application } = prefPage;
 
-    await application.tabEnvironment.click();
+      await application.tabEnvironment.click();
 
-    await expect(application.administrativeAccess).not.toBeVisible();
-    await expect(application.automaticUpdates).not.toBeVisible();
-    await expect(application.statistics).not.toBeVisible();
-    await expect(application.pathManagement).toBeVisible();
+      await expect(application.administrativeAccess).not.toBeVisible();
+      await expect(application.automaticUpdates).not.toBeVisible();
+      await expect(application.statistics).not.toBeVisible();
+      await expect(application.pathManagement).toBeVisible();
+    });
   });
 
   test.describe('Virtual Machine', () => {

--- a/pkg/rancher-desktop/components/Preferences/ApplicationBehavior.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationBehavior.vue
@@ -45,7 +45,7 @@ export default defineComponent({
     <div class="row">
       <div class="col span-6">
         <rd-fieldset
-          data-test="autoStart"
+          data-testid="autoStart"
           :legend-text="t('application.behavior.autoStart.legendText')"
         >
           <rd-checkbox
@@ -56,7 +56,7 @@ export default defineComponent({
           />
         </rd-fieldset>
         <rd-fieldset
-          data-test="background"
+          data-testid="background"
           :legend-text="t('application.behavior.background.legendText')"
           :legend-tooltip="t('application.behavior.background.legendTooltip')"
           class="checkbox-group"
@@ -75,7 +75,7 @@ export default defineComponent({
           />
         </rd-fieldset>
         <rd-fieldset
-          data-test="notificationIcon"
+          data-testid="notificationIcon"
           :legend-text="t('application.behavior.notificationIcon.legendText')"
         >
           <rd-checkbox
@@ -88,7 +88,7 @@ export default defineComponent({
       </div>
       <div class="col span-6 theme-options">
         <rd-fieldset
-          data-test="theme"
+          data-testid="theme"
           :legend-text="t('application.behavior.theme.legendText')"
           :is-locked="isPreferenceLocked('application.theme')"
         >
@@ -109,7 +109,7 @@ export default defineComponent({
                   :value="preferences.application.theme"
                   :val="option.value"
                   :disabled="isDisabled"
-                  :data-test="option.label"
+                  :data-testid="`theme-${option.value}`"
                   @update:value="onChange('application.theme', $event)"
                 >
                   <template #label>

--- a/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
@@ -40,7 +40,7 @@ export default defineComponent({
 
 <template>
   <rd-fieldset
-    data-test="pathManagement"
+    data-testid="pathManagement"
     :legend-text="t('pathManagement.label')"
     :legend-tooltip="t('pathManagement.tooltip')"
     :is-locked="isPreferenceLocked('application.pathManagementStrategy')"

--- a/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
@@ -22,13 +22,13 @@ function onLocaleChange(newLocale: string) {
 <template>
   <div class="application-general">
     <rd-fieldset
-      data-test="locale"
+      data-testid="locale"
       class="width-xs"
       :legend-text="t('application.locale.legendText')"
       :is-experimental="true"
     >
       <rd-select
-        data-test="localeSelect"
+        data-testid="localeSelect"
         :model-value="selectedLocale"
         :aria-label="t('application.locale.legendText')"
         :is-locked="isPreferenceLocked('application.locale')"
@@ -52,7 +52,7 @@ function onLocaleChange(newLocale: string) {
     <!-- We don't have sudo access at this point
     <rd-fieldset
       v-if="platform !== 'win32'"
-      data-test="administrativeAccess"
+      data-testid="administrativeAccess"
       :legend-text="t('application.general.adminAccess.legendText')"
       :legend-tooltip="t('application.general.adminAccess.legendTooltip')"
     >
@@ -65,18 +65,18 @@ function onLocaleChange(newLocale: string) {
     </rd-fieldset>
   -->
     <rd-fieldset
-      data-test="automaticUpdates"
+      data-testid="automaticUpdates"
       :legend-text="t('application.general.automaticUpdates.legendText')"
     >
       <rd-checkbox
         preference="application.updates.enabled"
-        data-test="automaticUpdatesCheckbox"
+        data-testid="automaticUpdatesCheckbox"
         :label="t('application.general.automaticUpdates.label')"
       />
     </rd-fieldset>
     <!--
     <rd-fieldset
-      data-test="statistics"
+      data-testid="statistics"
       :legend-text="t('application.general.statistics.legendText')"
     >
       <rd-checkbox


### PR DESCRIPTION
This implements E2E tests for the prefs dialog on switching languages.  It switches to Korean, and then tests that the _General_ tab turns into purely Hangul text.

Goes on top of #622.