### PR TITLE
rddepman: quote release notes without pinging upstream

### DIFF
--- a/scripts/lib/__tests__/release-notes.spec.ts
+++ b/scripts/lib/__tests__/release-notes.spec.ts
@@ -1,4 +1,4 @@
-import { quoteReleaseNotes } from '../release-notes';
+import { formatReleaseNotes, quoteReleaseNotes, Release } from '../release-notes';
 
 describe('quoteReleaseNotes', () => {
   /** A mention in its quoted form. */
@@ -53,5 +53,29 @@ describe('quoteReleaseNotes', () => {
     'https://github.com/other/project/compare/v1.0.0...v1.1.0',
   ])('leaves %j unchanged', (body) => {
     expect(quoteReleaseNotes(body, 'upstream', 'project')).toEqual(body);
+  });
+});
+
+describe('formatReleaseNotes', () => {
+  /** A release of upstream/project. */
+  function release(version: string, body: string): Release {
+    return {
+      name: version, tag_name: version, html_url: `https://github.com/upstream/project/releases/tag/${ version }`, body,
+    };
+  }
+
+  it('quotes the notes of the newest release and links the older ones', () => {
+    const releases = [release('v1.1.0', 'Older notes'), release('v1.2.0', 'Fix #13')];
+
+    expect(formatReleaseNotes(releases, 'v1.0.0', 'upstream', 'project')).toEqual([
+      '## v1.1.0 (v1.1.0)',
+      '[Release notes](https://github.com/upstream/project/releases/tag/v1.1.0)',
+      '[Compare between v1.0.0 and v1.1.0](https://github.com/upstream/project/compare/v1.0.0...v1.1.0)',
+      '',
+      '## v1.2.0 (v1.2.0)',
+      'Fix <a href="https://redirect.github.com/upstream/project/issues/13">#13</a>',
+      '[Compare between v1.1.0 and v1.2.0](https://github.com/upstream/project/compare/v1.1.0...v1.2.0)',
+      '',
+    ].join('\n'));
   });
 });

