### PR TITLE
Add PATH management to the App controller

### DIFF
--- a/pkg/rdd-client/gen/models/IoRancherdesktopAppV1alpha1AppSpecApplication.ts
+++ b/pkg/rdd-client/gen/models/IoRancherdesktopAppV1alpha1AppSpecApplication.ts
@@ -18,6 +18,17 @@ import { HttpFile } from '../http/http';
 */
 export class IoRancherdesktopAppV1alpha1AppSpecApplication {
     /**
+    * addPath controls whether and where the Rancher Desktop bin directory
+    * (~/.rd<suffix>/bin) is added to the user's PATH, by editing their shell
+    * startup files (Unix) or the user Environment (Windows):
+    *   - "front":  prepend, so the bin directory wins   (bin:$PATH)
+    *   - "back":   append,  so existing PATH entries win ($PATH:bin)
+    *   - "manual": leave PATH alone; remove any lines a previous front/back added.
+    * It defaults to "manual" so CLI-created instances don't touch shell startup
+    * files unasked; the GUI sends "front" when the user opts in.
+    */
+    'addPath'?: string;
+    /**
     * locale is the language/locale to use for the Rancher Desktop App.
     */
     'locale'?: string;
@@ -28,6 +39,12 @@ export class IoRancherdesktopAppV1alpha1AppSpecApplication {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "addPath",
+            "baseName": "addPath",
+            "type": "string",
+            "format": ""
+        },
         {
             "name": "locale",
             "baseName": "locale",

--- a/rdd/docs/design/api_app.md
+++ b/rdd/docs/design/api_app.md
@@ -59,6 +59,7 @@ spec:
     locale: en-zz
     updates:
       enabled: true
+    addPath: manual
   containerEngine:
     name: moby
   kubernetes:
@@ -95,6 +96,27 @@ status:
 - **spec.application.updates.enabled**: For use by the Electron front end, to control whether the
   application will attempt to update itself.  Defaults to `true`.
 
+- **spec.application.addPath**: Controls whether and where the Rancher Desktop bin directory
+  (`~/.rd<suffix>/bin`) is added to the user's `PATH`. The path-management controller edits the
+  user's shell startup files on Unix (`.bash_profile`/`.bash_login`/`.profile`, `.bashrc`,
+  `.zshrc`, `.cshrc`/`.tcshrc`, and fish's `config.fish`) and the user `Environment` in the
+  registry on Windows. Valide values:
+  - `front`: prepend, so the bin directory takes precedence (`bin:$PATH`).
+  - `back`: append, so existing `PATH` entries win (`$PATH:bin`).
+  - `manual`: do not manage `PATH`; remove any lines a previous `front`/`back` added.
+
+  Defaults to `manual`, so instances created by the CLI never edit shell startup files without user's
+  user's knowledge; the GUI is expected to send `front` explicitly when the user opts in.
+
+  On Unix, `manual` removes only the block between our start/end markers, so a hand-written
+  `PATH` line survives anywhere. On Windows the user `Environment` `Path` is a plain
+  semicolon-separated list with nowhere to fence our entry, so under `manual` we can't tell an
+  entry we added from one the user typed. We remove the bin directory only when it sits at the
+  very front or back of `Path` (the two spots `front`/`back` would have written) and leave a copy
+  placed in the middle alone. The trade-off: an entry parked at either end is treated as ours and
+  removed, so to put the bin directory at the front or back on Windows use `front`/`back` rather
+  than placing it there under `manual`.
+
 - **spec.namespace**: The namespace where the owned `LimaVM` and its ConfigMaps are created. Defaults to `default`. **Immutable after creation** — changing it would orphan resources in the original namespace.
 
 - **spec.running**: Set to `true` to start the LimaVM, `false` to stop it. The App controller propagates this value to `LimaVM.spec.running` on every reconcile.
@@ -107,7 +129,7 @@ status:
 
 - **status.kubernetesPort**: The host TCP port allocated for the k3s API server (`7441 + instance.Index()` by default). Set by the App reconciler on the first reconcile after `spec.kubernetes.enabled` becomes `true`, and cleared when `spec.kubernetes.enabled` is set back to `false` so that a fresh port is resolved on the next enable. The `KUBERNETES_PORT` Lima template param is set to this value; Lima's identity port-forward rule binds the same port on the host and forwards it to the guest.
 
-- **status.conditions**: Multiple controllers write here. The App controller mirrors `Created` and `Running` from the owned `LimaVM` and computes `Settled`, the engine controller writes `ContainerEngineReady`, and the Kubernetes controller writes `KubernetesReady`. All writers use `retry.RetryOnConflict` with a re-Get so concurrent status updates do not 409.
+- **status.conditions**: Multiple controllers write here. The App controller mirrors `Created` and `Running` from the owned `LimaVM` and computes `Settled`, the engine controller writes `ContainerEngineReady`, the Kubernetes controller writes `KubernetesReady`, and the PATH management controller writes `PathManagementReady`. All writers use `retry.RetryOnConflict` with a re-Get so concurrent status updates do not 409.
 
   | Type                   | Status    | Reason           | Description                                                       |
   |------------------------|-----------|------------------|-------------------------------------------------------------------|
@@ -130,14 +152,19 @@ status:
   | `KubernetesReady`      | `False`   | `Probing`        | Waiting for k3s API server to respond                             |
   | `KubernetesReady`      | `False`   | `WaitingForNode` | API server answers but no node has reached Ready                  |
   | `KubernetesReady`      | `False`   | `MergeFailed`    | k3s is reachable but merging the instance kubeconfig failed (see `message`) |
+  | `PathManagementReady`  | `True`    | `Applied`        | `spec.application.addPath` was applied for the current generation |
+  | `PathManagementReady`  | `False`   | `Failed`         | Editing a shell startup file or the user Environment failed with a repairable error, e.g. I/O (see `message`) |
+  | `PathManagementReady`  | `False`   | `Malformed`      | A startup file was hand-edited into an unparseable state (a lone marker, or markers in the wrong order); only the user can fix it |
   | `Settled`              | `True`    | `Settled`        | Reconcile chain has caught up with the current spec               |
   | `Settled`              | `False`   | `WaitingForLimaVM` | The App has no `Running` condition yet (nothing mirrored from LimaVM) |
   | `Settled`              | `False`   | `WaitingForEngine` | Engine controller has not yet written `ContainerEngineReady`    |
   | `Settled`              | `False`   | `EngineStale`    | Engine controller has not yet observed the current generation     |
   | `Settled`              | `False`   | `WaitingForKubernetes` | Kubernetes controller has not yet written `KubernetesReady`  |
   | `Settled`              | `False`   | `KubernetesStale` | Kubernetes controller has not yet observed the current generation |
+  | `Settled`              | `False`   | `WaitingForPathManagement` | PATH management controller has not yet written `PathManagementReady` |
+  | `Settled`              | `False`   | `PathManagementStale` | PATH management controller has not yet observed the current generation |
   | `Settled`              | `False`   | `ApplyingTemplate` | A spec change rewrote the template; the LimaVM has not yet restarted into it |
-  | `Settled`              | `False`   | *(forwarded)*    | Forwarded from the blocking `Running`, `ContainerEngineReady`, or `KubernetesReady` reason |
+  | `Settled`              | `False`   | *(forwarded)*    | Forwarded from the blocking `Running`, `ContainerEngineReady`, `KubernetesReady`, or `PathManagementReady` reason (the latter under `front`/`back`, or under `manual` for a repairable `Failed`) |
 
   `Running=True` means the Lima guest has finished booting and SSH is reachable. It says nothing about the container engine socket; consumers that depend on the engine (container/image/volume mirrors, `docker` against the forwarded socket) must also check `ContainerEngineReady`, which flips to `True` only after the engine controller has connected to the socket and completed its initial full sync.
 
@@ -147,6 +174,23 @@ status:
   - The LimaVM must be running, reported by the mirrored `Running` condition. `Created` and `Running` are both mirrored from LimaVM, including their `lastTransitionTime`, so the timestamps track the LimaVM transition.
   - `ContainerEngineReady` must be `True`. The engine reconciler stamps its `observedGeneration` with the App's `metadata.generation` as it writes the condition, keeping the condition current with the App.
   - `KubernetesReady` must be `True` when `spec.kubernetes.enabled` is set. The Kubernetes reconciler stamps its `observedGeneration` the same way.
+  - `PathManagementReady` must be `True` when the PATH management controller is enabled, but the gate
+    depends on `spec.application.addPath`. It runs host-side, independent of the VM, and stamps its
+    `observedGeneration` with the App's `metadata.generation`. Freshness always gates: until the
+    controller has observed the current generation (`PathManagementReady` absent or its
+    `observedGeneration` behind), `Settled` is `False`/`WaitingForPathManagement` or
+    `False`/`PathManagementStale`, so `rdd set --wait` can't report success before the edit runs —
+    this holds even for `manual`, which still removes a block a previous `front`/`back` left behind.
+    A *failure* holds `Settled` at `False` under `front`/`back`: there the user asked us to edit
+    files, so a failed startup-file or user-Environment edit is surfaced. Under `manual` (the CRD
+    default) it depends on whether the failure is repairable. A *repairable* failure
+    (`PathManagementReasonFailed` — I/O, a read-only home, a full disk) over an intact block still
+    gates: the reconciler requeues and clears it, so `rdd set --wait` shouldn't report success over a
+    residue that's about to go away. A *permanent* failure (`PathManagementReasonMalformed` — a
+    startup file the user hand-edited into an unparseable state) does not gate `Settled` under
+    `manual`: the controller can't repair it and gating would wedge `Settled` forever. Either way the
+    failure is recorded on `PathManagementReady`, so consumers should surface that condition rather
+    than assume `Settled` covers it.
 
   `Settled` carries its own `observedGeneration`: the App's generation observed when the reconciler computed the condition. `rdd set` therefore waits for `Settled=True` with `observedGeneration` at least the post-patch `metadata.generation`, so it settles on its own change rather than a stale snapshot from an earlier generation.
 

--- a/rdd/docs/design/bootstrap.md
+++ b/rdd/docs/design/bootstrap.md
@@ -67,19 +67,15 @@ Except for the backgrounding of the control plane process all other actions are 
 
 ### Setting up `PATH` and shell completions
 
-`rdd start` has installed additional utilities to `~/.rd2/bin`, but now that directory must be added to the `PATH` as well:
+`rdd start` has installed additional utilities to `~/.rd2/bin`, and that directory must be added to the `PATH`. Unless `spec.application.addPath` is `manual`, PATH management does this automatically: it writes a marker-fenced `export PATH` line into the user's shell startup files (the first existing of `~/.bash_profile`, `~/.bash_login`, `~/.profile`, plus `~/.bashrc` and `~/.zshrc`, with the equivalent for csh/tcsh and fish):
 
 ```bash
-export PATH="$HOME/.rd2/bin:$PATH
+### MANAGED BY RANCHER DESKTOP 2 START (DO NOT EDIT)
+export PATH="$HOME/.rd2/bin:$PATH"
+### MANAGED BY RANCHER DESKTOP 2 END (DO NOT EDIT)
 ```
 
-An alternative is run use [rdd shell-profile](cmd_app.md#rdd-shell-profile); it can also configure shell completions for `rdd` and the additional utilities.
-
-```bash
-source <(rdd shell-profile bash --path --completions)
-```
-
-This is the command that is being added by path-management to `~/.bash_profile`.
+The markers let a later `rdd set application.addPath=...` (or an instance deletion) update or remove just this block, leaving the rest of the file alone. Shell completions for `rdd` and the bundled utilities are not configured today; the planned [`rdd shell-profile`](cmd_app.md#rdd-shell-profile) command would add both `PATH` and completions in one line, but it is not implemented yet.
 
 ### Docker Context
 

--- a/rdd/docs/design/cmd_app.md
+++ b/rdd/docs/design/cmd_app.md
@@ -92,7 +92,9 @@ docker run --rm hello-world
 
 ## `rdd shell-profile`
 
-It prints a list of shell commands to STDOUT to put the `~/.rd2/bin` directory on the `PATH` and load completions for `rdd` and any bundled utilities (`docker`, `helm`, ...).
+> **Not implemented yet.** `rdd shell-profile` is a planned command. PATH management (see below) does **not** use it today; it writes the `export PATH` line directly.
+
+It would print a list of shell commands to STDOUT to put the `~/.rd2/bin` directory on the `PATH` and load completions for `rdd` and any bundled utilities (`docker`, `helm`, ...).
 
 ```console
 $ rdd shell-profile bash --path --completions
@@ -103,9 +105,13 @@ source <(helm completions bash)
 ...
 ```
 
-This is also the command the "path management" inserts into the users shell profile, e.g.
+What PATH management actually inserts today is the literal `export PATH` line, fenced by markers so it can be updated or removed later (on an `addPath` change, or on deletion) without disturbing the rest of the file:
 
 ```bash
-source <(~/.rd2/bin/rdd shell-profile bash --path)
+### MANAGED BY RANCHER DESKTOP 2 START (DO NOT EDIT)
+export PATH="$HOME/.rd2/bin:$PATH"
+### MANAGED BY RANCHER DESKTOP 2 END (DO NOT EDIT)
 ```
+
+With `addPath: back` the line is `export PATH="$PATH:$HOME/.rd2/bin"` instead; csh/tcsh and fish get the equivalent line for their syntax. Completions are not configured today — that is what the planned `rdd shell-profile` would add.
 

--- a/rdd/go.mod
+++ b/rdd/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/coreos/go-semver v0.3.1
 	github.com/docker/cli v29.7.2+incompatible
 	github.com/go-logr/logr v1.4.4
+	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/k3s-io/kine v1.14.2
@@ -185,7 +186,6 @@ require (
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/godoc-lint/godoc-lint v0.10.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/rdd/pkg/apis/app/v1alpha1/app_types.go
+++ b/rdd/pkg/apis/app/v1alpha1/app_types.go
@@ -20,6 +20,9 @@ const EngineControllerName = "engine"
 // KubernetesControllerName is the registry name of the Kubernetes context controller.
 const KubernetesControllerName = "kubernetes"
 
+// PathManagementControllerName is the registry name of the PATH management controller.
+const PathManagementControllerName = "path-management"
+
 // App condition types.
 //
 // Load-bearing invariant: every condition written to App status must stamp
@@ -60,6 +63,15 @@ const (
 	// App reconciler flips it back to True. `rdd set` waits on this
 	// condition.
 	AppConditionSettled = "Settled"
+
+	// AppConditionPathManagementReady goes True once the PATH management
+	// controller has applied spec.application.addPath for the current
+	// generation: the bin directory is present in (front/back) or absent from
+	// (manual) the user's shell startup files and, on Windows, the user
+	// Environment. It stamps the App's generation into ObservedGeneration; a
+	// failed edit sets it False with reason Failed, so Settled and `rdd set`
+	// can observe the failure instead of reporting success.
+	AppConditionPathManagementReady = "PathManagementReady"
 )
 
 // Reasons for the Settled condition. Consumers branch on these
@@ -89,6 +101,34 @@ const (
 	// into the current template, so a spec change that rewrote the template is
 	// not yet in effect.
 	AppSettledReasonApplyingTemplate = "ApplyingTemplate"
+
+	// AppSettledReasonWaitingForPathManagement means the PATH management
+	// controller has not yet written PathManagementReady.
+	AppSettledReasonWaitingForPathManagement = "WaitingForPathManagement"
+
+	// AppSettledReasonPathManagementStale means the PATH management controller
+	// has not yet observed the current generation.
+	AppSettledReasonPathManagementStale = "PathManagementStale"
+)
+
+// Reasons for the PathManagementReady condition.
+const (
+	// PathManagementReasonApplied means spec.application.addPath was applied
+	// for the current generation.
+	PathManagementReasonApplied = "Applied"
+
+	// PathManagementReasonFailed means applying spec.application.addPath
+	// failed with a transient error (I/O, permissions, a full disk); the
+	// message carries the underlying error. It's repairable, so the reconciler
+	// keeps retrying and it gates Settled until it clears.
+	PathManagementReasonFailed = "Failed"
+
+	// PathManagementReasonMalformed means a startup file was hand-edited into a
+	// state we can't parse (a lone marker, or markers in the wrong order), so the
+	// block can't be removed. Only the user can fix the file, so unlike Failed
+	// it's permanent: it doesn't gate Settled under manual (which would wedge it
+	// forever) and doesn't block App deletion.
+	PathManagementReasonMalformed = "Malformed"
 )
 
 // Reasons for the KubernetesReady condition.
@@ -177,11 +217,47 @@ type ApplicationSpec struct {
 	// +optional
 	// +kubebuilder:default={enabled:true}
 	Updates ApplicationUpdatesSpec `json:"updates,omitempty"`
+	// addPath controls whether and where the Rancher Desktop bin directory
+	// (~/.rd<suffix>/bin) is added to the user's PATH, by editing their shell
+	// startup files (Unix) or the user Environment (Windows):
+	//   - "front":  prepend, so the bin directory wins   (bin:$PATH)
+	//   - "back":   append,  so existing PATH entries win ($PATH:bin)
+	//   - "manual": leave PATH alone; remove any lines a previous front/back added.
+	// It defaults to "manual" so CLI-created instances don't touch shell startup
+	// files unasked; the GUI sends "front" when the user opts in.
+	//
+	// On Windows the user Environment Path is a plain semicolon-separated list
+	// with nowhere to fence our entry, so under "manual" we can't tell an entry
+	// we added from one the user typed. We therefore remove the bin directory
+	// only when it sits at the very front or back of Path (the two spots
+	// front/back would have written) and leave a copy the user placed in the
+	// middle alone. The trade-off: an entry parked at either end is treated as
+	// ours and removed, so a user who wants the bin directory at the front or
+	// back on Windows must use "front"/"back", not place it there under
+	// "manual". Unix files use start/end markers, so only our own block is
+	// touched regardless of position.
+	// +optional
+	// +kubebuilder:validation:Enum=front;back;manual
+	// +kubebuilder:default=manual
+	AddPath AddPathStrategy `json:"addPath,omitempty"`
 	// locale is the language/locale to use for the Rancher Desktop App.
 	// +optional
 	// +kubebuilder:default="en-us"
 	Locale string `json:"locale,omitempty"`
 }
+
+// AddPathStrategy selects whether and where the Rancher Desktop bin directory is
+// added to the user's PATH.
+type AddPathStrategy string
+
+const (
+	// AddPathFront prepends the bin directory (bin:$PATH).
+	AddPathFront AddPathStrategy = "front"
+	// AddPathBack appends the bin directory ($PATH:bin).
+	AddPathBack AddPathStrategy = "back"
+	// AddPathManual leaves PATH unmanaged.
+	AddPathManual AddPathStrategy = "manual"
+)
 
 // ApplicationUpdatesSpec defines settings for the Rancher Desktop App's update
 // mechanism.  RDD generally does not do anything with these.

--- a/rdd/pkg/controllers/app/app/controllers/app_controller.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller.go
@@ -67,6 +67,9 @@ const (
 	settledMessageKubernetesStale      = "Kubernetes context needs to be synchronized"
 	settledMessageLimaVMNotReached     = "LimaVM has not yet reached "
 	settledMessageApplyingTemplate     = "Applying the configuration change to the VM"
+
+	settledMessageWaitingForPathManagement = "Waiting for PATH management condition"
+	settledMessagePathManagementStale      = "PATH management needs to be synchronized"
 )
 
 // AppReconciler reconciles the singleton App resource and manages its LimaVM lifecycle.
@@ -113,6 +116,21 @@ func (r *AppReconciler) kubernetesEnabled(ctx context.Context) bool {
 		return true
 	}
 	return slices.Contains(enabled, v1alpha1.KubernetesControllerName)
+}
+
+// pathManagementEnabled reports whether PathManagementReady should gate Settled.
+// On discovery errors it defaults to true so the wait does not return
+// prematurely while discovery is transiently unavailable.
+func (r *AppReconciler) pathManagementEnabled(ctx context.Context) bool {
+	if r.Discovery == nil {
+		return false
+	}
+	enabled, err := r.Discovery.GetEnabledControllers(ctx)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to query controller-manager discovery; assuming path management is enabled")
+		return true
+	}
+	return slices.Contains(enabled, v1alpha1.PathManagementControllerName)
 }
 
 func applySpecToTemplate(baseTemplate string, spec v1alpha1.AppSpec, kubernetesPort int) (string, error) {
@@ -493,6 +511,7 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 	// writers 409-loop through controller-runtime requeues.
 	engineEnabled := r.engineEnabled(ctx)
 	kubernetesEnabled := r.kubernetesEnabled(ctx)
+	pathManagementEnabled := r.pathManagementEnabled(ctx)
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest := &v1alpha1.App{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(&app), latest); err != nil {
@@ -516,9 +535,10 @@ func (r *AppReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Res
 		// briefly stale against latest, but the next reconcile re-derives them
 		// and corrects Settled.
 		settled := computeSettledCondition(latest, settledInputs{
-			engineEnabled:     engineEnabled,
-			kubernetesEnabled: kubernetesEnabled,
-			templateUpToDate:  templateUpToDate,
+			engineEnabled:         engineEnabled,
+			kubernetesEnabled:     kubernetesEnabled,
+			templateUpToDate:      templateUpToDate,
+			pathManagementEnabled: pathManagementEnabled,
 		})
 		changed = apimeta.SetStatusCondition(&latest.Status.Conditions, settled) || changed
 		if !changed {
@@ -546,6 +566,9 @@ type settledInputs struct {
 	// templateUpToDate is false when the LimaVM has not yet restarted into the
 	// current template; it holds Settled at False with reason ApplyingTemplate.
 	templateUpToDate bool
+	// pathManagementEnabled is false when no controller writes
+	// PathManagementReady; in that case the PATH management condition is ignored.
+	pathManagementEnabled bool
 }
 
 // computeSettledCondition derives Settled from the feeding conditions
@@ -566,6 +589,7 @@ func computeSettledCondition(app *v1alpha1.App, in settledInputs) metav1.Conditi
 	runningCond := apimeta.FindStatusCondition(app.Status.Conditions, v1alpha1.AppConditionRunning)
 	engineCond := apimeta.FindStatusCondition(app.Status.Conditions, v1alpha1.AppConditionContainerEngineReady)
 	kubeCond := apimeta.FindStatusCondition(app.Status.Conditions, v1alpha1.AppConditionKubernetesReady)
+	pathCond := apimeta.FindStatusCondition(app.Status.Conditions, v1alpha1.AppConditionPathManagementReady)
 	desiredRunning := app.Spec.Running
 
 	settled := metav1.Condition{
@@ -668,7 +692,55 @@ func computeSettledCondition(app *v1alpha1.App, in settledInputs) metav1.Conditi
 		settled.Reason = v1alpha1.AppSettledReasonSettled
 		settled.Message = settledMessageSettled
 	}
+
+	// PATH management runs host-side, independent of the VM, so it gates every
+	// otherwise-settled outcome (running or stopped). Only downgrade a True
+	// result: the engine/kubernetes/VM reasons above are more specific, so a
+	// still-pending PATH edit should not mask them.
+	//
+	// Freshness always gates: even manual does work (removing a block a previous
+	// front/back left behind), so we can't report Settled until the reconciler
+	// has caught up to the current generation, or `rdd set addPath=manual --wait`
+	// would return while the block is still in the startup files.
+	//
+	// A failure gates when the user opted in (front/back), and also under manual
+	// when it's repairable. Under manual the user asked us to leave PATH alone, so
+	// once the reconciler has observed the current generation, a *permanent*
+	// failure — a startup file the user hand-edited into an unparseable state,
+	// reported as PathManagementReasonMalformed — must not block Settled for
+	// unrelated settings: the reconciler can't repair it and gating would wedge
+	// Settled forever. A *repairable* failure (I/O, read-only home, full disk)
+	// over an intact block still gates: the reconciler requeues and clears it, so
+	// `rdd set addPath=manual --wait` shouldn't report success over a residue that
+	// is about to go away. Both are recorded on PathManagementReady regardless.
+	pathManaged := effectiveAddPath(app) != v1alpha1.AddPathManual
+	if settled.Status == metav1.ConditionTrue && in.pathManagementEnabled {
+		switch {
+		case pathCond == nil:
+			settled.Status = metav1.ConditionFalse
+			settled.Reason = v1alpha1.AppSettledReasonWaitingForPathManagement
+			settled.Message = settledMessageWaitingForPathManagement
+		case pathCond.ObservedGeneration < app.Generation:
+			settled.Status = metav1.ConditionFalse
+			settled.Reason = v1alpha1.AppSettledReasonPathManagementStale
+			settled.Message = settledMessagePathManagementStale
+		case pathCond.Status != metav1.ConditionTrue &&
+			(pathManaged || pathCond.Reason != v1alpha1.PathManagementReasonMalformed):
+			settled.Status = metav1.ConditionFalse
+			settled.Reason = pathCond.Reason
+			settled.Message = pathCond.Message
+		}
+	}
 	return settled
+}
+
+// effectiveAddPath returns the addPath strategy with the empty (unset) value
+// resolved to its default, matching the PATH management reconciler.
+func effectiveAddPath(app *v1alpha1.App) v1alpha1.AddPathStrategy {
+	if s := app.Spec.Application.AddPath; s != "" {
+		return s
+	}
+	return v1alpha1.AddPathManual
 }
 
 // runningLimaVMMessage builds the Settled message when LimaVM's

--- a/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
+++ b/rdd/pkg/controllers/app/app/controllers/app_controller_test.go
@@ -71,16 +71,21 @@ func Test_computeSettledCondition(t *testing.T) {
 	engine := func(reason, message string, status metav1.ConditionStatus, gen int64) metav1.Condition {
 		return cond(v1alpha1.AppConditionContainerEngineReady, reason, message, status, gen)
 	}
+	pathMgmt := func(reason, message string, status metav1.ConditionStatus, gen int64) metav1.Condition {
+		return cond(v1alpha1.AppConditionPathManagementReady, reason, message, status, gen)
+	}
 
 	tests := []struct {
-		name              string
-		app               *v1alpha1.App
-		engineEnabled     bool
-		kubernetesEnabled bool
-		templateOutOfDate bool
-		wantStatus        metav1.ConditionStatus
-		wantReason        string
-		wantMessage       string
+		name                  string
+		app                   *v1alpha1.App
+		addPath               v1alpha1.AddPathStrategy
+		engineEnabled         bool
+		kubernetesEnabled     bool
+		templateOutOfDate     bool
+		pathManagementEnabled bool
+		wantStatus            metav1.ConditionStatus
+		wantReason            string
+		wantMessage           string
 	}{
 		{
 			name:          "no Running condition yet",
@@ -347,16 +352,155 @@ func Test_computeSettledCondition(t *testing.T) {
 			wantReason:        v1alpha1.AppSettledReasonApplyingTemplate,
 			wantMessage:       settledMessageApplyingTemplate,
 		},
+		{
+			// PATH management enabled but no condition yet: hold Settled false.
+			name: "path management enabled but not yet reported holds Settled false",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+			),
+			addPath:               v1alpha1.AddPathFront,
+			engineEnabled:         true,
+			pathManagementEnabled: true,
+			wantStatus:            metav1.ConditionFalse,
+			wantReason:            v1alpha1.AppSettledReasonWaitingForPathManagement,
+			wantMessage:           settledMessageWaitingForPathManagement,
+		},
+		{
+			name: "stale path management observed generation holds Settled false",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+				pathMgmt(v1alpha1.PathManagementReasonApplied, "PATH management applied", metav1.ConditionTrue, 1),
+			),
+			addPath:               v1alpha1.AddPathFront,
+			engineEnabled:         true,
+			pathManagementEnabled: true,
+			wantStatus:            metav1.ConditionFalse,
+			wantReason:            v1alpha1.AppSettledReasonPathManagementStale,
+			wantMessage:           settledMessagePathManagementStale,
+		},
+		{
+			name: "failed path management surfaces its reason and message",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+				pathMgmt(v1alpha1.PathManagementReasonFailed, "cannot write .zshrc", metav1.ConditionFalse, 2),
+			),
+			addPath:               v1alpha1.AddPathFront,
+			engineEnabled:         true,
+			pathManagementEnabled: true,
+			wantStatus:            metav1.ConditionFalse,
+			wantReason:            v1alpha1.PathManagementReasonFailed,
+			wantMessage:           "cannot write .zshrc",
+		},
+		{
+			// Under the manual default the user opted out of PATH management, so a
+			// permanent failure (a hand-edited dotfile with a dangling marker,
+			// reported as Malformed) is one we can't repair and must not block
+			// Settled for unrelated settings.
+			name: "manual strategy ignores a permanent (malformed) path management failure",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+				pathMgmt(v1alpha1.PathManagementReasonMalformed, "cannot parse .zshrc", metav1.ConditionFalse, 2),
+			),
+			addPath:               v1alpha1.AddPathManual,
+			engineEnabled:         true,
+			pathManagementEnabled: true,
+			wantStatus:            metav1.ConditionTrue,
+			wantReason:            v1alpha1.AppSettledReasonSettled,
+			wantMessage:           settledMessageSettled,
+		},
+		{
+			// A repairable failure (I/O, read-only home) over an intact block does
+			// gate under manual: the reconciler requeues and clears it, so --wait
+			// shouldn't report success over a residue that's about to go away.
+			name: "manual strategy waits on a repairable path management failure",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+				pathMgmt(v1alpha1.PathManagementReasonFailed, "cannot write .zshrc", metav1.ConditionFalse, 2),
+			),
+			addPath:               v1alpha1.AddPathManual,
+			engineEnabled:         true,
+			pathManagementEnabled: true,
+			wantStatus:            metav1.ConditionFalse,
+			wantReason:            v1alpha1.PathManagementReasonFailed,
+			wantMessage:           "cannot write .zshrc",
+		},
+		{
+			// Switching to manual still runs a removal, so Settled must wait for
+			// the reconciler to observe the current generation even though the
+			// stale condition is only Applied, not a failure.
+			name: "manual strategy still waits for a stale condition",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+				pathMgmt(v1alpha1.PathManagementReasonApplied, "PATH management applied", metav1.ConditionTrue, 1),
+			),
+			addPath:               v1alpha1.AddPathManual,
+			engineEnabled:         true,
+			pathManagementEnabled: true,
+			wantStatus:            metav1.ConditionFalse,
+			wantReason:            v1alpha1.AppSettledReasonPathManagementStale,
+			wantMessage:           settledMessagePathManagementStale,
+		},
+		{
+			// Manual also waits for the first report: the reconciler still runs
+			// and writes a condition, so a nil one means it hasn't caught up yet.
+			name: "manual strategy waits for the first path management report",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+			),
+			addPath:               v1alpha1.AddPathManual,
+			engineEnabled:         true,
+			pathManagementEnabled: true,
+			wantStatus:            metav1.ConditionFalse,
+			wantReason:            v1alpha1.AppSettledReasonWaitingForPathManagement,
+			wantMessage:           settledMessageWaitingForPathManagement,
+		},
+		{
+			name: "path management ready at current generation settles",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+				pathMgmt(v1alpha1.PathManagementReasonApplied, "PATH management applied", metav1.ConditionTrue, 2),
+			),
+			addPath:               v1alpha1.AddPathFront,
+			engineEnabled:         true,
+			pathManagementEnabled: true,
+			wantStatus:            metav1.ConditionTrue,
+			wantReason:            v1alpha1.AppSettledReasonSettled,
+			wantMessage:           settledMessageSettled,
+		},
+		{
+			// When path management is not enabled its condition is ignored,
+			// even if absent, so Settled still reaches True.
+			name: "path management disabled ignores its condition",
+			app: makeApp(2, true,
+				running("Started", "Lima instance is running", metav1.ConditionTrue, 2),
+				engine(v1alpha1.EngineReasonConnected, "Container engine synced", metav1.ConditionTrue, 2),
+			),
+			engineEnabled:         true,
+			pathManagementEnabled: false,
+			wantStatus:            metav1.ConditionTrue,
+			wantReason:            v1alpha1.AppSettledReasonSettled,
+			wantMessage:           settledMessageSettled,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			tt.app.Spec.Application.AddPath = tt.addPath
 			got := computeSettledCondition(tt.app, settledInputs{
-				engineEnabled:     tt.engineEnabled,
-				kubernetesEnabled: tt.kubernetesEnabled,
-				templateUpToDate:  !tt.templateOutOfDate,
+				engineEnabled:         tt.engineEnabled,
+				kubernetesEnabled:     tt.kubernetesEnabled,
+				templateUpToDate:      !tt.templateOutOfDate,
+				pathManagementEnabled: tt.pathManagementEnabled,
 			})
 			assert.Equal(t, got.Type, v1alpha1.AppConditionSettled)
 			assert.Equal(t, got.Status, tt.wantStatus)
@@ -403,6 +547,46 @@ func Test_engineEnabled(t *testing.T) {
 
 			r := &AppReconciler{Discovery: tt.discovery}
 			assert.Equal(t, r.engineEnabled(t.Context()), tt.want)
+		})
+	}
+}
+
+func Test_pathManagementEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		discovery ControllerDiscovery
+		want      bool
+	}{
+		{
+			name:      "nil discovery returns false",
+			discovery: nil,
+			want:      false,
+		},
+		{
+			name:      "path management present in discovery returns true",
+			discovery: fakeDiscovery{enabled: []string{"app", "lima", "path-management"}},
+			want:      true,
+		},
+		{
+			name:      "path management absent from discovery returns false",
+			discovery: fakeDiscovery{enabled: []string{"app", "lima"}},
+			want:      false,
+		},
+		{
+			name:      "discovery error defaults to true so the wait does not return prematurely",
+			discovery: fakeDiscovery{err: errors.New("kube-apiserver unreachable")},
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &AppReconciler{Discovery: tt.discovery}
+			assert.Equal(t, r.pathManagementEnabled(t.Context()), tt.want)
 		})
 	}
 }

