### PR TITLE
rdd: add the guest dependency downloader

### DIFF
--- a/rdd/.gitignore
+++ b/rdd/.gitignore
@@ -1,2 +1,3 @@
 /bin/*
 /pkg/guestagent/lima-guestagent.gz
+/pkg/embedded/distro.*.xz*

--- a/rdd/cmd/download-guest-deps/README.md
+++ b/rdd/cmd/download-guest-deps/README.md
@@ -1,0 +1,104 @@
+# download-guest-deps
+
+`download-guest-deps` stages the guest dependencies for the rdd build to embed.
+It currently stages only the distro image, as the raw disk image that Lima's
+`vz` and `qemu` drivers boot or, for a Windows build, as the rootfs tarball
+that WSL2 imports.
+
+It reads `dependencies.yaml`, which `yarn rddepman guest` writes, picks the
+asset for the build target, and checks the downloaded bytes against the sha256
+checksum recorded there. It keeps downloads in a cache outside the source tree,
+so every checkout and worktree shares one copy, and it skips a staged file that
+already matches its checksum.
+
+Run it from `rdd/` before `go build`; the default paths are relative to that
+directory.
+
+## Usage
+
+```sh
+go run ./cmd/download-guest-deps [--manifest FILE] [--dest DIR] [--cache DIR] [--os OS] [--arch ARCH]
+```
+
+| Option | Default | Meaning |
+|---|---|---|
+| `--manifest` | `dependencies.yaml` | The guest dependency manifest to read. |
+| `--dest` | `pkg/embedded` | The directory to stage the assets into. |
+| `--cache` | see [Cache](#cache) | The directory that keeps verified downloads. |
+| `--os` | the host's | The operating system the build targets, as a `GOOS` value. |
+| `--arch` | the host's | The architecture the build targets, as a `GOARCH` value. |
+
+A cross-compiling build passes `--os` and `--arch`. Setting `GOOS` or `GOARCH`
+in the environment instead would cross-compile this command as well, and leave
+nothing that runs on the build machine.
+
+A Windows target gets `distro.tar.xz` and any other target gets
+`distro.raw.xz`. Either one is the Linux asset for `--arch`, because the guest
+VM runs Linux.
+
+The command exits 0 once everything is staged, 1 on any failure, and 2 on a
+usage error. Failing to prune the cache only prints a warning.
+
+## Cache
+
+The default cache is `rancher-desktop.guest-deps` in the user cache directory,
+which is `~/Library/Caches` on macOS, `$XDG_CACHE_HOME` or `~/.cache` on Linux,
+and `%LocalAppData%` on Windows. Each download is kept at
+`<name>/v<version>/<file>`, for example
+`distro/v0.2.7/distro.v0.2.7.arm64.raw.xz`, so a new version is fetched beside
+the old one.
+
+The command checks a cached file against the manifest before copying it, and
+downloads it again if it does not match. Each run then removes the downloads no
+run has used for seven days. The prune touches nothing outside those version
+directories.
+
+## Network
+
+The command drops a transfer that goes 30 seconds without receiving data and
+tries again. An asset gets four attempts, all within two hours. Between
+attempts it waits for the delay the server names, or backs off from two
+seconds when it names none, but never longer than 30 seconds. A checksum
+mismatch fails the run at once, and so does a client error such as a 404. A
+408, a 429, or any response that names a delay is retried instead. A long
+download logs its progress every five seconds.
+
+## Trying it out
+
+These steps stage into a scratch directory with its own cache, so they leave
+`pkg/embedded` and your real cache alone and the first run has to download.
+Run them from `rdd/` in a POSIX shell.
+
+```sh
+scratch=$(mktemp -d)
+go run ./cmd/download-guest-deps --dest "$scratch/embedded" --cache "$scratch/cache"
+```
+
+The first run downloads the raw image for this machine's architecture, 200 to
+250 MiB, and stages it as `$scratch/embedded/distro.raw.xz`. Running the same
+command again reports the staged file up to date and does no network work.
+
+```sh
+go run ./cmd/download-guest-deps --dest "$scratch/embedded" --cache "$scratch/cache"
+```
+
+Damage the staged file, and the next run copies it back from the cache, still
+without downloading.
+
+```sh
+printf broken > "$scratch/embedded/distro.raw.xz"
+go run ./cmd/download-guest-deps --dest "$scratch/embedded" --cache "$scratch/cache"
+```
+
+Staging for Windows downloads the rootfs tarball, about 180 MiB, and stages it
+as `$scratch/embedded/distro.tar.xz`.
+
+```sh
+go run ./cmd/download-guest-deps --dest "$scratch/embedded" --cache "$scratch/cache" --os windows --arch amd64
+```
+
+Remove the scratch directory when you are done.
+
+```sh
+rm -rf "$scratch"
+```

--- a/rdd/cmd/download-guest-deps/main.go
+++ b/rdd/cmd/download-guest-deps/main.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Command download-guest-deps stages the guest dependencies the rdd build bakes
+// into its binaries.
+//
+// The target defaults to the host. A build that cross-compiles has to pass
+// --os and --arch; CI does cross-compile, packaging the macOS x86_64 build on
+// an arm64 runner with GOARCH set for `make build-rdd`. They are flags rather
+// than the GOOS and GOARCH environment variables, which would cross-compile
+// this tool too and leave nothing that can run.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/guestdeps"
+)
+
+func main() {
+	manifest := flag.String("manifest", "dependencies.yaml", "guest dependency manifest (YAML)")
+	dest := flag.String("dest", filepath.Join("pkg", "embedded"), "directory to stage the assets into")
+	cache := flag.String("cache", "", "directory the verified downloads are kept and pruned in (default: under the user cache directory)")
+	goos := flag.String("os", runtime.GOOS, "the operating system the build targets")
+	goarch := flag.String("arch", runtime.GOARCH, "the architecture the build targets")
+	flag.Parse()
+
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: download-guest-deps [--manifest M] [--dest D] [--cache C] [--os OS] [--arch ARCH]")
+		os.Exit(2)
+	}
+	// A download runs for minutes; let an interrupt abort it and clean up.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	err := run(ctx, os.Stderr, *manifest, *dest, *cache, *goos, *goarch)
+	stop()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "download-guest-deps:", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, log io.Writer, manifestPath, destDir, cacheDir, goos, goarch string) error {
+	manifest, err := guestdeps.LoadManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+	if cacheDir == "" {
+		if cacheDir, err = guestdeps.DefaultCacheDir(); err != nil {
+			return err
+		}
+	}
+	stager := &guestdeps.Stager{CacheDir: cacheDir, Log: log}
+	for _, staged := range stagedDeps(goos, goarch) {
+		dep, err := manifest.Select(staged.name, staged.selector)
+		if err != nil {
+			return fmt.Errorf("%s: %w", manifestPath, err)
+		}
+		if err := stager.Stage(ctx, dep, filepath.Join(destDir, staged.filename)); err != nil {
+			return err
+		}
+	}
+	// Everything the build needs is staged by now, so a cache that cannot be
+	// pruned is a nuisance rather than a failure.
+	if err := stager.Prune(); err != nil {
+		fmt.Fprintln(log, "warning: pruning the download cache:", err)
+	}
+	return nil
+}
+
+// A stagedDep is one guest dependency the build needs on disk, under the file
+// name the build expects it at.
+type stagedDep struct {
+	name     string
+	selector guestdeps.Selector
+	filename string
+}
+
+// stagedDeps lists what a build for goos/goarch stages. Guest dependencies run
+// in the Linux VM, so every asset is a linux one whatever the host; only the
+// image format follows the host, because WSL2 imports the rootfs tarball while
+// Lima's vz and qemu drivers boot the raw ext4 image.
+func stagedDeps(goos, goarch string) []stagedDep {
+	variant := "raw"
+	if goos == "windows" {
+		variant = "tar"
+	}
+	return []stagedDep{{
+		name:     "distro",
+		selector: guestdeps.Selector{Platform: "linux", Arch: goarch, Variant: variant},
+		filename: "distro." + variant + ".xz",
+	}}
+}

--- a/rdd/cmd/download-guest-deps/main_test.go
+++ b/rdd/cmd/download-guest-deps/main_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/guestdeps"
+)
+
+func TestStagedDepsPickTheImageFormatOfTheBackend(t *testing.T) {
+	for goos, want := range map[string]string{
+		"windows": "distro.tar.xz", // WSL2 imports a rootfs tarball
+		"darwin":  "distro.raw.xz", // Lima's vz and qemu drivers boot a raw image
+		"linux":   "distro.raw.xz",
+	} {
+		t.Run(goos, func(t *testing.T) {
+			deps := stagedDeps(goos, "amd64")
+			assert.Equal(t, len(deps), 1)
+			assert.Equal(t, deps[0].filename, want)
+			assert.Equal(t, deps[0].selector.Platform, "linux", "guest assets are Linux ones on every host")
+			assert.Equal(t, deps[0].selector.Arch, "amd64")
+		})
+	}
+}
+
+// Every target the build supports must resolve against the manifest as
+// checked in, so a rename or a dropped asset fails here rather than in a build.
+func TestStagedDepsResolveAgainstTheManifest(t *testing.T) {
+	manifest, err := guestdeps.LoadManifest(filepath.Join("..", "..", "dependencies.yaml"))
+	assert.NilError(t, err)
+
+	for _, goos := range []string{"darwin", "linux", "windows"} {
+		for _, goarch := range []string{"amd64", "arm64"} {
+			t.Run(goos+"/"+goarch, func(t *testing.T) {
+				for _, staged := range stagedDeps(goos, goarch) {
+					dep, err := manifest.Select(staged.name, staged.selector)
+					assert.NilError(t, err)
+					assert.Assert(t, dep.Version != "")
+				}
+			})
+		}
+	}
+}
+
+// seedRun writes a manifest naming one arm64 asset and seeds the cache with its
+// bytes, which keeps a run off the network. What these tests exercise is the
+// wiring from manifest to staged file.
+func seedRun(t *testing.T, body []byte) (manifestPath, cacheDir, destDir string) {
+	t.Helper()
+	sum := sha256.Sum256(body)
+	dir := t.TempDir()
+
+	manifestPath = filepath.Join(dir, "dependencies.yaml")
+	manifest := fmt.Sprintf(`
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      arch: arm64
+      variant: raw
+      url: https://example.test/distro.v0.2.7.arm64.raw.xz
+      checksum: sha256:%s
+`, hex.EncodeToString(sum[:]))
+	assert.NilError(t, os.WriteFile(manifestPath, []byte(manifest), 0o644))
+
+	cacheDir = filepath.Join(dir, "cache")
+	cachePath := filepath.Join(cacheDir, "distro", "v0.2.7", "distro.v0.2.7.arm64.raw.xz")
+	assert.NilError(t, os.MkdirAll(filepath.Dir(cachePath), 0o755))
+	assert.NilError(t, os.WriteFile(cachePath, body, 0o644))
+
+	return manifestPath, cacheDir, filepath.Join(dir, "embedded")
+}
+
+// run is what a build invokes. It reads the manifest, picks the asset for the
+// target, and leaves it staged under the name the build expects.
+func TestRunStagesTheAssetForTheTarget(t *testing.T) {
+	body := []byte("distro image")
+	manifestPath, cacheDir, destDir := seedRun(t, body)
+
+	var log bytes.Buffer
+	assert.NilError(t, run(t.Context(), &log, manifestPath, destDir, cacheDir, "linux", "arm64"))
+
+	staged, err := os.ReadFile(filepath.Join(destDir, "distro.raw.xz"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(staged), string(body))
+	assert.Assert(t, strings.Contains(log.String(), "distro 0.2.7 is already downloaded to"),
+		"the stager reports through run's log; it holds %q", log.String())
+	assert.Assert(t, strings.Contains(log.String(), filepath.Join(destDir, "distro.raw.xz")),
+		"the log names the staged file; it holds %q", log.String())
+}
+
+// run sweeps the cache once everything is staged, so a sweep that cannot read
+// it warns instead of failing the build.
+func TestRunWarnsWhenTheCacheCannotBePruned(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not restrict listing on Windows")
+	}
+	body := []byte("distro image")
+	manifestPath, cacheDir, destDir := seedRun(t, body)
+
+	// Write and search stay open, so staging still reaches the entry by name;
+	// only the listing Prune needs is refused.
+	assert.NilError(t, os.Chmod(cacheDir, 0o300))
+	t.Cleanup(func() { _ = os.Chmod(cacheDir, 0o755) })
+	if _, err := os.ReadDir(cacheDir); err == nil {
+		t.Skip("this user can list a directory with no read permission")
+	}
+
+	var log bytes.Buffer
+	assert.NilError(t, run(t.Context(), &log, manifestPath, destDir, cacheDir, "linux", "arm64"))
+
+	staged, err := os.ReadFile(filepath.Join(destDir, "distro.raw.xz"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(staged), string(body))
+	assert.Assert(t, strings.Contains(log.String(), "warning: pruning the download cache"),
+		"the log records the failed sweep; it holds %q", log.String())
+}
+
+// A manifest naming an asset the target has no entry for fails with the
+// manifest's own path, so the build says which file to fix.
+func TestRunReportsAManifestMissingTheTarget(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "dependencies.yaml")
+	assert.NilError(t, os.WriteFile(manifestPath, []byte(`
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      arch: amd64
+      variant: raw
+      url: https://example.test/distro.v0.2.7.amd64.raw.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`), 0o644))
+
+	var log bytes.Buffer
+	err := run(t.Context(), &log, manifestPath, filepath.Join(dir, "embedded"), filepath.Join(dir, "cache"), "linux", "arm64")
+	assert.ErrorContains(t, err, manifestPath)
+	assert.ErrorContains(t, err, "found 0")
+}

--- a/rdd/pkg/guestdeps/manifest.go
+++ b/rdd/pkg/guestdeps/manifest.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+// Package guestdeps reads the guest dependency manifest and stages the assets
+// it lists for a build: it picks the asset matching the build target, fetches
+// it, and verifies the bytes against the checksum the manifest records.
+//
+// The manifest is written by `yarn rddepman guest`, which resolves every
+// download URL and checksum ahead of time, so nothing here needs per-package
+// knowledge.
+package guestdeps
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// checksumPattern is the form `yarn rddepman` writes checksums in.
+var checksumPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// An Asset is one downloadable artifact of a dependency.
+type Asset struct {
+	// Platform is the Go platform name the artifact targets, plus `wsl` for a
+	// WSL-specific build.
+	Platform string `json:"platform"`
+	// Arch is the Go architecture name. It is empty for arch-independent
+	// artifacts, which match any architecture.
+	Arch string `json:"arch,omitempty"`
+	// Variant distinguishes artifacts that share a platform and architecture
+	// but differ in kind, such as the distro's raw disk image and its rootfs
+	// tarball.
+	Variant string `json:"variant,omitempty"`
+	// URL is the fully-resolved download URL.
+	URL string `json:"url"`
+	// Checksum is the sha256 of the downloaded bytes, `sha256:`-prefixed.
+	Checksum string `json:"checksum"`
+}
+
+// An Entry is one dependency in the manifest.
+type Entry struct {
+	Version string  `json:"version"`
+	Assets  []Asset `json:"assets"`
+}
+
+// A Manifest holds the guest dependencies, keyed by dependency name.
+type Manifest map[string]Entry
+
+// LoadManifest reads and validates the manifest at manifestPath.
+func LoadManifest(manifestPath string) (Manifest, error) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", manifestPath, err)
+	}
+	for name, entry := range m {
+		// cachePath joins the name into the download's path, alongside the version
+		// and file name that validate checks, so the name needs the same guard.
+		if !isPathElement(name) {
+			return nil, fmt.Errorf("dependency %q in %s: the name is not a single directory name", name, manifestPath)
+		}
+		if err := entry.validate(); err != nil {
+			return nil, fmt.Errorf("dependency %s in %s: %w", name, manifestPath, err)
+		}
+	}
+	return m, nil
+}
+
+// validate rejects an entry a downloader cannot act on. Everything it checks is
+// something `yarn rddepman` writes, so a failure means the manifest was
+// hand-edited or the two sides have drifted apart.
+func (e Entry) validate() error {
+	if e.Version == "" {
+		return errors.New("has no version")
+	}
+	if !isPathElement(e.Version) {
+		return fmt.Errorf("has version %q, want a single directory name", e.Version)
+	}
+	for _, asset := range e.Assets {
+		if err := asset.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isPathElement reports whether name is usable as one directory or file name of
+// a cached download. cachePath builds that path with filepath.Join, which
+// treats a backslash as a separator on Windows, and url.Parse decodes %5C into
+// one, so checking only for a slash would leave a traversal open there.
+func isPathElement(name string) bool {
+	return name != "" && name != "." && name != ".." && !strings.ContainsAny(name, `/\`)
+}
+
+func (a Asset) validate() error {
+	u, err := url.Parse(a.URL)
+	if err != nil {
+		return fmt.Errorf("asset %s has an unparseable url %q: %w", a, a.URL, err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("asset %s has url %q, want https", a, a.URL)
+	}
+	// url.Parse accepts https:///name, which only fails once the request is
+	// made, several retries into a build.
+	if u.Hostname() == "" {
+		return fmt.Errorf("asset %s has url %q with no host", a, a.URL)
+	}
+	// A path ending in a slash names a directory, and path.Base would hand its
+	// name to the download as a file name.
+	if !isPathElement(path.Base(u.Path)) || strings.HasSuffix(u.Path, "/") {
+		return fmt.Errorf("asset %s has url %q with no file name to download to", a, a.URL)
+	}
+	if !checksumPattern.MatchString(a.Checksum) {
+		return fmt.Errorf("asset %s has checksum %q, want sha256:<64 lowercase hex digits>", a, a.Checksum)
+	}
+	return nil
+}
+
+// String renders an asset by the axes it is selected on. It leaves out the url,
+// so an error about the url has to print that itself.
+func (a Asset) String() string {
+	parts := []string{a.Platform}
+	if a.Arch != "" {
+		parts = append(parts, a.Arch)
+	}
+	if a.Variant != "" {
+		parts = append(parts, a.Variant)
+	}
+	return "[" + strings.Join(parts, "/") + "]"
+}
+
+// A Selector picks one of a dependency's assets. Platform and Arch name the
+// build target; Variant is set only for a dependency that ships several assets
+// for one target.
+type Selector struct {
+	Platform string
+	Arch     string
+	Variant  string
+}
+
+// matches reports whether asset satisfies the selector. An empty Arch or
+// Variant matches any value, as does an asset with no architecture, which is
+// arch-independent. The platform always has to match.
+func (s Selector) matches(a Asset) bool {
+	return a.Platform == s.Platform &&
+		(s.Arch == "" || a.Arch == "" || a.Arch == s.Arch) &&
+		(s.Variant == "" || a.Variant == s.Variant)
+}
+
+// String renders a selector for error messages.
+func (s Selector) String() string {
+	parts := []string{"platform=" + s.Platform}
+	if s.Arch != "" {
+		parts = append(parts, "arch="+s.Arch)
+	}
+	if s.Variant != "" {
+		parts = append(parts, "variant="+s.Variant)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// A Dependency is the asset of one manifest entry chosen for a build target,
+// with the name and version it belongs to.
+type Dependency struct {
+	Name    string
+	Version string
+	Asset   Asset
+}
+
+// Select returns the asset of the named dependency that matches sel. Exactly
+// one must match; a manifest that grows a second matching asset fails the
+// build instead of letting the list order decide.
+func (m Manifest) Select(name string, sel Selector) (Dependency, error) {
+	entry, ok := m[name]
+	if !ok {
+		return Dependency{}, fmt.Errorf("no dependency %q in the manifest", name)
+	}
+	var matches []Asset
+	for _, asset := range entry.Assets {
+		if sel.matches(asset) {
+			matches = append(matches, asset)
+		}
+	}
+	if len(matches) != 1 {
+		return Dependency{}, fmt.Errorf("want exactly one %s asset for %s, found %d: %v",
+			name, sel, len(matches), matches)
+	}
+	return Dependency{Name: name, Version: entry.Version, Asset: matches[0]}, nil
+}

--- a/rdd/pkg/guestdeps/manifest_test.go
+++ b/rdd/pkg/guestdeps/manifest_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package guestdeps
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// sampleManifest is a manifest in the shape `yarn rddepman guest` writes: a
+// dependency shipping one asset per architecture and image variant, and one
+// shipping a single arch-independent asset.
+const sampleManifest = `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      arch: amd64
+      variant: raw
+      url: https://example.test/distro.v0.2.7.amd64.raw.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+    - platform: linux
+      arch: amd64
+      variant: tar
+      url: https://example.test/distro.v0.2.7.amd64.tar.xz
+      checksum: sha256:a6d9e52dbafa69138ac84d2812b01c158ba3b19cf7c8725edefcee0b776afb61
+    - platform: linux
+      arch: arm64
+      variant: raw
+      url: https://example.test/distro.v0.2.7.arm64.raw.xz
+      checksum: sha256:c03fb8f0ee367d608498adddaf3633491f803f4adab2d4a6499c2d9fb271ec76
+config:
+  version: 1.0.0
+  assets:
+    - platform: linux
+      url: https://example.test/config-1.0.0.tar.gz
+      checksum: sha256:4389cf04704d1b37317ab3e8dc7bec7611f1503af6efc3f9a68f872bcddf806a
+`
+
+func writeManifest(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dependencies.yaml")
+	assert.NilError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func loadSample(t *testing.T) Manifest {
+	t.Helper()
+	m, err := LoadManifest(writeManifest(t, sampleManifest))
+	assert.NilError(t, err)
+	return m
+}
+
+func TestLoadManifest(t *testing.T) {
+	m := loadSample(t)
+
+	assert.Equal(t, m["distro"].Version, "0.2.7")
+	assert.Equal(t, len(m["distro"].Assets), 3)
+	assert.Equal(t, m["distro"].Assets[0].URL, "https://example.test/distro.v0.2.7.amd64.raw.xz")
+	assert.Equal(t, m["config"].Assets[0].Arch, "", "an arch-independent asset records no arch")
+}
+
+func TestLoadManifestRejectsUnusableEntries(t *testing.T) {
+	for name, tc := range map[string]struct{ content, want string }{
+		"no version": {want: "has no version", content: `
+distro:
+  assets:
+    - platform: linux
+      url: https://example.test/distro.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		"unprefixed checksum": {want: "want sha256:", content: `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https://example.test/distro.xz
+      checksum: ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		"misspelled checksum key": {want: `checksum ""`, content: `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https://example.test/distro.xz
+      checkum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		"plain http url": {want: `url "http://example.test/distro.xz", want https`, content: `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: http://example.test/distro.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		"url with no file name": {want: "no file name", content: `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https://example.test/
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		// url.Parse accepts a url with no host, which reaches the download and
+		// fails there, a full retry schedule into the build.
+		"url with no host": {want: "with no host", content: `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https:///distro.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		// path.Base would hand the directory's own name to the download.
+		"url naming a directory": {want: "no file name", content: `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https://example.test/releases/
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		"url ending in a traversal": {want: "no file name", content: `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https://example.test/releases/..
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		// url.Parse decodes %5C into a backslash, which filepath.Join treats as
+		// a separator on Windows, so path.Base alone would hand cachePath a
+		// traversal there.
+		"url whose file name escapes on windows": {want: "no file name", content: `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https://example.test/..%5C..%5C..%5Cescape.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+		// cachePath joins the version into the download's directory, so a
+		// version escaping it would relocate the whole entry.
+		"version that escapes the cache directory": {want: "want a single directory name", content: `
+distro:
+  version: ../../../escape
+  assets:
+    - platform: linux
+      url: https://example.test/distro.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := LoadManifest(writeManifest(t, tc.content))
+			assert.ErrorContains(t, err, "dependency distro in ")
+			assert.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+// cachePath joins the dependency name into the download's directory alongside
+// the version and the file name, so a name escaping it would relocate the entry.
+func TestLoadManifestRejectsAnEscapingDependencyName(t *testing.T) {
+	_, err := LoadManifest(writeManifest(t, `
+"../../../escape":
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https://example.test/distro.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`))
+	assert.ErrorContains(t, err, `dependency "../../../escape" in `)
+	assert.ErrorContains(t, err, "not a single directory name")
+}
+
+// Dots are ordinary in a release file name, so only the traversal itself is
+// rejected.
+func TestLoadManifestAcceptsDotsInAFileName(t *testing.T) {
+	m, err := LoadManifest(writeManifest(t, `
+distro:
+  version: 0.2.7
+  assets:
+    - platform: linux
+      url: https://example.test/distro..amd64.raw.xz
+      checksum: sha256:ac6c23589bc4a92a4c7d823d59b029576fa9bb18bc2c081e95f59fb184547795
+`))
+	assert.NilError(t, err)
+	assert.Equal(t, m["distro"].Assets[0].URL, "https://example.test/distro..amd64.raw.xz")
+}
+
+func TestSelect(t *testing.T) {
+	m := loadSample(t)
+
+	dep, err := m.Select("distro", Selector{Platform: "linux", Arch: "amd64", Variant: "tar"})
+	assert.NilError(t, err)
+	assert.Equal(t, dep.Name, "distro")
+	assert.Equal(t, dep.Version, "0.2.7")
+	assert.Equal(t, dep.Asset.URL, "https://example.test/distro.v0.2.7.amd64.tar.xz")
+}
+
+func TestSelectArchIndependentAsset(t *testing.T) {
+	m := loadSample(t)
+
+	dep, err := m.Select("config", Selector{Platform: "linux", Arch: "arm64"})
+	assert.NilError(t, err)
+	assert.Equal(t, dep.Asset.URL, "https://example.test/config-1.0.0.tar.gz")
+}
+
+func TestSelectRejectsAmbiguousAndMissingAssets(t *testing.T) {
+	m := loadSample(t)
+
+	// Both amd64 variants match a selector that names no variant.
+	_, err := m.Select("distro", Selector{Platform: "linux", Arch: "amd64"})
+	assert.ErrorContains(t, err, "found 2")
+
+	_, err = m.Select("distro", Selector{Platform: "linux", Arch: "arm64", Variant: "tar"})
+	assert.ErrorContains(t, err, "found 0")
+
+	_, err = m.Select("nerdctl", Selector{Platform: "linux", Arch: "amd64"})
+	assert.ErrorContains(t, err, `no dependency "nerdctl"`)
+}

--- a/rdd/pkg/guestdeps/stage.go
+++ b/rdd/pkg/guestdeps/stage.go
@@ -1,0 +1,586 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package guestdeps
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// downloadAttempts bounds the retries of a transfer that drops, stalls or is
+// throttled partway through a several-hundred-megabyte asset. Anything longer
+// is an outage a re-run has to cover.
+const downloadAttempts = 4
+
+// stallTimeout is the longest a transfer may go without progress, waiting
+// either for the response headers or for the next bytes of the body. Tests
+// shorten it; newHTTPClient reads it, so that moves the body deadline alone
+// until httpClient is rebuilt.
+var stallTimeout = 30 * time.Second
+
+// downloadTimeout bounds every attempt at one asset together. stallTimeout ends
+// a peer that goes quiet; this ends one that keeps sending just enough to
+// restart that timer, which could otherwise hold the build open indefinitely.
+// No working link reaches it. The largest asset the manifest names is 250 MiB,
+// which needs only 36 KiB/s to arrive in time. Tests shorten it.
+var downloadTimeout = 2 * time.Hour
+
+// progressInterval is how often a running download reports how far it has got.
+// A quiet minute on a 200 MiB asset looks the same as a wedged one.
+const progressInterval = 5 * time.Second
+
+// cacheTTL is how long a download nothing has used is kept. Every build touches
+// the entries it stages from, so what goes untouched this long is a superseded
+// version or the partial file a killed build left behind.
+const cacheTTL = 7 * 24 * time.Hour
+
+// retryDelay is the wait before the second attempt, and maxRetryDelay the
+// ceiling retryWait may grow it to. They are variables so tests can shorten
+// them.
+var (
+	retryDelay    = 2 * time.Second
+	maxRetryDelay = 30 * time.Second
+)
+
+// httpClient bounds what http.DefaultClient leaves open.
+var httpClient = newHTTPClient()
+
+// newHTTPClient returns a client that bounds the wait for response headers.
+// DefaultTransport times out the dial and the TLS handshake only, so that wait
+// needs a limit of its own; progressReader bounds the body read.
+func newHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = stallTimeout
+	return &http.Client{Transport: transport}
+}
+
+// A Stager fetches guest dependencies into CacheDir and copies them into the
+// build tree. Progress goes to Log, or nowhere when Log is nil.
+type Stager struct {
+	CacheDir string
+	Log      io.Writer
+}
+
+// DefaultCacheDir returns the directory holding verified downloads. It is
+// outside the source tree, so a clean checkout and each bats worktree share one
+// copy of an asset. Prune deletes underneath it, so it needs a directory of its
+// own, clear of the app's cache on macOS and Linux and of every instance
+// directory on Windows, where os.UserCacheDir is %LocalAppData% and rdd svc
+// delete removes the instance whole. The dot keeps the name out of reach of
+// instance.Name(), which is always "rancher-desktop-" and a suffix.
+func DefaultCacheDir() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("locating the download cache: %w", err)
+	}
+	return filepath.Join(dir, "rancher-desktop.guest-deps"), nil
+}
+
+// Stage makes destPath hold dep's verified bytes, downloading them first unless
+// the cache already has them. It checksums both destPath and the cache entry
+// rather than trusting a timestamp, so a half-written file from an interrupted
+// build is replaced.
+func (s *Stager) Stage(ctx context.Context, dep Dependency, destPath string) error {
+	cachePath, err := s.cachePath(dep)
+	if err != nil {
+		return err
+	}
+	// Reaching for the cache before destPath would re-fetch a purged entry to
+	// produce a file the build already has, and would fail offline where the
+	// whole download is avoidable.
+	staged, err := fileHasChecksum(destPath, dep.Asset.Checksum)
+	if err != nil {
+		return err
+	}
+	if staged {
+		s.logf("%s is up to date", destPath)
+		s.touch(cachePath)
+		return nil
+	}
+
+	cached, err := fileHasChecksum(cachePath, dep.Asset.Checksum)
+	if err != nil {
+		return err
+	}
+	if cached {
+		s.logf("%s %s is already downloaded to %s", dep.Name, dep.Version, cachePath)
+		s.logf("Copying %s to %s", cachePath, destPath)
+		s.touch(cachePath)
+		// touch narrows the window but cannot close it: a concurrent prune
+		// decides from a stat taken before it, and unlink succeeds whatever the
+		// timestamp says. An entry that goes missing here is a cache miss, but
+		// copyFile reports a vanished destination directory the same way, so
+		// check which file is gone.
+		err := copyFile(cachePath, destPath)
+		if !errors.Is(err, fs.ErrNotExist) || !missing(cachePath) {
+			return err
+		}
+		s.logf("%s went away before it could be copied; downloading it again", cachePath)
+	}
+	if err := s.download(ctx, dep, cachePath); err != nil {
+		return err
+	}
+	s.logf("Copying %s to %s", cachePath, destPath)
+	return copyFile(cachePath, destPath)
+}
+
+// touch records that a build used a cache entry, so Prune keeps it for another
+// cacheTTL. A missing entry is not an error, because a build whose staged copy
+// is already correct never opens one. Nor does touch verify the entry, because
+// hashing it would cost what that staged copy exists to avoid; a corrupt entry
+// outlives its TTL and is replaced the first time a build needs it.
+func (s *Stager) touch(cachePath string) {
+	now := time.Now()
+	if err := os.Chtimes(cachePath, now, now); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		s.logf("Could not refresh %s: %v", cachePath, err)
+	}
+}
+
+// Prune removes downloads no build has used in cacheTTL, and with them the
+// partial files a build killed mid-transfer leaves behind. It descends only
+// directories named as isVersionDir describes, and removes nothing else: the
+// dependency directory stays, because an empty one is indistinguishable from a
+// directory this tool never made, and one per dependency costs nothing.
+//
+// Pruning is best effort. Another build sweeping the same cache removes
+// directories underfoot, so an entry that cannot be read is logged and skipped
+// rather than abandoning the rest of the sweep.
+func (s *Stager) Prune() error {
+	cutoff := time.Now().Add(-cacheTTL)
+	deps, err := os.ReadDir(s.CacheDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		// Nothing has been downloaded yet.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, dep := range deps {
+		if !dep.IsDir() {
+			continue
+		}
+		depDir := filepath.Join(s.CacheDir, dep.Name())
+		versions, err := os.ReadDir(depDir)
+		if err != nil {
+			s.skipped(depDir, err)
+			continue
+		}
+		for _, version := range versions {
+			if version.IsDir() && isVersionDir(version.Name()) {
+				s.pruneVersion(filepath.Join(depDir, version.Name()), cutoff)
+			}
+		}
+	}
+	return nil
+}
+
+// isVersionDir reports whether name is one of the directories cachePath names
+// after a dependency's version. Requiring a digit after the "v" keeps an
+// unrelated directory, a vendor directory say, out of the prune. A version that
+// does not start with a digit is never collected, which wastes disk rather than
+// deleting something this tool does not own.
+func isVersionDir(name string) bool {
+	return len(name) > 1 && name[0] == 'v' && name[1] >= '0' && name[1] <= '9'
+}
+
+// pruneVersion removes the downloads in one version directory that no build has
+// used since cutoff.
+func (s *Stager) pruneVersion(dir string, cutoff time.Time) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		s.skipped(dir, err)
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			s.skipped(filepath.Join(dir, entry.Name()), err)
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		name := filepath.Join(dir, entry.Name())
+		if err := os.Remove(name); err != nil {
+			s.skipped(name, err)
+			continue
+		}
+		s.logf("Removed the unused download %s", name)
+	}
+	removeStaleEmptyDir(dir, cutoff)
+}
+
+// skipped reports what a prune passed over. A path another build removed first
+// is the expected case and says nothing worth printing.
+func (s *Stager) skipped(path string, err error) {
+	if !errors.Is(err, fs.ErrNotExist) {
+		s.logf("Skipped %s: %v", path, err)
+	}
+}
+
+// removeStaleEmptyDir drops a directory holding nothing that nothing has
+// written to since cutoff. An empty directory's timestamp is the moment it was
+// created, so the one a concurrent build has just made for its temporary file
+// stays; a directory this run emptied is likewise too new, and goes on a later
+// run. Failing to remove one costs nothing, because it stays a candidate.
+func removeStaleEmptyDir(dir string, cutoff time.Time) {
+	info, err := os.Stat(dir)
+	if err != nil || info.ModTime().After(cutoff) {
+		return
+	}
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) > 0 {
+		return
+	}
+	_ = os.Remove(dir)
+}
+
+// cachePath returns where dep's download is kept, keyed by name, version and
+// file name, so a version bump goes beside the old download instead of
+// overwriting it. rddepman writes some versions with a leading "v" and some
+// without, and the prefix is normalised here so both land in a directory
+// isVersionDir recognises.
+func (s *Stager) cachePath(dep Dependency) (string, error) {
+	u, err := url.Parse(dep.Asset.URL)
+	if err != nil {
+		return "", fmt.Errorf("%s %s has an unparseable url %q: %w", dep.Name, dep.Asset, dep.Asset.URL, err)
+	}
+	version := "v" + strings.TrimPrefix(dep.Version, "v")
+	return filepath.Join(s.CacheDir, dep.Name, version, path.Base(u.Path)), nil
+}
+
+func (s *Stager) logf(format string, args ...any) {
+	if s.Log == nil {
+		return
+	}
+	fmt.Fprintf(s.Log, format+"\n", args...)
+}
+
+// fatalError marks a download failure no retry can fix, such as a URL the
+// server does not have or bytes that will never match the checksum.
+type fatalError struct{ err error }
+
+func (e *fatalError) Error() string { return e.err.Error() }
+
+func (e *fatalError) Unwrap() error { return e.err }
+
+// retryAfterError holds the delay a throttling server named, so the retry waits
+// that long instead of following its own schedule.
+type retryAfterError struct {
+	err   error
+	delay time.Duration
+}
+
+func (e *retryAfterError) Error() string { return e.err.Error() }
+
+func (e *retryAfterError) Unwrap() error { return e.err }
+
+// retryWait returns the wait before attempt, either the delay the server asked
+// for or an exponential backoff. Both stop at maxRetryDelay, so a server naming
+// an hour cannot park the build there.
+func retryWait(attempt int, err error) time.Duration {
+	var throttled *retryAfterError
+	if errors.As(err, &throttled) {
+		return min(throttled.delay, maxRetryDelay)
+	}
+	return min(retryDelay<<(attempt-1), maxRetryDelay)
+}
+
+// maxRetryAfterSeconds is the largest Retry-After a time.Duration can hold.
+// Converting anything above it wraps to a negative delay, which would retry at
+// once rather than waiting.
+const maxRetryAfterSeconds = math.MaxInt64 / int64(time.Second)
+
+// retryAfter reads a Retry-After header, which holds either a number of seconds
+// or an HTTP date. A value that is absent, malformed or already past reports
+// false.
+func retryAfter(value string, now time.Time) (time.Duration, bool) {
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0, false
+		}
+		return time.Duration(min(int64(seconds), maxRetryAfterSeconds)) * time.Second, true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	// Sub saturates rather than wrapping, so a far-future date is safe here.
+	delay := when.Sub(now)
+	return delay, delay > 0
+}
+
+// download fetches dep to destPath, retrying a transfer that fails partway.
+func (s *Stager) download(ctx context.Context, dep Dependency, destPath string) error {
+	// The attempts share one deadline, so the retries cannot multiply it.
+	// Keeping the caller's context separate tells a cancelled build from a
+	// download that ran out of time.
+	caller := ctx
+	ctx, cancel := context.WithTimeout(ctx, downloadTimeout)
+	defer cancel()
+
+	var err error
+attempts:
+	for attempt := range downloadAttempts {
+		if attempt > 0 {
+			wait := retryWait(attempt, err)
+			s.logf("Retrying in %s (attempt %d of %d): %v", wait, attempt+1, downloadAttempts, err)
+			select {
+			case <-ctx.Done():
+				break attempts
+			case <-time.After(wait):
+			}
+		}
+		s.logf("Downloading %s to %s", dep.Asset.URL, destPath)
+		start := time.Now()
+		var size int64
+		if size, err = s.downloadOnce(ctx, dep.Asset, destPath); err == nil {
+			s.logf("Downloaded %.1f MiB in %s", mib(size), time.Since(start).Round(time.Second))
+			return nil
+		}
+		var fatal *fatalError
+		if errors.As(err, &fatal) || ctx.Err() != nil {
+			break
+		}
+	}
+	switch {
+	case caller.Err() != nil:
+		return fmt.Errorf("downloading %s: %w", dep.Asset.URL, caller.Err())
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return fmt.Errorf("downloading %s: gave up after %s: %w", dep.Asset.URL, downloadTimeout, err)
+	}
+	return fmt.Errorf("downloading %s: %w", dep.Asset.URL, err)
+}
+
+// downloadOnce writes the asset to destPath through a temporary file, hashing
+// as it goes, and renames it into place only once the bytes match the
+// manifest's checksum.
+func (s *Stager) downloadOnce(ctx context.Context, asset Asset, destPath string) (size int64, err error) {
+	// The attempt gets its own cancellation, so a stall ends this attempt while
+	// leaving download's context untouched for the retry that follows.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, asset.URL, http.NoBody)
+	if err != nil {
+		return 0, &fatalError{err}
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		err := fmt.Errorf("unexpected status %s", resp.Status)
+		// A server naming a delay is asking to be retried, whatever status it sent.
+		// GitHub throttles release downloads with 403 as well as 429.
+		if delay, ok := retryAfter(resp.Header.Get("Retry-After"), time.Now()); ok {
+			return 0, &retryAfterError{err: err, delay: delay}
+		}
+		// Otherwise a 4xx means the manifest names something the server does not
+		// have, which a retry cannot conjure up. The two exceptions are about the
+		// request itself, so repeating it can succeed.
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 &&
+			resp.StatusCode != http.StatusTooManyRequests &&
+			resp.StatusCode != http.StatusRequestTimeout {
+			return 0, &fatalError{err}
+		}
+		return 0, err
+	}
+
+	tmp, err := createTemp(destPath)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err != nil {
+			tmp.Close()
+			os.Remove(tmp.Name())
+		}
+	}()
+
+	body := s.watchTransfer(resp, cancel)
+	defer body.stop()
+
+	hash := sha256.New()
+	if size, err = io.Copy(io.MultiWriter(tmp, hash), body); err != nil {
+		// A stall reaches the read as a bare cancellation, so name what happened.
+		if body.stalled.Load() {
+			err = fmt.Errorf("no data received for %s", stallTimeout)
+		}
+		return size, err
+	}
+	if sum := "sha256:" + hex.EncodeToString(hash.Sum(nil)); sum != asset.Checksum {
+		err = &fatalError{fmt.Errorf("checksum is %s, want %s", sum, asset.Checksum)}
+		return size, err
+	}
+	err = finishTemp(tmp, destPath)
+	return size, err
+}
+
+// copyFile copies src to dst through a temporary file, so an interrupted copy
+// leaves no partial dst behind for the build to embed.
+func copyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp, err := createTemp(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			tmp.Close()
+			os.Remove(tmp.Name())
+		}
+	}()
+
+	if _, err = io.Copy(tmp, in); err != nil {
+		return err
+	}
+	return finishTemp(tmp, dst)
+}
+
+// createTemp opens a temporary file beside destPath, creating the directory
+// that will hold it. A concurrent prune can drop that directory between the two
+// calls, so a second round makes it again rather than failing the attempt.
+func createTemp(destPath string) (*os.File, error) {
+	dir, prefix := filepath.Dir(destPath), filepath.Base(destPath)+".tmp-*"
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	tmp, err := os.CreateTemp(dir, prefix)
+	if !errors.Is(err, fs.ErrNotExist) {
+		return tmp, err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	return os.CreateTemp(dir, prefix)
+}
+
+// finishTemp flushes tmp and renames it to destPath. os.CreateTemp creates the
+// file 0o600; the staged asset is a build input others may read, so widen it.
+//
+// On Windows the rename can fail with a sharing violation while another build
+// reads destPath, because Go opens files without FILE_SHARE_DELETE and
+// MoveFileEx needs delete access to the file it replaces. Two builds sharing
+// one cache is the design, so this is reachable; a re-run clears it.
+func finishTemp(tmp *os.File, destPath string) error {
+	if err := tmp.Chmod(0o644); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), destPath)
+}
+
+// missing reports whether path does not exist. Any other error leaves the
+// question open, which counts as present, so the caller reports the error it
+// already has.
+func missing(path string) bool {
+	_, err := os.Stat(path)
+	return errors.Is(err, fs.ErrNotExist)
+}
+
+// fileHasChecksum reports whether path holds exactly the bytes checksum names.
+// A missing file is not an error, just not a match.
+func fileHasChecksum(path, checksum string) (bool, error) {
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return false, err
+	}
+	return "sha256:"+hex.EncodeToString(hash.Sum(nil)) == checksum, nil
+}
+
+// A progressReader wraps a download's body to report how far a long transfer
+// has got and to end one that goes quiet. Every read restarts the stall timer,
+// so that limit falls on the gap between bytes; downloadTimeout bounds the
+// transfer itself, which can run for minutes.
+type progressReader struct {
+	body    io.Reader
+	total   int64
+	read    int64
+	report  func(read, total int64)
+	timer   *time.Timer
+	stalled atomic.Bool
+	next    time.Time
+}
+
+// watchTransfer starts the stall timer on resp's body. cancel ends the attempt
+// when the timer fires, so the retry loop gets a failed attempt rather than a
+// wedged one.
+func (s *Stager) watchTransfer(resp *http.Response, cancel context.CancelFunc) *progressReader {
+	r := &progressReader{
+		body:   resp.Body,
+		total:  resp.ContentLength,
+		report: s.logProgress,
+		next:   time.Now().Add(progressInterval),
+	}
+	r.timer = time.AfterFunc(stallTimeout, func() {
+		r.stalled.Store(true)
+		cancel()
+	})
+	return r
+}
+
+func (r *progressReader) Read(p []byte) (int, error) {
+	n, err := r.body.Read(p)
+	r.read += int64(n)
+	r.timer.Reset(stallTimeout)
+	if now := time.Now(); now.After(r.next) {
+		r.next = now.Add(progressInterval)
+		r.report(r.read, r.total)
+	}
+	return n, err
+}
+
+func (r *progressReader) stop() { r.timer.Stop() }
+
+// logProgress reports how far a transfer has got. A server that sent no
+// Content-Length leaves the total unknown, so the report gives the bytes alone.
+func (s *Stager) logProgress(read, total int64) {
+	if total <= 0 {
+		s.logf("Downloaded %.1f MiB", mib(read))
+		return
+	}
+	s.logf("Downloaded %.1f MiB of %.1f MiB (%d%%)", mib(read), mib(total), read*100/total)
+}
+
+// mib renders a byte count in MiB.
+func mib(bytes int64) float64 { return float64(bytes) / (1 << 20) }

--- a/rdd/pkg/guestdeps/stage_test.go
+++ b/rdd/pkg/guestdeps/stage_test.go
@@ -1,0 +1,905 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package guestdeps
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+const (
+	testVersion  = "0.2.7"
+	testFilename = "distro.v" + testVersion + ".amd64.raw.xz"
+)
+
+// An assetServer stands in for the release the manifest points at. It counts
+// requests, so a test can show that a download happened once, was retried, or
+// never happened at all, and it can fail the first few requests to stand in for
+// a flaky transfer.
+type assetServer struct {
+	requests atomic.Int32
+	failures []int
+	body     []byte
+	url      string
+}
+
+func newAssetServer(t *testing.T, body []byte, failures ...int) *assetServer {
+	t.Helper()
+	s := &assetServer{body: body, failures: failures}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if n := int(s.requests.Add(1)); n <= len(s.failures) {
+			w.WriteHeader(s.failures[n-1])
+			return
+		}
+		_, _ = w.Write(s.body)
+	}))
+	t.Cleanup(srv.Close)
+	s.url = srv.URL + "/" + testFilename
+	return s
+}
+
+// newStallingServer answers with the response headers and the first byte of the
+// body, then stops sending. It stands in for a peer that accepts the request and
+// goes quiet, the failure no transport timeout catches.
+func newStallingServer(t *testing.T, body []byte) *assetServer {
+	t.Helper()
+	s := &assetServer{body: body}
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		s.requests.Add(1)
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body[:1])
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+	// Cleanups run last in, first out, so the handlers unblock before Close
+	// waits for them.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	s.url = srv.URL + "/" + testFilename
+	return s
+}
+
+// waitForRequest blocks until the server has taken a request, so a test can act
+// on a transfer that is under way.
+func (s *assetServer) waitForRequest(t *testing.T) {
+	t.Helper()
+	for range 2000 {
+		if s.requests.Load() > 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	assert.Assert(t, false, "the asset server was never asked for the download")
+}
+
+// dependency describes the served asset, claiming the checksum of want. Every
+// test but the corruption one passes the bytes the server actually serves.
+func (s *assetServer) dependency(want []byte) Dependency {
+	sum := sha256.Sum256(want)
+	return Dependency{
+		Name:    "distro",
+		Version: testVersion,
+		Asset: Asset{
+			Platform: "linux",
+			Arch:     "amd64",
+			Variant:  "raw",
+			URL:      s.url,
+			Checksum: "sha256:" + hex.EncodeToString(sum[:]),
+		},
+	}
+}
+
+// stagerFor returns a stager writing under a temporary directory, along with
+// the cache directory and the path a staged asset is written to.
+func stagerFor(t *testing.T, log io.Writer) (stager *Stager, cacheDir, destPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	cacheDir = filepath.Join(dir, "cache")
+	return &Stager{CacheDir: cacheDir, Log: log}, cacheDir, filepath.Join(dir, "embedded", "distro.raw.xz")
+}
+
+// shortenRetries collapses the retry schedule so a test that exercises it runs
+// in milliseconds rather than in the seconds a real build waits.
+func shortenRetries(t *testing.T) {
+	t.Helper()
+	delay, ceiling := retryDelay, maxRetryDelay
+	retryDelay, maxRetryDelay = time.Millisecond, 10*time.Millisecond
+	t.Cleanup(func() { retryDelay, maxRetryDelay = delay, ceiling })
+}
+
+// shortenStallTimeout brings the deadline on the body read within a test's
+// patience. httpClient keeps the response-header deadline it was built with;
+// shortenHeaderTimeout moves that one.
+func shortenStallTimeout(t *testing.T) {
+	t.Helper()
+	old := stallTimeout
+	stallTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { stallTimeout = old })
+}
+
+// shortenHeaderTimeout brings the deadline on the response headers down as
+// well, by rebuilding the client once stallTimeout is short, because that is
+// what newHTTPClient reads.
+func shortenHeaderTimeout(t *testing.T) {
+	t.Helper()
+	shortenStallTimeout(t)
+	old := httpClient
+	httpClient = newHTTPClient()
+	t.Cleanup(func() { httpClient = old })
+}
+
+// shortenDownloadTimeout brings the deadline covering every attempt at one
+// asset within a test's patience.
+func shortenDownloadTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := downloadTimeout
+	downloadTimeout = d
+	t.Cleanup(func() { downloadTimeout = old })
+}
+
+// newTricklingServer answers and then sends one byte every gap, forever. It
+// stands in for a throttled peer, too slow to finish and too regular to stall.
+func newTricklingServer(t *testing.T, gap time.Duration) *assetServer {
+	t.Helper()
+	s := &assetServer{}
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		for {
+			_, _ = w.Write([]byte("x"))
+			w.(http.Flusher).Flush()
+			select {
+			case <-r.Context().Done():
+				return
+			case <-release:
+				return
+			case <-time.After(gap):
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	s.url = srv.URL + "/" + testFilename
+	return s
+}
+
+// newThrottlingServer refuses the first request with status and a Retry-After
+// naming its own delay, then serves the asset.
+func newThrottlingServer(t *testing.T, body []byte, status int) *assetServer {
+	t.Helper()
+	s := &assetServer{body: body}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if s.requests.Add(1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(status)
+			return
+		}
+		_, _ = w.Write(s.body)
+	}))
+	t.Cleanup(srv.Close)
+	s.url = srv.URL + "/" + testFilename
+	return s
+}
+
+func cachedAsset(cacheDir string) string {
+	return filepath.Join(cacheDir, "distro", "v"+testVersion, testFilename)
+}
+
+func assertContent(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Assert(t, bytes.Equal(got, want), "%s holds %d bytes, want %d", path, len(got), len(want))
+}
+
+// assertNoTempFiles guards the atomic writes: neither a completed nor an
+// abandoned transfer may leave a partial file behind. It walks rather than
+// globbing a fixed depth, so it keeps guarding through a change to the cache
+// layout, and it covers the destination directory, where copyFile writes its
+// temporary files one level higher.
+func assertNoTempFiles(t *testing.T, dirs ...string) {
+	t.Helper()
+	var found []string
+	for _, dir := range dirs {
+		err := filepath.WalkDir(dir, func(name string, entry fs.DirEntry, err error) error {
+			switch {
+			case errors.Is(err, fs.ErrNotExist):
+				return nil // a failed stage may never create the directory
+			case err != nil:
+				return err
+			case !entry.IsDir() && strings.Contains(entry.Name(), ".tmp-"):
+				found = append(found, name)
+			}
+			return nil
+		})
+		assert.NilError(t, err)
+	}
+	assert.Assert(t, len(found) == 0, "leftover temp files: %v", found)
+}
+
+func TestStageDownloadsAndCaches(t *testing.T) {
+	body := bytes.Repeat([]byte("distro image\n"), 1000)
+	server := newAssetServer(t, body)
+	dep := server.dependency(body)
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assertContent(t, destPath, body)
+	assertContent(t, cachedAsset(cacheDir), body)
+	assert.Equal(t, server.requests.Load(), int32(1))
+	assertNoTempFiles(t, cacheDir, filepath.Dir(destPath))
+}
+
+// A second build stages from the cache: the bytes are already verified, so it
+// must not go back to the network even when the staged copy is gone.
+func TestStageReusesTheCachedDownload(t *testing.T) {
+	body := []byte("distro image")
+	server := newAssetServer(t, body)
+	dep := server.dependency(body)
+	stager, _, destPath := stagerFor(t, nil)
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assert.NilError(t, os.Remove(destPath))
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+
+	assertContent(t, destPath, body)
+	assert.Equal(t, server.requests.Load(), int32(1))
+}
+
+// A staged file that is already the asset is left alone; copying hundreds of
+// megabytes on every build would be the whole cost of the download again.
+func TestStageLeavesAnUpToDateFileAlone(t *testing.T) {
+	body := []byte("distro image")
+	server := newAssetServer(t, body)
+	dep := server.dependency(body)
+	var log bytes.Buffer
+	stager, _, destPath := stagerFor(t, &log)
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	before, err := os.Stat(destPath)
+	assert.NilError(t, err)
+
+	log.Reset()
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	after, err := os.Stat(destPath)
+	assert.NilError(t, err)
+
+	assert.Assert(t, after.ModTime().Equal(before.ModTime()), "the staged file was rewritten")
+	assert.Assert(t, bytes.Contains(log.Bytes(), []byte("is up to date")), "log: %s", log.String())
+}
+
+// Bytes that fail verification are dropped. Nothing is cached, nothing is
+// staged, and no retry follows.
+func TestStageRejectsUnexpectedBytes(t *testing.T) {
+	server := newAssetServer(t, []byte("someone else's image"))
+	dep := server.dependency([]byte("distro image"))
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	err := stager.Stage(t.Context(), dep, destPath)
+	assert.ErrorContains(t, err, "checksum is sha256:")
+	assert.Equal(t, server.requests.Load(), int32(1), "a mismatched download must not be retried")
+
+	_, statErr := os.Stat(destPath)
+	assert.Assert(t, os.IsNotExist(statErr), "nothing may be staged from a failed download")
+	assertNoTempFiles(t, cacheDir, filepath.Dir(destPath))
+}
+
+// A stale staged file (an older distro version, or a truncated write from an
+// interrupted build) is replaced rather than embedded as it stands.
+func TestStageReplacesAStaleFile(t *testing.T) {
+	body := []byte("distro image")
+	server := newAssetServer(t, body)
+	dep := server.dependency(body)
+	stager, _, destPath := stagerFor(t, nil)
+
+	assert.NilError(t, os.MkdirAll(filepath.Dir(destPath), 0o755))
+	assert.NilError(t, os.WriteFile(destPath, []byte("the previous distro"), 0o644))
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assertContent(t, destPath, body)
+}
+
+func TestStageRetriesATransientFailure(t *testing.T) {
+	shortenRetries(t)
+
+	body := []byte("distro image")
+	server := newAssetServer(t, body, http.StatusBadGateway, http.StatusTooManyRequests)
+	dep := server.dependency(body)
+	stager, _, destPath := stagerFor(t, nil)
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assertContent(t, destPath, body)
+	assert.Equal(t, server.requests.Load(), int32(3))
+}
+
+// A URL the release does not have is a manifest bug; retrying it only delays
+// the failure.
+func TestStageDoesNotRetryAMissingAsset(t *testing.T) {
+	server := newAssetServer(t, []byte("distro image"), http.StatusNotFound)
+	dep := server.dependency([]byte("distro image"))
+	stager, _, destPath := stagerFor(t, nil)
+
+	err := stager.Stage(t.Context(), dep, destPath)
+	assert.ErrorContains(t, err, "404")
+	assert.Equal(t, server.requests.Load(), int32(1))
+}
+
+// A cache entry whose bytes do not match is downloaded again. Trusting the
+// file's existence would stage bytes nothing has verified, and the build would
+// embed them.
+func TestStageReplacesACorruptCacheEntry(t *testing.T) {
+	body := []byte("distro image")
+	server := newAssetServer(t, body)
+	dep := server.dependency(body)
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	cachePath := cachedAsset(cacheDir)
+	assert.NilError(t, os.MkdirAll(filepath.Dir(cachePath), 0o755))
+	assert.NilError(t, os.WriteFile(cachePath, []byte("garbage"), 0o644))
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assertContent(t, destPath, body)
+	assertContent(t, cachePath, body)
+	assert.Equal(t, server.requests.Load(), int32(1), "the corrupt entry must be downloaded again")
+	assertNoTempFiles(t, cacheDir, filepath.Dir(destPath))
+}
+
+// A staged file that already verifies needs no download, even once the cache is
+// gone. macOS purges the cache directory under disk pressure, and a build that
+// has the bytes must not go back to the network for them.
+func TestStageSkipsTheDownloadWhenTheStagedFileIsCurrent(t *testing.T) {
+	body := []byte("distro image")
+	server := newAssetServer(t, body)
+	dep := server.dependency(body)
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assert.NilError(t, os.RemoveAll(cacheDir))
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assertContent(t, destPath, body)
+	assert.Equal(t, server.requests.Load(), int32(1), "a verified staged file must not be downloaded again")
+}
+
+// The attempt budget is spent and the last failure is reported with the url
+// that failed.
+func TestStageGivesUpAfterEveryAttemptFails(t *testing.T) {
+	shortenRetries(t)
+
+	body := []byte("distro image")
+	failures := make([]int, downloadAttempts)
+	for i := range failures {
+		failures[i] = http.StatusBadGateway
+	}
+	server := newAssetServer(t, body, failures...)
+	dep := server.dependency(body)
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	err := stager.Stage(t.Context(), dep, destPath)
+	assert.ErrorContains(t, err, "downloading "+server.url)
+	assert.ErrorContains(t, err, "502")
+	assert.Equal(t, server.requests.Load(), int32(downloadAttempts))
+	assertNoTempFiles(t, cacheDir, filepath.Dir(destPath))
+}
+
+// A peer that answers and then goes quiet fails its attempt rather than
+// blocking the build. Neither http.Client nor its transport bounds a body read,
+// so without the stall timer the retry loop never runs at all.
+func TestStageFailsAStalledTransfer(t *testing.T) {
+	shortenRetries(t)
+	shortenStallTimeout(t)
+
+	body := []byte("distro image")
+	server := newStallingServer(t, body)
+	dep := server.dependency(body)
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- stager.Stage(t.Context(), dep, destPath) }()
+
+	select {
+	case err := <-done:
+		assert.ErrorContains(t, err, "no data received for")
+		assert.Equal(t, server.requests.Load(), int32(downloadAttempts), "every attempt must stall and retry")
+	case <-time.After(30 * time.Second):
+		assert.Assert(t, false, "a stalled transfer blocked Stage; the retry loop never ran")
+	}
+	assertNoTempFiles(t, cacheDir, filepath.Dir(destPath))
+}
+
+// An interrupt during a transfer aborts it and cleans up, which is what the
+// command promises the developer who hits Ctrl-C on a multi-minute download.
+func TestStageCleansUpWhenCancelled(t *testing.T) {
+	body := []byte("distro image")
+	server := newStallingServer(t, body)
+	dep := server.dependency(body)
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- stager.Stage(ctx, dep, destPath) }()
+
+	// Cancel once the transfer is under way, so the cleanup under test is the
+	// one that runs with a temporary file already open.
+	server.waitForRequest(t)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(30 * time.Second):
+		assert.Assert(t, false, "Stage did not return after the context was cancelled")
+	}
+	assert.Equal(t, server.requests.Load(), int32(1), "a cancelled download must not be retried")
+	_, statErr := os.Stat(destPath)
+	assert.Assert(t, os.IsNotExist(statErr), "nothing may be staged from an interrupted download")
+	assertNoTempFiles(t, cacheDir, filepath.Dir(destPath))
+}
+
+// Prune deletes inside the cache directory, so the name has to be one nothing
+// else owns, clear of the app's cache and of anything instance.Name() produces.
+func TestDefaultCacheDirIsNobodyElses(t *testing.T) {
+	dir, err := DefaultCacheDir()
+	assert.NilError(t, err)
+	parent, err := os.UserCacheDir()
+	assert.NilError(t, err)
+
+	assert.Equal(t, dir, filepath.Join(parent, "rancher-desktop.guest-deps"))
+	assert.Assert(t, !strings.HasPrefix(dir, filepath.Join(parent, "rancher-desktop-")),
+		"%s is inside a directory instance.Name() can produce", dir)
+}
+
+// A peer sending just enough to restart the stall timer runs out the deadline
+// covering every attempt.
+func TestStageGivesUpOnATricklingTransfer(t *testing.T) {
+	shortenRetries(t)
+	shortenStallTimeout(t)
+	shortenDownloadTimeout(t, time.Second)
+
+	// A tenth of the stall window leaves the stall timer no chance to fire, so
+	// the deadline is what ends this, and it ends the first attempt: any retry
+	// here would mean the transfer stalled instead of running out of time.
+	server := newTricklingServer(t, stallTimeout/10)
+	dep := server.dependency([]byte("distro image"))
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- stager.Stage(t.Context(), dep, destPath) }()
+
+	select {
+	case err := <-done:
+		assert.ErrorContains(t, err, "gave up after "+downloadTimeout.String())
+		assert.Equal(t, server.requests.Load(), int32(1))
+	case <-time.After(30 * time.Second):
+		assert.Assert(t, false, "a trickling transfer held Stage past its deadline")
+	}
+	assertNoTempFiles(t, cacheDir, filepath.Dir(destPath))
+}
+
+// The transport catches a peer that accepts the request and never answers. The
+// stall timer starts on the body, which never arrives.
+func TestStageFailsAPeerThatNeverSendsHeaders(t *testing.T) {
+	shortenRetries(t)
+	shortenHeaderTimeout(t)
+
+	server := &assetServer{}
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		server.requests.Add(1)
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	server.url = srv.URL + "/" + testFilename
+
+	dep := server.dependency([]byte("distro image"))
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- stager.Stage(t.Context(), dep, destPath) }()
+
+	select {
+	case err := <-done:
+		assert.ErrorContains(t, err, "timeout awaiting response headers")
+		assert.Equal(t, server.requests.Load(), int32(downloadAttempts))
+	case <-time.After(30 * time.Second):
+		assert.Assert(t, false, "a peer that never answered held Stage; the header timeout never ran")
+	}
+	assertNoTempFiles(t, cacheDir, filepath.Dir(destPath))
+}
+
+// The progress line gives a percentage against the declared length, and the
+// bytes alone when the server declared none.
+func TestLogProgress(t *testing.T) {
+	for name, tc := range map[string]struct {
+		read, total int64
+		want        string
+	}{
+		"against a declared length": {read: 100 << 20, total: 200 << 20, want: "Downloaded 100.0 MiB of 200.0 MiB (50%)\n"},
+		"with no length to compare": {read: 100 << 20, total: -1, want: "Downloaded 100.0 MiB\n"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var log bytes.Buffer
+			(&Stager{Log: &log}).logProgress(tc.read, tc.total)
+			assert.Equal(t, log.String(), tc.want)
+		})
+	}
+}
+
+// Reading reports once the interval has passed and then goes quiet until the
+// next one. The reader is driven directly because the interval check compares
+// two clock readings, and a real transfer of a test-sized body finishes inside
+// one tick of the coarse monotonic clock Windows keeps.
+func TestProgressReaderReportsOnInterval(t *testing.T) {
+	var reads, totals []int64
+	r := &progressReader{
+		body:   bytes.NewReader(make([]byte, 64)),
+		total:  200,
+		next:   time.Now().Add(-time.Hour),
+		report: func(read, total int64) { reads, totals = append(reads, read), append(totals, total) },
+	}
+	r.timer = time.AfterFunc(time.Hour, func() {})
+	t.Cleanup(r.stop)
+
+	n, err := r.Read(make([]byte, 64))
+	assert.NilError(t, err)
+	assert.Equal(t, n, 64)
+	assert.DeepEqual(t, reads, []int64{64})
+	assert.DeepEqual(t, totals, []int64{200})
+
+	// The interval has just been reset, so the read after it says nothing.
+	_, _ = r.Read(make([]byte, 8))
+	assert.DeepEqual(t, reads, []int64{64})
+}
+
+// A server naming a delay is retried because of that header, even at a status
+// that would otherwise be fatal. maxRetryDelay still caps the wait, so it is
+// the ceiling, not the second the server named.
+func TestStageRetriesAServerThatNamesADelay(t *testing.T) {
+	shortenRetries(t)
+
+	for name, status := range map[string]int{
+		"too many requests": http.StatusTooManyRequests,
+		// GitHub throttles release downloads with 403 too, and a 403 carrying no
+		// delay is fatal, so the header is the whole difference here.
+		"forbidden": http.StatusForbidden,
+	} {
+		t.Run(name, func(t *testing.T) {
+			body := []byte("distro image")
+			server := newThrottlingServer(t, body, status)
+			dep := server.dependency(body)
+			var log bytes.Buffer
+			stager, _, destPath := stagerFor(t, &log)
+
+			assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+			assertContent(t, destPath, body)
+			assert.Equal(t, server.requests.Load(), int32(2))
+			assert.Assert(t, strings.Contains(log.String(), "Retrying in "+maxRetryDelay.String()),
+				"the named delay is consulted and capped, not replaced by the backoff; the log holds %q", log.String())
+		})
+	}
+}
+
+// A 408 says the request timed out, which a retry can fix, so it is not fatal.
+func TestStageRetriesARequestTimeout(t *testing.T) {
+	shortenRetries(t)
+
+	body := []byte("distro image")
+	server := newAssetServer(t, body, http.StatusRequestTimeout)
+	dep := server.dependency(body)
+	stager, _, destPath := stagerFor(t, nil)
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assertContent(t, destPath, body)
+	assert.Equal(t, server.requests.Load(), int32(2))
+}
+
+func TestRetryAfter(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	for name, tc := range map[string]struct {
+		value string
+		want  time.Duration
+		ok    bool
+	}{
+		"seconds":           {value: "120", want: 2 * time.Minute, ok: true},
+		"http date":         {value: "Wed, 09 Sep 2026 12:00:30 GMT", want: 30 * time.Second, ok: true},
+		"absent":            {value: ""},
+		"malformed":         {value: "in a while"},
+		"zero seconds":      {value: "0"},
+		"date already past": {value: "Wed, 09 Sep 2026 11:59:00 GMT"},
+		// Converting this many seconds to a Duration wraps negative, which would
+		// retry at once instead of waiting.
+		"seconds beyond a duration": {value: "31536000000", want: time.Duration(maxRetryAfterSeconds) * time.Second, ok: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := retryAfter(tc.value, now)
+			assert.Equal(t, ok, tc.ok)
+			if tc.ok {
+				assert.Equal(t, got, tc.want)
+			}
+		})
+	}
+}
+
+// The wait doubles per attempt, a server naming its own window overrides it, and
+// both stop at the ceiling so a throttle cannot park the build.
+func TestRetryWait(t *testing.T) {
+	dropped := errors.New("connection reset")
+
+	assert.Equal(t, retryWait(1, dropped), retryDelay)
+	assert.Equal(t, retryWait(3, dropped), 4*retryDelay)
+	assert.Equal(t, retryWait(9, dropped), maxRetryDelay)
+	assert.Equal(t, retryWait(1, &retryAfterError{err: dropped, delay: 5 * time.Second}), 5*time.Second)
+	assert.Equal(t, retryWait(1, &retryAfterError{err: dropped, delay: time.Hour}), maxRetryDelay)
+}
+
+// removeStaleEmptyDir treats an empty directory's timestamp as the moment it
+// was created, which is what leaves a concurrent build's fresh directory alone.
+// Go exposes no creation time on Linux, so the rule rests on mtime; this pins
+// that on every platform the tests run on, NTFS included. The cutoff sits a
+// minute back because a filesystem may coarsen timestamps, which the real
+// seven-day cutoff is far too wide to notice.
+func TestAFreshDirectoryOutlivesAPrune(t *testing.T) {
+	cutoff := time.Now().Add(-time.Minute)
+	dir := filepath.Join(t.TempDir(), "distro", "v"+testVersion)
+	assert.NilError(t, os.MkdirAll(dir, 0o755))
+
+	info, err := os.Stat(dir)
+	assert.NilError(t, err)
+	assert.Assert(t, info.ModTime().After(cutoff),
+		"a directory created just now reports mtime %s, older than the %s cutoff", info.ModTime(), cutoff)
+
+	removeStaleEmptyDir(dir, cutoff)
+	_, err = os.Stat(dir)
+	assert.NilError(t, err, "a directory younger than the cutoff must survive")
+}
+
+// An empty directory nothing has written to since the cutoff is the leftover of
+// a version that has aged out, so it goes.
+func TestPruneRemovesAStaleEmptyDirectory(t *testing.T) {
+	stager, cacheDir, _ := stagerFor(t, nil)
+	leftover := filepath.Join(cacheDir, "distro", "v0.2.6")
+	assert.NilError(t, os.MkdirAll(leftover, 0o755))
+	age(t, leftover)
+	age(t, filepath.Dir(leftover))
+
+	assert.NilError(t, stager.Prune())
+
+	assertMissing(t, leftover)
+	_, err := os.Stat(filepath.Dir(leftover))
+	assert.NilError(t, err, "the dependency directory is not removed")
+}
+
+// Prune drops what no build has used for cacheTTL, whether that is a superseded
+// download or the partial file a killed build left behind, and leaves the entry
+// a build touched. The directory it empties keeps its own timestamp until the
+// next run, so a second pass collects it.
+func TestPruneRemovesUnusedDownloads(t *testing.T) {
+	stager, cacheDir, _ := stagerFor(t, nil)
+	superseded := writeCacheFile(t, cacheDir, "distro", "v0.2.6", "distro.v0.2.6.amd64.raw.xz")
+	partial := writeCacheFile(t, cacheDir, "distro", "v"+testVersion, testFilename+".tmp-1234")
+	current := writeCacheFile(t, cacheDir, "distro", "v"+testVersion, testFilename)
+	age(t, superseded)
+	age(t, partial)
+
+	assert.NilError(t, stager.Prune())
+
+	assertMissing(t, superseded)
+	assertMissing(t, partial)
+	_, err := os.Stat(current)
+	assert.NilError(t, err, "an entry a build just used must survive")
+
+	emptied := filepath.Join(cacheDir, "distro", "v0.2.6")
+	_, err = os.Stat(emptied)
+	assert.NilError(t, err, "the directory this run emptied is too new to collect yet")
+	age(t, emptied)
+	assert.NilError(t, stager.Prune())
+	assertMissing(t, emptied)
+}
+
+// An empty directory a prune finds beside its own is not necessarily its own,
+// so nothing at that level is removed.
+func TestPruneLeavesForeignEmptyDirectoriesAlone(t *testing.T) {
+	stager, cacheDir, _ := stagerFor(t, nil)
+	stranger := filepath.Join(cacheDir, "GPUCache")
+	assert.NilError(t, os.MkdirAll(stranger, 0o755))
+	age(t, stranger)
+
+	assert.NilError(t, stager.Prune())
+
+	_, err := os.Stat(stranger)
+	assert.NilError(t, err, "an empty directory this tool did not create must survive")
+}
+
+// Prune descends only the <name>/v<version>/ directories cachePath creates.
+func TestPruneLeavesForeignFilesAlone(t *testing.T) {
+	stager, cacheDir, _ := stagerFor(t, nil)
+	strangers := []string{
+		writeCacheFile(t, cacheDir, "updater-longhorn.json"),
+		writeCacheFile(t, cacheDir, "Cache", "data_0"),
+		writeCacheFile(t, cacheDir, "tls", "server.crt"),
+		writeCacheFile(t, cacheDir, "distro", "notaversion", "keep-me"),
+	}
+	for _, path := range strangers {
+		age(t, path)
+	}
+
+	assert.NilError(t, stager.Prune())
+
+	for _, path := range strangers {
+		_, err := os.Stat(path)
+		assert.NilError(t, err, "%s is not this tool's to remove", path)
+	}
+}
+
+// A first build has no cache to prune.
+func TestPruneWithoutACache(t *testing.T) {
+	stager, _, _ := stagerFor(t, nil)
+	assert.NilError(t, stager.Prune())
+}
+
+// Staging marks the entry it used, both when it copies from the cache and when
+// it finds the staged file already current, so an entry a build still depends
+// on stops looking stale to the next prune.
+func TestStageTouchesTheCacheEntryItUses(t *testing.T) {
+	body := []byte("distro image")
+	server := newAssetServer(t, body)
+	dep := server.dependency(body)
+	stager, cacheDir, destPath := stagerFor(t, nil)
+	cachePath := cachedAsset(cacheDir)
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+
+	// Staging from the cache.
+	age(t, cachePath)
+	assert.NilError(t, os.Remove(destPath))
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assert.NilError(t, stager.Prune())
+	_, err := os.Stat(cachePath)
+	assert.NilError(t, err, "the entry this build copied from must survive a prune")
+
+	// Finding the staged file already current.
+	age(t, cachePath)
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assert.NilError(t, stager.Prune())
+	_, err = os.Stat(cachePath)
+	assert.NilError(t, err, "the entry backing an up-to-date build must survive a prune")
+}
+
+// age backdates path beyond cacheTTL, so the next prune would collect it.
+func age(t *testing.T, path string) {
+	t.Helper()
+	old := time.Now().Add(-cacheTTL - time.Hour)
+	assert.NilError(t, os.Chtimes(path, old, old))
+}
+
+func writeCacheFile(t *testing.T, cacheDir string, elem ...string) string {
+	t.Helper()
+	path := filepath.Join(append([]string{cacheDir}, elem...)...)
+	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	assert.NilError(t, os.WriteFile(path, []byte("cached bytes"), 0o644))
+	return path
+}
+
+func assertMissing(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.Assert(t, os.IsNotExist(err), "%s should have been pruned", path)
+}
+
+// A directory whose name only starts with "v" is not a version directory, so
+// nothing inside it is a download to collect.
+func TestPruneLeavesAVendorDirectoryAlone(t *testing.T) {
+	stager, cacheDir, _ := stagerFor(t, nil)
+	stranger := writeCacheFile(t, cacheDir, "distro", "vendor", "config.json")
+	age(t, stranger)
+
+	assert.NilError(t, stager.Prune())
+
+	_, err := os.Stat(stranger)
+	assert.NilError(t, err, "a vendor directory holds no downloads")
+}
+
+// Builds share the cache, so one of them removing a directory underfoot must
+// not stop the rest of the sweep.
+func TestPruneContinuesPastAnUnreadableDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not restrict listing on Windows")
+	}
+	stager, cacheDir, _ := stagerFor(t, nil)
+	// "aaa" sorts before "distro", so it is swept first.
+	writeCacheFile(t, cacheDir, "aaa", "v1.0.0", "asset.xz")
+	blocked := filepath.Join(cacheDir, "aaa")
+	stale := writeCacheFile(t, cacheDir, "distro", "v"+testVersion, testFilename)
+	age(t, stale)
+	assert.NilError(t, os.Chmod(blocked, 0))
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+	if _, err := os.ReadDir(blocked); err == nil {
+		t.Skip("this user can read a directory with no permissions")
+	}
+
+	assert.NilError(t, stager.Prune())
+
+	assertMissing(t, stale)
+}
+
+// removeOnLog deletes path the first time the stager logs, which falls between
+// Stage's checksum of the cache entry and its copy of that entry.
+type removeOnLog struct {
+	path string
+	done bool
+}
+
+func (w *removeOnLog) Write(p []byte) (int, error) {
+	if !w.done {
+		w.done = true
+		_ = os.Remove(w.path)
+	}
+	return len(p), nil
+}
+
+// An entry a concurrent prune takes between the checksum and the copy is a
+// cache miss, not a failed build. touch cannot close that window, because the
+// prune decides from a stat taken before it.
+func TestStageRecoversFromAVanishedCacheEntry(t *testing.T) {
+	body := []byte("distro image")
+	server := newAssetServer(t, body)
+	dep := server.dependency(body)
+	stager, cacheDir, destPath := stagerFor(t, nil)
+
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+	assert.NilError(t, os.Remove(destPath))
+
+	stager.Log = &removeOnLog{path: cachedAsset(cacheDir)}
+	assert.NilError(t, stager.Stage(t.Context(), dep, destPath))
+
+	assertContent(t, destPath, body)
+	assert.Equal(t, server.requests.Load(), int32(2), "the vanished entry must be downloaded again")
+}
+
+// rddepman writes some versions with a leading "v". Without normalising it the
+// entry would cache under vv1.2.3 and no prune would ever descend to it.
+func TestPruneCollectsAVPrefixedVersion(t *testing.T) {
+	stager, cacheDir, _ := stagerFor(t, nil)
+	dep := Dependency{
+		Name:    "wix",
+		Version: "v3.14.1",
+		Asset:   Asset{Platform: "linux", URL: "https://example.test/wix.tar.gz", Checksum: "sha256:" + strings.Repeat("0", 64)},
+	}
+	cachePath, err := stager.cachePath(dep)
+	assert.NilError(t, err)
+	assert.Equal(t, cachePath, filepath.Join(cacheDir, "wix", "v3.14.1", "wix.tar.gz"))
+
+	assert.NilError(t, os.MkdirAll(filepath.Dir(cachePath), 0o755))
+	assert.NilError(t, os.WriteFile(cachePath, []byte("archive"), 0o644))
+	age(t, cachePath)
+
+	assert.NilError(t, stager.Prune())
+	assertMissing(t, cachePath)
+}

--- a/scripts/dependencies/nerdctl.ts
+++ b/scripts/dependencies/nerdctl.ts
@@ -12,9 +12,9 @@ import {
 const ARCHES: readonly GoArch[] = ['amd64', 'arm64'];
 
 /**
- * nerdctl, baked into the guest image via the distro overlay.  rddepman tracks
- * it like any other GitHub dependency; the Go downloader fetches it at build
- * time, so there is no host install.
+ * nerdctl, which the distro overlay will bake into the guest image.  rddepman
+ * tracks it like any other GitHub dependency, so there is no host install.
+ * The Go downloader stages only the distro until the overlay work lands.
  */
 export class Nerdctl extends GlobalDependency(GitHubDependency) {
   readonly name = 'nerdctl';
@@ -23,7 +23,7 @@ export class Nerdctl extends GlobalDependency(GitHubDependency) {
   readonly manifestPath = GUEST_DEP_VERSIONS_PATH;
 
   download(_context: DownloadContext): Promise<void> {
-    return Promise.reject(new Error('nerdctl is staged by the build, not by postinstall'));
+    return Promise.reject(new Error('nerdctl is a guest-only dependency and is not installed by postinstall'));
   }
 
   async getAssets(version: string): Promise<DependencyAsset[]> {


### PR DESCRIPTION
Fixes #709.

Adds `download-guest-deps`, which stages the distro image for the rdd build to embed. It picks the asset for the build target from `rdd/dependencies.yaml` and verifies the bytes against the checksum rddepman recorded. Nothing calls it yet; the Makefile rule and the embed come with #708.

The second commit corrects rddepman's nerdctl note, which claimed the build already stages nerdctl.

To try it, follow "Trying it out" in `rdd/cmd/download-guest-deps/README.md`.
