### PR TITLE
Mark the control plane ready only once its webhooks answer

### DIFF
--- a/rdd/cmd/rdd/service.go
+++ b/rdd/cmd/rdd/service.go
@@ -147,9 +147,9 @@ func startAndWaitForReady(ctx context.Context, serveArgs []string, timeout time.
 // for the current control plane instance exists and is marked ready.
 // The serve command recreates the ConfigMap on every startup, so a
 // creationTimestamp at or after beforeStart identifies the current
-// instance. The ready annotation is set after CRDs are installed and
-// every controller manager has registered, so waiting for it lets
-// clients use both CRDs and discovery data without racing startup.
+// instance. Waiting for [controllers.ReadyAnnotation] lets clients use
+// the control plane without racing startup; its doc lists what the
+// annotation covers.
 func waitForFreshDiscoveryConfigMap(ctx context.Context, beforeStart time.Time) error {
 	restConfig, err := service.GetKubeRestConfig()
 	if err != nil {

--- a/rdd/docs/design/discovery.md
+++ b/rdd/docs/design/discovery.md
@@ -42,14 +42,14 @@ A controller manager patches the ConfigMap on startup (adding its API group key)
 
 ## Ready annotation
 
-The annotation `rdd.rancherdesktop.io/ready=true` signals that every enabled controller has installed its CRDs **and** registered its data entry in the ConfigMap. Clients that depend on CRDs (for example, `rdd set`, which fetches the App CRD schema) or on the enabled-controller list (for example, `rdd set running=true`, which checks whether the engine controller is present) must wait for the annotation; otherwise they race startup and see either `the server could not find the requested resource` or a stale, empty controller list.
+The annotation `rdd.rancherdesktop.io/ready=true` signals that every enabled controller has installed its CRDs **and** registered its data entry in the ConfigMap, and that its admission webhooks are configured and accept connections. Clients that depend on CRDs (for example, `rdd set`, which fetches the App CRD schema) or on the enabled-controller list (for example, `rdd set running=true`, which checks whether the engine controller is present) must wait for the annotation; otherwise they race startup and see either `the server could not find the requested resource` or a stale, empty controller list.
 
 The control plane sets the annotation in one of two places:
 
 1. Immediately after creating the ConfigMap, if no controllers are enabled.
-2. Otherwise, inside the shared controller manager's startup goroutine, after `installControllerCRDs` has established every CRD **and** `registerDiscovery` has written the controller-manager entry into `configMap.Data`.
+2. Otherwise, inside the shared controller manager's startup goroutine, after `installControllerCRDs` has established every CRD, `registerDiscovery` has written the controller-manager entry into `configMap.Data`, the webhook configurations are applied, and the webhook server accepts connections.
 
-Ordering both steps before the annotation keeps the "ready = clients may proceed" contract consistent: any client that waits for the annotation sees both CRDs and the enabled-controller list, not just one of the two.
+Ordering every step before the annotation keeps the "ready = clients may proceed" contract consistent. Any client that waits for the annotation sees the CRDs, the enabled-controller list, and working admission webhooks.
 
 The ConfigMap is recreated on every control plane startup, so a stale `ready` from a previous crash is always cleared before CRD installation begins.
 

--- a/rdd/pkg/service/controllers/discovery.go
+++ b/rdd/pkg/service/controllers/discovery.go
@@ -29,10 +29,11 @@ const (
 	RDDSystemNamespace = "rdd-system"
 
 	// ReadyAnnotation is set on the discovery ConfigMap after every
-	// enabled controller has installed its CRDs and every controller
-	// manager has registered its data entry. Clients must wait for
-	// this annotation because the ConfigMap itself exists from the
-	// moment the control plane starts, before any controller is ready.
+	// enabled controller has installed its CRDs, every controller
+	// manager has registered its data entry, and the admission
+	// webhooks are configured and answer. Clients must wait for this
+	// annotation because the ConfigMap itself exists from the moment
+	// the control plane starts, before any controller is ready.
 	ReadyAnnotation = "rdd.rancherdesktop.io/ready"
 )
 
@@ -355,9 +356,7 @@ func (d *ControllerManagerDiscovery) ensureNamespace(ctx context.Context) error 
 // empty one. The creationTimestamp serves as the control plane start
 // time. Call it after the API server is ready and before any
 // controller managers register. The new ConfigMap does not carry
-// [ReadyAnnotation]; [MarkControlPlaneReady] must be called once every
-// enabled controller has installed its CRDs and registered its data
-// entry in the ConfigMap.
+// [ReadyAnnotation] until [MarkControlPlaneReady] sets it.
 func InitDiscovery(ctx context.Context, client kubernetes.Interface) error {
 	d := &ControllerManagerDiscovery{client: client, namespace: RDDSystemNamespace}
 	if err := d.ensureNamespace(ctx); err != nil {
@@ -389,10 +388,8 @@ func InitDiscovery(ctx context.Context, client kubernetes.Interface) error {
 }
 
 // MarkControlPlaneReady sets [ReadyAnnotation] on the discovery
-// ConfigMap to signal that every enabled controller has installed
-// its CRDs and registered its data entry. Call it after the last
-// [ControllerManagerDiscoveryGroup.RegisterControllerManager] call,
-// or immediately after [InitDiscovery] when no controllers are
+// ConfigMap. Call it once the conditions in the [ReadyAnnotation] doc
+// hold, or immediately after [InitDiscovery] when no controllers are
 // configured.
 func MarkControlPlaneReady(ctx context.Context, client kubernetes.Interface) error {
 	patchData, err := json.Marshal(map[string]any{

--- a/rdd/pkg/service/controllers/manager.go
+++ b/rdd/pkg/service/controllers/manager.go
@@ -195,13 +195,6 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		// Don't fail startup for discovery registration errors
 	}
 
-	// Mark the control plane ready after registerDiscovery so clients
-	// waiting on the ready annotation see both CRDs installed and
-	// controller registration written, not just CRDs.
-	if err := MarkControlPlaneReady(ctx, scm.discovery.client); err != nil {
-		return fmt.Errorf("failed to mark control plane as ready: %w", err)
-	}
-
 	// Ensure cleanup on shutdown with a timeout to avoid blocking if apiserver is gone
 	defer func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -278,12 +271,45 @@ func (scm *SharedControllerManager) Start(ctx context.Context) error {
 		"metricsPort", scm.metricsPort,
 		"healthPort", scm.healthPort)
 
-	// Start the manager (this blocks until context is cancelled)
-	if err := mgr.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start shared controller manager: %w", err)
+	mgrCtx, mgrCancel := context.WithCancel(ctx)
+	defer mgrCancel()
+	mgrResult := make(chan error, 1)
+	go func() { mgrResult <- mgr.Start(mgrCtx) }()
+
+	managerResult := func(err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to start shared controller manager: %w", err)
+		}
+		return nil
 	}
 
-	return nil
+	if scm.hasWebhookControllers() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for mgr.GetWebhookServer().StartedChecker()(nil) != nil {
+			select {
+			case <-ctx.Done():
+				mgrCancel()
+				return managerResult(<-mgrResult)
+			case err := <-mgrResult:
+				if err != nil {
+					return fmt.Errorf("shared controller manager exited before its webhook server started: %w", err)
+				}
+				return nil
+			case <-ticker.C:
+			}
+		}
+	}
+
+	// Clients act on the ready annotation, so mark ready only after the
+	// webhook configurations exist and their server answers.
+	if err := MarkControlPlaneReady(ctx, scm.discovery.client); err != nil {
+		mgrCancel()
+		<-mgrResult
+		return fmt.Errorf("failed to mark control plane as ready: %w", err)
+	}
+
+	return managerResult(<-mgrResult)
 }
 
 // GetManager returns the underlying controller-runtime manager

--- a/rdd/pkg/service/controllers/manager_test.go
+++ b/rdd/pkg/service/controllers/manager_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+package controllers
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/rancher-sandbox/rancher-desktop-daemon/pkg/controllers/base"
+)
+
+// probeWebhookManager blocks in Setup until the test releases it.
+type probeWebhookManager struct {
+	setupStarted chan struct{}
+	releaseSetup chan struct{}
+}
+
+func (m *probeWebhookManager) GetConfigName() string            { return "probe-webhook" }
+func (m *probeWebhookManager) GetWebhookType() base.WebhookType { return base.ValidatingWebhook }
+func (m *probeWebhookManager) Setup() error {
+	close(m.setupStarted)
+	<-m.releaseSetup
+	return nil
+}
+
+// probeController is a webhook controller with no CRD and no reconciler.
+type probeController struct {
+	webhookPort    int
+	webhookManager *probeWebhookManager
+}
+
+func (c *probeController) GetName() string                        { return "probe" }
+func (c *probeController) GetAPIGroup() string                    { return "probe.test" }
+func (c *probeController) GetCRDData() string                     { return "" }
+func (c *probeController) RegisterWithManager(ctrl.Manager) error { return nil }
+func (c *probeController) SetWebhookPort(port int)                { c.webhookPort = port }
+func (c *probeController) GetWebhookServiceName() string          { return "probe-webhook-service" }
+func (c *probeController) GetWebhookManagers() []base.WebhookManager {
+	return []base.WebhookManager{c.webhookManager}
+}
+
+func TestSharedControllerManagerMarksReadyAfterWebhooks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("RDD_INSTANCE", "test-webhook-startup-order")
+
+	env := &envtest.Environment{
+		DownloadBinaryAssets: true,
+	}
+	cfg, err := env.Start()
+	assert.NilError(t, err, "failed to start environment")
+
+	defer func() {
+		err := env.Stop()
+		if runtime.GOOS != "windows" && err != nil {
+			checkError := os.Getenv("CI") == ""
+			checkError = checkError || !strings.Contains(err.Error(), "timeout waiting for process kube-apiserver to stop")
+			if checkError {
+				assert.NilError(t, err, "failed to stop environment")
+			}
+		}
+	}()
+
+	client, err := kubernetes.NewForConfig(cfg)
+	assert.NilError(t, err, "failed to create kubernetes client")
+	assert.NilError(t, InitDiscovery(t.Context(), client), "failed to init discovery")
+
+	scm, err := NewSharedControllerManager("test", cfg, 18080, 18081)
+	assert.NilError(t, err, "failed to create shared controller manager")
+	webhookManager := &probeWebhookManager{
+		setupStarted: make(chan struct{}),
+		releaseSetup: make(chan struct{}),
+	}
+	assert.NilError(t, scm.RegisterController(&probeController{webhookManager: webhookManager}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	startErr := make(chan error, 1)
+	go func() { startErr <- scm.Start(ctx) }()
+
+	select {
+	case <-webhookManager.setupStarted:
+	case err := <-startErr:
+		assert.Assert(t, false, "Start returned before webhook setup: %v", err)
+	case <-time.After(60 * time.Second):
+		assert.Assert(t, false, "timed out waiting for webhook setup to start")
+	}
+
+	readyAnnotation := func() string {
+		cm, err := client.CoreV1().ConfigMaps(RDDSystemNamespace).Get(t.Context(), ControllerManagerConfigMapName, metav1.GetOptions{})
+		assert.NilError(t, err, "failed to get discovery config map")
+		return cm.Annotations[ReadyAnnotation]
+	}
+	assert.Equal(t, readyAnnotation(), "", "control plane marked ready before its webhook configurations were applied")
+
+	close(webhookManager.releaseSetup)
+	deadline := time.Now().Add(30 * time.Second)
+	for readyAnnotation() != "true" {
+		assert.Assert(t, time.Now().Before(deadline), "timed out waiting for the control plane to be marked ready")
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(scm.GetWebhookPort()))
+	dialer := &tls.Dialer{Config: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec // the test only checks that the server answers
+	conn, err := dialer.DialContext(t.Context(), "tcp", addr)
+	assert.NilError(t, err, "webhook server not answering after the control plane was marked ready")
+	assert.NilError(t, conn.Close())
+
+	cancel()
+	select {
+	case err := <-startErr:
+		assert.NilError(t, err, "Start returned an error on shutdown")
+	case <-time.After(30 * time.Second):
+		assert.Assert(t, false, "timed out waiting for Start to return")
+	}
+}


### PR DESCRIPTION
Marks the control plane ready only after its webhook configurations exist and the webhook server accepts connections. `rdd set` creates the App as soon as it sees the ready annotation, and until now the annotation came first, so on a fresh control plane the App create could fail with `connection refused` on the app-defaulter webhook (a Windows bats-docker flake) or be admitted without running the defaulter and validator.

The new test holds webhook setup open and checks that the control plane is not marked ready before setup finishes and the webhook server answers; it fails on `main`.