--- a/rdd/pkg/controllers/app/app/crd.yaml
+++ b/rdd/pkg/controllers/app/app/crd.yaml
@@ -54,6 +54,33 @@ spec:
                 description: application specifies the settings for the Rancher Desktop
                   Electron frontend.
                 properties:
+                  addPath:
+                    default: manual
+                    description: |-
+                      addPath controls whether and where the Rancher Desktop bin directory
+                      (~/.rd<suffix>/bin) is added to the user's PATH, by editing their shell
+                      startup files (Unix) or the user Environment (Windows):
+                        - "front":  prepend, so the bin directory wins   (bin:$PATH)
+                        - "back":   append,  so existing PATH entries win ($PATH:bin)
+                        - "manual": leave PATH alone; remove any lines a previous front/back added.
+                      It defaults to "manual" so CLI-created instances don't touch shell startup
+                      files unasked; the GUI sends "front" when the user opts in.
+
+                      On Windows the user Environment Path is a plain semicolon-separated list
+                      with nowhere to fence our entry, so under "manual" we can't tell an entry
+                      we added from one the user typed. We therefore remove the bin directory
+                      only when it sits at the very front or back of Path (the two spots
+                      front/back would have written) and leave a copy the user placed in the
+                      middle alone. The trade-off: an entry parked at either end is treated as
+                      ours and removed, so a user who wants the bin directory at the front or
+                      back on Windows must use "front"/"back", not place it there under
+                      "manual". Unix files use start/end markers, so only our own block is
+                      touched regardless of position.
+                    enum:
+                    - front
+                    - back
+                    - manual
+                    type: string
                   locale:
                     default: en-us
                     description: locale is the language/locale to use for the Rancher

