### PR TITLE
CI: yarn-dedupe: Fix getting tokens

### DIFF
--- a/.github/workflows/yarn-dedupe.yaml
+++ b/.github/workflows/yarn-dedupe.yaml
@@ -8,27 +8,22 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # required for get-token
 
 jobs:
-  check-for-token:
-    outputs:
-      has-token: ${{ steps.calc.outputs.HAS_SECRET }}
-    runs-on: ubuntu-latest
-    steps:
-    - id: calc
-      run: echo "HAS_SECRET=${HAS_SECRET}" >> "${GITHUB_OUTPUT}"
-      env:
-        HAS_SECRET: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
-
   yarn-dedupe:
-    needs: check-for-token
-    if: needs.check-for-token.outputs.has-token == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - uses: ./.github/actions/yarn-install
+    - id: get-token
+      uses: ./.github/actions/get-token
+      continue-on-error: true
+      with:
+        token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
     - run: ./scripts/yarn-dedupe.sh --push
+      if: steps.get-token.outcome == 'success'
       env:
-        GITHUB_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+        GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
We no longer use `RUN_WORKFLOW_FROM_WORKFLOW`, at least in this repo.

This created #724.