### PR TITLE
[DO-NOT-MERGE] RDA: containers: Add a select-all checkbox to project groups

### DIFF
--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -651,3 +651,97 @@ test.describe.fixme('Container Stats Tab', () => {
     await expect(statsPage.cpuChart).not.toBeVisible();
   });
 });
+
+test.describe.fixme('Container Compose Group Actions', () => {
+  let electronApp: ElectronApplication;
+  let composeContainerId1: string;
+  let composeContainerId2: string;
+  const composeProjectName = `test-compose-project-${ Date.now() }`;
+
+  test.beforeAll(async({ colorScheme }, testInfo) => {
+    [electronApp, page] = await startSlowerDesktop(testInfo);
+
+    const navPage = new NavPage(page);
+    await navPage.waitForAppSettled();
+
+    // A shared label fakes a compose project, so these tests need no
+    // docker-compose CLI plugin.
+    const output1 = await tool(
+      'docker', 'run', '--detach',
+      '--label', `com.docker.compose.project=${ composeProjectName }`,
+      '--name', `${ composeProjectName }-app`,
+      'alpine', 'sleep', 'infinity',
+    );
+
+    composeContainerId1 = output1.trim();
+
+    const output2 = await tool(
+      'docker', 'run', '--detach',
+      '--label', `com.docker.compose.project=${ composeProjectName }`,
+      '--name', `${ composeProjectName }-db`,
+      'alpine', 'sleep', 'infinity',
+    );
+
+    composeContainerId2 = output2.trim();
+  });
+
+  test.afterAll(async({ colorScheme }, testInfo) => {
+    for (const id of [composeContainerId1, composeContainerId2]) {
+      if (id) {
+        try {
+          await tool('docker', 'rm', '-f', id);
+        } catch {}
+      }
+    }
+    await teardown(electronApp, testInfo);
+  });
+
+  test('compose project group shows a select-all checkbox', async() => {
+    const navPage = new NavPage(page);
+    const containersPage = await navPage.navigateTo('Containers');
+
+    await containersPage.waitForTableToLoad();
+    await containersPage.waitForContainerToAppear(composeContainerId1);
+    await containersPage.waitForContainerToAppear(composeContainerId2);
+    await containersPage.waitForGroupToAppear(composeProjectName);
+
+    await expect(containersPage.getGroupCheckbox(composeProjectName)).toBeVisible();
+  });
+
+  test('group checkbox selects every container in the project for bulk actions', async() => {
+    const navPage = new NavPage(page);
+    const containersPage = await navPage.navigateTo('Containers');
+
+    await containersPage.waitForTableToLoad();
+    await containersPage.waitForContainerToAppear(composeContainerId1);
+    await containersPage.waitForContainerToAppear(composeContainerId2);
+    await containersPage.waitForGroupToAppear(composeProjectName);
+    await containersPage.selectGroup(composeProjectName);
+
+    // The row checkboxes do not set the native `checked` DOM property, so
+    // assert on the table's own selection count label.
+    await expect(containersPage.getSelectionCount(2)).toBeVisible();
+
+    await containersPage.clickBulkStop();
+
+    for (const id of [composeContainerId1, composeContainerId2]) {
+      await expect(containersPage.getContainerRow(id).getByText('exited')).toBeVisible({ timeout: 15_000 });
+    }
+  });
+
+  test('group checkbox plus the regular delete button removes every container in the project', async() => {
+    const navPage = new NavPage(page);
+    const containersPage = await navPage.navigateTo('Containers');
+
+    await containersPage.waitForTableToLoad();
+    await containersPage.waitForContainerToAppear(composeContainerId1);
+    await containersPage.waitForContainerToAppear(composeContainerId2);
+    await containersPage.waitForGroupToAppear(composeProjectName);
+    await containersPage.selectGroup(composeProjectName);
+    await containersPage.clickBulkDelete();
+
+    for (const id of [composeContainerId1, composeContainerId2]) {
+      await expect(containersPage.getContainerRow(id)).not.toBeVisible({ timeout: 15_000 });
+    }
+  });
+});