--- a/rdd/pkg/controllers/app/pathmanagement/controller.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controller.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package pathmanagement registers the PATH management controller. The
+// controller adds or removes the Rancher Desktop bin directory
+// (~/.rd<suffix>/bin) from the user's PATH according to spec.application.addPath,
+// by editing shell startup files on Unix and the user Environment on Windows.
+package pathmanagement
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/pathmanagement/controllers"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/instance"
+)
+
+func init() {
+	base.RegisterController(&controller{})
+}
+
+// Unwind removes this instance's PATH edits (shell startup files on Unix, the
+// user Environment on Windows). Service deletion calls it before removing the bin
+// directory, so a stale block isn't left behind pointing at a directory that no
+// longer exists. It runs host-side and needs no API client.
+func Unwind(ctx context.Context) error {
+	r := &controllers.PathManagementReconciler{
+		BinDir: instance.BinDir(),
+		Suffix: instance.Suffix(),
+	}
+	return r.Unwind(ctx)
+}
+
+type controller struct{}
+
+var _ base.Controller = &controller{}
+
+func (c *controller) GetName() string {
+	return appv1alpha1.PathManagementControllerName
+}
+
+func (c *controller) GetAPIGroup() string {
+	// We only use the app CRD, so there is no extra group to register.
+	return ""
+}
+
+func (c *controller) GetCRDData() string {
+	return ""
+}
+
+func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+	if err := appv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+	r := &controllers.PathManagementReconciler{
+		Client: mgr.GetClient(),
+		BinDir: instance.BinDir(),
+		Suffix: instance.Suffix(),
+	}
+	return r.SetupWithManager(mgr)
+}

--- a/rdd/pkg/controllers/app/pathmanagement/controllers/pathlist.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controllers/pathlist.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"strings"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+// computeWindowsPath returns the new user Path after applying strategy, and
+// whether it changed. It takes the raw semicolon-separated Path so we can test
+// it off Windows.
+//
+// front and back drop every existing binDir entry (case-insensitive, to match
+// Windows) and re-add it at the chosen end, so the result is idempotent and the
+// entry can move between front and back.
+//
+// manual is more careful. Windows has no fenced block like the Unix startup
+// files, so we can't tell an entry we added from one the user typed by value
+// alone. We therefore only remove a binDir entry that sits at the very front or
+// back of the Path — the two positions front/back would have written. An entry
+// the user placed in the middle is a deliberate choice, so manual leaves it
+// alone. "Middle" means a real, unrelated entry sits on both sides of ours:
+// anchoring on the other entries (not the raw front/back of the Path) makes one
+// pass a fixed point, so a duplicated entry that would otherwise slide to an edge
+// on the next apply is removed now. The consequence, which the docs call out, is
+// that a user who wants binDir at the front or back must use front/back: under
+// manual an entry parked at either end is treated as ours and removed. Empty
+// segments are only tidied up when we're actually adding our entry.
+//
+// forceRemove overrides the manual middle-entry rule and drops every binDir
+// entry regardless of position. Service deletion uses it to fully unwind before
+// removing the bin directory, so a middle entry isn't left pointing at a
+// directory that no longer exists.
+func computeWindowsPath(current, binDir string, strategy appv1alpha1.AddPathStrategy, forceRemove bool) (string, bool) {
+	segments := strings.Split(current, ";")
+	wanted := normalizeWindowsPathEntry(binDir)
+	adding := strategy == appv1alpha1.AddPathFront || strategy == appv1alpha1.AddPathBack
+
+	// First and last non-empty segments that aren't ours anchor the "middle": our
+	// entry is a deliberate placement (kept under manual) only when one of these
+	// sits before it and another after it. Computing this against the other
+	// entries — rather than the raw front/back — means removing one copy can't
+	// promote a second copy to an edge on a later pass.
+	firstOtherIdx, lastOtherIdx := -1, -1
+	for i, seg := range segments {
+		trimmed := strings.TrimSpace(seg)
+		if trimmed == "" || strings.EqualFold(normalizeWindowsPathEntry(trimmed), wanted) {
+			continue
+		}
+		if firstOtherIdx < 0 {
+			firstOtherIdx = i
+		}
+		lastOtherIdx = i
+	}
+
+	kept := make([]string, 0, len(segments)+1)
+	for i, seg := range segments {
+		trimmed := strings.TrimSpace(seg)
+		if trimmed != "" && strings.EqualFold(normalizeWindowsPathEntry(trimmed), wanted) {
+			// Our entry. front/back and forceRemove drop every copy; manual keeps
+			// it only when it's genuinely in the middle — a non-ours entry on each
+			// side of it.
+			middle := firstOtherIdx >= 0 && i > firstOtherIdx && i < lastOtherIdx
+			if adding || forceRemove || !middle {
+				continue
+			}
+			// A middle entry under manual: the user's chosen location, kept.
+		}
+		if trimmed == "" && adding {
+			// Empty segments just leave stray semicolons; drop them when adding.
+			continue
+		}
+		kept = append(kept, seg)
+	}
+
+	switch strategy {
+	case appv1alpha1.AddPathFront:
+		kept = append([]string{binDir}, kept...)
+	case appv1alpha1.AddPathBack:
+		kept = append(kept, binDir)
+	}
+
+	updated := strings.Join(kept, ";")
+	return updated, updated != current
+}
+
+// normalizeWindowsPathEntry rewrites a Path entry so slash direction and a
+// trailing separator stop mattering: C:/foo/bin and C:\foo\bin\ both come out
+// as C:\foo\bin. filepath.Clean would handle this on Windows, but off Windows
+// it leaves backslash paths alone, and these tests run off Windows. Callers
+// still compare case-insensitively.
+func normalizeWindowsPathEntry(p string) string {
+	p = strings.ReplaceAll(p, "/", `\`)
+	// Strip trailing separators, but leave a drive root like C:\ alone.
+	for len(p) > 3 && p[len(p)-1] == '\\' {
+		p = p[:len(p)-1]
+	}
+	return p
+}

--- a/rdd/pkg/controllers/app/pathmanagement/controllers/pathlist_test.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controllers/pathlist_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+func TestComputeWindowsPath(t *testing.T) {
+	cases := []struct {
+		name        string
+		current     string
+		binDir      string
+		strategy    appv1alpha1.AddPathStrategy
+		forceRemove bool
+		want        string
+		wantChanged bool
+	}{
+		{
+			name:        "front prepends",
+			current:     `C:\Windows;C:\Windows\System32`,
+			binDir:      `C:\Users\me\.rd2\bin`,
+			strategy:    appv1alpha1.AddPathFront,
+			want:        `C:\Users\me\.rd2\bin;C:\Windows;C:\Windows\System32`,
+			wantChanged: true,
+		},
+		{
+			name:        "back appends",
+			current:     `C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathBack,
+			want:        `C:\Windows;C:\bin`,
+			wantChanged: true,
+		},
+		{
+			name:        "manual removes our entry at the front",
+			current:     `C:\bin;C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows`,
+			wantChanged: true,
+		},
+		{
+			name:        "front is idempotent when already at front",
+			current:     `C:\bin;C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathFront,
+			want:        `C:\bin;C:\Windows`,
+			wantChanged: false,
+		},
+		{
+			name:        "moves entry from front to back",
+			current:     `C:\bin;C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathBack,
+			want:        `C:\Windows;C:\bin`,
+			wantChanged: true,
+		},
+		{
+			name:        "dedup is case insensitive",
+			current:     `c:\BIN;C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathFront,
+			want:        `C:\bin;C:\Windows`,
+			wantChanged: true,
+		},
+		{
+			name:        "front on empty path",
+			current:     "",
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathFront,
+			want:        `C:\bin`,
+			wantChanged: true,
+		},
+		{
+			name:        "manual on empty path is a no-op",
+			current:     "",
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        "",
+			wantChanged: false,
+		},
+		{
+			name:        "dedup ignores a trailing backslash",
+			current:     `C:\bin\;C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathFront,
+			want:        `C:\bin;C:\Windows`,
+			wantChanged: true,
+		},
+		{
+			name:        "dedup ignores slash direction",
+			current:     `C:/bin;C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathFront,
+			want:        `C:\bin;C:\Windows`,
+			wantChanged: true,
+		},
+		{
+			name:        "manual leaves a trailing semicolon alone",
+			current:     `C:\Windows;C:\Windows\System32;`,
+			binDir:      `C:\Users\me\.rd2\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows;C:\Windows\System32;`,
+			wantChanged: false,
+		},
+		{
+			name:        "manual leaves an empty segment alone",
+			current:     `C:\Windows;;C:\Windows\System32`,
+			binDir:      `C:\Users\me\.rd2\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows;;C:\Windows\System32`,
+			wantChanged: false,
+		},
+		{
+			name:        "manual still removes our entry, keeping empty segments",
+			current:     `C:\Windows;C:\bin;`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows;`,
+			wantChanged: true,
+		},
+		{
+			name:        "manual keeps our entry in the middle",
+			current:     `C:\Windows;C:\bin;C:\Windows\System32`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows;C:\bin;C:\Windows\System32`,
+			wantChanged: false,
+		},
+		{
+			name:        "force remove takes our entry out of the middle",
+			current:     `C:\Windows;C:\bin;C:\Windows\System32`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			forceRemove: true,
+			want:        `C:\Windows;C:\Windows\System32`,
+			wantChanged: true,
+		},
+		{
+			name:        "force remove strips every copy",
+			current:     `C:\bin;C:\Windows;c:/BIN;C:\Windows\System32;C:\bin`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			forceRemove: true,
+			want:        `C:\Windows;C:\Windows\System32`,
+			wantChanged: true,
+		},
+		{
+			name:        "force remove on a path without our entry is a no-op",
+			current:     `C:\Windows;C:\Windows\System32`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			forceRemove: true,
+			want:        `C:\Windows;C:\Windows\System32`,
+			wantChanged: false,
+		},
+		{
+			name:        "manual removes our entry at the back",
+			current:     `C:\Windows;C:\bin`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows`,
+			wantChanged: true,
+		},
+		{
+			name:        "manual removes a front entry padded by empty segments",
+			current:     `;C:\bin;C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `;C:\Windows`,
+			wantChanged: true,
+		},
+		{
+			name:        "manual keeps a middle entry even with slash and case differences",
+			current:     `C:\Windows;c:/BIN;C:\Windows\System32`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows;c:/BIN;C:\Windows\System32`,
+			wantChanged: false,
+		},
+		{
+			name:        "manual collapses a duplicated front entry in one pass",
+			current:     `C:\bin;C:\bin;C:\Windows`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows`,
+			wantChanged: true,
+		},
+		{
+			name:        "manual keeps unrelated duplicates and removes our back entry",
+			current:     `C:\foo;c:\foo;C:\bin`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\foo;c:\foo`,
+			wantChanged: true,
+		},
+		{
+			name:        "manual keeps a duplicated middle entry",
+			current:     `C:\Windows;C:\bin;C:\bin;C:\Windows\System32`,
+			binDir:      `C:\bin`,
+			strategy:    appv1alpha1.AddPathManual,
+			want:        `C:\Windows;C:\bin;C:\bin;C:\Windows\System32`,
+			wantChanged: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := computeWindowsPath(tc.current, tc.binDir, tc.strategy, tc.forceRemove)
+			assert.Equal(t, changed, tc.wantChanged)
+			assert.Equal(t, got, tc.want)
+			// One pass must be a fixed point: re-applying to our own output
+			// changes nothing.
+			again, changedAgain := computeWindowsPath(got, tc.binDir, tc.strategy, tc.forceRemove)
+			assert.Assert(t, !changedAgain, "second pass changed %q -> %q", got, again)
+			assert.Equal(t, again, got)
+		})
+	}
+}

