### PR TITLE
Resolve steve assets from the platform matrix

### DIFF
--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 
-import { defined } from '@/pkg/rancher-desktop/utils/typeUtils';
 import {
   AssetPlatform,
   DependencyAsset,
@@ -211,22 +210,16 @@ export class Steve extends GlobalDependency(GitHubDependency) {
   async getAssets(version: string): Promise<DependencyAsset[]> {
     const steveURLBase = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ version }`;
     const upstream = await fetchUpstreamChecksums(`${ steveURLBase }/steve.sha512sum`, 'sha512');
-    const archiveMatch = /^steve-(linux|darwin|windows)-(amd64|arm64)\.tar\.gz$/;
 
-    return (await Promise.all(Object.keys(upstream).map(async(archiveName) => {
-      const match = archiveMatch.exec(archiveName);
-
-      if (!match) {
-        return;
-      }
-      const [, platform, arch] = match as unknown as [string, AssetPlatform, GoArch];
+    return Promise.all(cartesian(HOST_PLATFORMS, ARCHES).map(async([platform, arch]) => {
+      const archiveName = `steve-${ platform }-${ arch }.tar.gz`;
       const url = `${ steveURLBase }/${ archiveName }`;
       const checksum = await downloadAndHash(url, {
         verify: { algorithm: 'sha512', expected: upstream[archiveName] },
       });
 
       return { platform, arch, url, checksum };
-    }))).filter(defined);
+    }));
   }
 }
 


### PR DESCRIPTION
Verified both directions against the real releases. At v0.1.0-beta9.3 the six assets come out with checksums identical to those in `dependencies.yaml` today, so the rewrite changes nothing. At v0.1.0-beta9.2 it now fails loudly, with a 404 on the absent `steve-windows-arm64.tar.gz`.

That silent case is how the missing Windows build in #662 went unnoticed until someone packaged for arm64.

Needs #662's bump to v0.1.0-beta9.3 to merge first.