--- a/scripts/lib/__tests__/release-notes.spec.ts
+++ b/scripts/lib/__tests__/release-notes.spec.ts
@@ -11,6 +11,9 @@ describe('quoteReleaseNotes', () => {
     return `<a href="https://redirect.github.com/${ repository }/issues/${ number }">${ text }</a>`;
   }
 
+  /** A bare pull request URL in its quoted form. */
+  const pullRequest = '<a href="https://redirect.github.com/other/project/pull/56">other/project#56</a>';
+
   it.each([
     ['* Fix it by @someone in #12', `* Fix it by ${ mention('someone') } in ${ link('upstream/project', 12) }`],
     ['Thanks (@another-person)', `Thanks (${ mention('another-person') })`],
@@ -25,10 +28,14 @@ describe('quoteReleaseNotes', () => {
     ['Thanks _@someone_', `Thanks _${ mention('someone') }_`],
     ['See _other/project#34_', `See _${ link('other/project', 34, 'other/project#34') }_`],
     ['Fixes _#12_ and __GH-13__', `Fixes _${ link('upstream/project', 12) }_ and __${ link('upstream/project', 13, 'GH-13') }__`],
-    ['in https://github.com/other/project/pull/56', 'in https://redirect.github.com/other/project/pull/56'],
-    ['in http://github.com/other/project/pull/56', 'in https://redirect.github.com/other/project/pull/56'],
-    ['_https://github.com/other/project/pull/56_', '_https://redirect.github.com/other/project/pull/56_'],
+    ['in https://github.com/other/project/pull/56', `in ${ pullRequest }`],
+    ['in http://github.com/other/project/pull/56', `in ${ pullRequest }`],
+    ['_https://github.com/other/project/pull/56_', `_${ pullRequest }_`],
     ['[fixes #56](https://github.com/other/project/pull/56)', '[fixes #56](https://redirect.github.com/other/project/pull/56)'],
+    ['[56]: https://github.com/other/project/pull/56', '[56]: https://redirect.github.com/other/project/pull/56'],
+    ['<https://github.com/other/project/pull/56>', '<https://redirect.github.com/other/project/pull/56>'],
+    ['<a href="https://github.com/other/project/pull/56">fix</a>', '<a href="https://redirect.github.com/other/project/pull/56">fix</a>'],
+    ['https://github.com/other/project/pull/56/files', 'https://redirect.github.com/other/project/pull/56/files'],
   ])('rewrites %j', (body, expected) => {
     expect(quoteReleaseNotes(body, 'upstream', 'project')).toEqual(expected);
   });

--- a/scripts/lib/__tests__/release-notes.spec.ts
+++ b/scripts/lib/__tests__/release-notes.spec.ts
@@ -1,0 +1,38 @@
+import { quoteReleaseNotes } from '../release-notes';
+
+describe('quoteReleaseNotes', () => {
+  /** A mention in its quoted form. */
+  function code(handle: string): string {
+    return `<code>@\u200B${ handle }</code>`;
+  }
+
+  /** An issue reference in its quoted form. */
+  function link(repository: string, number: number): string {
+    return `[${ repository }#${ number }](https://redirect.github.com/${ repository }/issues/${ number })`;
+  }
+
+  it.each([
+    ['* Fix it by @someone in #12', `* Fix it by ${ code('someone') } in ${ link('example/tool', 12) }`],
+    ['Thanks (@another-person)', `Thanks (${ code('another-person') })`],
+    ['cc @example/maintainers', `cc ${ code('example/maintainers') }`],
+    ['See other/project#34', `See ${ link('other/project', 34) }`],
+    ['See [#34]', `See [${ link('example/tool', 34) }]`],
+    ['in https://github.com/example/tool/pull/56', 'in https://redirect.github.com/example/tool/pull/56'],
+    ['[fixes #56](https://github.com/example/tool/pull/56)', '[fixes #56](https://redirect.github.com/example/tool/pull/56)'],
+  ])('rewrites %j', (body, expected) => {
+    expect(quoteReleaseNotes(body, 'example', 'tool')).toEqual(expected);
+  });
+
+  it.each([
+    'Write to someone@example.com',
+    'Read https://blog.example.com/@someone/post',
+    '[found by @someone](https://example.com)',
+    'Run `npm install @scope/package`',
+    '```\n@someone fixed #12\n```',
+    'https://example.com/page#12',
+    'Zero&#8203;width',
+    'https://github.com/example/tool/compare/v1.0.0...v1.1.0',
+  ])('leaves %j unchanged', (body) => {
+    expect(quoteReleaseNotes(body, 'example', 'tool')).toEqual(body);
+  });
+});

--- a/scripts/lib/__tests__/release-notes.spec.ts
+++ b/scripts/lib/__tests__/release-notes.spec.ts
@@ -22,6 +22,9 @@ describe('quoteReleaseNotes', () => {
     ['Fixes GH-12', `Fixes ${ link('upstream/project', 12, 'GH-12') }`],
     ['Fixes #12/#13', `Fixes ${ link('upstream/project', 12) }/${ link('upstream/project', 13) }`],
     ['Escaped \\#12 and \\@someone', `Escaped ${ link('upstream/project', 12, '\\#12') } and ${ mention('someone') }`],
+    ['Thanks _@someone_', `Thanks _${ mention('someone') }_`],
+    ['See _other/project#34_', `See _${ link('other/project', 34, 'other/project#34') }_`],
+    ['Fixes _#12_ and __GH-13__', `Fixes _${ link('upstream/project', 12) }_ and __${ link('upstream/project', 13, 'GH-13') }__`],
     ['in https://github.com/other/project/pull/56', 'in https://redirect.github.com/other/project/pull/56'],
     ['in http://github.com/other/project/pull/56', 'in https://redirect.github.com/other/project/pull/56'],
     ['_https://github.com/other/project/pull/56_', '_https://redirect.github.com/other/project/pull/56_'],
@@ -32,6 +35,7 @@ describe('quoteReleaseNotes', () => {
 
   it.each([
     'Write to someone@example.com',
+    'snake_#12 and snake_@someone',
     'Read https://blog.example.com/@someone/post',
     '[found by @someone](https://example.com)',
     'Run `npm install @scope/package`',

--- a/scripts/lib/__tests__/release-notes.spec.ts
+++ b/scripts/lib/__tests__/release-notes.spec.ts
@@ -2,25 +2,27 @@ import { quoteReleaseNotes } from '../release-notes';
 
 describe('quoteReleaseNotes', () => {
   /** A mention in its quoted form. */
-  function code(handle: string): string {
-    return `<code>@\u200B${ handle }</code>`;
+  function mention(handle: string, profile = handle): string {
+    return `<a href="https://github.com/${ profile }"><code>@\u200B${ handle }</code></a>`;
   }
 
   /** An issue reference in its quoted form. */
-  function link(repository: string, number: number): string {
-    return `[${ repository }#${ number }](https://redirect.github.com/${ repository }/issues/${ number })`;
+  function link(repository: string, number: number, text = `#${ number }`): string {
+    return `<a href="https://redirect.github.com/${ repository }/issues/${ number }">${ text }</a>`;
   }
 
   it.each([
-    ['* Fix it by @someone in #12', `* Fix it by ${ code('someone') } in ${ link('example/tool', 12) }`],
-    ['Thanks (@another-person)', `Thanks (${ code('another-person') })`],
-    ['cc @example/maintainers', `cc ${ code('example/maintainers') }`],
-    ['See other/project#34', `See ${ link('other/project', 34) }`],
-    ['See [#34]', `See [${ link('example/tool', 34) }]`],
+    ['* Fix it by @someone in #12', `* Fix it by ${ mention('someone') } in ${ link('upstream/project', 12) }`],
+    ['Thanks (@another-person)', `Thanks (${ mention('another-person') })`],
+    ['Thanks @someone.', `Thanks ${ mention('someone') }.`],
+    ['cc @example/maintainers', `cc ${ mention('example/maintainers', 'orgs/example/teams/maintainers') }`],
+    ['See other/project#34', `See ${ link('other/project', 34, 'other/project#34') }`],
+    ['See [#34]', `See [${ link('upstream/project', 34) }]`],
     ['in https://github.com/example/tool/pull/56', 'in https://redirect.github.com/example/tool/pull/56'],
+    ['_https://github.com/example/tool/pull/56_', '_https://redirect.github.com/example/tool/pull/56_'],
     ['[fixes #56](https://github.com/example/tool/pull/56)', '[fixes #56](https://redirect.github.com/example/tool/pull/56)'],
   ])('rewrites %j', (body, expected) => {
-    expect(quoteReleaseNotes(body, 'example', 'tool')).toEqual(expected);
+    expect(quoteReleaseNotes(body, 'upstream', 'project')).toEqual(expected);
   });
 
   it.each([
@@ -33,6 +35,6 @@ describe('quoteReleaseNotes', () => {
     'Zero&#8203;width',
     'https://github.com/example/tool/compare/v1.0.0...v1.1.0',
   ])('leaves %j unchanged', (body) => {
-    expect(quoteReleaseNotes(body, 'example', 'tool')).toEqual(body);
+    expect(quoteReleaseNotes(body, 'upstream', 'project')).toEqual(body);
   });
 });

--- a/scripts/lib/__tests__/release-notes.spec.ts
+++ b/scripts/lib/__tests__/release-notes.spec.ts
@@ -22,10 +22,10 @@ describe('quoteReleaseNotes', () => {
     ['Fixes GH-12', `Fixes ${ link('upstream/project', 12, 'GH-12') }`],
     ['Fixes #12/#13', `Fixes ${ link('upstream/project', 12) }/${ link('upstream/project', 13) }`],
     ['Escaped \\#12 and \\@someone', `Escaped ${ link('upstream/project', 12, '\\#12') } and ${ mention('someone') }`],
-    ['in https://github.com/example/tool/pull/56', 'in https://redirect.github.com/example/tool/pull/56'],
-    ['in http://github.com/example/tool/pull/56', 'in https://redirect.github.com/example/tool/pull/56'],
-    ['_https://github.com/example/tool/pull/56_', '_https://redirect.github.com/example/tool/pull/56_'],
-    ['[fixes #56](https://github.com/example/tool/pull/56)', '[fixes #56](https://redirect.github.com/example/tool/pull/56)'],
+    ['in https://github.com/other/project/pull/56', 'in https://redirect.github.com/other/project/pull/56'],
+    ['in http://github.com/other/project/pull/56', 'in https://redirect.github.com/other/project/pull/56'],
+    ['_https://github.com/other/project/pull/56_', '_https://redirect.github.com/other/project/pull/56_'],
+    ['[fixes #56](https://github.com/other/project/pull/56)', '[fixes #56](https://redirect.github.com/other/project/pull/56)'],
   ])('rewrites %j', (body, expected) => {
     expect(quoteReleaseNotes(body, 'upstream', 'project')).toEqual(expected);
   });
@@ -39,7 +39,7 @@ describe('quoteReleaseNotes', () => {
     'https://example.com/page#12',
     'https://example.com/#12',
     'Zero&#8203;width',
-    'https://github.com/example/tool/compare/v1.0.0...v1.1.0',
+    'https://github.com/other/project/compare/v1.0.0...v1.1.0',
   ])('leaves %j unchanged', (body) => {
     expect(quoteReleaseNotes(body, 'upstream', 'project')).toEqual(body);
   });

--- a/scripts/lib/__tests__/release-notes.spec.ts
+++ b/scripts/lib/__tests__/release-notes.spec.ts
@@ -16,9 +16,14 @@ describe('quoteReleaseNotes', () => {
     ['Thanks (@another-person)', `Thanks (${ mention('another-person') })`],
     ['Thanks @someone.', `Thanks ${ mention('someone') }.`],
     ['cc @example/maintainers', `cc ${ mention('example/maintainers', 'orgs/example/teams/maintainers') }`],
+    ['Thanks @someone/@another-person', `Thanks ${ mention('someone') }/${ mention('another-person') }`],
     ['See other/project#34', `See ${ link('other/project', 34, 'other/project#34') }`],
     ['See [#34]', `See [${ link('upstream/project', 34) }]`],
+    ['Fixes GH-12', `Fixes ${ link('upstream/project', 12, 'GH-12') }`],
+    ['Fixes #12/#13', `Fixes ${ link('upstream/project', 12) }/${ link('upstream/project', 13) }`],
+    ['Escaped \\#12 and \\@someone', `Escaped ${ link('upstream/project', 12, '\\#12') } and ${ mention('someone') }`],
     ['in https://github.com/example/tool/pull/56', 'in https://redirect.github.com/example/tool/pull/56'],
+    ['in http://github.com/example/tool/pull/56', 'in https://redirect.github.com/example/tool/pull/56'],
     ['_https://github.com/example/tool/pull/56_', '_https://redirect.github.com/example/tool/pull/56_'],
     ['[fixes #56](https://github.com/example/tool/pull/56)', '[fixes #56](https://redirect.github.com/example/tool/pull/56)'],
   ])('rewrites %j', (body, expected) => {
@@ -32,6 +37,7 @@ describe('quoteReleaseNotes', () => {
     'Run `npm install @scope/package`',
     '```\n@someone fixed #12\n```',
     'https://example.com/page#12',
+    'https://example.com/#12',
     'Zero&#8203;width',
     'https://github.com/example/tool/compare/v1.0.0...v1.1.0',
   ])('leaves %j unchanged', (body) => {

--- a/scripts/lib/release-notes.ts
+++ b/scripts/lib/release-notes.ts
@@ -1,0 +1,40 @@
+const quotablePattern = new RegExp([
+  // Code spans, fenced code blocks and link text, copied unchanged, since
+  // GitHub finds no mentions or references inside them.
+  /(?<ticks>`+)[\s\S]*?\k<ticks>/.source,
+  /\[[^\]\n]*\](?=\()/.source,
+  // A link to an issue or pull request.
+  /https:\/\/github\.com\/(?<path>[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+)/.source,
+  // An issue reference, `#12` or `owner/repo#12`, outside URLs and HTML entities.
+  /(?<![\w.&/-])(?:(?<repository>[\w-]+\/[\w.-]+))?#(?<number>\d+)\b/.source,
+  // A user or team mention, outside email addresses and URLs.
+  /(?<![\w/])@(?<mention>[a-z\d](?:-?[a-z\d])*(?:\/[\w.-]+)?)(?![\w-])/.source,
+].join('|'), 'gi');
+
+/**
+ * Rewrite upstream release notes for quoting in a pull request body.
+ * GitHub notifies every user a body mentions and adds a backlink to every
+ * issue or pull request it references, so mentions become code and references
+ * link through redirect.github.com, which GitHub renders as a plain link.
+ */
+export function quoteReleaseNotes(body: string, owner: string, repo: string): string {
+  return body.replace(quotablePattern, (match, ...args) => {
+    // The last argument to a replacer is the named groups object.
+    const { path, repository, number, mention } = args.at(-1);
+
+    if (path) {
+      return `https://redirect.github.com/${ path }`;
+    }
+    if (number) {
+      const target = repository ?? `${ owner }/${ repo }`;
+
+      return `[${ target }#${ number }](https://redirect.github.com/${ target }/issues/${ number })`;
+    }
+    if (mention) {
+      // The zero-width space keeps a copy of the rendered text from mentioning anyone.
+      return `<code>@\u200B${ mention }</code>`;
+    }
+
+    return match;
+  });
+}

--- a/scripts/lib/release-notes.ts
+++ b/scripts/lib/release-notes.ts
@@ -19,6 +19,10 @@ const quotablePattern = new RegExp([
   String.raw`(?<![a-z\d\\]|[a-z\d]_)\\?@(?<mention>${ login }(?:/[\w.-]+)?)(?![a-z\d-]|_[a-z\d])`,
 ].join('|'), 'gis');
 
+// Text that ends where only a URL fits: a markdown link destination or
+// reference definition, an autolink, or an HTML attribute.
+const urlOnlyContext = /(?:\][(:]\s*|[<"])$/;
+
 /**
  * Rewrite upstream release notes for quoting in a pull request body.
  * GitHub notifies every user a body mentions and adds a backlink to every
@@ -29,11 +33,25 @@ const quotablePattern = new RegExp([
  */
 export function quoteReleaseNotes(body: string, owner: string, repo: string): string {
   return body.replace(quotablePattern, (match, ...args) => {
-    // The last argument to a replacer is the named groups object.
-    const { path, repository, number, mention } = args.at(-1);
+    // A replacer's last three arguments are the match offset, the whole
+    // string, and the named groups object.
+    const [offset, , { path, repository, number, mention }] = args.slice(-3);
 
     if (path) {
-      return `https://redirect.github.com/${ path }`;
+      const href = `https://redirect.github.com/${ path }`;
+      const before = body.slice(0, offset);
+      const after = body.slice(offset + match.length);
+
+      // Keep the URL where an HTML link would break the markup, or where the
+      // link's `owner/repo#12` text would drop whatever follows the number.
+      if (urlOnlyContext.test(before) || /^[/#?]/.test(after)) {
+        return href;
+      }
+      // In an HTML block, GitHub would link the `owner/repo/pull/12` inside a
+      // bare redirect URL.
+      const [pathOwner, pathRepo, , pathNumber] = path.split('/');
+
+      return `<a href="${ href }">${ pathOwner }/${ pathRepo }#${ pathNumber }</a>`;
     }
     // HTML links work inside HTML blocks too, where GitHub parses no markdown.
     if (number) {

--- a/scripts/lib/release-notes.ts
+++ b/scripts/lib/release-notes.ts
@@ -1,7 +1,7 @@
 const quotablePattern = new RegExp([
   // Code spans, fenced code blocks and link text, copied unchanged, since
   // GitHub finds no mentions or references inside them.
-  /(?<ticks>`+)[\s\S]*?\k<ticks>/.source,
+  /(?<ticks>`+).*?\k<ticks>/.source,
   /\[[^\]\n]*\](?=\()/.source,
   // A link to an issue or pull request.
   /https:\/\/github\.com\/(?<path>[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+)/.source,
@@ -9,13 +9,15 @@ const quotablePattern = new RegExp([
   /(?<![\w.&/-])(?:(?<repository>[\w-]+\/[\w.-]+))?#(?<number>\d+)\b/.source,
   // A user or team mention, outside email addresses and URLs.
   /(?<![\w/])@(?<mention>[a-z\d](?:-?[a-z\d])*(?:\/[\w.-]+)?)(?![\w-])/.source,
-].join('|'), 'gi');
+].join('|'), 'gis');
 
 /**
  * Rewrite upstream release notes for quoting in a pull request body.
  * GitHub notifies every user a body mentions and adds a backlink to every
- * issue or pull request it references, so mentions become code and references
- * link through redirect.github.com, which GitHub renders as a plain link.
+ * issue or pull request it references; show mentions as code, and use
+ * `redirect.github.com` to construct links instead, which disables the
+ * backlink.
+ * @see https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#avoiding-backlinks-to-linked-references
  */
 export function quoteReleaseNotes(body: string, owner: string, repo: string): string {
   return body.replace(quotablePattern, (match, ...args) => {
@@ -25,14 +27,18 @@ export function quoteReleaseNotes(body: string, owner: string, repo: string): st
     if (path) {
       return `https://redirect.github.com/${ path }`;
     }
+    // HTML links work inside HTML blocks too, where GitHub parses no markdown.
     if (number) {
       const target = repository ?? `${ owner }/${ repo }`;
 
-      return `[${ target }#${ number }](https://redirect.github.com/${ target }/issues/${ number })`;
+      return `<a href="https://redirect.github.com/${ target }/issues/${ number }">${ match }</a>`;
     }
     if (mention) {
+      const [login, team] = mention.split('/');
+      const profile = team ? `orgs/${ login }/teams/${ team }` : login;
+
       // The zero-width space keeps a copy of the rendered text from mentioning anyone.
-      return `<code>@\u200B${ mention }</code>`;
+      return `<a href="https://github.com/${ profile }"><code>@\u200B${ mention }</code></a>`;
     }
 
     return match;

--- a/scripts/lib/release-notes.ts
+++ b/scripts/lib/release-notes.ts
@@ -1,14 +1,17 @@
 const quotablePattern = new RegExp([
-  // Code spans, fenced code blocks and link text, copied unchanged, since
-  // GitHub finds no mentions or references inside them.
+  // A link to an issue or pull request.
+  /https?:\/\/github\.com\/(?<path>[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+)/.source,
+  // Code spans, fenced code blocks, link text, and other URLs, copied
+  // unchanged, since GitHub finds no mentions or references inside them.
   /(?<ticks>`+).*?\k<ticks>/.source,
   /\[[^\]\n]*\](?=\()/.source,
-  // A link to an issue or pull request.
-  /https:\/\/github\.com\/(?<path>[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+)/.source,
-  // An issue reference, `#12` or `owner/repo#12`, outside URLs and HTML entities.
-  /(?<![\w.&/-])(?:(?<repository>[\w-]+\/[\w.-]+))?#(?<number>\d+)\b/.source,
-  // A user or team mention, outside email addresses and URLs.
-  /(?<![\w/])@(?<mention>[a-z\d](?:-?[a-z\d])*(?:\/[\w.-]+)?)(?![\w-])/.source,
+  /(?:https?:\/\/|www\.)[^\s<>]*/.source,
+  // An issue reference, `#12`, `GH-12`, or `owner/repo#12`, outside HTML
+  // entities. GitHub links references and mentions even after a backslash
+  // escape, so the match includes the backslash.
+  /(?<![\w&\\])\\?(?:(?<repository>[\w-]+\/[\w.-]+)#|#|GH-)(?<number>\d+)\b/.source,
+  // A user or team mention, outside email addresses.
+  /(?<![\w\\])\\?@(?<mention>[a-z\d](?:-?[a-z\d])*(?:\/[\w.-]+)?)(?![\w-])/.source,
 ].join('|'), 'gis');
 
 /**

--- a/scripts/lib/release-notes.ts
+++ b/scripts/lib/release-notes.ts
@@ -1,6 +1,9 @@
+// A user or organization name, in a mention or as a repository owner.
+const login = /[a-z\d](?:-?[a-z\d])*/.source;
+
 const quotablePattern = new RegExp([
   // A link to an issue or pull request.
-  /https?:\/\/github\.com\/(?<path>[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+)/.source,
+  String.raw`https?://github\.com/(?<path>${ login }/[\w.-]+/(?:issues|pull)/\d+)`,
   // Code spans, fenced code blocks, link text, and other URLs, copied
   // unchanged, since GitHub finds no mentions or references inside them.
   /(?<ticks>`+).*?\k<ticks>/.source,
@@ -8,10 +11,12 @@ const quotablePattern = new RegExp([
   /(?:https?:\/\/|www\.)[^\s<>]*/.source,
   // An issue reference, `#12`, `GH-12`, or `owner/repo#12`, outside HTML
   // entities. GitHub links references and mentions even after a backslash
-  // escape, so the match includes the backslash.
-  /(?<![\w&\\])\\?(?:(?<repository>[\w-]+\/[\w.-]+)#|#|GH-)(?<number>\d+)\b/.source,
+  // escape, so the match includes the backslash. GitHub also links them
+  // inside `_emphasis_`, but not beside an underscore that is part of a
+  // word, as in `snake_#12`.
+  String.raw`(?<![a-z\d&\\]|[a-z\d]_)\\?(?:(?<repository>${ login }/[\w.-]+)#|#|GH-)(?<number>\d+)(?![a-z\d]|_[a-z\d])`,
   // A user or team mention, outside email addresses.
-  /(?<![\w\\])\\?@(?<mention>[a-z\d](?:-?[a-z\d])*(?:\/[\w.-]+)?)(?![\w-])/.source,
+  String.raw`(?<![a-z\d\\]|[a-z\d]_)\\?@(?<mention>${ login }(?:/[\w.-]+)?)(?![a-z\d-]|_[a-z\d])`,
 ].join('|'), 'gis');
 
 /**

--- a/scripts/lib/release-notes.ts
+++ b/scripts/lib/release-notes.ts
@@ -70,3 +70,39 @@ export function quoteReleaseNotes(body: string, owner: string, repo: string): st
     return match;
   });
 }
+
+/** The fields of a GitHub release that `formatReleaseNotes` reads. */
+export interface Release {
+  name:     string | null;
+  tag_name: string;
+  html_url: string;
+  body?:    string | null;
+}
+
+/**
+ * Format the notes of `releases`, which must be sorted oldest first, for the
+ * body of a pull request that bumps a dependency from `previousTag`.
+ */
+export function formatReleaseNotes(releases: Release[], previousTag: string, owner: string, repo: string): string {
+  let lastVersion = previousTag;
+
+  return releases.map((release, index) => {
+    // GitHub rejects a pull request body over 65,536 characters, which the
+    // notes of several releases can exceed, so link all but the newest.
+    let body = `[Release notes](${ release.html_url })`;
+
+    if (index === releases.length - 1) {
+      body = release.body
+        ? quoteReleaseNotes(release.body, owner, repo)
+        : `Release ${ release.name } does not have release notes.`;
+    }
+    const compareLink = [
+      `[Compare between ${ lastVersion } and ${ release.tag_name }]`,
+      `(https://github.com/${ owner }/${ repo }/compare/${ lastVersion }...${ release.tag_name })`,
+    ].join('');
+
+    lastVersion = release.tag_name;
+
+    return `## ${ release.name } (${ release.tag_name })\n${ body }\n${ compareLink }\n`;
+  }).join('\n');
+}

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -33,6 +33,7 @@ import {
   Version,
   VersionedDependency,
 } from '@/scripts/lib/dependencies';
+import { quoteReleaseNotes } from '@/scripts/lib/release-notes';
 
 const MAIN_BRANCH = 'main';
 const GITHUB_OWNER = process.env.GITHUB_REPOSITORY?.split('/')[0] || 'rancher-sandbox';
@@ -165,7 +166,7 @@ async function getBody(dependency: VersionedDependency, currentVersion: Version,
   let lastVersion = dependency.versionToTagName(currentVersion);
 
   return releaseNotes.map(([, release]) => {
-    const body = release.body?.replace(/(?<!\w)(#\d+)\b/g, (n) => `${ owner }/${ repo }${ n }`) || `Release ${ release.name } does not have release notes.`;
+    const body = release.body ? quoteReleaseNotes(release.body, owner, repo) : `Release ${ release.name } does not have release notes.`;
     const compareLink = [
       `[Compare between ${ lastVersion } and ${ release.tag_name }]`,
       `(https://github.com/${ owner }/${ repo }/compare/${ lastVersion }...${ release.tag_name })`,

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -166,7 +166,9 @@ async function getBody(dependency: VersionedDependency, currentVersion: Version,
   let lastVersion = dependency.versionToTagName(currentVersion);
 
   return releaseNotes.map(([, release]) => {
-    const body = release.body ? quoteReleaseNotes(release.body, owner, repo) : `Release ${ release.name } does not have release notes.`;
+    const body = release.body
+      ? quoteReleaseNotes(release.body, owner, repo)
+      : `Release ${ release.name } does not have release notes.`;
     const compareLink = [
       `[Compare between ${ lastVersion } and ${ release.tag_name }]`,
       `(https://github.com/${ owner }/${ repo }/compare/${ lastVersion }...${ release.tag_name })`,

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -33,7 +33,7 @@ import {
   Version,
   VersionedDependency,
 } from '@/scripts/lib/dependencies';
-import { quoteReleaseNotes } from '@/scripts/lib/release-notes';
+import { formatReleaseNotes } from '@/scripts/lib/release-notes';
 
 const MAIN_BRANCH = 'main';
 const GITHUB_OWNER = process.env.GITHUB_REPOSITORY?.split('/')[0] || 'rancher-sandbox';
@@ -163,33 +163,9 @@ async function getBody(dependency: VersionedDependency, currentVersion: Version,
   }
 
   releaseNotes.sort(([a], [b]) => semver.compare(a, b));
-  let lastVersion = dependency.versionToTagName(currentVersion);
+  const releases = releaseNotes.map(([, release]) => release);
 
-  return releaseNotes.map(([, release]) => {
-    const body = release.body
-      ? quoteReleaseNotes(release.body, owner, repo)
-      : `Release ${ release.name } does not have release notes.`;
-    const compareLink = [
-      `[Compare between ${ lastVersion } and ${ release.tag_name }]`,
-      `(https://github.com/${ owner }/${ repo }/compare/${ lastVersion }...${ release.tag_name })`,
-    ].join('');
-
-    lastVersion = release.tag_name;
-    if (releaseNotes.length > 1) {
-      // Make sure we don't have leading spaces or this turns into <pre>.
-      return [
-        '<details>',
-        `<summary><h3>${ release.name } (${ release.tag_name })</h3></summary>`,
-        '',
-        body,
-        '</details>',
-        '',
-        compareLink,
-      ].join('\n');
-    }
-
-    return `## ${ release.name } (${ release.tag_name })\n${ body }\n${ compareLink }\n`;
-  }).join('\n');
+  return formatReleaseNotes(releases, dependency.versionToTagName(currentVersion), owner, repo);
 }
 
 async function createDependencyBumpPR(dependency: VersionedDependency, currentVersion: Version, latestVersion: Version): Promise<void> {


### PR DESCRIPTION
rddepman quotes upstream release notes in its bump PRs, so GitHub notified everyone those notes mentioned and added a backlink to every issue they referenced.

This turns mentions into code and links issue references through redirect.github.com, which GitHub renders as a plain link.

It also quotes only the newest release's notes and links the notes of each older release, because GitHub rejects a pull request body over 65,536 characters and the nerdctl bump from 2.2.2 to 2.3.5 exceeds it (https://github.com/rancher-sandbox/rancher-desktop-2/actions/runs/34683522022).