--- a/rdd/pkg/controllers/app/pathmanagement/controllers/pathmanagement_unix.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controllers/pathmanagement_unix.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build !windows
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/managedlines"
+)
+
+// startMarker and endMarker fence the block we manage in a shell startup file.
+// The suffix keeps our markers distinct from other instances and from Rancher
+// Desktop 1 (which uses "RANCHER DESKTOP" with no number).
+func (r *PathManagementReconciler) startMarker() string {
+	return fmt.Sprintf("### MANAGED BY RANCHER DESKTOP %s START (DO NOT EDIT)", r.Suffix)
+}
+
+func (r *PathManagementReconciler) endMarker() string {
+	return fmt.Sprintf("### MANAGED BY RANCHER DESKTOP %s END (DO NOT EDIT)", r.Suffix)
+}
+
+// applyPath enforces the strategy by editing the user's shell startup files. The
+// forceRemove flag (used when unwinding for deletion) is ignored here: the Unix
+// files are fenced with start/end markers, so removing the block already takes
+// out only our own lines regardless of where they sit. It matters only on
+// Windows, where the Path has no such fence.
+//
+// The caller (apply) holds a cross-process lock, so the read-compute-write in
+// managedlines.Manage can't lose a concurrent instance's block from a shared
+// startup file.
+func (r *PathManagementReconciler) applyPath(_ context.Context, strategy appv1alpha1.AddPathStrategy, _ bool) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("locate home directory: %w", err)
+	}
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		configHome = filepath.Join(home, ".config")
+	}
+	return applyPosix(home, configHome, r.BinDir, strategy, r.startMarker(), r.endMarker())
+}
+
+// applyPosix mirrors Rancher Desktop 1's RcFilePathManager: it manages the bash
+// login-shell files (only the first existing one carries the block), the bash
+// and zsh rc files, the csh rc files, and the fish config. A failure on one file
+// doesn't stop the rest; the errors are joined so the caller sees every offender
+// and the remaining files still converge.
+func applyPosix(home, configHome, binDir string, strategy appv1alpha1.AddPathStrategy, start, end string) error {
+	present := strategy != appv1alpha1.AddPathManual
+	posixLine := posixPathLine(binDir, strategy)
+	var errs []error
+
+	// Bash login files, in precedence order. Only the first existing file gets the
+	// block (so PATH isn't extended twice); the rest have it removed.
+	loginFiles := []string{".bash_profile", ".bash_login", ".profile"}
+	if present {
+		var blockInfo os.FileInfo
+		handled := false
+		loginExisted := false
+		for _, name := range loginFiles {
+			p := filepath.Join(home, name)
+			info, err := os.Stat(p)
+			if err != nil {
+				if os.IsNotExist(err) {
+					// Rancher Desktop 1 skips login files that aren't there
+					// rather than creating all of them; do the same.
+					continue
+				}
+				errs = append(errs, err)
+				continue
+			}
+			loginExisted = true
+			if handled {
+				if blockInfo != nil && os.SameFile(blockInfo, info) {
+					// A later name resolving to the file we already wrote (e.g.
+					// .bash_profile symlinked to .profile); leave that block alone.
+					continue
+				}
+				// A distinct, later login file: strip any block an earlier run
+				// left, since only the first existing file carries ours.
+				if err := managedlines.Manage(p, start, end, []string{posixLine}, false); err != nil {
+					errs = append(errs, err)
+				}
+				continue
+			}
+			// First existing login file: it carries the block. Mark it handled
+			// before the write so a failure here doesn't push the block onto a
+			// later file that bash never sources (it reads only the first one).
+			handled = true
+			if err := managedlines.Manage(p, start, end, []string{posixLine}, true); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			// The atomic write replaces the file, so re-stat to capture the
+			// identity that later names are compared against.
+			if blockInfo, err = os.Stat(p); err != nil {
+				errs = append(errs, err)
+				// Without blockInfo we can't tell a later symlink to this file
+				// from a distinct one, so stop rather than risk writing the
+				// block twice and doubling the PATH entry.
+				break
+			}
+		}
+		if !loginExisted {
+			p := filepath.Join(home, loginFiles[0])
+			if err := managedlines.Manage(p, start, end, []string{posixLine}, true); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	} else {
+		for _, name := range loginFiles {
+			p := filepath.Join(home, name)
+			if err := managedlines.Manage(p, start, end, nil, false); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	// bash and zsh rc files always carry the block (or have it removed).
+	for _, name := range []string{".bashrc", ".zshrc"} {
+		p := filepath.Join(home, name)
+		if err := managedlines.Manage(p, start, end, []string{posixLine}, present); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// csh reads .cshrc; tcsh reads .tcshrc if it exists, otherwise .cshrc. Manage
+	// .cshrc always, but only touch .tcshrc when the user already has one, so we
+	// don't create a .tcshrc that shadows their existing .cshrc.
+	cshLine := cshPathLine(binDir, strategy)
+	if err := managedlines.Manage(filepath.Join(home, ".cshrc"), start, end, []string{cshLine}, present); err != nil {
+		errs = append(errs, err)
+	}
+	tcshrc := filepath.Join(home, ".tcshrc")
+	if tcshExists, err := fileExists(tcshrc); err != nil {
+		errs = append(errs, err)
+	} else if tcshExists {
+		if err := managedlines.Manage(tcshrc, start, end, []string{cshLine}, present); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// fish.
+	fishDir := filepath.Join(configHome, "fish")
+	fishPath := filepath.Join(fishDir, "config.fish")
+	if present {
+		if err := os.MkdirAll(fishDir, 0o700); err != nil {
+			errs = append(errs, fmt.Errorf("create fish config directory: %w", err))
+		}
+	}
+	if err := managedlines.Manage(fishPath, start, end, []string{fishPathLine(binDir, strategy)}, present); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+// fileExists reports whether path resolves to an existing file (following
+// symlinks). A missing file is not an error.
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// posixPathLine returns the POSIX-shell line adding binDir to PATH.
+func posixPathLine(binDir string, strategy appv1alpha1.AddPathStrategy) string {
+	if strategy == appv1alpha1.AddPathBack {
+		return fmt.Sprintf(`export PATH="$PATH:%s"`, binDir)
+	}
+	return fmt.Sprintf(`export PATH="%s:$PATH"`, binDir)
+}
+
+// cshPathLine returns the csh/tcsh line adding binDir to PATH.
+func cshPathLine(binDir string, strategy appv1alpha1.AddPathStrategy) string {
+	if strategy == appv1alpha1.AddPathBack {
+		return fmt.Sprintf(`setenv PATH "$PATH":"%s"`, binDir)
+	}
+	return fmt.Sprintf(`setenv PATH "%s":"$PATH"`, binDir)
+}
+
+// fishPathLine returns the fish line adding binDir to PATH.
+func fishPathLine(binDir string, strategy appv1alpha1.AddPathStrategy) string {
+	op := "--prepend"
+	if strategy == appv1alpha1.AddPathBack {
+		op = "--append"
+	}
+	return fmt.Sprintf(`set --export %s PATH "%s"`, op, binDir)
+}

--- a/rdd/pkg/controllers/app/pathmanagement/controllers/pathmanagement_unix_test.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controllers/pathmanagement_unix_test.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build !windows
+
+package controllers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+const (
+	testStart = "### MANAGED BY RANCHER DESKTOP 2 START (DO NOT EDIT)"
+	testEnd   = "### MANAGED BY RANCHER DESKTOP 2 END (DO NOT EDIT)"
+	testBin   = "/home/me/.rd2/bin"
+)
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	return string(data)
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func TestUnwindRemovesBlock(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+	r := &PathManagementReconciler{BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	zshrc := filepath.Join(home, ".zshrc")
+	block := r.startMarker() + "\nexport PATH=\"" + r.BinDir + ":$PATH\"\n" + r.endMarker() + "\n"
+	assert.NilError(t, os.WriteFile(zshrc, []byte("keep\n"+block), 0o644))
+
+	assert.NilError(t, r.Unwind(context.Background()))
+
+	// The block is gone; the user's own content stays.
+	assert.Equal(t, readFile(t, zshrc), "keep\n")
+}
+
+func TestApplyPosixFrontCreatesBashProfile(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd)
+	assert.NilError(t, err)
+
+	// No login file existed, so .bash_profile is created; the others are not.
+	assert.Assert(t, exists(filepath.Join(home, ".bash_profile")))
+	assert.Assert(t, !exists(filepath.Join(home, ".bash_login")))
+	assert.Assert(t, !exists(filepath.Join(home, ".profile")))
+
+	got := readFile(t, filepath.Join(home, ".bash_profile"))
+	assert.Equal(t, got, testStart+"\nexport PATH=\""+testBin+":$PATH\"\n"+testEnd+"\n")
+
+	// .bashrc and .zshrc always get the line.
+	assert.Equal(t, readFile(t, filepath.Join(home, ".bashrc")),
+		testStart+"\nexport PATH=\""+testBin+":$PATH\"\n"+testEnd+"\n")
+	assert.Equal(t, readFile(t, filepath.Join(home, ".zshrc")),
+		testStart+"\nexport PATH=\""+testBin+":$PATH\"\n"+testEnd+"\n")
+
+	// csh and fish.
+	assert.Equal(t, readFile(t, filepath.Join(home, ".cshrc")),
+		testStart+"\nsetenv PATH \""+testBin+"\":\"$PATH\"\n"+testEnd+"\n")
+	assert.Equal(t, readFile(t, filepath.Join(configHome, "fish", "config.fish")),
+		testStart+"\nset --export --prepend PATH \""+testBin+"\"\n"+testEnd+"\n")
+}
+
+func TestApplyPosixBackAppends(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathBack, testStart, testEnd)
+	assert.NilError(t, err)
+
+	assert.Equal(t, readFile(t, filepath.Join(home, ".bashrc")),
+		testStart+"\nexport PATH=\"$PATH:"+testBin+"\"\n"+testEnd+"\n")
+	assert.Equal(t, readFile(t, filepath.Join(home, ".cshrc")),
+		testStart+"\nsetenv PATH \"$PATH\":\""+testBin+"\"\n"+testEnd+"\n")
+	assert.Equal(t, readFile(t, filepath.Join(configHome, "fish", "config.fish")),
+		testStart+"\nset --export --append PATH \""+testBin+"\"\n"+testEnd+"\n")
+}
+
+func TestApplyPosixFirstExistingLoginFileWins(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+	// .profile exists but .bash_profile/.bash_login do not: only .profile gets it.
+	assert.NilError(t, os.WriteFile(filepath.Join(home, ".profile"), []byte("# mine\n"), 0o644))
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd)
+	assert.NilError(t, err)
+
+	assert.Assert(t, !exists(filepath.Join(home, ".bash_profile")))
+	assert.Assert(t, !exists(filepath.Join(home, ".bash_login")))
+	got := readFile(t, filepath.Join(home, ".profile"))
+	assert.Equal(t, got, "# mine\n\n"+testStart+"\nexport PATH=\""+testBin+":$PATH\"\n"+testEnd+"\n")
+}
+
+func TestApplyPosixOnlyFirstOfMultipleLoginFiles(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+	assert.NilError(t, os.WriteFile(filepath.Join(home, ".bash_profile"), []byte("a\n"), 0o644))
+	assert.NilError(t, os.WriteFile(filepath.Join(home, ".profile"), []byte("b\n"), 0o644))
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd)
+	assert.NilError(t, err)
+
+	// .bash_profile (first in precedence) carries the block; .profile is left clean.
+	assert.Equal(t, readFile(t, filepath.Join(home, ".bash_profile")),
+		"a\n\n"+testStart+"\nexport PATH=\""+testBin+":$PATH\"\n"+testEnd+"\n")
+	assert.Equal(t, readFile(t, filepath.Join(home, ".profile")), "b\n")
+}
+
+func TestApplyPosixDoesNotCreateTcshrc(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+	assert.NilError(t, os.WriteFile(filepath.Join(home, ".cshrc"),
+		[]byte("setenv EDITOR vim\n"), 0o644))
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd)
+	assert.NilError(t, err)
+
+	// .cshrc keeps the user's content and gets the block; .tcshrc is not created,
+	// so it can't shadow .cshrc for tcsh.
+	assert.Equal(t, readFile(t, filepath.Join(home, ".cshrc")),
+		"setenv EDITOR vim\n\n"+testStart+"\nsetenv PATH \""+testBin+"\":\"$PATH\"\n"+testEnd+"\n")
+	assert.Assert(t, !exists(filepath.Join(home, ".tcshrc")))
+}
+
+func TestApplyPosixUpdatesExistingTcshrc(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+	assert.NilError(t, os.WriteFile(filepath.Join(home, ".tcshrc"),
+		[]byte("alias ll ls -l\n"), 0o644))
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd)
+	assert.NilError(t, err)
+
+	// An existing .tcshrc gets the block, since tcsh reads it instead of .cshrc.
+	assert.Equal(t, readFile(t, filepath.Join(home, ".tcshrc")),
+		"alias ll ls -l\n\n"+testStart+"\nsetenv PATH \""+testBin+"\":\"$PATH\"\n"+testEnd+"\n")
+}
+
+func TestApplyPosixFirstLoginFileFailureDoesNotMoveBlock(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+	// The first login file bash sources, .bash_profile, has a dangling start
+	// marker, so Manage can't parse it. .bash_login exists and is clean.
+	bad := filepath.Join(home, ".bash_profile")
+	assert.NilError(t, os.WriteFile(bad, []byte("# mine\n"+testStart+"\nexport PATH=x\n"), 0o644))
+	login := filepath.Join(home, ".bash_login")
+	assert.NilError(t, os.WriteFile(login, []byte("# mine\n"), 0o644))
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd)
+	assert.ErrorContains(t, err, bad)
+
+	// The block must not migrate to .bash_login: bash reads only .bash_profile,
+	// so the block there would never be sourced, and .bash_login is edited
+	// against the user's intent.
+	assert.Assert(t, !strings.Contains(readFile(t, login), testStart))
+}
+
+func TestApplyPosixSymlinkedLoginFile(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+	// .bash_profile is a symlink to .profile, a common dotfiles layout. The block
+	// must land in .profile and stay there, not get removed by the later name.
+	assert.NilError(t, os.WriteFile(filepath.Join(home, ".profile"), []byte("# user profile\n"), 0o644))
+	assert.NilError(t, os.Symlink(filepath.Join(home, ".profile"), filepath.Join(home, ".bash_profile")))
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd)
+	assert.NilError(t, err)
+
+	got := readFile(t, filepath.Join(home, ".profile"))
+	assert.Equal(t, got, "# user profile\n\n"+testStart+"\nexport PATH=\""+testBin+":$PATH\"\n"+testEnd+"\n")
+	// The symlink is preserved and still points at .profile.
+	info, err := os.Lstat(filepath.Join(home, ".bash_profile"))
+	assert.NilError(t, err)
+	assert.Assert(t, info.Mode()&os.ModeSymlink != 0)
+}
+
+func TestApplyPosixConvergesPastMalformedFile(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+	// The user hand-deleted the end marker from .bash_profile, leaving a dangling
+	// start marker.
+	bad := filepath.Join(home, ".bash_profile")
+	assert.NilError(t, os.WriteFile(bad, []byte("# mine\n"+testStart+"\nexport PATH=x\n"), 0o644))
+
+	err := applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd)
+	// The error surfaces and names the offending file.
+	assert.ErrorContains(t, err, bad)
+
+	// The other shells still get managed despite the bad file.
+	block := testStart + "\nexport PATH=\"" + testBin + ":$PATH\"\n" + testEnd + "\n"
+	assert.Equal(t, readFile(t, filepath.Join(home, ".bashrc")), block)
+	assert.Equal(t, readFile(t, filepath.Join(home, ".zshrc")), block)
+	assert.Assert(t, exists(filepath.Join(home, ".cshrc")))
+	assert.Assert(t, exists(filepath.Join(configHome, "fish", "config.fish")))
+}
+
+func TestApplyPosixManualEmptiesFilesWeCreated(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+
+	assert.NilError(t, applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd))
+	assert.NilError(t, applyPosix(home, configHome, testBin, appv1alpha1.AddPathManual, testStart, testEnd))
+
+	// We remove our block but leave the files in place (empty), since we can't
+	// tell one we created from an empty startup file the user already had.
+	assert.Equal(t, readFile(t, filepath.Join(home, ".bash_profile")), "")
+	assert.Equal(t, readFile(t, filepath.Join(home, ".bashrc")), "")
+	assert.Equal(t, readFile(t, filepath.Join(configHome, "fish", "config.fish")), "")
+}
+
+func TestApplyPosixManualPreservesUserContent(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config-home")
+	assert.NilError(t, os.WriteFile(filepath.Join(home, ".bashrc"), []byte("user line\n"), 0o644))
+
+	assert.NilError(t, applyPosix(home, configHome, testBin, appv1alpha1.AddPathFront, testStart, testEnd))
+	assert.NilError(t, applyPosix(home, configHome, testBin, appv1alpha1.AddPathManual, testStart, testEnd))
+
+	assert.Equal(t, readFile(t, filepath.Join(home, ".bashrc")), "user line\n")
+}

