### PR TITLE
Extract the shared mirror client from the Docker watcher

### DIFF
--- a/rdd/bats/helpers/controller.bash
+++ b/rdd/bats/helpers/controller.bash
@@ -84,3 +84,29 @@ setup_rdd_control_plane() {
     rdd svc create --controllers="${controllers}"
     rdd svc start
 }
+
+# assert_action_consumed reports success once the reconciler has
+# removed the action annotation, which is how we know the dispatch
+# has completed.
+assert_action_consumed() {
+    local cid=$1
+    run -0 rdd ctl get container "${cid}" --namespace="${RDD_NAMESPACE}" \
+        -o "jsonpath={.metadata.annotations['containers\.rancherdesktop\.io/action']}"
+    refute_output
+}
+
+# request_action sets the action annotation and blocks until the
+# reconciler removes it. The annotation is a one-shot trigger.
+request_action() {
+    local cid=$1 action=$2
+    rdd ctl annotate container "${cid}" --namespace="${RDD_NAMESPACE}" --overwrite \
+        "containers.rancherdesktop.io/action=${action}"
+    try --max 30 --delay 1 -- assert_action_consumed "${cid}"
+}
+
+assert_last_action() {
+    local cid=$1 action=$2 state=$3
+    run -0 rdd ctl get container "${cid}" --namespace="${RDD_NAMESPACE}" \
+        -o jsonpath='{.status.lastAction.action}={.status.lastAction.state}'
+    assert_output "${action}=${state}"
+}

--- a/rdd/bats/tests/32-app-controllers/engine-docker.bats
+++ b/rdd/bats/tests/32-app-controllers/engine-docker.bats
@@ -486,32 +486,8 @@ assert_single_mirror() { # <image-id> <expected-tag>
 }
 
 # --- Container actions via annotation ---
