### PR TITLE
Enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,11 @@ updates:
     # updates of webpack until we can migrate off @vue/cli-service (which is
     # unlikely to be fixed as it is in maintenance mode).
     dependency-name: "webpack"
+  - # TypeScript 7 is the Go port; its npm package exports only version and
+    # versionMajorMinor, so ts-loader and @typescript-eslint fail with a
+    # TypeError.  Drop this rule once they support 7.x.
+    dependency-name: "typescript"
+    update-types: [version-update:semver-major]
 
 # Maintain dependencies for Golang
 - package-ecosystem: "gomod"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,10 @@ updates:
     # TypeError.  Drop this rule once they support 7.x.
     dependency-name: "typescript"
     update-types: [version-update:semver-major]
+  groups:
+    # vue pins @vue/compiler-sfc exactly, so separate bumps break the lockfile.
+    vue:
+      patterns: ["vue", "@vue/compiler-sfc"]
 
 # Maintain dependencies for Golang
 - package-ecosystem: "gomod"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     interval: "daily"
   cooldown:
     default-days: 7
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 12
   labels: ["component/dependencies"]
   groups:
     # init and analyze share a config file and abort when their versions differ.
@@ -24,7 +24,7 @@ updates:
     interval: "daily"
   cooldown:
     default-days: 7
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 12
   labels: ["component/dependencies"]
   ignore:
   - # Needs to be updated along with NodeJS version.
@@ -51,7 +51,7 @@ updates:
     interval: "daily"
   cooldown:
    default-days: 7
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 12
   labels: ["component/dependencies"]
   ignore:
   - # Swagger dependencies must match whatever the CLI generate.


### PR DESCRIPTION
We disabled them while we were still merging the tree from RD1, but that should not be necessary anymore.

I copied the limit of 12 from RD1.