### PR TITLE
Drop node-gyp and the last native addon

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -29,7 +29,7 @@ runs:
   - name: Install Windows dependencies
     if: runner.os == 'Windows'
     shell: powershell
-    run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
+    run: .\scripts\windows-setup.ps1 -SkipTools
 
   - name: Build RDD
     shell: bash

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -26,12 +26,6 @@ runs:
       go-version-file: rdd/go.mod
       cache-dependency-path: src/go/**/go.sum
 
-  - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-    with:
-      python-version: '3.x'
-  - run: pip install setuptools
-    shell: bash
-
   - name: Install Windows dependencies
     if: runner.os == 'Windows'
     shell: powershell

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "intl-messageformat": "11.2.12",
     "jsonpath-plus": "10.4.0",
     "lodash": "4.18.1",
-    "native-reg": "1.1.1",
     "node-forge": "1.4.0",
     "proxy-agent": "^8.0.2",
     "semver": "7.8.5",
@@ -132,8 +131,6 @@
     "mustache": "4.2.0",
     "node-abi": "^4.33.0",
     "node-addon-api": "8",
-    "node-gyp": "13.0.1",
-    "node-gyp-build": "4.8.4",
     "node-loader": "^2.1.0",
     "octokit": "5.0.5",
     "plist": "5.0.0",