-
-# assert_action_consumed reports success once the reconciler has
-# removed the action annotation, which is how we know the dispatch
-# has completed.
-assert_action_consumed() {
-    local cid=$1
-    run -0 rdd ctl get container "${cid}" --namespace="${RDD_NAMESPACE}" \
-        -o "jsonpath={.metadata.annotations['containers\.rancherdesktop\.io/action']}"
-    refute_output
-}
-
-# request_action sets the action annotation and blocks until the
-# reconciler removes it. The annotation is a one-shot trigger.
-request_action() {
-    local cid=$1 action=$2
-    rdd ctl annotate container "${cid}" --namespace="${RDD_NAMESPACE}" --overwrite \
-        "containers.rancherdesktop.io/action=${action}"
-    try --max 30 --delay 1 -- assert_action_consumed "${cid}"
-}
-
-assert_last_action() {
-    local cid=$1 action=$2 state=$3
-    run -0 rdd ctl get container "${cid}" --namespace="${RDD_NAMESPACE}" \
-        -o jsonpath='{.status.lastAction.action}={.status.lastAction.state}'
-    assert_output "${action}=${state}"
-}
+# request_action, assert_action_consumed and assert_last_action are in
+# helpers/controller.bash, shared by every engine suite.
 
 @test "stop action stops a running container" {
     run_e -0 docker run -d --name test-state busybox sleep inf

--- a/rdd/bats/tests/32-app-controllers/engine-docker.bats
+++ b/rdd/bats/tests/32-app-controllers/engine-docker.bats
@@ -39,13 +39,13 @@ local_setup_file() {
     if is_windows; then
         export DOCKER_HOST="npipe:////./pipe/docker_engine"
     else
-        run -0 rdd svc paths docker_socket
+        run_e -0 rdd svc paths docker_socket
         export DOCKER_HOST="unix://${output}"
     fi
     # Mirror resources live in App.spec.namespace. Override RDD_NAMESPACE
     # to whatever the App was created with so the test queries the same
     # namespace the engine controller uses, regardless of CRD defaults.
-    run -0 rdd ctl get app app -o jsonpath='{.spec.namespace}'
+    run_e -0 rdd ctl get app app -o jsonpath='{.spec.namespace}'
     RDD_NAMESPACE=${output}
     export RDD_NAMESPACE
 }
@@ -822,7 +822,7 @@ assert_docker_context() { # <expected-context>
         run -0 jq_raw '.Endpoints.docker.Host' "${meta}"
         assert_output "npipe:////./pipe/docker_engine"
     else
-        run -0 rdd service paths docker_socket
+        run_e -0 rdd service paths docker_socket
         socket_path=${output}
         run -0 jq_raw '.Endpoints.docker.Host' "${meta}"
         assert_output "unix://${socket_path}"

--- a/rdd/bats/tests/32-app-controllers/engine-docker.bats
+++ b/rdd/bats/tests/32-app-controllers/engine-docker.bats
@@ -45,7 +45,8 @@ local_setup_file() {
     # Mirror resources live in App.spec.namespace. Override RDD_NAMESPACE
     # to whatever the App was created with so the test queries the same
     # namespace the engine controller uses, regardless of CRD defaults.
-    RDD_NAMESPACE=$(rdd ctl get app app -o jsonpath='{.spec.namespace}')
+    run -0 rdd ctl get app app -o jsonpath='{.spec.namespace}'
+    RDD_NAMESPACE=${output}
     export RDD_NAMESPACE
 }
 

--- a/rdd/pkg/controllers/app/engine/controllers/docker_watcher.go
+++ b/rdd/pkg/controllers/app/engine/controllers/docker_watcher.go
@@ -18,11 +18,8 @@ import (
 	"github.com/moby/moby/api/types/events"
 	mobyclient "github.com/moby/moby/client"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -35,11 +32,9 @@ var _ engine = (*dockerWatcher)(nil)
 // dockerWatcher manages a Docker client connection and event stream. It
 // performs a full sync on connect and then watches for incremental changes.
 type dockerWatcher struct {
-	cli *mobyclient.Client
-	k8s client.Client
+	mirrorClient
 
-	// apiNamespace is the Kubernetes namespace where mirror resources live.
-	apiNamespace string
+	cli *mobyclient.Client
 
 	cancel context.CancelFunc
 	done   chan struct{}
@@ -69,9 +64,8 @@ func newDockerWatcher(ctx context.Context, k8s client.Client, apiNamespace strin
 	watchCtx, watchCancel := context.WithCancel(ctx)
 
 	w := &dockerWatcher{
+		mirrorClient:  mirrorClient{k8s: k8s, apiNamespace: apiNamespace},
 		cli:           cli,
-		k8s:           k8s,
-		apiNamespace:  apiNamespace,
 		cancel:        watchCancel,
 		done:          make(chan struct{}),
 		reconcileChan: reconcileChan,
@@ -314,36 +308,6 @@ func (w *dockerWatcher) handleVolumeEvent(ctx context.Context, msg events.Messag
 	}
 }
 
-// removeMirrorResource strips the finalizer from a mirror resource and
-// deletes it, used when Docker has already deleted the underlying
-// object. Update retries on conflict to survive a stale cache;
-// NotFound counts as success. obj is a template: one DeepCopyObject
-// carries name and apiNamespace through both the retry's Get target
-// (each Get overwrites its contents) and the final Delete (which keys
-// off name+namespace).
-func (w *dockerWatcher) removeMirrorResource(ctx context.Context, obj client.Object, name string) error {
-	latest := obj.DeepCopyObject().(client.Object)
-	latest.SetName(name)
-	latest.SetNamespace(w.apiNamespace)
-	key := client.ObjectKeyFromObject(latest)
-	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := w.k8s.Get(ctx, key, latest); err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-		if !controllerutil.RemoveFinalizer(latest, mirrorFinalizer) {
-			return nil
-		}
-		return w.k8s.Update(ctx, latest)
-	})
-	if retryErr != nil {
-		return fmt.Errorf("failed to remove finalizer from %s: %w", name, retryErr)
-	}
-	return client.IgnoreNotFound(w.k8s.Delete(ctx, latest))
-}
-
 // processContainerAction handles a container carrying the AnnotationAction
 // annotation. It dispatches the Docker call, records the outcome in
 // status.lastAction, and then removes the annotation.
@@ -495,72 +459,6 @@ func (w *dockerWatcher) containerRunState(ctx context.Context, id string) (runni
 		return false, false, err
 	}
 	return inspect.Container.State.Running, inspect.Container.State.Paused, nil
-}
-
-// patchContainerLastAction writes status.lastAction with retry-on-conflict
-// and returns the updated Container. The main engine sync writes the
-// status subresource on every reconcile, so this write races against it.
-// If the mirror is deleted concurrently, any step may return NotFound;
-// the caller treats a nil Container as "nothing left to do".
-func (w *dockerWatcher) patchContainerLastAction(ctx context.Context, id string, lastAction *containersv1alpha1.ContainerLastAction) (*containersv1alpha1.Container, error) {
-	key := client.ObjectKey{Name: id, Namespace: w.apiNamespace}
-	var result *containersv1alpha1.Container
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		var latest containersv1alpha1.Container
-		if err := w.k8s.Get(ctx, key, &latest); err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
-		latest.Status.LastAction = lastAction
-		if err := w.k8s.Status().Patch(ctx, &latest, patch); err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-		result = &latest
-		return nil
-	})
-	return result, err
-}
-
-// removeActionAnnotation clears the AnnotationAction annotation only if
-// its value still matches the action just processed. A concurrent writer
-// may replace the annotation with a different action between dispatch
-// and cleanup; that new value must survive so the next reconcile picks
-// it up. Callers pass either a fresh Container from patchContainerLastAction
-// (which bypasses the informer cache, not yet showing the preceding status
-// write) or a cached one (which may 409 on the first Patch). On conflict,
-// the retry re-reads from the cache; by then it has usually caught up.
-func (w *dockerWatcher) removeActionAnnotation(ctx context.Context, latest *containersv1alpha1.Container, observed string) error {
-	firstAttempt := true
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if !firstAttempt {
-			if err := w.k8s.Get(ctx, client.ObjectKeyFromObject(latest), latest); err != nil {
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}
-		}
-		firstAttempt = false
-		current, present := latest.Annotations[containersv1alpha1.AnnotationAction]
-		if !present || current != observed {
-			return nil
-		}
-		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
-		delete(latest.Annotations, containersv1alpha1.AnnotationAction)
-		if err := w.k8s.Patch(ctx, latest, patch); err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-		return nil
-	})
 }
 
 // deleteContainer removes a container from Docker. NotFound is treated