--- a/e2e/pages/containers-page.ts
+++ b/e2e/pages/containers-page.ts
@@ -73,4 +73,43 @@ export class ContainersPage {
   async waitForTableToLoad() {
     await this.table.waitFor({ state: 'visible' });
   }
+
+  getGroupRow(groupName: string) {
+    return this.table.locator(`tr.group-row[data-testid="container-group-${ groupName }"]`);
+  }
+
+  async waitForGroupToAppear(groupName: string, timeout = 30_000) {
+    await expect(this.getGroupRow(groupName)).toBeVisible({ timeout });
+  }
+
+  getGroupCheckbox(groupName: string) {
+    return this.getGroupRow(groupName).locator('.group-select-checkbox');
+  }
+
+  async selectGroup(groupName: string) {
+    const nativeCheckbox = this.getGroupRow(groupName).locator('input[type="checkbox"]');
+
+    // The selection persists across navigations within the app, so a previous
+    // test may have left this group selected; clicking again would toggle it off.
+    if (!await nativeCheckbox.isChecked()) {
+      await this.getGroupCheckbox(groupName).click();
+    }
+    await expect(nativeCheckbox).toBeChecked();
+  }
+
+  /**
+   * The "N selected" label is in the table header, a sibling of
+   * `.sortable-table`, so `this.table` cannot find it.
+   */
+  getSelectionCount(count: number) {
+    return this.page.locator('.action-availability').getByText(`${ count } selected`, { exact: true });
+  }
+
+  async clickBulkStop() {
+    await this.page.getByRole('button', { name: 'Stop' }).first().click();
+  }
+
+  async clickBulkDelete() {
+    await this.page.getByRole('button', { name: 'Delete' }).first().click();
+  }
 }

--- a/pkg/rancher-desktop/components/SortableTable/actions.js
+++ b/pkg/rancher-desktop/components/SortableTable/actions.js
@@ -105,9 +105,9 @@ export default {
         if (selectedRowsText) {
           selectedRowsText.style.display = displayType;
           selectedRowsTextWidth = selectedRowsText.offsetWidth;
-        } else {
-          selectedRowsText.style.display = 'none;';
         }
+      } else if (selectedRowsText) {
+        selectedRowsText.style.display = 'none';
       }
 
       this.hiddenActions = [];

--- a/pkg/rancher-desktop/components/SortableTable/index.vue
+++ b/pkg/rancher-desktop/components/SortableTable/index.vue
@@ -1836,12 +1836,14 @@ export default {
           margin-top: 20px;
         }
 
