### PR TITLE
Revert "build(deps-dev): bump @rancher/components"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,11 @@ updates:
     # TypeError.  Drop this rule once they support 7.x.
     dependency-name: "typescript"
     update-types: [version-update:semver-major]
+  - # @rancher/components is currently undergoing major changes, where new
+    # components under different names are being introduced.  The old components
+    # are not being maintained as well.  Instead of updating, we will have
+    # better results forking instead.
+    dependency-name: "@rancher/components"
   groups:
     # vue pins @vue/compiler-sfc exactly, so separate bumps break the lockfile.
     vue:

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@eslint/config-helpers": "0.7.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.62.1",
-    "@rancher/components": "0.3.0-alpha.4",
+    "@rancher/components": "0.3.0-alpha.1",
     "@types/cross-spawn": "6.0.6",
     "@types/dompurify": "3.2.0",
     "@types/ejs": "3.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3406,23 +3406,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rancher/components@npm:0.3.0-alpha.4":
-  version: 0.3.0-alpha.4
-  resolution: "@rancher/components@npm:0.3.0-alpha.4"
+"@rancher/components@npm:0.3.0-alpha.1":
+  version: 0.3.0-alpha.1
+  resolution: "@rancher/components@npm:0.3.0-alpha.1"
   dependencies:
-    "@rancher/icons": "npm:^2.0.54"
     lodash.debounce: "npm:4.0.8"
   peerDependencies:
-    core-js: 3.40.0
-    vue: ^3.2.13
-  checksum: 10c0/24752e322bb1ff10dc823e17411f29691f7691b600b8c94fc483a40509a42ba4cc00623491e872697cbf4d57ff831d3b6c72cfcfe6317cdb557e9e0da0c42e73
-  languageName: node
-  linkType: hard
-
-"@rancher/icons@npm:^2.0.54":
-  version: 2.0.63
-  resolution: "@rancher/icons@npm:2.0.63"
-  checksum: 10c0/b775e08c5d8e5c16650d20b82d96acd5ad931e9b80302e0c5cd1d7e4477463b32b6a4c2b594b162f002701e760d8075f86bc1f9eaad84b2d51abfcc478ad5dca
+    core-js: 3.25.3
+    vue: ~3.2.13
+  checksum: 10c0/ba6cef3e764671711c72042321c3129fbb75df8f0824b60acaf8c53da69adb9988994d6d1aba7604217ca510f6e8e36158abb785ec3148dd4fce42a746afab6f
   languageName: node
   linkType: hard
 
@@ -14374,7 +14366,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@kubernetes/client-node": "npm:2.0.0"
     "@playwright/test": "npm:1.62.1"
-    "@rancher/components": "npm:0.3.0-alpha.4"
+    "@rancher/components": "npm:0.3.0-alpha.1"
     "@types/cross-spawn": "npm:6.0.6"
     "@types/dompurify": "npm:3.2.0"
     "@types/ejs": "npm:3.1.5"


### PR DESCRIPTION
This reverts commit 5e004f71c9af86a39283420a1eacec307ac13514.

Also update dependabot configuration to never update that component; it currently does not appear to be worth bumping.  For deatails, see https://github.com/rancher-sandbox/rancher-desktop-2/issues/740