### PR TITLE
CI: Make the Package workflow sign input work

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -181,7 +181,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.sign)
+      (github.event_name == 'workflow_dispatch' && inputs.sign)
     permissions:
       contents: read
     steps:
@@ -234,7 +234,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.sign)
+      (github.event_name == 'workflow_dispatch' && inputs.sign)
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Dispatching the Package workflow with `sign: false` ran the signing tests regardless; I watched both succeed in a run dispatched with `--field sign=false`.

It costs two extra jobs on a manual dispatch, which is presumably why it went unnoticed.
