### PR TITLE
RDD: Add the arm64 guest image for WSL

### DIFF
--- a/rdd/pkg/controllers/app/app/lima-images-wsl2.yaml
+++ b/rdd/pkg/controllers/app/app/lima-images-wsl2.yaml
@@ -3,4 +3,7 @@ images:
 - location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.8/distro.v0.2.8.amd64.tar.xz
   arch: x86_64
   digest: sha256:3d356fc196a5b929de075d132a3f46688fd881fadad16219172bde392a3a82e0
+- location: https://github.com/rancher-sandbox/rancher-desktop-opensuse/releases/download/v0.2.8/distro.v0.2.8.arm64.tar.xz
+  arch: aarch64
+  digest: sha256:cd8d237c230bebc04dd1b77c5597302f68195de25b063b5f2876d6377ecafa79
 mountType: wsl2


### PR DESCRIPTION
Companion to #662 and independent of it: this is what the daemon needs at runtime, not what CI needs to build a package.

Not tested on hardware. The entry is inert on x64 hosts, which pick the image matching their own architecture.