--- a/rdd/pkg/controllers/app/pathmanagement/controllers/pathmanagement_windows.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controllers/pathmanagement_windows.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build windows
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+const (
+	// hwndBroadcast sends the message to all top-level windows.
+	hwndBroadcast = windows.HWND(0xffff)
+	// wmSettingChange notifies applications that a system-wide setting changed.
+	wmSettingChange = 0x001A
+	// smtoAbortIfHung skips windows that have stopped responding instead of
+	// blocking on them.
+	smtoAbortIfHung = 0x0002
+)
+
+// Loaded once and shared across broadcasts. LazyDLL/LazyProc resolve on first
+// use, so declaring them here costs nothing if we never broadcast.
+var (
+	user32             = windows.NewLazySystemDLL("user32.dll")
+	sendMessageTimeout = user32.NewProc("SendMessageTimeoutA")
+)
+
+// envSubKey is the HKCU subkey that holds the user Path. It's a var so tests can
+// point at a throwaway key instead of the real one.
+var envSubKey = `Environment`
+
+// applyPath edits the user's Path in HKCU\Environment and, if it changed,
+// broadcasts WM_SETTINGCHANGE so new processes (and refresh-aware apps) pick it
+// up. forceRemove drops our entry regardless of position (used when unwinding
+// for deletion); see computeWindowsPath.
+//
+// The caller (apply) holds a cross-process lock, so the read-modify-write of the
+// user Path can't lose a concurrent instance's entry.
+func (r *PathManagementReconciler) applyPath(_ context.Context, strategy appv1alpha1.AddPathStrategy, forceRemove bool) error {
+	changed, err := r.writeUserPath(strategy, forceRemove)
+	if err != nil {
+		return err
+	}
+	if changed {
+		broadcastEnvironmentChange()
+	}
+	return nil
+}
+
+// writeUserPath applies strategy to the user Path in the registry and reports
+// whether it changed. It's separate from apply, and skips the broadcast, so a
+// test can run it against a throwaway key.
+func (r *PathManagementReconciler) writeUserPath(strategy appv1alpha1.AddPathStrategy, forceRemove bool) (bool, error) {
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, envSubKey, registry.QUERY_VALUE|registry.SET_VALUE)
+	if err != nil {
+		return false, fmt.Errorf("open HKCU\\%s: %w", envSubKey, err)
+	}
+	defer key.Close()
+
+	current, valType, err := key.GetStringValue("Path")
+	if err != nil && !errors.Is(err, registry.ErrNotExist) {
+		return false, fmt.Errorf("read user Path: %w", err)
+	}
+
+	updated, changed := computeWindowsPath(current, r.BinDir, strategy, forceRemove)
+	if !changed {
+		return false, nil
+	}
+
+	// Keep the existing value type. The user Path is usually REG_EXPAND_SZ (it can
+	// contain things like %USERPROFILE%), so use that when it did not exist yet.
+	if valType == registry.SZ {
+		err = key.SetStringValue("Path", updated)
+	} else {
+		err = key.SetExpandStringValue("Path", updated)
+	}
+	if err != nil {
+		return false, fmt.Errorf("write user Path: %w", err)
+	}
+	return true, nil
+}
+
+// broadcastEnvironmentChange tells running applications the environment changed.
+// Errors are ignored: the Path is already written and new processes pick it up.
+func broadcastEnvironmentChange() {
+	env, err := windows.BytePtrFromString("Environment")
+	if err != nil {
+		return
+	}
+	var result uintptr
+	_, _, _ = sendMessageTimeout.Call(
+		uintptr(hwndBroadcast),
+		wmSettingChange,
+		0,
+		uintptr(unsafe.Pointer(env)),
+		smtoAbortIfHung,
+		5000,
+		uintptr(unsafe.Pointer(&result)),
+	)
+}

--- a/rdd/pkg/controllers/app/pathmanagement/controllers/pathmanagement_windows_test.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controllers/pathmanagement_windows_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build windows
+
+package controllers
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows/registry"
+	"gotest.tools/v3/assert"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+)
+
+// withTestEnvKey points envSubKey at a throwaway HKCU key so tests stay away
+// from the real user Path, seeding it with the given value and type. It returns
+// the key path and registers cleanup.
+func withTestEnvKey(t *testing.T, seed string, seedType uint32) string {
+	t.Helper()
+	keyPath := fmt.Sprintf(`Software\rancher-desktop-daemon-test\%d`, time.Now().UnixNano())
+
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, keyPath, registry.QUERY_VALUE|registry.SET_VALUE)
+	assert.NilError(t, err)
+	if seed != "" {
+		if seedType == registry.SZ {
+			assert.NilError(t, key.SetStringValue("Path", seed))
+		} else {
+			assert.NilError(t, key.SetExpandStringValue("Path", seed))
+		}
+	}
+	assert.NilError(t, key.Close())
+
+	old := envSubKey
+	envSubKey = keyPath
+	t.Cleanup(func() {
+		envSubKey = old
+		_ = registry.DeleteKey(registry.CURRENT_USER, keyPath)
+	})
+	return keyPath
+}
+
+func readTestPath(t *testing.T, keyPath string) (value string, valType uint32) {
+	t.Helper()
+	key, err := registry.OpenKey(registry.CURRENT_USER, keyPath, registry.QUERY_VALUE)
+	assert.NilError(t, err)
+	defer key.Close()
+	val, valType, err := key.GetStringValue("Path")
+	assert.NilError(t, err)
+	return val, valType
+}
+
+func TestWriteUserPathFrontPreservesExpandSZ(t *testing.T) {
+	keyPath := withTestEnvKey(t, `%SystemRoot%\system32;C:\Windows`, registry.EXPAND_SZ)
+	r := &PathManagementReconciler{BinDir: `C:\Users\me\.rd2\bin`}
+
+	changed, err := r.writeUserPath(appv1alpha1.AddPathFront, false)
+	assert.NilError(t, err)
+	assert.Equal(t, changed, true)
+
+	val, valType := readTestPath(t, keyPath)
+	assert.Equal(t, val, `C:\Users\me\.rd2\bin;%SystemRoot%\system32;C:\Windows`)
+	// REG_EXPAND_SZ has to survive the rewrite, or entries like %SystemRoot%
+	// stop expanding.
+	assert.Equal(t, valType, uint32(registry.EXPAND_SZ))
+}
+
+func TestWriteUserPathKeepsPlainSZ(t *testing.T) {
+	keyPath := withTestEnvKey(t, `C:\Windows`, registry.SZ)
+	r := &PathManagementReconciler{BinDir: `C:\bin`}
+
+	changed, err := r.writeUserPath(appv1alpha1.AddPathBack, false)
+	assert.NilError(t, err)
+	assert.Equal(t, changed, true)
+
+	val, valType := readTestPath(t, keyPath)
+	assert.Equal(t, val, `C:\Windows;C:\bin`)
+	assert.Equal(t, valType, uint32(registry.SZ))
+}
+
+func TestWriteUserPathManualRemoves(t *testing.T) {
+	keyPath := withTestEnvKey(t, `C:\bin;C:\Windows`, registry.EXPAND_SZ)
+	r := &PathManagementReconciler{BinDir: `C:\bin`}
+
+	changed, err := r.writeUserPath(appv1alpha1.AddPathManual, false)
+	assert.NilError(t, err)
+	assert.Equal(t, changed, true)
+
+	val, _ := readTestPath(t, keyPath)
+	assert.Equal(t, val, `C:\Windows`)
+}
+
+func TestWriteUserPathForceRemovesMiddleEntry(t *testing.T) {
+	keyPath := withTestEnvKey(t, `C:\Windows;C:\bin;C:\Windows\System32`, registry.EXPAND_SZ)
+	r := &PathManagementReconciler{BinDir: `C:\bin`}
+
+	// manual leaves a middle entry alone, but the unwind path forces it out.
+	changed, err := r.writeUserPath(appv1alpha1.AddPathManual, false)
+	assert.NilError(t, err)
+	assert.Equal(t, changed, false)
+
+	changed, err = r.writeUserPath(appv1alpha1.AddPathManual, true)
+	assert.NilError(t, err)
+	assert.Equal(t, changed, true)
+
+	val, _ := readTestPath(t, keyPath)
+	assert.Equal(t, val, `C:\Windows;C:\Windows\System32`)
+}
+
+func TestWriteUserPathIdempotent(t *testing.T) {
+	withTestEnvKey(t, `C:\bin;C:\Windows`, registry.EXPAND_SZ)
+	r := &PathManagementReconciler{BinDir: `C:\bin`}
+
+	changed, err := r.writeUserPath(appv1alpha1.AddPathFront, false)
+	assert.NilError(t, err)
+	assert.Equal(t, changed, false)
+}
+
+func TestWriteUserPathCreatesWhenMissing(t *testing.T) {
+	keyPath := withTestEnvKey(t, "", registry.EXPAND_SZ)
+	r := &PathManagementReconciler{BinDir: `C:\bin`}
+
+	changed, err := r.writeUserPath(appv1alpha1.AddPathFront, false)
+	assert.NilError(t, err)
+	assert.Equal(t, changed, true)
+
+	val, valType := readTestPath(t, keyPath)
+	assert.Equal(t, val, `C:\bin`)
+	// A brand new value comes out as REG_EXPAND_SZ.
+	assert.Equal(t, valType, uint32(registry.EXPAND_SZ))
+}

