### PR TITLE
RDD: controllers: Pass context to RegisterWithManager

### DIFF
--- a/rdd/pkg/controllers/app/app/controller.go
+++ b/rdd/pkg/controllers/app/app/controller.go
@@ -8,6 +8,7 @@
 package app
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"runtime"
@@ -165,7 +166,7 @@ func (c *controller) setupWebhook(mgr ctrl.Manager) error {
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
 // It registers the CRD types with the scheme and sets up the controller with the manager.
 // It also registers Lima types, which allows App controller to create and watch LimaVM resources.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}

--- a/rdd/pkg/controllers/app/demo/controller.go
+++ b/rdd/pkg/controllers/app/demo/controller.go
@@ -9,6 +9,7 @@
 package demo
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"io"
@@ -109,7 +110,7 @@ func (c *controller) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/rdd/pkg/controllers/app/engine/controller.go
+++ b/rdd/pkg/controllers/app/engine/controller.go
@@ -10,6 +10,7 @@
 package engine
 
 import (
+	"context"
 	"maps"
 	"net/http"
 	"slices"
@@ -75,7 +76,7 @@ func (c *controller) GetPassthroughHandler(endpoint string) http.Handler {
 	return c.passthroughs[endpoint]
 }
 
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	if err := appv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}

--- a/rdd/pkg/controllers/app/k3sversions/controller.go
+++ b/rdd/pkg/controllers/app/k3sversions/controller.go
@@ -7,6 +7,8 @@
 package k3sversions
 
 import (
+	"context"
+
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -104,7 +106,7 @@ func (c *controller) setupWebhook(mgr ctrl.Manager) error {
 
 // RegisterWithManager implements the complete controller registration for both
 // embedded and external modes.  It sets up the controller with the manager.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}

--- a/rdd/pkg/controllers/app/kubernetes/controller.go
+++ b/rdd/pkg/controllers/app/kubernetes/controller.go
@@ -9,6 +9,8 @@
 package kubernetes
 
 import (
+	"context"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	appv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/app/v1alpha1"
@@ -39,7 +41,7 @@ func (c *controller) GetCRDData() string {
 	return ""
 }
 
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	if err := appv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}

--- a/rdd/pkg/controllers/base/controller.go
+++ b/rdd/pkg/controllers/base/controller.go
@@ -31,8 +31,10 @@ type Controller interface {
 	// GetCRDData returns the embedded CRD YAML data
 	GetCRDData() string
 
-	// RegisterWithManager provides complete controller registration including scheme and setup
-	RegisterWithManager(mgr ctrl.Manager) error
+	// RegisterWithManager provides complete controller registration including
+	// scheme and setup.  The provided context must last for the lifetime of the
+	// controller, and must be cancelled to signal controller shut down.
+	RegisterWithManager(ctx context.Context, mgr ctrl.Manager) error
 }
 
 // WebhookController is an optional interface that controllers can implement

--- a/rdd/pkg/controllers/builtin/namespace/controller.go
+++ b/rdd/pkg/controllers/builtin/namespace/controller.go
@@ -9,6 +9,8 @@
 package namespace
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,7 +51,7 @@ func (c *controller) GetCRDData() string {
 }
 
 // RegisterWithManager implements the complete controller registration.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	klog.InfoS("Setting up namespace controller watch", "controller", ControllerName)
 
 	// Register the controller

--- a/rdd/pkg/controllers/containers/container/container_controller.go
+++ b/rdd/pkg/controllers/containers/container/container_controller.go
@@ -5,6 +5,7 @@
 package container
 
 import (
+	"context"
 	_ "embed"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -104,7 +105,7 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/rdd/pkg/controllers/containers/containernamespace/container_namespace_controller.go
+++ b/rdd/pkg/controllers/containers/containernamespace/container_namespace_controller.go
@@ -5,6 +5,7 @@
 package containernamespace
 
 import (
+	"context"
 	_ "embed"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -92,7 +93,7 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/rdd/pkg/controllers/containers/image/image_controller.go
+++ b/rdd/pkg/controllers/containers/image/image_controller.go
@@ -8,6 +8,7 @@
 package image
 
 import (
+	"context"
 	_ "embed"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -54,7 +55,7 @@ func (c *controller) GetCRDData() string {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	return v1alpha1.AddToScheme(mgr.GetScheme())
 }

--- a/rdd/pkg/controllers/containers/volume/volume_controller.go
+++ b/rdd/pkg/controllers/containers/volume/volume_controller.go
@@ -7,6 +7,7 @@
 package volume
 
 import (
+	"context"
 	_ "embed"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -52,7 +53,7 @@ func (c *controller) GetCRDData() string {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	return v1alpha1.AddToScheme(mgr.GetScheme())
 }

--- a/rdd/pkg/controllers/lima/limavm/controller.go
+++ b/rdd/pkg/controllers/lima/limavm/controller.go
@@ -178,7 +178,7 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	// Set LIMA_HOME for the Lima library to use the correct instance directory.
 	// This must be set before any Lima operations are performed.
 	if err := os.Setenv("LIMA_HOME", instance.LimaHome()); err != nil {

--- a/rdd/pkg/controllers/mock/mock_controller.go
+++ b/rdd/pkg/controllers/mock/mock_controller.go
@@ -196,9 +196,8 @@ func (c *controller) createNamespace(ctx context.Context, mgr ctrl.Manager) erro
 }
 
 // RegisterWithManager implements [base.Controller].
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	mgr.GetLogger().Info("Registering Mock Controller with Manager")
-	ctx := context.Background()
 	c.mgr = mgr
 
 	if err := appv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {

--- a/rdd/pkg/controllers/rdd/configmapreplicaset/controller.go
+++ b/rdd/pkg/controllers/rdd/configmapreplicaset/controller.go
@@ -8,6 +8,7 @@
 package configmapreplicaset
 
 import (
+	"context"
 	_ "embed"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -52,7 +53,7 @@ func (c *controller) GetCRDData() string {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/rdd/pkg/controllers/rdd/hostinfo/controller.go
+++ b/rdd/pkg/controllers/rdd/hostinfo/controller.go
@@ -7,6 +7,7 @@
 package hostinfo
 
 import (
+	"context"
 	_ "embed"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,7 +39,7 @@ func (c *controller) GetAPIGroup() string { return APIGroup }
 func (c *controller) GetCRDData() string  { return hostInfoCRD }
 
 // RegisterWithManager registers the CRD scheme and the HostInfo reconciler.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	if err := rddv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}

--- a/rdd/pkg/controllers/rdd/notary/controller.go
+++ b/rdd/pkg/controllers/rdd/notary/controller.go
@@ -109,7 +109,7 @@ func (c *controller) setupWebhookWithRuntimeConfig(mgr ctrl.Manager) error {
 }
 
 // RegisterWithManager implements the complete controller registration for both embedded and external modes.
-func (c *controller) RegisterWithManager(mgr ctrl.Manager) error {
+func (c *controller) RegisterWithManager(_ context.Context, mgr ctrl.Manager) error {
 	// Register the CRD types with the scheme
 	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		return err

--- a/rdd/pkg/service/controllers/manager.go
+++ b/rdd/pkg/service/controllers/manager.go
@@ -229,7 +229,7 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 			webhookController.SetWebhookPort(scm.webhookPort)
 		}
 
-		if err := registration.RegisterWithManager(mgr); err != nil {
+		if err := registration.RegisterWithManager(ctx, mgr); err != nil {
 			return fmt.Errorf("failed to register controller %s: %w", registration.GetName(), err)
 		}
 	}


### PR DESCRIPTION
This passes a context to `RegisterWithManager`, which is defined to last for the lifetime of the the controller.  This is to be used for controllers that need to track resources outside of a reconcile; the planned immediate use is to be able to track processes (`docker compose up`, etc.) which will take longer than a single reconcile iteration.