### PR TITLE
Stop requiring createdAt on Volume mirrors

### DIFF
--- a/rdd/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/volumestatus.go
+++ b/rdd/pkg/apis/containers/v1alpha1/applyconfiguration/containers/v1alpha1/volumestatus.go
@@ -18,7 +18,8 @@ type VolumeStatusApplyConfiguration struct {
 	// same Kubernetes namespace.
 	//
 	Namespace *string `json:"namespace,omitempty"`
-	// CreatedAt is the time the volume was created.
+	// CreatedAt is the time the volume was created; unset if the engine
+	// reported no readable timestamp.
 	//
 	CreatedAt *v1.Time `json:"createdAt,omitempty"`
 	// Driver the volume uses.

--- a/rdd/pkg/apis/containers/v1alpha1/container_types.go
+++ b/rdd/pkg/apis/containers/v1alpha1/container_types.go
@@ -181,15 +181,15 @@ type ContainerStatus struct {
 	// CreatedAt is the time this container was initially created.
 	//
 	// +optional
-	CreatedAt metav1.Time `json:"createdAt"`
+	CreatedAt metav1.Time `json:"createdAt,omitempty,omitzero"`
 	// StartedAt is the time this container was started; unset if the container is stopped.
 	//
 	// +optional
-	StartedAt metav1.Time `json:"startedAt"`
+	StartedAt metav1.Time `json:"startedAt,omitempty,omitzero"`
 	// FinishedAt is the time this container was last stopped; unset if the container never ran.
 	//
 	// +optional
-	FinishedAt metav1.Time `json:"finishedAt"`
+	FinishedAt metav1.Time `json:"finishedAt,omitempty,omitzero"`
 	// Conditions represent the calculated state of the container.
 	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
 	//

--- a/rdd/pkg/apis/containers/v1alpha1/image_types.go
+++ b/rdd/pkg/apis/containers/v1alpha1/image_types.go
@@ -32,7 +32,7 @@ type ImageStatus struct {
 	// CreatedAt is the time the image was created.
 	//
 	// +optional
-	CreatedAt metav1.Time `json:"createdAt"`
+	CreatedAt metav1.Time `json:"createdAt,omitempty,omitzero"`
 	// Architecture associated with the image.
 	//
 	// +required

--- a/rdd/pkg/apis/containers/v1alpha1/timestamps_test.go
+++ b/rdd/pkg/apis/containers/v1alpha1/timestamps_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestOptionalTimestampsAreOmitted guards the omitzero tag on every optional
+// timestamp. omitempty alone does not omit a struct, so without omitzero an
+// unset metav1.Time reaches the API server as null.
+func TestOptionalTimestampsAreOmitted(t *testing.T) {
+	tests := []struct {
+		name   string
+		status any
+		fields []string
+	}{
+		{"ContainerStatus", ContainerStatus{}, []string{"createdAt", "startedAt", "finishedAt"}},
+		{"ContainerLastAction", ContainerLastAction{}, []string{"observedAt", "completedAt"}},
+		{"ImageStatus", ImageStatus{}, []string{"createdAt"}},
+		{"VolumeStatus", VolumeStatus{}, []string{"createdAt"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.status)
+			assert.NilError(t, err)
+			var encoded map[string]json.RawMessage
+			assert.NilError(t, json.Unmarshal(data, &encoded))
+			for _, field := range tc.fields {
+				_, present := encoded[field]
+				assert.Assert(t, !present, "%s should be absent when unset, got %s", field, data)
+			}
+		})
+	}
+}
+
+func TestSetTimestampIsEncoded(t *testing.T) {
+	data, err := json.Marshal(ContainerStatus{StartedAt: metav1.Unix(1700000000, 0)})
+	assert.NilError(t, err)
+	var encoded struct {
+		StartedAt string `json:"startedAt"`
+	}
+	assert.NilError(t, json.Unmarshal(data, &encoded))
+	assert.Equal(t, encoded.StartedAt, "2023-11-14T22:13:20Z")
+}

--- a/rdd/pkg/apis/containers/v1alpha1/volume_types.go
+++ b/rdd/pkg/apis/containers/v1alpha1/volume_types.go
@@ -19,10 +19,11 @@ type VolumeStatus struct {
 	//
 	// +required
 	Namespace string `json:"namespace"`
-	// CreatedAt is the time the volume was created.
+	// CreatedAt is the time the volume was created; unset if the engine
+	// reported no readable timestamp.
 	//
-	// +required
-	CreatedAt metav1.Time `json:"createdAt"`
+	// +optional
+	CreatedAt metav1.Time `json:"createdAt,omitempty,omitzero"`
 	// Driver the volume uses.
 	//
 	// +required

--- a/rdd/pkg/controllers/app/engine/controllers/sync_volumes.go
+++ b/rdd/pkg/controllers/app/engine/controllers/sync_volumes.go
@@ -114,9 +114,20 @@ func (w *dockerWatcher) applyVolume(ctx context.Context, vol mobyvolume.Volume) 
 		WithMountPoint(vol.Mountpoint).
 		WithScope(vol.Scope)
 
+	// CreatedAt is required, so an unreadable timestamp reports the epoch
+	// rather than dropping the field: an apply missing it is rejected whole,
+	// and the zero Time cannot stand in because it marshals as null. The
+	// epoch is indistinguishable from a real date once it reaches the UI, so
+	// say here that it was substituted.
+	createdAt := metav1.Unix(0, 0)
 	if t, err := time.Parse(time.RFC3339Nano, vol.CreatedAt); err == nil {
-		statusApply.WithCreatedAt(metav1.NewTime(t))
+		createdAt = metav1.NewTime(t)
+	} else {
+		logf.FromContext(ctx).WithName("docker-watcher").
+			V(1).Info("Reporting the epoch as the volume creation time",
+			"volume", vol.Name, "created", vol.CreatedAt)
 	}
+	statusApply.WithCreatedAt(createdAt)
 
 	err = w.k8s.Status().Apply(ctx,
 		containersv1alpha1apply.Volume(mirrorName, w.apiNamespace).

--- a/rdd/pkg/controllers/app/engine/controllers/sync_volumes.go
+++ b/rdd/pkg/controllers/app/engine/controllers/sync_volumes.go
@@ -94,6 +94,7 @@ func (w *dockerWatcher) syncVolume(ctx context.Context, name string) error {
 
 // applyVolume creates or updates a `Volume` mirror from a Docker volume.
 func (w *dockerWatcher) applyVolume(ctx context.Context, vol mobyvolume.Volume) error {
+	log := logf.FromContext(ctx).WithName("docker-watcher")
 	mirrorName := volumeMirrorName(vol.Name)
 
 	applyConfig := containersv1alpha1apply.Volume(mirrorName, w.apiNamespace).
@@ -114,20 +115,15 @@ func (w *dockerWatcher) applyVolume(ctx context.Context, vol mobyvolume.Volume) 
 		WithMountPoint(vol.Mountpoint).
 		WithScope(vol.Scope)
 
-	// CreatedAt is required, so an unreadable timestamp reports the epoch
-	// rather than dropping the field: an apply missing it is rejected whole,
-	// and the zero Time cannot stand in because it marshals as null. The
-	// epoch is indistinguishable from a real date once it reaches the UI, so
-	// say here that it was substituted.
-	createdAt := metav1.Unix(0, 0)
+	// Leave createdAt unset when the timestamp will not parse. A stand-in
+	// such as the epoch reaches the UI as a real date, with nothing to mark
+	// it as invented.
 	if t, err := time.Parse(time.RFC3339Nano, vol.CreatedAt); err == nil {
-		createdAt = metav1.NewTime(t)
+		statusApply.WithCreatedAt(metav1.NewTime(t))
 	} else {
-		logf.FromContext(ctx).WithName("docker-watcher").
-			V(1).Info("Reporting the epoch as the volume creation time",
+		log.V(1).Info("Volume has no readable creation time",
 			"volume", vol.Name, "created", vol.CreatedAt)
 	}
-	statusApply.WithCreatedAt(createdAt)
 
 	err = w.k8s.Status().Apply(ctx,
 		containersv1alpha1apply.Volume(mirrorName, w.apiNamespace).

--- a/rdd/pkg/controllers/containers/volume/crd.yaml
+++ b/rdd/pkg/controllers/containers/volume/crd.yaml
@@ -188,7 +188,9 @@ spec:
             description: Status describes the observed state of the volume.
             properties:
               createdAt:
-                description: CreatedAt is the time the volume was created.
+                description: |-
+                  CreatedAt is the time the volume was created; unset if the engine
+                  reported no readable timestamp.
                 format: date-time
                 type: string
               driver:
@@ -219,7 +221,6 @@ spec:
                 description: Scope of the volume.
                 type: string
             required:
-            - createdAt
             - driver
             - mountpoint
             - name

--- a/rdd/pkg/controllers/mock/crd.yaml
+++ b/rdd/pkg/controllers/mock/crd.yaml
@@ -1694,7 +1694,9 @@ spec:
             description: Status describes the observed state of the volume.
             properties:
               createdAt:
-                description: CreatedAt is the time the volume was created.
+                description: |-
+                  CreatedAt is the time the volume was created; unset if the engine
+                  reported no readable timestamp.
                 format: date-time
                 type: string
               driver:
@@ -1725,7 +1727,6 @@ spec:
                 description: Scope of the volume.
                 type: string
             required:
-            - createdAt
             - driver
             - mountpoint
             - name

--- a/rdd/pkg/controllers/mock/volume_reconciler.go
+++ b/rdd/pkg/controllers/mock/volume_reconciler.go
@@ -86,11 +86,17 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			WithOptions(inspect.Options).
 			WithMountPoint(inspect.Mountpoint).
 			WithScope(inspect.Scope)
+		// CreatedAt is a required status field, so an unparsable value
+		// reports the epoch rather than dropping it: an apply missing it is
+		// rejected whole, leaving a mirror with no status at all.
+		createdAt := metav1.Unix(0, 0)
 		if t, err := time.Parse(time.RFC3339Nano, inspect.CreatedAt); err == nil {
-			statusApplyConfig = statusApplyConfig.WithCreatedAt(metav1.NewTime(t))
-		} else if inspect.CreatedAt != "" {
-			log.Error(err, "Failed to parse volume created time", "volume", inspect.Name, "created", inspect.CreatedAt)
+			createdAt = metav1.NewTime(t)
+		} else {
+			log.V(1).Info("Reporting the epoch as the volume creation time",
+				"volume", inspect.Name, "created", inspect.CreatedAt)
 		}
+		statusApplyConfig = statusApplyConfig.WithCreatedAt(createdAt)
 		err = r.Client.Status().Apply(
 			ctx,
 			containersv1alpha1apply.

--- a/rdd/pkg/controllers/mock/volume_reconciler.go
+++ b/rdd/pkg/controllers/mock/volume_reconciler.go
@@ -86,17 +86,14 @@ func (r *volumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			WithOptions(inspect.Options).
 			WithMountPoint(inspect.Mountpoint).
 			WithScope(inspect.Scope)
-		// CreatedAt is a required status field, so an unparsable value
-		// reports the epoch rather than dropping it: an apply missing it is
-		// rejected whole, leaving a mirror with no status at all.
-		createdAt := metav1.Unix(0, 0)
+		// Leave createdAt unset when the timestamp will not parse. A
+		// substituted date reaches the UI as a real one.
 		if t, err := time.Parse(time.RFC3339Nano, inspect.CreatedAt); err == nil {
-			createdAt = metav1.NewTime(t)
+			statusApplyConfig = statusApplyConfig.WithCreatedAt(metav1.NewTime(t))
 		} else {
-			log.V(1).Info("Reporting the epoch as the volume creation time",
+			log.V(1).Info("Volume has no readable creation time",
 				"volume", inspect.Name, "created", inspect.CreatedAt)
 		}
-		statusApplyConfig = statusApplyConfig.WithCreatedAt(createdAt)
 		err = r.Client.Status().Apply(
 			ctx,
 			containersv1alpha1apply.


### PR DESCRIPTION
The Volume CRD required `status.createdAt`, so an unparsable engine timestamp dropped the field and the API server rejected the whole status apply, leaving a mirror with a finalizer and no status.

The first commit substituted the epoch. The second reverses that approach: `createdAt` was never meant to be required, and the epoch reaches the UI as a real date. The requirement arrived when the struct was `VolumeSpec`, where every field was immutable, and outlived both the rename to `VolumeStatus` and the removal of the immutability rules. Container and Image already declare `createdAt` optional, and the mock container reconciler never sets one.

Every optional timestamp now has `,omitempty,omitzero`, matching `ObservedAt` and `CompletedAt`. Without `omitzero` an unset `metav1.Time` marshals as null and depends on the API server pruning it before validation; `omitempty` alone is a no-op on structs.

The Volumes page already guards on `status.createdAt`, so an absent value renders as an empty Created column. The generated `pkg/rdd-client` model still declares the field non-optional; regenerating needs a host dockerd, so that is not in this PR.