--- a/rdd/pkg/controllers/app/pathmanagement/controllers/reconciler.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controllers/reconciler.go
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package controllers implements the PATH management reconciler, which keeps the
+// user's PATH in sync with spec.application.addPath.
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/predicates"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/managedlines"
+)
+
+// appName is the name of the singleton App resource.
+const appName = "app"
+
+// pathManagementFinalizer blocks App deletion until we've unwound our PATH
+// edits, so `rdd ctl delete app` doesn't orphan a block in the user's startup
+// files. It's distinct from the App controller's cleanup finalizer so each
+// controller manages its own.
+const pathManagementFinalizer = "rdd.rancherdesktop.io/path-management"
+
+// pathManagementLockFile is the name of the cross-process lock that serializes
+// PATH edits. It lives in the per-user data root shared by every instance (not
+// under a single instance's directory), so two daemons editing the same startup
+// files or user Environment take turns. See acquirePathLock.
+const pathManagementLockFile = "rancher-desktop-pathmanagement.lock"
+
+// pathManagementLockTimeout bounds how long we wait for the lock before giving
+// up, so a stuck holder requeues the reconcile instead of blocking forever.
+const pathManagementLockTimeout = 30 * time.Second
+
+// pathUnwindRetryGrace bounds how long App deletion retries a repairable unwind
+// failure before giving up and releasing the finalizer anyway. Measured from the
+// App's deletionTimestamp, so a momentary problem (a brief full disk) still gets
+// a few attempts to clear, but a permanently unreadable startup file — or, on
+// Windows, any Environment write failure, since nothing there is ever classified
+// permanent — can't strand the App in Terminating forever.
+const pathUnwindRetryGrace = 30 * time.Second
+
+// pathUnwindRetryInterval is how long to wait between those bounded retries.
+const pathUnwindRetryInterval = 5 * time.Second
+
+// PathManagementReconciler adds or removes the Rancher Desktop bin directory
+// from the user's PATH based on spec.application.addPath. It watches the App
+// singleton and runs whether or not the VM is up, since PATH edits are host-side.
+type PathManagementReconciler struct {
+	client.Client
+
+	// BinDir is the directory to add to PATH (e.g. ~/.rd2/bin).
+	BinDir string
+	// Suffix is the instance suffix (e.g. "2"). It goes into the fence markers so
+	// separate instances (and Rancher Desktop 1) don't touch each other's blocks.
+	Suffix string
+}
+
+// Reconcile applies spec.application.addPath: front/back add the bin directory
+// (prepended or appended); manual (or unset) removes any block we added before.
+// It is idempotent, so extra reconciles are harmless.
+func (r *PathManagementReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	var app appv1alpha1.App
+	if err := r.Get(ctx, client.ObjectKey{Name: appName}, &app); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// The App is being deleted: unwind our PATH edits, then release our
+	// finalizer so deletion can finish. Without this, a reconcile during the
+	// terminating window would re-apply the block and orphan it once the App is
+	// gone. `rdd svc delete` unwinds separately in service.Delete, since it stops
+	// the daemon before deleting and leaves no reconciler to run this branch.
+	if !app.DeletionTimestamp.IsZero() {
+		if !controllerutil.ContainsFinalizer(&app, pathManagementFinalizer) {
+			return ctrl.Result{}, nil
+		}
+		// An unwind failure is handled best-effort so a bad file can't strand the
+		// App in Terminating forever. A malformed block — a dotfile the user
+		// hand-edited into an unparseable state — is permanent, so release the
+		// finalizer at once. A repairable failure (I/O, read-only home, full disk,
+		// or on Windows any Environment write failure) might clear, so retry, but
+		// only within a grace window measured from deletionTimestamp: an unrelated
+		// file that's permanently unreadable, or a policy-locked Windows
+		// Environment, would otherwise requeue forever (controller-runtime backs
+		// off but never gives up). After the window we log and release anyway.
+		if err := r.apply(ctx, appv1alpha1.AddPathManual, false); err != nil {
+			switch {
+			case permanentPathError(err):
+				log.Error(err, "Managed block is malformed; releasing finalizer without removing it")
+			case time.Since(app.DeletionTimestamp.Time) < pathUnwindRetryGrace:
+				log.Error(err, "Failed to unwind PATH management before App deletion; will retry")
+				return ctrl.Result{RequeueAfter: pathUnwindRetryInterval}, nil
+			default:
+				log.Error(err, "Failed to unwind PATH management before App deletion within grace period; releasing finalizer anyway")
+			}
+		}
+		controllerutil.RemoveFinalizer(&app, pathManagementFinalizer)
+		if err := r.Update(ctx, &app); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure our finalizer is present so a later deletion runs the unwind above.
+	if controllerutil.AddFinalizer(&app, pathManagementFinalizer) {
+		if err := r.Update(ctx, &app); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	strategy := app.Spec.Application.AddPath
+	if strategy == "" {
+		strategy = appv1alpha1.AddPathManual
+	}
+
+	if err := r.apply(ctx, strategy, false); err != nil {
+		log.Error(err, "Failed to apply PATH management", "strategy", strategy)
+		// Record the failure so Settled (and `rdd set --wait`) can see it instead
+		// of reporting success, then requeue on the original error. A malformed
+		// block is permanent (only the user can fix it), so it gets a distinct
+		// reason: under manual that keeps Settled from wedging on a file we can't
+		// repair, while a transient failure still gates.
+		reason := appv1alpha1.PathManagementReasonFailed
+		if permanentPathError(err) {
+			reason = appv1alpha1.PathManagementReasonMalformed
+		}
+		if condErr := r.setCondition(ctx, app.Name, app.Generation, metav1.ConditionFalse, reason, err.Error()); condErr != nil {
+			log.Error(condErr, "Failed to record PathManagementReady failure")
+		}
+		return ctrl.Result{}, err
+	}
+	log.V(1).Info("Applied PATH management", "strategy", strategy, "binDir", r.BinDir)
+	if err := r.setCondition(ctx, app.Name, app.Generation, metav1.ConditionTrue, appv1alpha1.PathManagementReasonApplied, "PATH management applied"); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// setCondition writes the PathManagementReady condition on the App. It stamps
+// generation (the generation of the App read that chose the strategy) into
+// ObservedGeneration, not the re-Get's generation: if the spec changed between
+// the two reads, this result belongs to the earlier generation, and unlike the
+// engine controller there's no second gate holding Settled, so stamping the
+// newer number would let `rdd set --wait` settle before the new strategy is
+// applied. The next reconcile (triggered by the spec change) stamps the newer
+// generation. It mirrors the engine controller otherwise: the App controller
+// writes the same object in parallel, so a naive Update races and 409s; retry on
+// conflict with a re-Get.
+func (r *PathManagementReconciler) setCondition(ctx context.Context, name string, generation int64, status metav1.ConditionStatus, reason, message string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &appv1alpha1.App{}
+		if err := r.Get(ctx, client.ObjectKey{Name: name}, latest); err != nil {
+			// Concurrent `rdd svc delete` can remove the App mid-reconcile.
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		changed := meta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
+			Type:               appv1alpha1.AppConditionPathManagementReady,
+			Status:             status,
+			Reason:             reason,
+			Message:            base.TruncateConditionMessage(message),
+			ObservedGeneration: generation,
+		})
+		if !changed {
+			return nil
+		}
+		return r.Status().Update(ctx, latest)
+	})
+}
+
+// Unwind removes this instance's bin directory from the user's PATH, leaving it
+// unmanaged. Service deletion calls it before removing the bin directory, so the
+// user isn't left with an entry pointing at a directory that no longer exists.
+// It force-removes the entry even from the middle of the Windows Path: the whole
+// instance is going away, so a placement we'd otherwise preserve under manual
+// would just dangle.
+func (r *PathManagementReconciler) Unwind(ctx context.Context) error {
+	return r.apply(ctx, appv1alpha1.AddPathManual, true)
+}
+
+// apply serializes the platform edit (shell startup files on Unix, the user
+// Environment on Windows) behind a cross-process lock, then runs it. The lock is
+// what makes the fence markers' promise — that separate instances can share one
+// ~/.zshrc — hold across daemons: without it, two instances read, compute, and
+// write concurrently, and the last writer drops the other's block. The in-process
+// mutex in atomicfile can't help, since the instances are separate processes and
+// the read/compute happens before the write anyway.
+func (r *PathManagementReconciler) apply(ctx context.Context, strategy appv1alpha1.AddPathStrategy, forceRemove bool) error {
+	unlock, err := acquirePathLock(ctx)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return r.applyPath(ctx, strategy, forceRemove)
+}
+
+// permanentPathError reports whether err is non-nil and every underlying cause is
+// a malformed managed block — a file the user corrupted that retrying can't fix.
+// applyPosix joins one error per startup file, so a single transient cause (I/O,
+// permissions, a full disk) anywhere makes the whole failure repairable: the
+// reconciler keeps retrying and Settled keeps gating until it clears. Only when
+// every cause is permanent do we stop retrying and drop the manual Settled gate.
+func permanentPathError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		causes := joined.Unwrap()
+		if len(causes) == 0 {
+			return false
+		}
+		for _, cause := range causes {
+			if !permanentPathError(cause) {
+				return false
+			}
+		}
+		return true
+	}
+	return errors.Is(err, managedlines.ErrMalformedBlock)
+}
+
+// acquirePathLock takes the shared PATH lock and returns a function that
+// releases it. It blocks up to pathManagementLockTimeout; a stuck holder surfaces
+// as an error so the reconcile requeues rather than hanging.
+func acquirePathLock(ctx context.Context) (func(), error) {
+	dir, err := sharedDataDir()
+	if err != nil {
+		return nil, fmt.Errorf("locate PATH lock directory: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create PATH lock directory: %w", err)
+	}
+	fl := flock.New(filepath.Join(dir, pathManagementLockFile))
+
+	lockCtx, cancel := context.WithTimeout(ctx, pathManagementLockTimeout)
+	defer cancel()
+	locked, err := fl.TryLockContext(lockCtx, 50*time.Millisecond)
+	if err != nil {
+		return nil, fmt.Errorf("acquire PATH lock: %w", err)
+	}
+	if !locked {
+		return nil, fmt.Errorf("acquire PATH lock: timed out after %s", pathManagementLockTimeout)
+	}
+	return func() { _ = fl.Unlock() }, nil
+}
+
+// sharedDataDir returns the per-user data root that every instance shares (the
+// parent of instance.Dir()). The PATH lock lives here rather than under a single
+// instance's directory, so all of a user's daemons serialize on the same file.
+// It mirrors instance.Dir()'s layout but drops the instance-specific leaf, and
+// avoids instance.Dir()'s memoization so it tracks HOME in tests.
+func sharedDataDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join(home, "AppData", "Local"), nil
+	case "linux":
+		return filepath.Join(home, ".local", "share"), nil
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support"), nil
+	default:
+		return "", fmt.Errorf("platform %s not supported", runtime.GOOS)
+	}
+}
+
+// SetupWithManager wires the reconciler to the App singleton.
+func (r *PathManagementReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appv1alpha1.App{}, builder.WithPredicates(predicates.WatchEventLogger("path-management-reconciler"))).
+		Named("path-management-reconciler").
+		Complete(r)
+}