-        td {
+        // Zero padding lets .group-tab hug its cell, but the checkbox cell
+        // keeps the column's own padding to stay aligned with the rows below.
+        td:not(.row-check) {
           padding: 0;
+        }
 
-          &:first-of-type {
-            border-left: 1px solid var(--sortable-table-accent-bg);
-          }
+        td:first-of-type {
+          border-left: 1px solid var(--sortable-table-accent-bg);
         }
 
         .group-tab {

--- a/pkg/rancher-desktop/components/SortableTable/selection.js
+++ b/pkg/rancher-desktop/components/SortableTable/selection.js
@@ -123,15 +123,14 @@ export default {
     pagedRows() {
       // When the table contents changes:
       // - Remove items that are in the selection but no longer in the table.
+      //
+      // `selectedRows` (local data) and `pagedRows` (from the `rows` prop) can
+      // wrap the same underlying row in different Vue proxies, so compare by
+      // keyField instead of object identity.
 
       const content = this.pagedRows;
-      const toRemove = [];
-
-      for (const node of this.selectedRows) {
-        if (!content.includes(node) ) {
-          toRemove.push(node);
-        }
-      }
+      const contentKeys = new Set(content.map((row) => get(row, this.keyField)));
+      const toRemove = this.selectedRows.filter((node) => !contentKeys.has(get(node, this.keyField)));
 
       this.update([], toRemove);
     },
@@ -441,7 +440,7 @@ export default {
 
     update(toAdd, toRemove) {
       toRemove.forEach((row) => {
-        const index = this.selectedRows.findIndex((r) => r._key === row._key);
+        const index = this.selectedRows.findIndex((r) => get(r, this.keyField) === get(row, this.keyField));
 
         if (index !== -1) {
           this.selectedRows.splice(index, 1);

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -21,6 +21,7 @@
       :loading="containers === null"
       group-by="projectGroup"
       :group-sort="['projectGroup']"
+      @selection="onSelectionChange"
     >
       <template #header-middle>
         <div class="header-middle">
@@ -103,12 +104,25 @@
           </div>
         </td>
       </template>
-      <template #group-row="{ group }">
+      <template #group-row="{ group, fullColspan }">
         <tr
           class="group-row"
           :aria-expanded="!collapsed[group.ref]"
+          :data-testid="`container-group-${group.ref}`"
         >
-          <td :colspan="headers.length + 1">
+          <td
+            class="row-check"
+            align="middle"
+          >
+            <Checkbox
+              class="group-select-checkbox"
+              :value="isGroupSelected(group)"
+              :indeterminate="isGroupIndeterminate(group)"
+              @update:value="setGroupSelected(group, $event)"
+              @click.stop
+            />
+          </td>
+          <td :colspan="fullColspan - 1">
             <div class="group-tab">
               <i
                 data-title="Toggle Expand"
@@ -130,10 +144,10 @@
 </template>
 
 <script lang="ts">
-import { Banner } from '@rancher/components';
+import { Banner, Checkbox } from '@rancher/components';
 import dayjs from 'dayjs';
 import { shell } from 'electron';
-import { defineComponent } from 'vue';
+import { defineComponent, markRaw } from 'vue';
 
 import ContainerStatusBadge from '@pkg/components/ContainerStatusBadge.vue';
 import SortableTable from '@pkg/components/SortableTable';
@@ -165,15 +179,24 @@ type RowItem = Container & {
   portList:          (readonly [number, number])[];
 };
 
+interface RowGroup {
+  ref:  string;
+  rows: { row: RowItem }[];
+}
+
 export default defineComponent({
   name:       'Containers',
-  components: { SortableTable, ContainerStatusBadge, Banner },
+  components: { SortableTable, ContainerStatusBadge, Banner, Checkbox },
   data() {
     return {
       // The type cast is necessary to correctly type `collapsed`.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      collapsed: {} as Record<string, boolean>,
-      headers:   [
+      collapsed:    {} as Record<string, boolean>,
+      selectedRows: [] as RowItem[],
+      // markRaw keeps the cache out of the reactivity system. `rows` both
+      // reads and writes it while computing, which would otherwise recurse.
+      rowCache:     markRaw<Record<string, RowItem | undefined>>({}),
+      headers:      [
         {
           name:  'containerState',
           label: this.t('containers.manage.table.header.state'),
@@ -211,7 +234,7 @@ export default defineComponent({
     },
     rows(): RowItem[] {
       const StatusRunning = 'running';
-      return (this.containers ?? [])
+      const result = (this.containers ?? [])
         .filter(hasField('metadata'))
         .filter(hasField('status'))
         .filter(container => {
@@ -229,10 +252,11 @@ export default defineComponent({
         })
         .map<RowItem>(container => {
           const portList = this.getPortList(container);
-          return {
+          const id = container.metadata.name!;
+          const fresh: RowItem = {
             ...container,
             uptime:           container.status.startedAt ? dayjs(container.status.startedAt).toNow(true) : '',
-            id:               container.metadata.name!,
+            id,
             imageName: (() => {
               const image = this.images?.find(image => image.status?.id === container.status?.image);
               return image?.status?.repoTag ?? container.status?.image;
@@ -260,7 +284,30 @@ export default defineComponent({
             portList,
             portsSortKey:     portList.map(([hostPort]) => hostPort).sort((a, b) => a - b),
           };
+
+          // SortableTable tracks the selection by object identity, and this
+          // computed re-runs whenever any container changes, so handing out a
+          // fresh object per recompute would drop the selection.
+          const cached = this.rowCache[id];
+
+          if (!cached) {
+            this.rowCache[id] = fresh;
+
+            return fresh;
+          }
+
+          return Object.assign(cached, fresh);
         });
+
+      const liveIds = new Set(result.map(row => row.id));
+
+      for (const id of Object.keys(this.rowCache)) {
+        if (!liveIds.has(id)) {
+          delete this.rowCache[id];
+        }
+      }
+
+      return result;
     },
     errorMessage(): string | null {
       if (['containers', 'images', 'namespaces'].includes(this.error?.source ?? '')) {
@@ -432,6 +479,35 @@ export default defineComponent({
       shell.openExternal(url);
     },
 
+    /** SortableTable's displayRows() wraps each row as { row, key, ... }. */
+    groupContainers(group: RowGroup): RowItem[] {
+      return group.rows.map(r => r.row);
+    },
+    onSelectionChange(rows: RowItem[]) {
+      this.selectedRows = rows;
+    },
+    isGroupSelected(group: RowGroup): boolean {
+      const containers = this.groupContainers(group);
+
+      return containers.length > 0 && containers.every(c => this.selectedRows.includes(c));
+    },
+    isGroupIndeterminate(group: RowGroup): boolean {
+      const containers = this.groupContainers(group);
+      const selectedCount = containers.filter(c => this.selectedRows.includes(c)).length;
+
+      return selectedCount > 0 && selectedCount < containers.length;
+    },
+    setGroupSelected(group: RowGroup, selected: boolean) {
+      const containers = this.groupContainers(group);
+      const tableRef: any = this.$refs.sortableTableRef;
+
+      if (selected) {
+        tableRef.update(containers, []);
+      } else {
+        tableRef.update([], containers);
+      }
+    },
+
     toggleExpand(group: string) {
       this.collapsed[group] = !this.collapsed[group];
     },
@@ -454,8 +530,11 @@ export default defineComponent({
 
   .group-row {
     .group-tab {
+      display: flex;
+      align-items: center;
+      gap: 6px;
       font-weight: bold;
-      .icon {
+      > .icon {
         cursor: pointer;
       }
     }

--- a/pkg/rancher-desktop/pages/__tests__/Containers.spec.ts
+++ b/pkg/rancher-desktop/pages/__tests__/Containers.spec.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { mount } from '@vue/test-utils';
+import { reactive } from 'vue';
 
 import mockModules from '@pkg/utils/testUtils/mockModules';
 import { t } from '@pkg/utils/testUtils/translations';
@@ -9,6 +10,9 @@ import {
 } from '@rdd-client';
 
 const componentStub = { template: '<div />' };
+
+/** Backs the mapped `container-engine` state; assign to it before mounting. */
+const mockState = reactive<Record<string, any>>({});
 
 mockModules({
   '@pkg/entry/store':  {
@@ -36,7 +40,7 @@ mockModules({
     },
     mapTypedState(module: string, arg: string[] | Record<string, string>) {
       const props = Array.isArray(arg) ? arg : Object.values(arg);
-      return Object.fromEntries(props.map((prop) => [prop, jest.fn()]));
+      return Object.fromEntries(props.map((prop) => [prop, () => mockState[prop]]));
     },
   },
   '@pkg/utils/ipcRenderer': {
@@ -58,33 +62,52 @@ mockModules({
 
 const { default: Containers } = await import('@pkg/pages/Containers.vue');
 
+function mountContainers() {
+  return mount(Containers, {
+    global: {
+      directives: {
+        'clean-html':      {},
+        'clean-tooltip':   {},
+        'close-popper':    {},
+        shortkey:          {},
+        tooltip:           {},
+        'trim-whitespace': {},
+      },
+      mocks: {
+        $store: {
+          getters:  {
+            'resource-fetch/isTooManyItemsToAutoUpdate': false,
+            'resource-fetch/manualRefreshIsLoading':     false,
+          },
+          commit:   jest.fn(),
+          dispatch: jest.fn(),
+        },
+        t,
+      },
+      stubs: {
+        T: { template: '<span></span>' },
+      },
+    },
+  });
+}
+
+function makeContainer(name: string, composeProject?: string): Container {
+  return {
+    metadata: { name },
+    status:   {
+      image:     'scratch',
+      namespace: 'default',
+      name,
+      path:      '/bin/false',
+      status:    ContainerStatus.Running,
+      labels:    composeProject ? { 'com.docker.compose.project': composeProject } : {},
+    },
+  };
+}
+
 describe('Containers methods', () => {
   it('adds restart actions for running containers', () => {
-    const wrapper = mount(Containers, {
-      global: {
-        directives: {
-          'clean-html':      {},
-          'clean-tooltip':   {},
-          'close-popper':    {},
-          shortkey:          {},
-          tooltip:           {},
-          'trim-whitespace': {},
-        },
-        mocks: {
-          $store: {
-            getters:  {
-              'resource-fetch/isTooManyItemsToAutoUpdate': false,
-            },
-            commit:   jest.fn(),
-            dispatch: jest.fn(),
-          },
-          t,
-        },
-        stubs: {
-          T: { template: '<span></span>' },
-        },
-      },
-    });
+    const wrapper = mountContainers();
     const running: Container = {
       status: {
         image:     'scratch',
@@ -120,5 +143,74 @@ describe('Containers methods', () => {
         enabled:  false,
       }),
     ]));
+  });
+});
+
+describe('Containers group selection', () => {
+  const project = 'demo';
+
+  beforeEach(() => {
+    mockState.containers = [makeContainer('app', project), makeContainer('db', project)];
+  });
+
+  /** Wrap the rows the way SortableTable's group-row slot hands them over. */
+  function groupOf(rows: any[]) {
+    return { ref: project, rows: rows.map((row) => ({ row })) };
+  }
+
+  it('reuses row objects across recomputes so the selection survives', () => {
+    const wrapper = mountContainers();
+    const before = wrapper.vm.rows;
+
+    expect(before).toHaveLength(2);
+
+    // Fresh container objects, as a daemon update would deliver them.
+    mockState.containers = [makeContainer('app', project), makeContainer('db', project)];
+
+    const after = wrapper.vm.rows;
+
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).toBe(before[1]);
+  });
+
+  it('drops cached rows for containers that are gone', () => {
+    const wrapper = mountContainers();
+
+    expect(Object.keys(wrapper.vm.rowCache).sort()).toEqual(['app', 'db']);
+
+    mockState.containers = [makeContainer('app', project)];
+    expect(wrapper.vm.rows).toHaveLength(1);
+    expect(Object.keys(wrapper.vm.rowCache)).toEqual(['app']);
+  });
+
+  it('reports a group as selected only when every container in it is', () => {
+    const wrapper = mountContainers();
+    const rows = wrapper.vm.rows;
+    const group = groupOf(rows);
+
+    expect(wrapper.vm.isGroupSelected(group)).toBe(false);
+    expect(wrapper.vm.isGroupIndeterminate(group)).toBe(false);
+
+    wrapper.vm.selectedRows = [rows[0]];
+    expect(wrapper.vm.isGroupSelected(group)).toBe(false);
+    expect(wrapper.vm.isGroupIndeterminate(group)).toBe(true);
+
+    wrapper.vm.selectedRows = [rows[0], rows[1]];
+    expect(wrapper.vm.isGroupSelected(group)).toBe(true);
+    expect(wrapper.vm.isGroupIndeterminate(group)).toBe(false);
+  });
+
+  it('adds and removes the whole group from the table selection', () => {
+    const wrapper = mountContainers();
+    const rows = wrapper.vm.rows;
+    const group = groupOf(rows);
+    const table: any = wrapper.vm.$refs.sortableTableRef;
+    const update = jest.spyOn(table, 'update');
+
+    wrapper.vm.setGroupSelected(group, true);
+    expect(update).toHaveBeenCalledWith(rows, []);
+
+    wrapper.vm.setGroupSelected(group, false);
+    expect(update).toHaveBeenCalledWith([], rows);
   });
 });


### PR DESCRIPTION
The containers table already groups rows by compose project, but stopping or deleting a whole project meant ticking every row by hand. The group row now has its own checkbox that selects every container under it, so the bulk Stop and Delete buttons act on the project.

SortableTable tracks the selection by object identity, so `rows` now hands out the same object for a container across recomputes; otherwise the selection cleared itself whenever the daemon reported any container change. The table also matches rows by key field, because the same row can reach the selection through a different Vue proxy. A dead `else` in the bulk-action layout dereferenced the element it had just found missing; it now hides the "N selected" label instead.

Ported from rancher-sandbox/rancher-desktop#10511, which is still open. If it changes before it merges, this will need a follow-up.

The e2e coverage that came with it builds fixtures with the docker CLI, so it is marked `fixme` like the other docker-CLI blocks in that file; four unit tests cover the group-selection logic and the row-object reuse instead.