--- a/rdd/pkg/controllers/app/engine/controllers/docker_watcher.go
+++ b/rdd/pkg/controllers/app/engine/controllers/docker_watcher.go
@@ -405,7 +405,7 @@ func (w *dockerWatcher) processContainerAction(ctx context.Context, c *container
 }
 
 // dispatchContainerAction executes the Docker call for a single action. The
-// caller pre-validates the action name; the default branch triggers only
+// caller pre-validates the action name; the trailing error fires only
 // when a new ContainerAction value is added to the type but not to the switch.
 //
 // Pause and unpause pre-check the current Docker state and return nil when

--- a/rdd/pkg/controllers/app/engine/controllers/mirror_client.go
+++ b/rdd/pkg/controllers/app/engine/controllers/mirror_client.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	containersv1alpha1 "github.com/rancher-sandbox/rancher-desktop-daemon/pkg/apis/containers/v1alpha1"
+)
+
+// mirrorClient holds the Kubernetes client and namespace every engine watcher
+// uses to maintain mirror resources and to record container action outcomes.
+type mirrorClient struct {
+	k8s client.Client
+	// apiNamespace is the Kubernetes namespace where mirror resources live.
+	apiNamespace string
+}
+
+// removeMirrorResource strips the finalizer from a mirror resource and
+// deletes it, used when the engine has already deleted the underlying
+// object. Update retries on conflict to survive a stale cache;
+// NotFound counts as success. obj is a template: one DeepCopyObject
+// carries name and apiNamespace through both the retry's Get target
+// (each Get overwrites its contents) and the final Delete (which keys
+// off name+namespace).
+func (m *mirrorClient) removeMirrorResource(ctx context.Context, obj client.Object, name string) error {
+	latest := obj.DeepCopyObject().(client.Object)
+	latest.SetName(name)
+	latest.SetNamespace(m.apiNamespace)
+	key := client.ObjectKeyFromObject(latest)
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := m.k8s.Get(ctx, key, latest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if !controllerutil.RemoveFinalizer(latest, mirrorFinalizer) {
+			return nil
+		}
+		return m.k8s.Update(ctx, latest)
+	})
+	if retryErr != nil {
+		return fmt.Errorf("failed to remove finalizer from %s: %w", name, retryErr)
+	}
+	return client.IgnoreNotFound(m.k8s.Delete(ctx, latest))
+}
+
+// patchContainerLastAction writes status.lastAction with retry-on-conflict
+// and returns the updated Container. The main engine sync writes the
+// status subresource on every reconcile, so this write races against it.
+// If the mirror is deleted concurrently, any step may return NotFound;
+// the caller treats a nil Container as "nothing left to do".
+func (m *mirrorClient) patchContainerLastAction(ctx context.Context, id string, lastAction *containersv1alpha1.ContainerLastAction) (*containersv1alpha1.Container, error) {
+	key := client.ObjectKey{Name: id, Namespace: m.apiNamespace}
+	var result *containersv1alpha1.Container
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var latest containersv1alpha1.Container
+		if err := m.k8s.Get(ctx, key, &latest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		latest.Status.LastAction = lastAction
+		if err := m.k8s.Status().Patch(ctx, &latest, patch); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		result = &latest
+		return nil
+	})
+	return result, err
+}
+
+// removeActionAnnotation clears the AnnotationAction annotation only if
+// its value still matches the action just processed. A concurrent writer
+// may replace the annotation with a different action between dispatch
+// and cleanup; that new value must survive so the next reconcile picks
+// it up. Callers pass either a fresh Container from patchContainerLastAction
+// (which bypasses the informer cache, not yet showing the preceding status
+// write) or a cached one (which may 409 on the first Patch). On conflict,
+// the retry re-reads from the cache; by then it has usually caught up.
+func (m *mirrorClient) removeActionAnnotation(ctx context.Context, latest *containersv1alpha1.Container, observed string) error {
+	firstAttempt := true
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if !firstAttempt {
+			if err := m.k8s.Get(ctx, client.ObjectKeyFromObject(latest), latest); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+		}
+		firstAttempt = false
+		current, present := latest.Annotations[containersv1alpha1.AnnotationAction]
+		if !present || current != observed {
+			return nil
+		}
+		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		delete(latest.Annotations, containersv1alpha1.AnnotationAction)
+		if err := m.k8s.Patch(ctx, latest, patch); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Groundwork for the containerd backend (#658) that touches only the moby path. The three Kubernetes-side helpers move out of the Docker watcher into a `mirrorClient` that it embeds, the action-annotation bats helpers move from the moby suite into `helpers/controller.bash` for any engine suite to share, a comment on `dispatchContainerAction` stops claiming a default branch that does not exist, and the moby suite setup captures the App namespace with `run -0`. No behavior change.