--- a/rdd/pkg/controllers/app/pathmanagement/controllers/reconciler_test.go
+++ b/rdd/pkg/controllers/app/pathmanagement/controllers/reconciler_test.go
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+//go:build !windows
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/managedlines"
+)
+
+func reconcilerTestScheme(t *testing.T) *k8sruntime.Scheme {
+	t.Helper()
+	s := k8sruntime.NewScheme()
+	assert.NilError(t, appv1alpha1.AddToScheme(s))
+	return s
+}
+
+// TestReconcileWritesReadyCondition checks that a successful apply stamps
+// PathManagementReady=True with the App's generation.
+func TestReconcileWritesReadyCondition(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Generation: 3},
+		Spec:       appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).WithStatusSubresource(app).Build()
+	r := &PathManagementReconciler{Client: c, BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.NilError(t, err)
+
+	var got appv1alpha1.App
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, &got))
+	cond := findCondition(got.Status.Conditions, appv1alpha1.AppConditionPathManagementReady)
+	assert.Assert(t, cond != nil)
+	assert.Equal(t, cond.Status, metav1.ConditionTrue)
+	assert.Equal(t, cond.Reason, appv1alpha1.PathManagementReasonApplied)
+	assert.Equal(t, cond.ObservedGeneration, int64(3))
+}
+
+// TestReconcileWritesFailureCondition checks that an apply failure stamps
+// PathManagementReady=False and still requeues on the error. A directory in
+// place of ~/.zshrc makes managedlines.Manage fail to read it.
+func TestReconcileWritesFailureCondition(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+	assert.NilError(t, os.Mkdir(filepath.Join(home, ".zshrc"), 0o755))
+
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Generation: 5},
+		Spec:       appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).WithStatusSubresource(app).Build()
+	r := &PathManagementReconciler{Client: c, BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.Assert(t, err != nil)
+
+	var got appv1alpha1.App
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, &got))
+	cond := findCondition(got.Status.Conditions, appv1alpha1.AppConditionPathManagementReady)
+	assert.Assert(t, cond != nil)
+	assert.Equal(t, cond.Status, metav1.ConditionFalse)
+	assert.Equal(t, cond.Reason, appv1alpha1.PathManagementReasonFailed)
+	assert.Equal(t, cond.ObservedGeneration, int64(5))
+}
+
+// TestReconcileStampsAppliedGeneration checks that when the spec changes between
+// the read that chose the strategy and the condition write, the condition is
+// stamped with the applied generation, not the newer one — otherwise Settled
+// could report the new generation as done before its strategy ran.
+func TestReconcileStampsAppliedGeneration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Generation: 1},
+		Spec:       appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+
+	// Bump the generation on the setCondition re-Get (the second Get), the way an
+	// external spec change landing mid-reconcile would.
+	gets := 0
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).WithStatusSubresource(app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := cl.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				gets++
+				if a, ok := obj.(*appv1alpha1.App); ok && gets > 1 {
+					a.Generation = 2
+					a.Spec.Application.AddPath = appv1alpha1.AddPathManual
+				}
+				return nil
+			},
+		}).Build()
+	r := &PathManagementReconciler{Client: c, BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.NilError(t, err)
+
+	var got appv1alpha1.App
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, &got))
+	cond := findCondition(got.Status.Conditions, appv1alpha1.AppConditionPathManagementReady)
+	assert.Assert(t, cond != nil)
+	// We applied front at generation 1; the condition must claim 1, not the
+	// generation-2 spec we never applied.
+	assert.Equal(t, cond.ObservedGeneration, int64(1))
+}
+
+func findCondition(conds []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == condType {
+			return &conds[i]
+		}
+	}
+	return nil
+}
+
+// TestReconcileAddsFinalizer checks that a normal reconcile puts our finalizer
+// on the App, so a later deletion runs the unwind branch.
+func TestReconcileAddsFinalizer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Generation: 1},
+		Spec:       appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).WithStatusSubresource(app).Build()
+	r := &PathManagementReconciler{Client: c, BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.NilError(t, err)
+
+	var got appv1alpha1.App
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, &got))
+	assert.Assert(t, slices.Contains(got.Finalizers, pathManagementFinalizer))
+}
+
+// TestReconcileUnwindsOnDeletion checks that deleting the App removes our block
+// and releases the finalizer, rather than orphaning the block.
+func TestReconcileUnwindsOnDeletion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+	r := &PathManagementReconciler{BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	zshrc := filepath.Join(home, ".zshrc")
+	block := r.startMarker() + "\nexport PATH=\"" + r.BinDir + ":$PATH\"\n" + r.endMarker() + "\n"
+	assert.NilError(t, os.WriteFile(zshrc, []byte("keep\n"+block), 0o644))
+
+	now := metav1.NewTime(time.Now())
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              appName,
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{pathManagementFinalizer},
+		},
+		Spec: appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	r.Client = c
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.NilError(t, err)
+
+	// The block is gone (the user's own content survives).
+	assert.Equal(t, readFile(t, zshrc), "keep\n")
+	// With the last finalizer removed, the App is deleted.
+	var got appv1alpha1.App
+	err = c.Get(context.Background(), client.ObjectKey{Name: appName}, &got)
+	assert.Assert(t, err != nil)
+}
+
+// TestReconcileReleasesFinalizerWhenUnwindFails checks that a dotfile the user
+// hand-edited into an unparseable state (only one marker survives) doesn't
+// strand App deletion: the unwind fails, but the finalizer is released anyway.
+func TestReconcileReleasesFinalizerWhenUnwindFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+	r := &PathManagementReconciler{BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	// The end marker is gone, so managedlines.Manage errors on every attempt.
+	zshrc := filepath.Join(home, ".zshrc")
+	assert.NilError(t, os.WriteFile(zshrc,
+		[]byte("# mine\n"+r.startMarker()+"\nexport PATH=\"x:$PATH\"\n"), 0o644))
+
+	now := metav1.NewTime(time.Now())
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              appName,
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{pathManagementFinalizer},
+		},
+		Spec: appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	r.Client = c
+
+	// Reconcile doesn't propagate the unwind error, so deletion isn't retried
+	// forever on a file we can't repair.
+	_, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.NilError(t, err)
+
+	// The finalizer is gone, so the App can be deleted despite the broken file.
+	var got appv1alpha1.App
+	err = c.Get(context.Background(), client.ObjectKey{Name: appName}, &got)
+	assert.Assert(t, err != nil)
+}
+
+// TestReconcileRetriesFinalizerWhenUnwindRepairable checks the other side: a
+// repairable unwind failure (here a directory in place of ~/.zshrc, so
+// managedlines.Manage can't read it) within the grace window keeps the finalizer
+// and requeues, so the block isn't abandoned for a failure that a later pass
+// could clear.
+func TestReconcileRetriesFinalizerWhenUnwindRepairable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+	r := &PathManagementReconciler{BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	// A directory in place of ~/.zshrc makes the read fail with an I/O error, not
+	// a malformed-block error.
+	assert.NilError(t, os.Mkdir(filepath.Join(home, ".zshrc"), 0o755))
+
+	// Deletion requested just now, so we're inside the grace window.
+	now := metav1.NewTime(time.Now())
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              appName,
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{pathManagementFinalizer},
+		},
+		Spec: appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	r.Client = c
+
+	// Within the grace window the reconcile requeues (no error, RequeueAfter set)
+	// rather than releasing.
+	res, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.NilError(t, err)
+	assert.Assert(t, res.RequeueAfter > 0)
+
+	// The finalizer is still there, so the App isn't deleted while the block might
+	// still be removable on a later pass.
+	var got appv1alpha1.App
+	assert.NilError(t, c.Get(context.Background(), client.ObjectKey{Name: appName}, &got))
+	assert.Assert(t, controllerutil.ContainsFinalizer(&got, pathManagementFinalizer))
+}
+
+// TestReconcileReleasesFinalizerAfterUnwindGrace checks the bound: a repairable
+// unwind failure that never clears (here a permanently unreadable ~/.zshrc) must
+// not strand the App forever. Once the grace window measured from
+// deletionTimestamp has passed, the finalizer is released anyway.
+func TestReconcileReleasesFinalizerAfterUnwindGrace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+	r := &PathManagementReconciler{BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	assert.NilError(t, os.Mkdir(filepath.Join(home, ".zshrc"), 0o755))
+
+	// Deletion was requested well before the grace window; the retries are spent.
+	old := metav1.NewTime(time.Now().Add(-2 * pathUnwindRetryGrace))
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              appName,
+			Generation:        1,
+			DeletionTimestamp: &old,
+			Finalizers:        []string{pathManagementFinalizer},
+		},
+		Spec: appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	r.Client = c
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.NilError(t, err)
+
+	// The finalizer is gone, so the App can finish deleting despite the file we
+	// can't read.
+	var got appv1alpha1.App
+	err = c.Get(context.Background(), client.ObjectKey{Name: appName}, &got)
+	assert.Assert(t, err != nil)
+}
+
+func TestReconcileDoesNotReapplyWhileDeleting(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+
+	zshrc := filepath.Join(home, ".zshrc")
+	assert.NilError(t, os.WriteFile(zshrc, []byte("keep\n"), 0o644))
+
+	now := metav1.NewTime(time.Now())
+	app := &appv1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              appName,
+			Generation:        1,
+			DeletionTimestamp: &now,
+			// A second finalizer keeps the App around after we drop ours, so we
+			// can still observe that no block was written.
+			Finalizers: []string{pathManagementFinalizer, "rdd.rancherdesktop.io/cleanup"},
+		},
+		Spec: appv1alpha1.AppSpec{Application: appv1alpha1.ApplicationSpec{AddPath: appv1alpha1.AddPathFront}},
+	}
+	scheme := reconcilerTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).Build()
+	r := &PathManagementReconciler{Client: c, BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{})
+	assert.NilError(t, err)
+
+	got := readFile(t, zshrc)
+	assert.Assert(t, !strings.Contains(got, r.startMarker()))
+}
+
+// TestApplyConcurrentInstancesKeepBothBlocks checks that two instances editing
+// the same ~/.zshrc at once don't lose each other's block. The fence markers are
+// suffix-tagged so the instances can share the file, but managedlines.Manage does
+// read-compute-write, so without the cross-process lock the later writer computes
+// from a stale read and drops the earlier block. apply holds the lock across the
+// whole edit, so both blocks survive.
+func TestApplyConcurrentInstancesKeepBothBlocks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config-home"))
+
+	r2 := &PathManagementReconciler{BinDir: filepath.Join(home, ".rd2", "bin"), Suffix: "2"}
+	r3 := &PathManagementReconciler{BinDir: filepath.Join(home, ".rd3", "bin"), Suffix: "3"}
+	zshrc := filepath.Join(home, ".zshrc")
+
+	// The overlap that loses a block is timing-dependent, so repeat: resetting the
+	// file each round makes a regression fail reliably instead of flaking green.
+	for range 30 {
+		assert.NilError(t, os.WriteFile(zshrc, []byte("# mine\n"), 0o644))
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		errs := make([]error, 2)
+		for i, r := range []*PathManagementReconciler{r2, r3} {
+			wg.Add(1)
+			go func(i int, r *PathManagementReconciler) {
+				defer wg.Done()
+				<-start // release both at once to force the overlap
+				errs[i] = r.apply(context.Background(), appv1alpha1.AddPathFront, false)
+			}(i, r)
+		}
+		close(start)
+		wg.Wait()
+
+		assert.NilError(t, errs[0])
+		assert.NilError(t, errs[1])
+
+		got := readFile(t, zshrc)
+		assert.Assert(t, strings.Contains(got, r2.startMarker()), "instance 2 block missing: %q", got)
+		assert.Assert(t, strings.Contains(got, r3.startMarker()), "instance 3 block missing: %q", got)
+	}
+}
+
+// TestPermanentPathError checks the classifier that decides whether an apply
+// failure is permanent (a malformed block only the user can fix) or repairable
+// (I/O). It treats a joined error as permanent only when every cause is, so one
+// transient failure among several files keeps the whole thing repairable.
+func TestPermanentPathError(t *testing.T) {
+	malformed := fmt.Errorf(".zshrc: %w", managedlines.ErrMalformedBlock)
+	ioErr := errors.New("open .bashrc: permission denied")
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not permanent", nil, false},
+		{"a bare I/O error is repairable", ioErr, false},
+		{"a malformed error is permanent", malformed, true},
+		{"all-malformed join is permanent", errors.Join(malformed, malformed), true},
+		{"a join with one I/O error is repairable", errors.Join(malformed, ioErr), false},
+		{"a join of only I/O errors is repairable", errors.Join(ioErr, ioErr), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, permanentPathError(tc.err), tc.want)
+		})
+	}
+}

--- a/rdd/pkg/controllers/mock/crd.yaml
+++ b/rdd/pkg/controllers/mock/crd.yaml
@@ -54,6 +54,33 @@ spec:
                 description: application specifies the settings for the Rancher Desktop
                   Electron frontend.
                 properties:
+                  addPath:
+                    default: manual
+                    description: |-
+                      addPath controls whether and where the Rancher Desktop bin directory
+                      (~/.rd<suffix>/bin) is added to the user's PATH, by editing their shell
+                      startup files (Unix) or the user Environment (Windows):
+                        - "front":  prepend, so the bin directory wins   (bin:$PATH)
+                        - "back":   append,  so existing PATH entries win ($PATH:bin)
+                        - "manual": leave PATH alone; remove any lines a previous front/back added.
+                      It defaults to "manual" so CLI-created instances don't touch shell startup
+                      files unasked; the GUI sends "front" when the user opts in.
+
+                      On Windows the user Environment Path is a plain semicolon-separated list
+                      with nowhere to fence our entry, so under "manual" we can't tell an entry
+                      we added from one the user typed. We therefore remove the bin directory
+                      only when it sits at the very front or back of Path (the two spots
+                      front/back would have written) and leave a copy the user placed in the
+                      middle alone. The trade-off: an entry parked at either end is treated as
+                      ours and removed, so a user who wants the bin directory at the front or
+                      back on Windows must use "front"/"back", not place it there under
+                      "manual". Unix files use start/end markers, so only our own block is
+                      touched regardless of position.
+                    enum:
+                    - front
+                    - back
+                    - manual
+                    type: string
                   locale:
                     default: en-us
                     description: locale is the language/locale to use for the Rancher

--- a/rdd/pkg/instance/instance.go
+++ b/rdd/pkg/instance/instance.go
@@ -131,6 +131,13 @@ var LimaHome = sync.OnceValue(func() string {
 	return filepath.Join(ShortDir(), "lima")
 })
 
+// BinDir returns the directory holding this instance's user-facing executables
+// (e.g., ~/.rd2/bin). This is the directory the path-management controller adds
+// to the user's PATH.
+var BinDir = sync.OnceValue(func() string {
+	return filepath.Join(ShortDir(), "bin")
+})
+
 // KubeConfig returns the path to the instance's standalone kubeconfig
 // (e.g., ~/.rd2/kube.config). It holds only the rancher-desktop-{instance}
 // context and is published alongside the ~/.kube/config merge, so rdd run