@@ -157,9 +154,6 @@
   },
   "dependenciesMeta": {
     "esbuild": {
-      "built": true
-    },
-    "native-reg": {
       "built": true
     },
     "unrs-resolver": {

--- a/pkg/rancher-desktop/main/update/MSIUpdater.ts
+++ b/pkg/rancher-desktop/main/update/MSIUpdater.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import path from 'path';
 
 import { AllPublishOptions, newError } from 'builder-util-runtime';
@@ -8,7 +8,6 @@ import { ElectronHttpExecutor } from 'electron-updater/out/electronHttpExecutor'
 import { findFile } from 'electron-updater/out/providers/Provider';
 import { verifySignature } from 'electron-updater/out/windowsExecutableCodeSignatureVerifier';
 import { Lazy } from 'lazy-val';
-import * as reg from 'native-reg';
 
 import mainEvents from '@pkg/main/mainEvents';
 import paths from '@pkg/utils/paths';
@@ -140,27 +139,16 @@ export default class MsiUpdater extends NsisUpdater {
    * shouldElevate indicates whether we need elevation to install the update.
    */
   protected get shouldElevate(): boolean {
-    let key: any = null;
-    let isAdmin = false;
+    // An administrative install records this value; a per-user install does not.
+    const { error, status } = spawnSync(
+      'reg.exe',
+      ['query', 'HKLM\\SOFTWARE\\SUSE\\RancherDesktop', '/v', 'AdminInstall'],
+      { stdio: 'ignore', windowsHide: true });
 
-    try {
-      key = reg.openKey(reg.HKLM, 'SOFTWARE', reg.Access.READ);
-
-      if (key) {
-        const parsedValue = reg.getValue(key, 'SUSE\\RancherDesktop', 'AdminInstall');
-
-        isAdmin = parsedValue !== null;
-
-        return isAdmin;
-      } else {
-        this._logger.debug?.(`Failed to open registry key: HKEY_LOCAL_MACHINE\SOFTWARE: ${ key }/${ isAdmin }`);
-      }
-    } catch (error) {
+    if (error) {
       this._logger.error(`Error accessing registry: ${ error }`);
-    } finally {
-      reg.closeKey(key);
     }
 
-    return isAdmin;
+    return status === 0;
   }
 }

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -1,5 +1,4 @@
 param (
-    [switch] $SkipVisualStudio,
     [switch] $SkipTools,
     [switch] $SkipWSL
 )
@@ -10,45 +9,13 @@ Write-Information 'Installing components required for Rancher Desktop developmen
 
 # Start separate jobs for things we want to install (in subprocesses).
 
-if (!$SkipVisualStudio) {
-    Start-Job -Name 'Visual Studio' -ErrorAction Stop -ScriptBlock {
-        $location = Get-CimInstance -ClassName MSFT_VSInstance `
-            | Where-Object { $_.IsComplete } `
-            | Select-Object -First 1 -ExpandProperty InstallLocation
-        # This path appears to be hard-coded:
-        # https://docs.microsoft.com/en-us/visualstudio/install/modify-visual-studio#open-the-visual-studio-installer
-        $installer = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe'
-
-        # Updating first is required; otherwise, the installer just complains that
-        # the installer itself is out of date.
-        Write-Information 'Updating Visual Studio components...'
-        & $installer update --installPath $location --passive
-        Write-Information 'Waiting for Visual Studio update to complete...'
-        Get-Process | Where-Object Name -in ('setup', 'vs_installer') | Wait-Process
-
-        Write-Information 'Installing additional Visual Studio components...'
-        & $installer modify --installPath $location --passive `
-            --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 `
-            --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
-        Write-Information 'Waiting for Visual Studio installation to complete...'
-        Get-Process | Where-Object Name -in ('setup', 'vs_installer') | Wait-Process
-
-        # Tell NPM to use MSBuild from the just-updated copy of Visual Studio.
-        # This is required as otherwise node-gyp will be unable to find it.
-        $msbuild = Join-Path $location 'MSBuild/Current/Bin/MSBuild.exe'
-        Write-Output "msbuild_path=${msbuild}" `
-            | Out-File -Encoding UTF8 -FilePath ~/.npmrc
-    }
-}
-
-
 if (!$SkipTools) {
     Start-Job -Name 'Install Tools' -ErrorAction Stop -ScriptBlock {
         Write-Information 'Installing Tools...'
 
         Invoke-WebRequest -UseBasicParsing -Uri 'https://get.scoop.sh' `
             | Invoke-Expression
-        scoop install 7zip git go mingw nvm python unzip
+        scoop install 7zip git go mingw nvm unzip
         # Install and use latest node 18* version
         nvm install 18
         nvm use $(nvm list | Select-String '[18\.[0-9.]+]' | Select-Object -First 1 | ForEach-Object { $_.Matches.Value })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5958,13 +5958,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "abbrev@npm:5.0.0"
-  checksum: 10c0/8e88f5c798ea4562d28c5a3e9ad69e3879890bc5d695d8f2dffb8609be4c890aacc8f80ef4553fdd2c6a62d70c2ce8bc57b38074e383beb7487bdafa9ed42ea5
-  languageName: node
-  linkType: hard
-
 "accepts@npm:^2.0.0":
   version: 2.0.0
   resolution: "accepts@npm:2.0.0"
@@ -12606,16 +12599,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"native-reg@npm:1.1.1":
-  version: 1.1.1
-  resolution: "native-reg@npm:1.1.1"
-  dependencies:
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:4"
-  checksum: 10c0/ffa357defbc68ed694e65662223dcffb4f5291d73e96982874d5c3f335014b4424942f617f9598f295d9f927a242da107e449d2689baa771fe31186c916c925b
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -12741,37 +12724,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:4, node-gyp-build@npm:4.8.4":
-  version: 4.8.4
-  resolution: "node-gyp-build@npm:4.8.4"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 10c0/444e189907ece2081fe60e75368784f7782cfddb554b60123743dfb89509df89f1f29c03bbfa16b3a3e0be3f48799a4783f487da6203245fa5bed239ba7407e1
-  languageName: node
-  linkType: hard
-
-"node-gyp@npm:13.0.1":
-  version: 13.0.1
-  resolution: "node-gyp@npm:13.0.1"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    graceful-fs: "npm:^4.2.6"
-    nopt: "npm:^10.0.0"
-    proc-log: "npm:^7.0.0"
-    semver: "npm:^7.3.5"
-    tar: "npm:^7.5.4"
-    tinyglobby: "npm:^0.2.12"
-    undici: "npm:^8.4.1"
-    which: "npm:^7.0.0"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10c0/424077bc9e9bbe953a8e86db473ba818cbc6a121714008c977fd589e21e5f0c811fbf22faac730dc7182450b5e52df301811d01ae3373898658d999b7710f4e6
-  languageName: node
-  linkType: hard
-
 "node-gyp@npm:^11.2.0":
   version: 11.5.0
   resolution: "node-gyp@npm:11.5.0"
@@ -12841,17 +12793,6 @@ __metadata:
   version: 0.7.3
   resolution: "node-watch@npm:0.7.3"
   checksum: 10c0/dea5c2ab482280b6b2b39c9b8fcf67943f8e3dc033d103d4521c7106a39a1d214756663fa2c9bd1012dc840d69f763d865cd47f1e9374231ee3c0f42e95d14df
-  languageName: node
-  linkType: hard
-
-"nopt@npm:^10.0.0":
-  version: 10.0.1
-  resolution: "nopt@npm:10.0.1"
-  dependencies:
-    abbrev: "npm:^5.0.0"
-  bin:
-    nopt: bin/nopt.js
-  checksum: 10c0/980d89257f9587f3e1f77877ddbf905d6aa3b738ec33e49a4fa1a059a0dd82eb28063982b150654a7ae9de386f2ead60e56172db7d37cf56de545f7392a2a26a
   languageName: node
   linkType: hard
 
@@ -14089,13 +14030,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proc-log@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "proc-log@npm:7.0.0"
-  checksum: 10c0/b89c2d862604f35fec795477b0c7e376feab3ba0d4f4d291c4e959567442697cf451ac557d0623c1cc38af45a78128b983410f397a10c5d3a67f76c33de4754b
-  languageName: node
-  linkType: hard
-
 "process-nextick-args@npm:~2.0.0":
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
@@ -14399,12 +14333,9 @@ __metadata:
     lodash: "npm:4.18.1"
     marked: "npm:18.0.7"
     mustache: "npm:4.2.0"
-    native-reg: "npm:1.1.1"
     node-abi: "npm:^4.33.0"
     node-addon-api: "npm:8"
     node-forge: "npm:1.4.0"
-    node-gyp: "npm:13.0.1"
-    node-gyp-build: "npm:4.8.4"
     node-loader: "npm:^2.1.0"
     octokit: "npm:5.0.5"
     plist: "npm:5.0.0"
@@ -14433,8 +14364,6 @@ __metadata:
     dmg-license:
       optional: true
     esbuild:
-      built: true
-    native-reg:
       built: true
     unrs-resolver:
       built: true
@@ -15933,7 +15862,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.3, tar@npm:^7.5.3, tar@npm:^7.5.4, tar@npm:^7.5.6, tar@npm:^7.5.7":
+"tar@npm:^7.4.3, tar@npm:^7.5.3, tar@npm:^7.5.6, tar@npm:^7.5.7":
   version: 7.5.16
   resolution: "tar@npm:7.5.16"
   dependencies:
@@ -16507,7 +16436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:8.8.0, undici@npm:^8.4.1":
+"undici@npm:8.8.0":
   version: 8.8.0
   resolution: "undici@npm:8.8.0"
   checksum: 10c0/6ee51e6b814b67e212b19349c38657be988d878ca669ccf2ad33f0ebbb0d83e851aa57554b6ce3c6668a9a4df3010fb6a6af7bd28692ade911083ef376a3a75d
@@ -17304,7 +17233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:7.0.0, which@npm:^7.0.0":
+"which@npm:7.0.0":
   version: 7.0.0
   resolution: "which@npm:7.0.0"
   dependencies:


### PR DESCRIPTION
`native-reg` was the app's only native addon, kept for a single HKLM read. Removing it takes node-gyp, `node-gyp-build`, Python, setuptools and the Visual Studio setup with it.

There is a bug behind the cleanup: `native-reg` has been unbuildable from source since node-addon-api 8, because its `binding.gyp` uses the deprecated `require('node-addon-api').gyp`, which resolves to a target that defines nothing. Windows x64 escapes it only because `@electron/rebuild` finds a prebuilt binary; arm64 does not.

The last commit is the one CI never exercised, since it always passed `-SkipVisualStudio`. What the green build does show is `@electron/rebuild` reporting no native module to rebuild at all, so nothing still wants MSBuild. Drop that commit if you would rather keep VS in the developer setup.
