### PR TITLE
E2E: Update configuration

### DIFF
--- a/e2e/config/playwright-config.ts
+++ b/e2e/config/playwright-config.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import * as path from 'path';
 
 import { defineConfig } from '@playwright/test';
@@ -11,10 +12,11 @@ const timeScale = ci ? 4 : 1;
 const config = defineConfig({
   testDir,
   outputDir,
+  forbidOnly:    ci,
   timeout:       10 * 60 * 1000 * timeScale,
   globalTimeout: 30 * 60 * 1000 * timeScale,
-  workers:       1,
-  reporter:      'list',
+  workers:       ci ? 1 : os.availableParallelism(),
+  reporter:      ci ? [['github'], ['list']] : 'list',
   retries:       ci ? 2 : 0,
   use:           {
     trace: {


### PR DESCRIPTION
- Use multiple workers on developer machines; this is possible because we use a different RDD instance per test file anyway.
- Forbid `test.only` in CI.
- Add the `github` built-in reporter in CI.

Sample run: https://github.com/mook-as/rd2/actions/runs/34418158732 — there's a new annotation (from the `github` reporter, I believe).