### PR TITLE
CI: use self-repository syntax for uses:

### DIFF
--- a/.github/workflows/docker-cli-monitor.yaml
+++ b/.github/workflows/docker-cli-monitor.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/yarn-install
+      - uses: $/.github/actions/yarn-install
 
       - run: yarn dcmonitor
         env:

--- a/.github/workflows/e2e-playwright.yaml
+++ b/.github/workflows/e2e-playwright.yaml
@@ -17,7 +17,7 @@ jobs:
       github.repository_owner != 'rancher-sandbox' ||
       github.ref_name == 'main' ||
       startsWith(github.ref_name, 'release-')
-    uses: ./.github/workflows/paths-ignore.yaml
+    uses: $/.github/workflows/paths-ignore.yaml
   e2e-tests:
     needs: check-paths
     if: needs.check-paths.outputs.should-run == 'true'
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/yarn-install
+      - uses: $/.github/actions/yarn-install
       - name: Enable kvm access
         run: sudo chmod a+rwx /dev/kvm
       - name: Run e2e Tests

--- a/.github/workflows/go-mod-k8s-sync.yaml
+++ b/.github/workflows/go-mod-k8s-sync.yaml
@@ -63,18 +63,17 @@ jobs:
       && (!github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-      id-token: write # Required for ./.github/actions/get-token
+      id-token: write # Required for $/.github/actions/get-token
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rdd
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - # Get a GitHub token that can write to the repository, and will trigger CI
       # on commit.  The normal github.token will not trigger further CI.
       id: get-token
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-      uses: ./.github/actions/get-token
+      uses: $/.github/actions/get-token
       continue-on-error: true
       with:
         token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
     - run: yarn test:unit:jest
   test-wix-helper:
     name: Wix Helper Tests
@@ -196,7 +196,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
     - run: yarn lint:typescript:nofix
 #  spelling:
 #    name: Check Spelling
@@ -245,7 +245,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
     - run: yarn license-check
     - run: ./scripts/go-license-check.sh
       shell: bash

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   check-paths:
-    uses: ./.github/workflows/paths-ignore.yaml
+    uses: $/.github/workflows/paths-ignore.yaml
     with:
       paths-ignore-globs: |
         .github/actions/spelling/**
@@ -65,7 +65,7 @@ jobs:
         persist-credentials: false
         # Needed to run `git describe` to get full version info
         fetch-depth: 0
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
       with:
         GOARCH: ${{ env.GOARCH }}
     - run: yarn build
@@ -188,7 +188,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       name: Download artifact
       with:
@@ -241,7 +241,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       name: Download artifact
       with:

--- a/.github/workflows/paths-ignore.yaml
+++ b/.github/workflows/paths-ignore.yaml
@@ -6,7 +6,7 @@
 # Usage:
 #   jobs:
 #     check-paths:
-#        uses: ./.github/workflows/paths-ignore.yaml
+#        uses: $/.github/workflows/paths-ignore.yaml
 #     do_thing:
 #        needs: check-paths
 #        if: needs.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/rdd-bats.yaml
+++ b/.github/workflows/rdd-bats.yaml
@@ -192,7 +192,7 @@ jobs:
 
     - name: "Windows: disable Compatibility Telemetry"
       if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
-      uses: ./.github/actions/disable-compat-telemetry
+      uses: $/.github/actions/disable-compat-telemetry
 
     - name: "Windows: WSL debugging"
       if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
@@ -204,14 +204,14 @@ jobs:
 
     - name: "Windows: capture machine info"
       if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
-      uses: ./.github/actions/windows-machine-info
+      uses: $/.github/actions/windows-machine-info
       with:
         output-path: rdd/rdd-logs/_diag/machine-info.txt
       continue-on-error: true
 
     - name: "Windows: start typeperf sampler"
       if: needs.check-paths.outputs.should-run && runner.os == 'Windows'
-      uses: ./.github/actions/windows-typeperf-sampler
+      uses: $/.github/actions/windows-typeperf-sampler
       with:
         command: start
         output-dir: rdd/rdd-logs/_diag
@@ -267,7 +267,7 @@ jobs:
 
     - name: "Windows: stop typeperf sampler"
       if: always() && needs.check-paths.outputs.should-run && runner.os == 'Windows'
-      uses: ./.github/actions/windows-typeperf-sampler
+      uses: $/.github/actions/windows-typeperf-sampler
       with:
         command: stop
         output-dir: rdd/rdd-logs/_diag

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -13,9 +13,13 @@ jobs:
   check-update-versions:
     permissions:
       contents: read
-      id-token: write # Required for ./.github/actions/get-token
+      id-token: write # Required for $/.github/actions/get-token
     runs-on: ubuntu-latest
     steps:
+      - id: get-token
+        uses: $/.github/actions/get-token
+        with:
+          token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -24,12 +28,7 @@ jobs:
           # github.token would override that, so keep it out of git config.
           persist-credentials: false
 
-      - uses: ./.github/actions/yarn-install
-
-      - id: get-token
-        uses: ./.github/actions/get-token
-        with:
-          token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+      - uses: $/.github/actions/yarn-install
 
       - run: yarn rddepman host
         env:

--- a/.github/workflows/release-merge-to-main.yaml
+++ b/.github/workflows/release-merge-to-main.yaml
@@ -32,7 +32,7 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
     - run: node scripts/ts-wrapper.js scripts/release-merge-to-main.ts
       env:
         GITHUB_WRITE_TOKEN: ${{ github.token }}

--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -70,8 +70,8 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/yarn-install
-    - uses: ./.github/actions/setup-environment
+    - uses: $/.github/actions/yarn-install
+    - uses: $/.github/actions/setup-environment
     - name: Override version
       if: inputs.mock_version
       run: echo "RD_MOCK_VERSION=${{ inputs.mock_version }}" >> "${GITHUB_ENV}"

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -155,7 +155,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up environment
-      uses: ./.github/actions/setup-environment
+      uses: $/.github/actions/setup-environment
 
     - name: "Linux: Set startup command"
       if: runner.os == 'Linux'
@@ -258,7 +258,7 @@ jobs:
         echo "RDD_LOG_DIR=$RDD_LOG_DIR" >> "$GITHUB_ENV"
         mkdir -p $RDD_LOG_DIR
         chown --recursive ci-user "$LOGS_DIR"
-    - uses: ./.github/actions/setup-environment
+    - uses: $/.github/actions/setup-environment
     - name: Install Rancher Desktop from package
       if: runner.os == 'Linux'
       run: .github/workflows/smoke-test/install-from-repo.sh
@@ -347,7 +347,7 @@ jobs:
         echo "RDD_LOG_DIR=$RDD_LOG_DIR" >> "$GITHUB_ENV"
         mkdir -p $RDD_LOG_DIR
         chown --recursive ci-user "$LOGS_DIR"
-    - uses: ./.github/actions/setup-environment
+    - uses: $/.github/actions/setup-environment
       with:
         user: ci-user
 

--- a/.github/workflows/ucmonitor.yaml
+++ b/.github/workflows/ucmonitor.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/yarn-install
+      - uses: $/.github/actions/yarn-install
 
       - run: yarn ucmonitor
         env:

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -23,7 +23,7 @@ jobs:
         persist-credentials: false
         # Needed to run `git describe` to get full version info
         fetch-depth: 0
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
       with:
         GOARCH: ${{ case(matrix.arch == 'aarch64', 'arm64', 'amd64') }}
     - run: yarn build
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/yarn-install
+    - uses: $/.github/actions/yarn-install
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: gh-pages

--- a/.github/workflows/yarn-dedupe.yaml
+++ b/.github/workflows/yarn-dedupe.yaml
@@ -14,15 +14,15 @@ jobs:
   yarn-dedupe:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 0
-    - uses: ./.github/actions/yarn-install
     - id: get-token
-      uses: ./.github/actions/get-token
+      uses: $/.github/actions/get-token
       continue-on-error: true
       with:
         token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+    - uses: $/.github/actions/yarn-install
     - run: ./scripts/yarn-dedupe.sh --push
       if: steps.get-token.outcome == 'success'
       env:


### PR DESCRIPTION
GitHub now supports a new syntax to indicate that a reusable workflow comes from the same repository; it does not require an explicit checkout before use.  Switch to that syntax to avoid the potential of using the incorrect workflow.

See: https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/