--- a/rdd/pkg/service/cmd/service.go
+++ b/rdd/pkg/service/cmd/service.go
@@ -60,6 +60,7 @@ import (
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/engine"
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/k3sversions"
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/kubernetes"
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/app/pathmanagement"
 	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
 	// Import built-in system controllers.
 	_ "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/builtin/namespace"
@@ -536,6 +537,13 @@ func Delete(ctx context.Context, timeout time.Duration) error {
 	// registration, which the next `rdd svc create` would boot against a
 	// missing disk.
 	wsl.UnregisterInstanceDistros(ctx, instance.LimaHome())
+	// Remove this instance's PATH edits before deleting the bin directory, so the
+	// user isn't left with a block in their shell startup files (or the Windows
+	// user Environment) pointing at a directory that no longer exists. Best-effort:
+	// a failure here shouldn't stop the instance from being deleted.
+	if err := pathmanagement.Unwind(ctx); err != nil {
+		logrus.WithError(err).Warn("Failed to remove PATH management entries")
+	}
 	_ = os.RemoveAll(instance.ShortDir())
 	return os.RemoveAll(instance.Dir())
 }

--- a/rdd/pkg/util/managedlines/managedlines.go
+++ b/rdd/pkg/util/managedlines/managedlines.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package managedlines adds or removes a fenced block of lines in a text file,
+// idempotently. It's a Go port of Rancher Desktop 1's manageLinesInFile, and we
+// use it to put the Rancher Desktop bin directory on PATH via the user's shell
+// startup files.
+//
+// The block sits between caller-supplied start/end marker lines, so different
+// tools (and different Rancher Desktop instances) can edit the same file without
+// stepping on each other. Text outside the markers is left as-is, except that
+// leading and trailing blank lines get trimmed.
+package managedlines
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/util/atomicfile"
+)
+
+// fileMode is used for startup files we create.
+const fileMode = 0o644
+
+// ErrMalformedBlock marks a file the user hand-edited into a state we can't
+// parse: a lone marker, or the end marker before the start. It's permanent —
+// only the user can fix the file, so retrying can't clear the block — which lets
+// callers tell it apart from a transient I/O error and stop retrying forever.
+var ErrMalformedBlock = errors.New("managed block is malformed")
+
+// Manage adds (present=true) or removes (present=false) managedLines between
+// startMarker and endMarker in the file at path. The write is atomic, and text
+// outside the block isn't touched.
+//
+// If removing the block leaves the file empty, we write an empty file rather
+// than deleting it. We can't tell a file we created from one the user already
+// had — an empty ~/.zshrc or ~/.bashrc is ordinary, and zsh even writes one when
+// the user declines its setup wizard — so deleting it could destroy the user's
+// file or resurface that wizard. A file that doesn't exist yet is left alone,
+// since there's nothing to remove.
+func Manage(path, startMarker, endMarker string, managedLines []string, present bool) error {
+	desired := desiredLines(startMarker, endMarker, managedLines, present)
+
+	current, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	target, changed, err := computeTargetContents(string(current), startMarker, endMarker, desired)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	if !changed {
+		return nil
+	}
+
+	// An empty result means we just removed the last of our own content. Don't
+	// create a file that wasn't there; otherwise write the empty file, leaving a
+	// pre-existing (possibly empty) startup file in place instead of deleting it.
+	if target == "" {
+		if _, statErr := os.Lstat(path); os.IsNotExist(statErr) {
+			return nil
+		}
+	}
+	return atomicfile.Write(path, []byte(target), fileMode)
+}
+
+// desiredLines returns the full block (markers included) we want in the file, or
+// nil when there shouldn't be one.
+func desiredLines(startMarker, endMarker string, managedLines []string, present bool) []string {
+	if !present || len(managedLines) == 0 {
+		return nil
+	}
+	block := make([]string, 0, len(managedLines)+2)
+	block = append(block, startMarker)
+	block = append(block, managedLines...)
+	block = append(block, endMarker)
+	return block
+}
+
+// markerSplit is the result of splitting a file around the managed block.
+type markerSplit struct {
+	before, managed, after []string
+	// hasBlock is true when a start/end pair was found.
+	hasBlock bool
+	// duplicates is true when more than one block was present and the extras were
+	// collapsed away, so the caller must rewrite even if the first block matched.
+	duplicates bool
+}
+
+// splitByMarkers splits lines into the parts before, inside, and after the
+// block, and reports whether the markers were there at all. With no markers, the
+// whole file counts as "before".
+//
+// A file should only ever hold one block, but if it somehow ends up with more
+// than one (a bad merge, a hand-edit, a past bug), the extra pairs are collapsed:
+// managed is the first block's content, after has every later complete pair
+// stripped out, and duplicates says a pair was removed. Without this a duplicated
+// block is a permanent fixed point — the first pair matches what we want, so we'd
+// never rewrite, and the directory would stay on PATH twice forever. A lone,
+// unbalanced marker is left as ordinary text (kept in before/after), same as
+// before.
+func splitByMarkers(lines []string, startMarker, endMarker string) (markerSplit, error) {
+	startIdx := slices.Index(lines, startMarker)
+	endIdx := slices.Index(lines, endMarker)
+
+	switch {
+	case startIdx < 0 && endIdx < 0:
+		return markerSplit{before: lines}, nil
+	case startIdx < 0 || endIdx < 0:
+		return markerSplit{}, fmt.Errorf("%w: exactly one of the delimiter lines is present", ErrMalformedBlock)
+	case startIdx >= endIdx:
+		return markerSplit{}, fmt.Errorf("%w: the delimiter lines are in the wrong order", ErrMalformedBlock)
+	}
+
+	rest := lines[endIdx+1:]
+	after := stripBlocks(rest, startMarker, endMarker)
+	return markerSplit{
+		before:     lines[:startIdx],
+		managed:    lines[startIdx+1 : endIdx],
+		after:      after,
+		hasBlock:   true,
+		duplicates: len(after) != len(rest),
+	}, nil
+}
+
+// stripBlocks removes every complete start/end marker pair (and the lines
+// between) from lines, leaving all other content in place. A lone, unbalanced
+// marker is treated as ordinary text and kept, matching splitByMarkers's
+// leniency. It's used to collapse a file that ended up with the managed block
+// more than once down to a single block.
+func stripBlocks(lines []string, startMarker, endMarker string) []string {
+	result := make([]string, 0, len(lines))
+	for i := 0; i < len(lines); i++ {
+		if lines[i] == startMarker {
+			if rel := slices.Index(lines[i+1:], endMarker); rel >= 0 {
+				i += rel + 1 // skip to the end marker; the loop's i++ moves past it
+				continue
+			}
+		}
+		result = append(result, lines[i])
+	}
+	return result
+}
+
+// computeTargetContents works out what the file should contain, given its
+// current contents and the desired block (markers included). changed is false
+// when nothing needs to be written. The result has no leading blank lines and
+// ends in a single newline; an empty result is "".
+func computeTargetContents(current, startMarker, endMarker string, desired []string) (target string, changed bool, err error) {
+	split, err := splitByMarkers(strings.Split(current, "\n"), startMarker, endMarker)
+	if err != nil {
+		return "", false, err
+	}
+
+	var currentBlock []string
+	if split.hasBlock {
+		currentBlock = append(append([]string{startMarker}, split.managed...), endMarker)
+	}
+	// Skip the rewrite only when the single existing block already matches. If we
+	// collapsed duplicate blocks, the first one may match while extra copies still
+	// need stripping, so always write in that case.
+	if !split.duplicates && slices.Equal(currentBlock, desired) {
+		return "", false, nil
+	}
+
+	lines := slices.Concat(split.before, desired, split.after)
+
+	for len(lines) > 0 && lines[0] == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return "", true, nil
+	}
+	return strings.Join(lines, "\n") + "\n", true, nil
+}

--- a/rdd/pkg/util/managedlines/managedlines_test.go
+++ b/rdd/pkg/util/managedlines/managedlines_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package managedlines
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+const (
+	startMarker = "# TEST BLOCK START"
+	endMarker   = "# TEST BLOCK END"
+)
+
+func read(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	return string(data)
+}
+
+func TestManageAddsBlockToNewFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bashrc")
+	err := Manage(path, startMarker, endMarker, []string{"export PATH=x"}, true)
+	assert.NilError(t, err)
+	assert.Equal(t, read(t, path), startMarker+"\nexport PATH=x\n"+endMarker+"\n")
+}
+
+func TestManagePreservesSurroundingContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bashrc")
+	assert.NilError(t, os.WriteFile(path, []byte("before\n\nafter\n"), 0o644))
+	err := Manage(path, startMarker, endMarker, []string{"line"}, true)
+	assert.NilError(t, err)
+	assert.Equal(t, read(t, path), "before\n\nafter\n\n"+startMarker+"\nline\n"+endMarker+"\n")
+}
+
+func TestManageIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bashrc")
+	assert.NilError(t, os.WriteFile(path, []byte("keep\n"), 0o600))
+	assert.NilError(t, Manage(path, startMarker, endMarker, []string{"line"}, true))
+	first := read(t, path)
+	info1, err := os.Stat(path)
+	assert.NilError(t, err)
+	assert.NilError(t, Manage(path, startMarker, endMarker, []string{"line"}, true))
+	assert.Equal(t, read(t, path), first)
+	info2, err := os.Stat(path)
+	assert.NilError(t, err)
+	// A no-op must not rewrite the file (mtime unchanged) or alter its mode.
+	assert.Equal(t, info1.ModTime(), info2.ModTime())
+	assert.Equal(t, info1.Mode(), info2.Mode())
+}
+
+func TestManageUpdatesExistingBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bashrc")
+	assert.NilError(t, os.WriteFile(path,
+		[]byte("keep\n"+startMarker+"\nold\n"+endMarker+"\ntail\n"), 0o644))
+	err := Manage(path, startMarker, endMarker, []string{"new"}, true)
+	assert.NilError(t, err)
+	assert.Equal(t, read(t, path), "keep\n"+startMarker+"\nnew\n"+endMarker+"\ntail\n")
+}
+
+func TestManageRemovesBlockKeepingContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bashrc")
+	assert.NilError(t, os.WriteFile(path,
+		[]byte("keep\n"+startMarker+"\nline\n"+endMarker+"\ntail\n"), 0o644))
+	err := Manage(path, startMarker, endMarker, nil, false)
+	assert.NilError(t, err)
+	assert.Equal(t, read(t, path), "keep\ntail\n")
+}
+
+func TestManageEmptiesFileInsteadOfDeleting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bash_profile")
+	assert.NilError(t, os.WriteFile(path,
+		[]byte(startMarker+"\nline\n"+endMarker+"\n"), 0o644))
+	err := Manage(path, startMarker, endMarker, nil, false)
+	assert.NilError(t, err)
+	// The file stays put (it may be one the user already had); it's just emptied.
+	assert.Equal(t, read(t, path), "")
+}
+
+func TestManageRemoveOnMissingFileIsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bash_profile")
+	err := Manage(path, startMarker, endMarker, nil, false)
+	assert.NilError(t, err)
+	_, statErr := os.Stat(path)
+	assert.Assert(t, os.IsNotExist(statErr))
+}
+
+func TestManageDanglingMarkerErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bashrc")
+	assert.NilError(t, os.WriteFile(path, []byte("keep\n"+startMarker+"\nline\n"), 0o644))
+	err := Manage(path, startMarker, endMarker, []string{"x"}, true)
+	assert.ErrorContains(t, err, "exactly one of the delimiter lines")
+	// The error names the offending file so the user can find it.
+	assert.ErrorContains(t, err, path)
+}
+
+// TestManageCollapsesDuplicateBlock checks that a file that ended up with our
+// block twice is collapsed to one in a single pass, keeping the content between
+// the blocks. Without collapsing, the first block matches what we want, so Manage
+// would report no change and leave the directory on PATH twice forever.
+func TestManageCollapsesDuplicateBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bashrc")
+	block := startMarker + "\nexport PATH=x\n" + endMarker + "\n"
+	assert.NilError(t, os.WriteFile(path, []byte("keep\n"+block+"mid\n"+block+"tail\n"), 0o644))
+
+	assert.NilError(t, Manage(path, startMarker, endMarker, []string{"export PATH=x"}, true))
+	// One block survives, at the first block's position, and the user's own
+	// content (keep/mid/tail) is preserved.
+	want := "keep\n" + startMarker + "\nexport PATH=x\n" + endMarker + "\nmid\ntail\n"
+	assert.Equal(t, read(t, path), want)
+
+	// Now a fixed point: re-applying changes nothing.
+	before := read(t, path)
+	assert.NilError(t, Manage(path, startMarker, endMarker, []string{"export PATH=x"}, true))
+	assert.Equal(t, read(t, path), before)
+}
+
+// TestManageRemovesDuplicateBlocks checks that removal takes out every copy, not
+// just the first.
+func TestManageRemovesDuplicateBlocks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".bashrc")
+	block := startMarker + "\nexport PATH=x\n" + endMarker + "\n"
+	assert.NilError(t, os.WriteFile(path, []byte("keep\n"+block+block+"tail\n"), 0o644))
+
+	assert.NilError(t, Manage(path, startMarker, endMarker, nil, false))
+	assert.Equal(t, read(t, path), "keep\ntail\n")
+}


### PR DESCRIPTION
Add a `spec.application.addPath` field (front/back/manual) to control whether `~/.rd<suffix>/bin` is added to the user's PATH and where. front prepends it, back appends it, and manual leaves PATH unchanged (and removes anything previously added by front or back).

Add a new path-management controller that watches the App singleton and applies the setting on the host. On Unix, it updates the usual shell startup files (`.bash_profile/.bash_login/.profile, .bashrc, .zshrc, .cshrc/.tcshrc, and fish's config.fish`), using the same login-file precedence as Rancher Desktop 1. On Windows, it updates the user's Path in `HKCU\Environment` and broadcasts `WM_SETTINGCHANGE`.

The controller runs regardless of VM state since this is all host-side. It should also be idempotent so repeated reconciles don't keep changing the files.

Use a new managedlines helper for the edits, based on RD1's `manageLinesInFile`. It keeps the managed lines inside suffix-tagged markers so different instances (and RD1) don't interfere with each other, and writes the files atomically.

The field defaults to manual so CLI-created instances don't modify shell files unless requested. The GUI sends front when the user opts in.

Addresses: https://github.com/rancher-sandbox/rancher-desktop-2/issues/497